### PR TITLE
Add network policy for limit-env and add label for ingress controllers

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/ingress-controllers/00-namespace.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/ingress-controllers/00-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-controllers
+  labels:
+    name: ingress-controllers

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/limit-env/networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/limit-env/networkpolicy.yaml
@@ -1,0 +1,11 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {} 
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          purpose: ingress-controllers

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/limit-env/networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/limit-env/networkpolicy.yaml
@@ -9,3 +9,4 @@ spec:
     - namespaceSelector:
         matchLabels:
           name: ingress-controllers
+          

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/limit-env/networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/limit-env/networkpolicy.yaml
@@ -8,4 +8,4 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          purpose: ingress-controllers
+          name: ingress-controllers


### PR DESCRIPTION
Add test network policy to allow only ingress controllers access to limit-env namespace 
Added label name: ingress-controllers to ingress-controllers namespace