### PR TITLE
Add restricted and unrestricted pod security policy to test-1 cluster

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/restricted-psp.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/restricted-psp.yaml
@@ -1,0 +1,47 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'MustRunAs'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/unrestricted-psp.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/unrestricted-psp.yaml
@@ -1,0 +1,27 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'


### PR DESCRIPTION
connects to: https://github.com/ministryofjustice/cloud-platform/issues/203

**WHAT**
---
- First draft of the default restricted pod security policy document. This includes restrictions to:

**privileged: false** - ensures the pod cannot access any devices on the host.

**AllowPrivilegeEscalation** - Setting it to false ensures that no child process of a container can gain more privileges than its parent.

**volumes** - this allows core volumes to be used and is the recommended minimum set by Kubernetes in their docs. 

**HostPID: false** - Controls whether the pod containers can share the host process ID namespace. Note that when paired with ptrace this can be used to escalate privileges outside of the container (ptrace is forbidden by default).

**HostIPC: false** - Controls whether the pod containers can share the host IPC namespace.

**HostNetwork: false** - Controls whether the pod may use the node network namespace. Doing so gives the pod access to the loopback device, services listening on localhost, and could be used to snoop on network activity of other pods on the same node.

**runAsUser** - controls what the user ID containers run as. 

**selinux** -  Requires seLinuxOptions to be configured. Uses seLinuxOptions as the default. Validates against seLinuxOptions.

**FSGroup** - Controls the supplemental group applied to some volumes.

**ReadOnlyRootFilesystem** - Requires that containers must run with a read-only root filesystem (i.e. no writable layer).

- First draft of the unrestricted pod security policy. Including:

**Allowed privilege escalation**
**privileged: true**
**Allow all volumes and capabilities**

**WHY**
---

- This will allow us to default all pods to use this restricted policy unless specified. This file sits at the root of the test-1 dir as it will be a cluster wide policy. 

- This will allow us to specify pods to use the unrestricted version of the psp. This file sits at the root of the test-1 dir as it will be a cluster wide policy. 

**NOTES** 
---

- This PR allows fellow engineers to review and assess, it does not mean the task is complete. There is still the need for a privileged pod security policy and relevant amendments to RBAC roles. 
- The above restrictions will be written up in a README.  
- The official Kubernetes psp docs: https://kubernetes.io/docs/concepts/policy/pod-security-policy/