### PR TITLE
Grant users permissions to list namespaces and check their own permissions

### DIFF
--- a/namespaces/non-production.k8s.integration.dsd.io/analytics-hq-dev/analytics-hq-dev-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/analytics-hq-dev/analytics-hq-dev-admin-role.yaml
@@ -1,3 +1,54 @@
+# Role to allow listing of namespaces.
+#
+# As this role is not bound to a namespace, it could be created once
+# at the cluster scope, rather than multiple roles being created for
+# each namespace. This is the simplest solution for now however.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: analytics-hq-dev-namespaces-list
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+
+# Bind namespace-list role to team group
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: analytics-hq-dev-namespaces-list
+subjects:
+- kind: Group
+  name: "github:analytics-hq"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: analytics-hq-dev-namespaces-list
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind basic-user role to team group
+# This allows users to use the Authorization API to check their
+# access levels
+#
+# https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L576
+# https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: analytics-hq-dev-basic-user
+subjects:
+- kind: Group
+  name: "github:analytics-hq"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind admin role for namespace to team group
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/namespaces/non-production.k8s.integration.dsd.io/cccd-dev/cccd-dev-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/cccd-dev/cccd-dev-admin-role.yaml
@@ -1,3 +1,54 @@
+# Role to allow listing of namespaces.
+#
+# As this role is not bound to a namespace, it could be created once
+# at the cluster scope, rather than multiple roles being created for
+# each namespace. This is the simplest solution for now however.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cccd-dev-namespaces-list
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+
+# Bind namespace-list role to team group
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cccd-dev-namespaces-list
+subjects:
+- kind: Group
+  name: "github:crime-billing-online"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cccd-dev-namespaces-list
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind basic-user role to team group
+# This allows users to use the Authorization API to check their
+# access levels
+#
+# https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L576
+# https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cccd-dev-basic-user
+subjects:
+- kind: Group
+  name: "github:crime-billing-online"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind admin role for namespace to team group
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/namespaces/non-production.k8s.integration.dsd.io/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
@@ -1,3 +1,54 @@
+# Role to allow listing of namespaces.
+#
+# As this role is not bound to a namespace, it could be created once
+# at the cluster scope, rather than multiple roles being created for
+# each namespace. This is the simplest solution for now however.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-dev-namespaces-list
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+
+# Bind namespace-list role to team group
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-dev-namespaces-list
+subjects:
+- kind: Group
+  name: "github:form-builder"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: formbuilder-services-dev-namespaces-list
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind basic-user role to team group
+# This allows users to use the Authorization API to check their
+# access levels
+#
+# https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L576
+# https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-dev-basic-user
+subjects:
+- kind: Group
+  name: "github:form-builder"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind admin role for namespace to team group
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/namespaces/non-production.k8s.integration.dsd.io/laa-fee-calculator-dev/laa-fee-calculator-dev-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/laa-fee-calculator-dev/laa-fee-calculator-dev-admin-role.yaml
@@ -1,3 +1,54 @@
+# Role to allow listing of namespaces.
+#
+# As this role is not bound to a namespace, it could be created once
+# at the cluster scope, rather than multiple roles being created for
+# each namespace. This is the simplest solution for now however.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-fee-calculator-dev-namespaces-list
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+
+# Bind namespace-list role to team group
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-fee-calculator-dev-namespaces-list
+subjects:
+- kind: Group
+  name: "github:crime-billing-online"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: laa-fee-calculator-dev-namespaces-list
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind basic-user role to team group
+# This allows users to use the Authorization API to check their
+# access levels
+#
+# https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L576
+# https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-fee-calculator-dev-basic-user
+subjects:
+- kind: Group
+  name: "github:crime-billing-online"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind admin role for namespace to team group
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/namespaces/non-production.k8s.integration.dsd.io/mps-dev/mps-dev-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/mps-dev/mps-dev-admin-role.yaml
@@ -1,3 +1,54 @@
+# Role to allow listing of namespaces.
+#
+# As this role is not bound to a namespace, it could be created once
+# at the cluster scope, rather than multiple roles being created for
+# each namespace. This is the simplest solution for now however.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mps-dev-namespaces-list
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+
+# Bind namespace-list role to team group
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mps-dev-namespaces-list
+subjects:
+- kind: Group
+  name: "github:moving-people-safely"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: mps-dev-namespaces-list
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind basic-user role to team group
+# This allows users to use the Authorization API to check their
+# access levels
+#
+# https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L576
+# https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mps-dev-basic-user
+subjects:
+- kind: Group
+  name: "github:moving-people-safely"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind admin role for namespace to team group
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/namespaces/non-production.k8s.integration.dsd.io/pvbpublic-dev/pvbpublic-dev-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/pvbpublic-dev/pvbpublic-dev-admin-role.yaml
@@ -1,3 +1,54 @@
+# Role to allow listing of namespaces.
+#
+# As this role is not bound to a namespace, it could be created once
+# at the cluster scope, rather than multiple roles being created for
+# each namespace. This is the simplest solution for now however.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pvbpublic-dev-namespaces-list
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+
+# Bind namespace-list role to team group
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pvbpublic-dev-namespaces-list
+subjects:
+- kind: Group
+  name: "github:prison-visits-booking"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: pvbpublic-dev-namespaces-list
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind basic-user role to team group
+# This allows users to use the Authorization API to check their
+# access levels
+#
+# https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L576
+# https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pvbpublic-dev-basic-user
+subjects:
+- kind: Group
+  name: "github:prison-visits-booking"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind admin role for namespace to team group
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
This PR adds additional `ClusterRole` and `ClusterRoleBinding` resources for users' team accounts, to grant them permissions to list namespaces, and to use the authorization API to check their own permission level (e.g. with `kubectl auth can-i list namespaces`).

These changes will add a new `ClusterRole` resource for each user namespace, which grants `list` on `namespaces`. As this role is at the cluster scope, and does not refer to any specific namespaces, groups or teams, it would be better to create a single role once, and bind it to each user group; however we don't currently have a defined method for creating cluster-level resources as part of cluster creation, so creating an individual role for each namespace seems simpler for now.

**To test these changes:**

Copy an existing namespace definition:

```
$ cd namespaces/non-production.k8s.integration.dsd.io
$ cp laa-fee-calculator-dev my-test-namespace
```

Edit the `role.yaml` and `namespace.yaml` to refer to `my-test-namespace` instead of `laa-fee-calculator-dev`.

Change the github team referenced from `github:crime-billing-online` to a Github team you're a member of (but not `webops`, as that team has cluster admin privileges).

Create namespace, roles, and rolebindings:

```
$ kubectl apply -f my-test-namespace/
```

Verify that you can list namespaces, and check your privileges:

```
$ kubectl get namespaces
NAME                           STATUS    AGE
analytics-hq-dev               Active    2h
...

$ kubectl auth can-i list namespaces \
    --as https://moj-cloud-platforms-dev.eu.auth0.com/#your-github-username \
    --as-group github:your-github-team
yes
```