### PR TITLE
Add namespace to each policy

### DIFF
--- a/namespace-resources/02-limitrange.yaml
+++ b/namespace-resources/02-limitrange.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: limitrange
+  namespace: <namespace-name>
 spec:
   limits:
   - default:

--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: namespace-quota
+  namespace: <namespace-name>
 spec:
   hard:
     requests.cpu: 4000m
     requests.memory: 8Gi
     limits.cpu: 6000m
     limits.memory: 12Gi
-    

--- a/namespace-resources/04-networkpolicy.yaml
+++ b/namespace-resources/04-networkpolicy.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default
+  namespace: <namespace-name>
 spec:
   podSelector: {}
   policyTypes:
@@ -23,4 +24,3 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-


### PR DESCRIPTION
I have added the namespace name as part of the metadata for each of the
default policies for namespaces. We need to do this to limit the
resources to that particular namespace, rather than scope them globally.