### PR TITLE
kubeconfig should be managed by the pipeline or user

### DIFF
--- a/whichNamespace.sh
+++ b/whichNamespace.sh
@@ -6,13 +6,6 @@ if [ `echo $LIST_OF_CHANGED_FILES | wc -l` -lt 1 ]; then
   echo "No clusters changes to apply"
 else
   for CLUSTER in $LIST_OF_CHANGED_FILES; do
-    if [[ "$CLUSTER" =~ non-production\.k8s.* ]]; then
-      KEYSTORE='non-production-cluster-keystore'
-    elif [[ "$CLUSTER" =~ cloud-platforms-test\.k8s.* ]]; then
-      KEYSTORE="cloud-platform-test-cluster-keystore"
-    fi
-    echo "Running aws s3 cp s3://$KEYSTORE/kubecfg.yaml ~/.kube/config"
-    aws s3 cp s3://$KEYSTORE/kubecfg.yaml ~/.kube/config
     echo "Running kubectl config use-context $CLUSTER"
     kubectl config use-context $CLUSTER
     echo "Running python3 namespace.py -c $CLUSTER"


### PR DESCRIPTION
This change breaks the `build-environments` pipeline until https://github.com/ministryofjustice/cloud-platform-concourse/pull/14 is merged.