### PR TITLE
add ns resource folder with ns creation files

### DIFF
--- a/namespace-resources/00-namespace.yaml
+++ b/namespace-resources/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: <namespace-name>

--- a/namespace-resources/01-rbac.yaml
+++ b/namespace-resources/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <namespace-name>-admin
+  namespace: <namespace-name>
+subjects:
+  - kind: Group
+    name: "github:<github-team>"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespace-resources/02-limitrange.yaml
+++ b/namespace-resources/02-limitrange.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+spec:
+  limits:
+  - default:
+      cpu: 2
+      memory: 2Gi
+    defaultRequest:
+      cpu: 0.1
+      memory: 128Mi
+    type: Container

--- a/namespace-resources/02-limitrange.yaml
+++ b/namespace-resources/02-limitrange.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 2
+      cpu: 1000m
       memory: 2Gi
     defaultRequest:
-      cpu: 0.1
+      cpu: 100m
       memory: 128Mi
     type: Container

--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -4,7 +4,7 @@ metadata:
   name: namespace-quota
 spec:
   hard:
-    requests.cpu: "3000m"
-    requests.memory: 3Gi
+    requests.cpu: "4000m"
+    requests.memory: 8Gi
     limits.cpu: "6000m"
-    limits.memory: 6Gi
+    limits.memory: 12Gi

--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+spec:
+  hard:
+    requests.cpu: "3000m"
+    requests.memory: 3Gi
+    limits.cpu: "6000m"
+    limits.memory: 6Gi


### PR DESCRIPTION
WHAT
Created a new folder with mandatory files that are required to create a new ns including new files for limitrange and resourcequota

WHY
limitrange and resourcequota are required so we can have better sizing and node utilisation.
The values are based on live-0 node sizes of c4 2xl. These will need to be adjusted when using on lower spec clusters