### PR TITLE
raise monitoring ns limits

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: monitoring
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 8000m
+    requests.memory: 16Gi
+    limits.cpu: 12000m
+    limits.memory: 24Gi


### PR DESCRIPTION
**Why**
```
6m          6m           1         prometheus-operator-d75587d6.1556679b4e14bff3         ReplicaSet               Warning   FailedCreate   replicaset-controller   Error creating: pods "prometheus-operator-d75587d6-w2tz8" is forbidden: exceeded quota: namespace-quota, requested: limits.cpu=1, used: limits.cpu=5426m, limited: limits.cpu=6
bash-3.2$ kubectl --context live-0 -n monitoring get deployments
NAME                                  DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
dsd-kibana                            1         0         0            0           7d
grafana-oauth2-proxy                  1         1         1            1           28d
kibana-proxy                          1         0         0            0           31d
kube-prometheus-exporter-kube-state   1         1         1            1           16d
kube-prometheus-grafana               1         0         0            0           16d
oidc-proxy                            1         1         1            1           31d
prometheus-operator                   1         0         0            0           16d
```