### PR TITLE
Fix erronious team name.

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development-test/00-namespace.yml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development-test/00-namespace.yml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: digicop-development-test 
-  labels:
-    name: digicop-development-test

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development/digicop-development-admin-role.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development/digicop-development-admin-role.yaml
@@ -1,11 +1,8 @@
-opg-webops
-
-
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: digicop-development-admin
-  namespace: digicop-development 
+  namespace: digicop-development
 subjects:
   - kind: Group
     name: "github:opg-webops"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-test/00-namespace.yml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-test/00-namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: digicop-test
+  labels:
+    name: digicop-test

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-test/digicop-test-admin-role.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-test/digicop-test-admin-role.yaml
@@ -1,10 +1,8 @@
-opg-webops
-
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: digicop-development-test-admin
-  namespace: digicop-development-test 
+  name: digicop-test-admin
+  namespace: digicop-test
 subjects:
   - kind: Group
     name: "github:opg-webops"


### PR DESCRIPTION
- Rename digicop-development-test --> digicop-test
- Remove opg-webops word wrongly placed in the yaml