### PR TITLE
Increase logging namespace resourcequota

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/03-resourcequota.yaml
@@ -6,6 +6,6 @@ spec:
   hard:
     requests.cpu: 4000m
     requests.memory: 8Gi
-    limits.cpu: 6000m
+    limits.cpu: 12000m
     limits.memory: 12Gi
     


### PR DESCRIPTION
connects to closed ticket ministryofjustice/cloud-platform#287

**WHAT**
- Increase logging namespace resourcequota from 6000m to 12000m.

**WHY**
The elasticsearch-curator pods start everyday at 1am. Once the job is complete, the pods stay with a status of `completed`. Kubernetes by default will only keep 3 successful pods and 1 failed pod at a time. The namespace is also shared with fluentd who uses all 6 pods. After a discussion with @alkar , it was discussed to either limit elasticsearch-curator to use less than 1 CPU or to double the CPU limit. After research, limiting a cronjob's CPU did not seem configurable. 
