### PR TITLE
Create ServiceAccount role for CircleCI

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/05-serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/05-serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-cla-public-staging
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-cla-public-staging
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-cla-public-staging
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-cla-public-staging
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Creates a `ServiceAccount` role for CircleCI in the `laa-cla-public-staging` namespace.

We need this as part of https://github.com/ministryofjustice/cla_public/pull/751 to be able to deploy `cla_public` from CircleCI.