### PR TITLE
Add laa-fee-calculator-dev namespace and serviceaccount for CircleCI

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/laa-fee-calculator-dev/namespace.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/laa-fee-calculator-dev/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-fee-calculator-dev

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/laa-fee-calculator-dev/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/laa-fee-calculator-dev/serviceaccount-circleci.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-fee-calculator-dev
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-fee-calculator-dev
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+
+  
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-fee-calculator-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-fee-calculator-dev
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/laa-fee-calculator-dev/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/laa-fee-calculator-dev/serviceaccount-circleci.yaml
@@ -37,9 +37,6 @@ rules:
       - "create"
       - "patch"
 
-
-  
-
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
connects to #138

**WHAT**

- laa-fee-calculator-dev namespace 
- CircleCI Service Account for laa-fee-calculator-dev pipeline

**WHY**

Testing the laa-fee-calculator app in the test-1 cluster before promoting to live later this week. The namespace creates an environment for the app and the Service Account authenticates CircleCI with the test-1 cluster. CircleCI has access to all resources and verbs named below in the 'role' section of the Service Account. 