### PR TITLE
SSL connection for fluentd - live-0 / test-1

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/kube-fluentd-es-config.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/kube-fluentd-es-config.yaml
@@ -439,8 +439,8 @@ data:
       @log_level info
       include_tag_key true
       host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
-      port "#{ENV['FLUENT_ELASTICSEARCH_PORT'] || '80'}"
-      scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
+      port "#{ENV['FLUENT_ELASTICSEARCH_PORT'] || '443'}"
+      scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'https'}"
       logstash_format true
 
       # Prevent reloading connections to AWS ES

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/kube-fluentd-es.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/kube-fluentd-es.yaml
@@ -89,9 +89,9 @@ spec:
         - name:  FLUENT_ELASTICSEARCH_HOST
           value: "search-cloud-platform-live-7qrzc26xexgxtkt5qz72gt6cxa.eu-west-1.es.amazonaws.com"
         - name:  FLUENT_ELASTICSEARCH_PORT
-          value: "80"
+          value: "443"
         - name: FLUENT_ELASTICSEARCH_SCHEME
-          value: "http"
+          value: "https"
         resources:
           limits:
             memory: 500Mi

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/kube-fluentd-es-config.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/kube-fluentd-es-config.yaml
@@ -439,8 +439,8 @@ data:
       @log_level info
       include_tag_key true
       host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
-      port "#{ENV['FLUENT_ELASTICSEARCH_PORT'] || '80'}"
-      scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
+      port "#{ENV['FLUENT_ELASTICSEARCH_PORT'] || '443'}"
+      scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'https'}"
       logstash_format true
 
       # Prevent reloading connections to AWS ES

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/kube-fluentd-es.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/kube-fluentd-es.yaml
@@ -89,9 +89,9 @@ spec:
         - name:  FLUENT_ELASTICSEARCH_HOST
           value: "search-cloud-platform-test-o2m2taivvjpovbcl63mlytnpua.eu-west-1.es.amazonaws.com"
         - name:  FLUENT_ELASTICSEARCH_PORT
-          value: "80"
+          value: "443"
         - name: FLUENT_ELASTICSEARCH_SCHEME
-          value: "http"
+          value: "https"
         resources:
           limits:
             memory: 500Mi


### PR DESCRIPTION
Currently fluentd is configured to connect to elasticsearch on port 80, http. We need to change that to a secured connection.