### PR TITLE
Add ECR for support labelling webhook

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-dev/resources/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=master"
+
+  team_name = "cloud-platform"
+  repo_name = "support-labelling-webhook"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-support-labelling-webhook"
+    namespace = "support-labelling-webhook"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo.repo_url}"
+    access_key_id     = "${module.ecr-repo.access_key_id}"
+    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  }
+}


### PR DESCRIPTION
To deploy the support labelling webhook to Kubernetes I'll need an ECR
repo (that's what the docs tell me!). I've added the terraform here to
add that repo.