### PR TITLE
Add an environment for the support labelling app

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-app-dev/namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-app-dev/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: support-labelling-app-dev 
+  labels:
+    name: support-labelling-app-dev 

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-app-dev/support-labelling-app-dev-admin-role.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-app-dev/support-labelling-app-dev-admin-role.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: support-labelling-app-dev-admins 
+  namespace: support-labelling-app-dev # Your namespace `$servicename-$env`
+subjects:
+  - kind: Group
+    name: "github:$cloud-platform-test" # Make this the name of the GitHub team you want to give access to
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
I'm taking a look at moving the app that adds the "support" label to our github issues([cloud-platform-support-labelling-webhook](https://github.com/ministryofjustice/cloud-platform-support-labelling-webhook)  from Heroku to Kubernetes.

I'm following the guidance so this seems like the first step to getting the namespace set up ;)