### PR TITLE
storageClass.yaml for test-1 / live-0 cluster

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/storageClass.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/storageClass.yaml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: persistent-storage
+  namespace: monitoring
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Retain
+mountOptions:
+  - debug

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/storageClass.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/storageClass.yaml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: persistent-storage
+  namespace: monitoring
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Retain
+mountOptions:
+  - debug


### PR DESCRIPTION
***What***

StorageClass which defines which cloud provider we will be provisioning our volumes from and the Retain policy. This class will be used anytime you want to add an Volume to your deployment.

***Why***

In order to create PersistentVolumes for Prometheus, we needed to define a StorageClass which will be used in the VolumeClaims Template. The VolumeClaims will use this class to understand what type of Volume to provision, in this case. AWS EBS