### PR TITLE
Enables concourse metrics scraping by prometheus

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/04-networkpolicy.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default
+  namespace: concourse
 spec:
   podSelector: {}
   policyTypes:
@@ -14,6 +15,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
+  namespace: concourse
 spec:
   podSelector: {}
   policyTypes:
@@ -23,4 +25,20 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: concourse
+spec:
+  podSelector:
+    matchLabels:
+      app: concourse-web
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/monitoring.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/monitoring.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: concourse
+  namespace: concourse
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: concourse-web
+  namespaceSelector:
+    matchNames:
+      - concourse
+  endpoints:
+    - port: prometheus
+      interval: 30s

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/00-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  labels:
+    component: monitoring

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/00-namespace.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/00-namespace.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  component: monitoring


### PR DESCRIPTION
Metrics are already enabled. The `ServiceMonitor` and `NetworkPolicy` introduced by this PR allow prometheus to discover and scrape the metrics.