### PR TITLE
Add reference-app namespace to the cloud-platform-live-0 cluster

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reference-app

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: reference-app-admin
+  namespace: reference-app
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/02-limitrange.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app/03-resourcequota.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi


### PR DESCRIPTION
**WHAT**
- Added namespace.yaml to create my namespace on live-0.
- Added RBAC to permission my namespace.
- Added Limitrange and resource quota as per requirements.

**WHY**
Our documentation for new users requires us to reference this namespace on live-0. This will assist new users in, `namespace creation`, `application deployment` and `circle ci`. 