### PR TITLE
FIX allow inter-pod traffic

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/concourse-main/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/concourse-main/04-networkpolicy.yaml
@@ -1,12 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: concourse-main
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
+  namespace: concourse-main
 spec:
-  podSelector: {} 
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-          

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/concourse/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/concourse/04-networkpolicy.yaml
@@ -1,12 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: concourse
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
+  namespace: concourse
 spec:
-  podSelector: {} 
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-          

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/limit-env/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/limit-env/04-networkpolicy.yaml
@@ -1,12 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: limit-env
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
+  namespace: limit-env
 spec:
-  podSelector: {} 
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/logging/04-networkpolicy.yaml
@@ -1,12 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: logging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
+  namespace: logging
 spec:
-  podSelector: {} 
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-          

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/04-networkpolicy.yaml
@@ -1,12 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
+  namespace: monitoring
 spec:
-  podSelector: {} 
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-          

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/platforms-dev/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/platforms-dev/04-networkpolicy.yaml
@@ -1,12 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: platforms-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
+  namespace: platforms-dev
 spec:
-  podSelector: {} 
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-          


### PR DESCRIPTION
the allow-ingress-controllers policy alone blocks traffic between pods in the same namespace