### PR TITLE
Add new namespace:monitoring on Test-1 cluster

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/namespace.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring


### PR DESCRIPTION
connects to https://waffle.io/ministryofjustice/cloud-platform/cards/5b226c477357e5001de038f5

New namespace for the Prometheus. Will just contain the namespace for now.