### PR TITLE
Change which team has access

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: support-labelling-webhook-dev
 subjects:
   - kind: Group
-    name: "github:cloud-platform-support"
+    name: "github:cloud-platform-test"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
When creating the namespace we gave access to the
`cloud-platform-support` team in github. Unfortunately this team doesn't
exist, we meant to give access to the `cloud-platform-test` team. So
just fixing that here.