### PR TITLE
Laa cla public production

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-cla-public-production
+  labels:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/application: "Civil Legal Advice Public"
+    cloud-platform.justice.gov.uk/owner: "LAA Get Access: laa-get-access@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cla_public"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-cla-public-production-admins
+  namespace: laa-cla-public-production
+subjects:
+  - kind: Group
+    name: "github:laa-get-access"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-cla-public-production
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-cla-public-production
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-cla-public-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-cla-public-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/05-serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/05-serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-cla-public-production
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-cla-public-production
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-cla-public-production
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-cla-public-production
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/00-namespace.yaml
@@ -3,4 +3,10 @@ kind: Namespace
 metadata:
   name: laa-cla-public-staging
   labels:
-    name: laa-cla-public-staging 
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
+  annotations:
+    cloud-platform.justice.gov.uk/application: "Civil Legal Advice Public"
+    cloud-platform.justice.gov.uk/owner: "LAA Get Access: laa-get-access@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cla_public"


### PR DESCRIPTION
This pull request creates a new namespace called `laa-cla-public-production`. It is a duplicate of `laa-cla-public-staging`.

I've also added the tags to both namespaces. 