### PR TITLE
Custom PriorityClasses for critical components.

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/kube-fluentd-es.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/kube-fluentd-es.yaml
@@ -75,7 +75,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: node-critical
       serviceAccountName: fluentd-es
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/priorityclasses.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/priorityclasses.yaml
@@ -1,0 +1,15 @@
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PriorityClass
+metadata:
+  name: cluster-critical
+value: 999999000
+globalDefault: false
+description: "This priority class is meant to be used as the system-cluster-critical class, outside of the kube-system namespace."
+---
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PriorityClass
+metadata:
+  name: node-critical
+value: 1000000000
+globalDefault: false
+description: "This priority class is meant to be used as the system-node-critical class, outside of the kube-system namespace."


### PR DESCRIPTION
Starting with kubernetes 1.11.1, the default system-critical- PriorityClasses are reserved for use in kube-system only. This prevents fluentd from being deployed in the logging namespace. The two new PriorityClasses introduced by this PR are equivalent to the defaults and use the maximum priority available to custom classes.

Reference:
- https://kubernetes.io/docs/setup/release/notes/#urgent-upgrade-notes
- https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#action-required-1

Documentation on `PriorityClasses`:
- https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical-when-priorites-are-enabled
- https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
