### PR TITLE
Amend default network policy

### DIFF
--- a/namespace-resources/04-networkpolicy.yaml
+++ b/namespace-resources/04-networkpolicy.yaml
@@ -1,9 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
 spec:
-  podSelector: {} 
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/342
**WHAT**
- This commit amends the 'template' network resource, adding a required default network policy. 

**WHY** 
- Before we start the process of applying this policy to live namespaces I wanted to correct the template network policy. 