### PR TITLE
Add Elasticsearch-Curator to `test-1` and `live-0` to rotate logs

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/README.md
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/README.md
@@ -34,6 +34,14 @@ In addition to the application's `DaemonSet`, there are an additional 3 parts to
 
 The `kube-fluentd-es-config.yaml` file is the config file that `fluentd-es` depends on for all of it's default configurations. Don't be overwhelmed by the size of this file as over 99% of it's contents are default and shouldn't be touched. The only part of this file that you should concern yourself with is the very last block of code at the bottom, within the `<match>` tag.
 
+### ElasticSearch Curator
+
+The `elasticsearch-curator.yaml` file is made up of two resources, a ConfigMap and a CronJob. The ConfigMap contains a Python script that generates AWS credentials in the `aws-platforms-integration` account and deletes logs older than 1 month in the `cloud-platform-live` elasticsearch cluster. 
+https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/curator.html
+
+The CronJob is responsible for scheduling the Python script to run every day at 1am. 
+
+Note: The script only works if the Kubernetes cluster is whitelisted on Elasticsearch. This can be done from the AWS console by `Modifying the access policy` and adding the K8s cluster NAT Gateway IP's.
 
 ## Configuration 
 

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: elasticsearch-curator-cronjob
+  namespace: logging
+spec: 
+  schedule: "0 1 * * *"
+  jobTemplate: 
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: alpine
+            image: alpine
+            command:
+            - /bin/sh
+            - -c
+            - |
+              apk update
+              apk add --no-cache python3 
+              pip3 install --upgrade pip
+              pip3 install boto3 elasticsearch-curator requests_aws4auth elasticsearch
+              python3 /etc/es-curator/elasticsearch-curator
+            args:
+            - --config
+            - /etc/es-curator/elasticsearch-curator
+            volumeMounts:
+            - name: elasticsearch-curator-python
+              mountPath: /etc/es-curator
+          volumes:
+            - name: elasticsearch-curator-python
+              configMap:
+                name: elasticsearch-curator-python
+           
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-curator-python
+  namespace: logging
+data:
+  elasticsearch-curator: |
+    #!/usr/bin/env python3
+
+    import boto3
+    from requests_aws4auth import AWS4Auth
+    from elasticsearch import Elasticsearch, RequestsHttpConnection
+    import curator
+
+    host = 'search-cloud-platform-live-7qrzc26xexgxtkt5qz72gt6cxa.eu-west-1.es.amazonaws.com' 
+    region = 'eu-west-1' 
+    service = 'es'
+    credentials = boto3.Session().get_credentials()
+    awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+
+    es = Elasticsearch(
+        hosts = [{'host': host, 'port': 443}],
+        http_auth = awsauth,
+        use_ssl = True,
+        verify_certs = True,
+        connection_class = RequestsHttpConnection
+    )
+
+    index_list = curator.IndexList(es)
+
+    # Filters by age, anything with a time stamp older than 30 days in the index name.
+    # index_list.filter_by_age(source='name', direction='older', timestring='%Y.%m.%d', unit='days', unit_count=30)
+
+    # Filters by naming prefix.
+    # index_list.filter_by_regex(kind='prefix', value='my-logs-2017')
+
+    # Filters by age, anything created more than one month ago.
+    index_list.filter_by_age(source='creation_date', direction='older', unit='months', unit_count=1)
+
+    # Delete all indices in the filtered list.
+    curator.DeleteIndices(index_list).do_action()

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/README.md
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/README.md
@@ -34,6 +34,11 @@ In addition to the application's `DaemonSet`, there are an additional 3 parts to
 
 The `kube-fluentd-es-config.yaml` file is the config file that `fluentd-es` depends on for all of it's default configurations. Don't be overwhelmed by the size of this file as over 99% of it's contents are default and shouldn't be touched. The only part of this file that you should concern yourself with is the very last block of code at the bottom, within the `<match>` tag.
 
+### ElasticSearch Curator
+
+The `elasticsearch-curator.yaml` file is made up of two resources, a ConfigMap and a CronJob. The ConfigMap contains a Python script that generates AWS credentials in the `aws-platforms-integration` account and deletes logs older than 1 month in the `cloud-platform-test` elasticsearch cluster. 
+
+The CronJob is responsible for scheduling the Python script to run every day at 1am. 
 
 ## Configuration 
 
@@ -71,3 +76,4 @@ tolerations:
 ```
 
 * Currently the ElasticSearch domain accepts logs into it's endpoint based on IP Whitelisting. If you experience any connection issues, check the access policy for your ES Domain and ensure that the IP addresses for all of the availability zones for your cluster are properly defined in the policy.
+

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/README.md
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/README.md
@@ -79,4 +79,3 @@ tolerations:
 ```
 
 * Currently the ElasticSearch domain accepts logs into it's endpoint based on IP Whitelisting. If you experience any connection issues, check the access policy for your ES Domain and ensure that the IP addresses for all of the availability zones for your cluster are properly defined in the policy.
-

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/README.md
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/README.md
@@ -37,8 +37,11 @@ The `kube-fluentd-es-config.yaml` file is the config file that `fluentd-es` depe
 ### ElasticSearch Curator
 
 The `elasticsearch-curator.yaml` file is made up of two resources, a ConfigMap and a CronJob. The ConfigMap contains a Python script that generates AWS credentials in the `aws-platforms-integration` account and deletes logs older than 1 month in the `cloud-platform-test` elasticsearch cluster. 
+https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/curator.html
 
 The CronJob is responsible for scheduling the Python script to run every day at 1am. 
+
+Note: The script only works if the Kubernetes cluster is whitelisted on Elasticsearch. This can be done from the AWS console by `Modifying the access policy` and adding the K8s cluster NAT Gateway IP's.
 
 ## Configuration 
 

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: elasticsearch-curator-cronjob
+  namespace: logging
+spec: 
+  schedule: "* * * * *"
+  jobTemplate: 
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: alpine
+            image: alpine
+            command:
+            - /bin/sh
+            - -c
+            - |
+              apk update
+              apk add --no-cache python3 
+              pip3 install --upgrade pip
+              pip3 install boto3 elasticsearch-curator requests_aws4auth elasticsearch
+              python3 /etc/es-curator/elasticsearch-curator
+            args:
+            - --config
+            - /etc/es-curator/elasticsearch-curator
+            volumeMounts:
+            - name: elasticsearch-curator-python
+              mountPath: /etc/es-curator
+          volumes:
+            - name: elasticsearch-curator-python
+              configMap:
+                name: elasticsearch-curator-python
+           
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-curator-python
+  namespace: logging
+data:
+  elasticsearch-curator: |
+    #!/usr/bin/env python3
+
+    import boto3
+    from requests_aws4auth import AWS4Auth
+    from elasticsearch import Elasticsearch, RequestsHttpConnection
+    import curator
+
+    host = 'search-cloud-platform-test-o2m2taivvjpovbcl63mlytnpua.eu-west-1.es.amazonaws.com' 
+    region = 'eu-west-1' 
+    service = 'es'
+    credentials = boto3.Session().get_credentials()
+    awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+
+    es = Elasticsearch(
+        hosts = [{'host': host, 'port': 443}],
+        http_auth = awsauth,
+        use_ssl = True,
+        verify_certs = True,
+        connection_class = RequestsHttpConnection
+    )
+
+    index_list = curator.IndexList(es)
+
+    # Filters by age, anything with a time stamp older than 30 days in the index name.
+    # index_list.filter_by_age(source='name', direction='older', timestring='%Y.%m.%d', unit='days', unit_count=30)
+
+    # Filters by naming prefix.
+    # index_list.filter_by_regex(kind='prefix', value='my-logs-2017')
+
+    # Filters by age, anything created more than one month ago.
+    index_list.filter_by_age(source='creation_date', direction='older', unit='months', unit_count=1)
+
+    # Delete all indices in the filtered list.
+    curator.DeleteIndices(index_list).do_action()

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elasticsearch-curator-cronjob
   namespace: logging
 spec: 
-  schedule: "* * * * *"
+  schedule: "0 1 * * *"
   jobTemplate: 
     spec:
       template:


### PR DESCRIPTION
ministryofjustice/cloud-platform#287

**WHAT**
- A elasticsearch-curator.yaml that contains a ConfigMap and CronJob Kubernetes resource. The ConfigMap contains a python script provided by [AWS](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/curator.html) that creates AWS credentials in `aws-platforms-integration` and deletes logs in the configured Elasticsearch cluster that are older than a month.
- The CronJob is responsible for scheduling the script to run once a day at 1am. Scheduling and log rotation is configurable in the elasticsearch-curator.yaml. 
- The elasticsearch-curator yaml has been added to the kubernetes live-0 and test-1 clusters and configured differently to delete logs from their specific elasticsearch cluster. 
- A section on `Elasticsearch-curator` is in the READ.me section of logging.

**WHY**
- To complete ministryofjustice/cloud-platform#287
- To ensure a clean up of logs is done regularly in AWS Elasticsearch