### PR TITLE
Add network policy manifest to remaining namespaces

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse-main/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse-main/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kath-sample-dev/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kath-sample-dev/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-production/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-production/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-staging/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-staging/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/toby-myapp-dev/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/toby-myapp-dev/04-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+


### PR DESCRIPTION
connected to https://github.com/ministryofjustice/cloud-platform/issues/342

**WHAT**
- Apply default network policy to remaining namespaces in the Cloud Platform. When merged to master the network policy will be applied to the following namespaces:
**concourse-***
**digicop-***
**formbuilder-***
**kath-sample-dev**
**laa-apply-***
**laa-fee-calc***
**toby-myapp-dev**

**WHY**
- This will deny ingress traffic from anything but the ingress controllers. This has been performed on over half the namespaces currently in live-0. 
- This is the final piece of work required in: https://github.com/ministryofjustice/cloud-platform/issues/342

**NOTES**
- Testing has been completed in test-1 and is active in over half the namespaces on live-0. The default network policy will not be applied to kube-system or the ingress-controller namespace. 
- This ticket links to PR #132 
- To revert the work in this PR, remove the 04-network-policy.yaml and run `kubectl delete networkpolicy -n <name> default`