### PR TITLE
Create the Big Book of Acronyms' namespace

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/big-book-of-acronyms/namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/big-book-of-acronyms/namespace.yaml
@@ -4,11 +4,11 @@ metadata:
   name: big-book-of-acronyms
   labels:
     name: big-book-of-acronyms
-    business-unit: platforms
-    is-production: true
-    environment-name: production
+    cloud-platform.justice.gov.uk/business-unit: platforms
+    cloud-platform.justice.gov.uk/is-production: true
+    cloud-platform.justice.gov.uk/environment-name: production
   annotations:
-    application: "Big Book of Acronyms"
-    owner: "Steve Marshall: steve.marshall@digital.justice.gov.uk"
-    infrastructure-support: "Steve Marshall: steve.marshall@digital.justice.gov.uk"
-    source-code: "https://github.com/ministryofjustice/bba"
+    cloud-platform.justice.gov.uk/application: "Big Book of Acronyms"
+    cloud-platform.justice.gov.uk/owner: "Steve Marshall: steve.marshall@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/infrastructure-support: "Steve Marshall: steve.marshall@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/bba"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/big-book-of-acronyms/namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/big-book-of-acronyms/namespace.yaml
@@ -4,10 +4,11 @@ metadata:
   name: big-book-of-acronyms
   labels:
     name: big-book-of-acronyms
-    application: Big Book of Acronyms
     business-unit: platforms
     is-production: true
     environment-name: production
+  annotations:
+    application: "Big Book of Acronyms"
     owner: "Steve Marshall: steve.marshall@digital.justice.gov.uk"
     infrastructure-support: "Steve Marshall: steve.marshall@digital.justice.gov.uk"
-    source-code: https://github.com/ministryofjustice/bba
+    source-code: "https://github.com/ministryofjustice/bba"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/big-book-of-acronyms/namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/big-book-of-acronyms/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: big-book-of-acronyms
+  labels:
+    name: big-book-of-acronyms
+    application: Big Book of Acronyms
+    business-unit: platforms
+    is-production: true
+    environment-name: production
+    owner: "Steve Marshall: steve.marshall@digital.justice.gov.uk"
+    infrastructure-support: "Steve Marshall: steve.marshall@digital.justice.gov.uk"
+    source-code: https://github.com/ministryofjustice/bba


### PR DESCRIPTION
I'm investigating migrating the [Big Book of Acronyms](https://github.com/ministryofjustice/bba/) from [Heroku](https://bigbookofacronyms.herokuapp.com) (where it's running out of free compute) to the Cloud Platform.

A few things to note:

- We don't need multiple environments, because it's only really looked after by me, and isn't really business-critical.
- I've intentionally omitted a `RoleBinding` because I'm not sure that anyone other than me is really in a position to look after this, and I get access by virtue of being a member of the Cloud Platform team. We might want to reconsider that, though, and add an explicit owner.
- I've tried to adhere to [our standards for documenting owners of infrastructure](https://ministryofjustice.github.io/technical-guidance/standards/documenting-infrastructure-owners/). I've set the `owner` and `infrastructure-support` to me; should they perhaps point to the Cloud Platform team?

And, one thing to discuss is the use of `cloud-platform.justice.gov.uk` as our cluster-wide label/annotation prefix. Does anyone already use something, or should we standardise on that?