### PR TITLE
Remove deprecated attribute.

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/platforms-dev/resources/main.tf
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/platforms-dev/resources/main.tf
@@ -10,7 +10,6 @@ module "example_team_s3" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=master"
 
   team_name              = "cloud-platform"
-  bucket_identifier      = "bucket-example"
   acl                    = "private"
   versioning             = false
   business-unit          = "mojdigital"


### PR DESCRIPTION
The S3 bucket module no longer accepts `bucket_identifier`. These kinds of issues should be resolved as we pin modules to specific refs.