### PR TITLE
Global user RBAC manifests.

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/user-roles.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/user-roles.yaml
@@ -1,0 +1,36 @@
+# As this role and rolebindings are not bound to a namespace, they are created
+# once at the cluster scope.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: list-namespaces
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: authenticated-list-namespaces
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: list-namespaces
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: authenticated-basic-user
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/non-production.k8s.integration.dsd.io/user-roles.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/user-roles.yaml
@@ -1,0 +1,36 @@
+# As this role and rolebindings are not bound to a namespace, they are created
+# once at the cluster scope.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: list-namespaces
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: authenticated-list-namespaces
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: list-namespaces
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: authenticated-basic-user
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/95

The user permissions are created on the cluster scope and apply to all users. They don't need to be declared in each namespace.

The pipeline already supports global resources.