### PR TITLE
Add new default Network Policy yaml file to resources folder

### DIFF
--- a/docs/networkpolicy.md
+++ b/docs/networkpolicy.md
@@ -1,5 +1,25 @@
 # Network Policy
 
-ABC
+Network policies are applied per namespace. By default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. 
 
-#### Step 1: Create a namespace
+Another way to explain network policies are firewall rules that allow or deny tarffic between pods, these are declarativly configrable in a manifiest (yaml) file. 
+
+Network Policies are applied in near real-time. If you have open connections between pods, applying a Network Policy that would prevent that connection will cause the connections to be terminated immediately. This near real-time gain comes with a small performance penalty on the networking
+
+The current default 04-networkpolicy.yaml prohibits all network traffic from other namespaces except from the namespace with the label - component=ingress-controllers
+
+```yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {} 
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+```
+
+Link to [Offical Network Policies documentation](https://kubernetes.io/docs/concepts/services-networking/network-policies/)

--- a/docs/networkpolicy.md
+++ b/docs/networkpolicy.md
@@ -1,0 +1,5 @@
+# Network Policy
+
+ABC
+
+#### Step 1: Create a namespace

--- a/docs/networkpolicy.md
+++ b/docs/networkpolicy.md
@@ -1,12 +1,12 @@
 # Network Policy
 
-Network policies are applied per namespace. By default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. 
+Network policies are applied to namespaces. By default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. 
 
 Another way to explain network policies are firewall rules that allow or deny tarffic between pods, these are declarativly configrable in a manifiest (yaml) file. 
 
 Network Policies are applied in near real-time. If you have open connections between pods, applying a Network Policy that would prevent that connection will cause the connections to be terminated immediately. This near real-time gain comes with a small performance penalty on the networking
 
-The current default 04-networkpolicy.yaml prohibits all network traffic from other namespaces except from the namespace with the label - component=ingress-controllers
+The current default 04-networkpolicy.yaml prohibits all network traffic from other namespaces except from the namespace with the label - component: ingress-controllers
 
 ```yaml
 kind: NetworkPolicy

--- a/namespace-resources/04-networkpolicy.yaml
+++ b/namespace-resources/04-networkpolicy.yaml
@@ -1,0 +1,12 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {} 
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/00-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-controllers
+  labels:
+    component: ingress-controllers


### PR DESCRIPTION
New default network policy created 
Network policy prohibits all traffic from one namespace to another except for ingress-controllers namespaces to all other namespaces

Added label to ingress controller NS - component=ingress-controllers

networkpolicy.md file created 