### PR TITLE
add RoleBinding for FB Publisher app service account

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-platform-dev
+  labels:
+    name: formbuilder-platform-dev

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/formbuilder-platform-dev-admin-role.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/formbuilder-platform-dev-admin-role.yaml
@@ -1,0 +1,64 @@
+# Role to allow listing of namespaces.
+#
+# As this role is not bound to a namespace, it could be created once
+# at the cluster scope, rather than multiple roles being created for
+# each namespace. This is the simplest solution for now however.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-dev-namespaces-list
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+
+# Bind namespace-list role to team group
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-dev-namespaces-list
+subjects:
+- kind: Group
+  name: "github:form-builder"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: formbuilder-platform-dev-namespaces-list
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind basic-user role to team group
+# This allows users to use the Authorization API to check their
+# access levels
+#
+# https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L576
+# https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-dev-basic-user
+subjects:
+- kind: Group
+  name: "github:form-builder"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-dev-admins
+  namespace: formbuilder-platform-dev
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/publisher-workers-service-account.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/publisher-workers-service-account.yaml
@@ -1,0 +1,8 @@
+# We need to run the publisher worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-(env) namespace so that they can deploy services
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-publisher-workers-dev
+  namespace: formbuilder-platform-dev

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-platform-staging
+  labels:
+    name: formbuilder-platform-staging

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/formbuilder-platform-staging-admin-role.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/formbuilder-platform-staging-admin-role.yaml
@@ -1,0 +1,17 @@
+
+
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-staging-admins
+  namespace: formbuilder-platform-staging
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/publisher-workers-service-account.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/publisher-workers-service-account.yaml
@@ -1,0 +1,8 @@
+# We need to run the publisher worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-(env) namespace so that they can deploy services
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-publisher-workers-staging
+  namespace: formbuilder-platform-staging

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-services-dev
+  labels:
+    name: formbuilder-services-dev

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
@@ -1,0 +1,67 @@
+# Role to allow listing of namespaces.
+#
+# As this role is not bound to a namespace, it could be created once
+# at the cluster scope, rather than multiple roles being created for
+# each namespace. This is the simplest solution for now however.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-dev-namespaces-list
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+
+# Bind namespace-list role to team group
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-dev-namespaces-list
+subjects:
+- kind: Group
+  name: "github:form-builder"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: formbuilder-services-dev-namespaces-list
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind basic-user role to team group
+# This allows users to use the Authorization API to check their
+# access levels
+#
+# https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L576
+# https://kubernetes.io/docs/reference/access-authn-authz/authorization/
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-dev-basic-user
+subjects:
+- kind: Group
+  name: "github:form-builder"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:basic-user
+  apiGroup: rbac.authorization.k8s.i960
+
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-dev-admins
+  namespace: formbuilder-services-dev
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: "formbuilder-platform-dev:formbuilder-publisher-workers-dev"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-services-staging
+  labels:
+    name: formbuilder-services-staging

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/formbuilder-services-staging-admin-role.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/formbuilder-services-staging-admin-role.yaml
@@ -1,0 +1,19 @@
+
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-staging-admins
+  namespace: formbuilder-services-staging
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: "formbuilder-platform-staging:formbuilder-publisher-workers-staging"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/non-production.k8s.integration.dsd.io/formbuilder-platform-dev/publisher-workers-service-account.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/formbuilder-platform-dev/publisher-workers-service-account.yaml
@@ -1,0 +1,8 @@
+# We need to run the publisher worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-(env) namespace so that they can deploy services
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-publisher-workers-dev
+  namespace: formbuilder-platform-dev

--- a/namespaces/non-production.k8s.integration.dsd.io/formbuilder-platform-staging/publisher-workers-service-account.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/formbuilder-platform-staging/publisher-workers-service-account.yaml
@@ -1,0 +1,8 @@
+# We need to run the publisher worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-(env) namespace so that they can deploy services
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-publisher-workers-staging
+  namespace: formbuilder-platform-staging

--- a/namespaces/non-production.k8s.integration.dsd.io/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
@@ -58,6 +58,9 @@ subjects:
   - kind: Group
     name: "github:form-builder"
     apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: "formbuilder-platform-dev:formbuilder-publisher-dev"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin

--- a/namespaces/non-production.k8s.integration.dsd.io/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/formbuilder-services-dev/formbuilder-services-dev-admin-role.yaml
@@ -45,7 +45,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: system:basic-user
-  apiGroup: rbac.authorization.k8s.io
+  apiGroup: rbac.authorization.k8s.i960
 
 # Bind admin role for namespace to team group
 ---
@@ -59,7 +59,7 @@ subjects:
     name: "github:form-builder"
     apiGroup: rbac.authorization.k8s.io
   - kind: ServiceAccount
-    name: "formbuilder-platform-dev:formbuilder-publisher-dev"
+    name: "formbuilder-platform-dev:formbuilder-publisher-workers-dev"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/non-production.k8s.integration.dsd.io/formbuilder-services-staging/formbuilder-services-staging-admin-role.yaml
+++ b/namespaces/non-production.k8s.integration.dsd.io/formbuilder-services-staging/formbuilder-services-staging-admin-role.yaml
@@ -10,6 +10,9 @@ subjects:
   - kind: Group
     name: "github:form-builder"
     apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: "formbuilder-platform-staging:formbuilder-publisher-workers-staging"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
We need the formbuilder-publisher app workers (which will be running as a distinct service account in the formbuilder-platform-(env) namespaces) to be able to perform k8s operations in the formbuilder-services-(env) namespaces

This PR adds:

- a distinct service account
- a RoleBinding to grant admin access to the service account

...for the dev and staging environments