### PR TITLE
Add elasticsearch-curator to live-0 and configure test-1

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
@@ -48,7 +48,7 @@ data:
     from elasticsearch import Elasticsearch, RequestsHttpConnection
     import curator
 
-    host = 'search-cloud-platform-test-o2m2taivvjpovbcl63mlytnpua.eu-west-1.es.amazonaws.com' 
+    host = 'https://search-cloud-platform-live-7qrzc26xexgxtkt5qz72gt6cxa.eu-west-1.es.amazonaws.com' 
     region = 'eu-west-1' 
     service = 'es'
     credentials = boto3.Session().get_credentials()

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
@@ -48,7 +48,7 @@ data:
     from elasticsearch import Elasticsearch, RequestsHttpConnection
     import curator
 
-    host = 'https://search-cloud-platform-live-7qrzc26xexgxtkt5qz72gt6cxa.eu-west-1.es.amazonaws.com' 
+    host = 'search-cloud-platform-live-7qrzc26xexgxtkt5qz72gt6cxa.eu-west-1.es.amazonaws.com' 
     region = 'eu-west-1' 
     service = 'es'
     credentials = boto3.Session().get_credentials()


### PR DESCRIPTION
connects to ministryofjustice/cloud-platform#287

**WHAT**
- Add elasticsearch-curator back to live-0 with exception handling
- Configure test-1 elasticsearch curator with exception handling

**WHY**
- The script fails if there aren't any logs for the curator to delete. An exception has been added to print `("index_list object is empty")` if this occurs. As most logs are not 30 days old, it is expected that this may happen for a while. 