### PR TITLE
Add env for support labelling webhook

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: support-labelling-webhook-dev

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/00-namespace.yaml
@@ -4,9 +4,9 @@ metadata:
   name: support-labelling-webhook-dev
   labels:
     name: support-labelling-webhook
-    cloud-platform.justice.gov.uk/business-unit: cloud-platform
-    cloud-platform.justice.gov.uk/is-production: false
-    cloud-platform.justice.gov.uk/environment-name: development
+    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
     cloud-platform.justice.gov.uk/application: "Support Labelling Webhook"
     cloud-platform.justice.gov.uk/owner: "Kalbir Sohi: kalbir.sohi@digital.justice.gov.uk"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/00-namespace.yaml
@@ -2,3 +2,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: support-labelling-webhook-dev
+  labels:
+    name: support-labelling-webhook
+    cloud-platform.justice.gov.uk/business-unit: cloud-platform
+    cloud-platform.justice.gov.uk/is-production: false
+    cloud-platform.justice.gov.uk/environment-name: development
+  annotations:
+    cloud-platform.justice.gov.uk/application: "Support Labelling Webhook"
+    cloud-platform.justice.gov.uk/owner: "Kalbir Sohi: kalbir.sohi@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/infrastructure-support: "Kalbir Sohi: kalbir.sohi@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-support-labelling-webhook"
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: support-labelling-webhook-dev-admin
+  namespace: support-labelling-webhook-dev
+subjects:
+  - kind: Group
+    name: "github:cloud-platform-support"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: support-labelling-webhook-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/03-resourcequota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: support-labelling-webhook-dev
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi
+    

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: support-labelling-webhook-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+


### PR DESCRIPTION
The [support labelling webhook](https://github.com/ministryofjustice/cloud-platform-support-labelling-webhook) currently runs on Heroku. We are investigating running it on Kubernetes instead. 

This namespace is to try deploying the app on the cluster and seeing how well it works.