### PR TITLE
Set up Tiller in jenny-myapp-dev namespace

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/jenny-myapp-dev/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/jenny-myapp-dev/01-rbac.yaml
@@ -11,3 +11,23 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: jenny-myapp-dev
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: tiller
+  namespace: jenny-myapp-dev
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: jenny-myapp-dev
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
I've put this in `01-rbac.yaml` to keep all access-related config together, rather than creating a separate file for it as the docs suggest.