### PR TITLE
Terraform backend configuration for environment resources

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -24,7 +24,11 @@ for _c in namespaces/*; do
       terraform_resources_path="namespaces/${cluster}/${namespace}/resources"
       if [ -d "${terraform_resources_path}" ]; then
         log blue "applying terraform resources for namespace ${namespace} in ${cluster}"
-        terraform init "${terraform_resources_path}"
+        terraform init \
+          -backend-config="bucket=moj-cp-k8s-investigation-environments-terraform" \
+          -backend-config="key=${cluster}/${namespace}/terraform.tfstate" \
+          -backend-config="region=eu-west-1"
+          "${terraform_resources_path}"
         terraform apply -auto-approve "${terraform_resources_path}"
       fi
     fi

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/platforms-dev/resources/main.tf
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/platforms-dev/resources/main.tf
@@ -1,5 +1,9 @@
+terraform {
+  backend "s3" {}
+}
+
 provider "aws" {
-  region   = "eu-west-1"
+  region = "eu-west-1"
 }
 
 module "example_team_s3" {

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/platforms-dev/resources/main.tf
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/platforms-dev/resources/main.tf
@@ -19,3 +19,16 @@ module "example_team_s3" {
   environment-name       = "dev"
   infrastructure-support = "platform@digtal.justice.gov.uk"
 }
+
+resource "kubernetes_secret" "example_s3_bucket_credentials" {
+  metadata {
+    name      = "s3-bucket-example"
+    namespace = "platforms-dev"
+  }
+
+  data {
+    bucket_name       = "${module.example_team_s3.bucket_name}"
+    access_key_id     = "${module.example_team_s3.access_key_id}"
+    secret_access_key = "${module.example_team_s3.secret_access_key}"
+  }
+}


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/74

Backend configuration is done in the `apply` script to avoid a lot of boilerplate for users and to restrict control.