### PR TITLE
Introduces additional variables for terraform.

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -29,7 +29,10 @@ for _c in namespaces/*; do
           -backend-config="bucket=moj-cp-k8s-investigation-environments-terraform" \
           -backend-config="key=${cluster}/${namespace}/terraform.tfstate" \
           -backend-config="region=eu-west-1"
-        terraform apply -auto-approve
+        terraform apply \
+          -auto-approve \
+          -var="cluster_name=${cluster%.k8s.integration.dsd.io}" \
+          -var="cluster_state_bucket=moj-cp-k8s-investigation-platform-terraform"
         cd $OLDPWD
       fi
     fi


### PR DESCRIPTION
When applying terraform for user-requested resouces, the variables `clouster_name` and `cluster_state_bucket` are now provided at runtime. This allows us to use `terraform_remote_state` in order to retrieve outputs from the cluster terraform state.

Connects to https://github.com/ministryofjustice/cloud-platform/issues/362