### PR TITLE
Open up Prometheus, Alertmanager and Grafana to the org

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/grafana-oauth2.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/grafana-oauth2.yaml
@@ -20,7 +20,6 @@ spec:
       - args:
         - --provider=github
         - --github-org=ministryofjustice
-        - --github-team=webops
         - --email-domain=*
         - --upstream=file:///dev/null
         - --http-address=0.0.0.0:4180

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/oidc-proxy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/oidc-proxy.yaml
@@ -25,21 +25,8 @@ data:
         ngx.exit(ngx.HTTP_FORBIDDEN)
     end
 
-    allowed = false
-    if res.id_token["https://k8s.integration.dsd.io/groups"] ~= nil then
-      for k, v in pairs(res.id_token["https://k8s.integration.dsd.io/groups"]) do
-          if v == "github:webops" then
-              allowed = true
-              break
-          end
-      end
-    end
-    if not allowed then
-      ngx.exit(ngx.HTTP_FORBIDDEN)
-    end
-
     ngx.log(ngx.DEBUG, "Authentication successful, setting Auth header...")
-    ngx.req.set_header("Authorization", "Bearer "..session.data.enc_id_token)
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/grafana-oauth2.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/grafana-oauth2.yaml
@@ -20,7 +20,6 @@ spec:
       - args:
         - --provider=github
         - --github-org=ministryofjustice
-        - --github-team=webops
         - --email-domain=*
         - --upstream=file:///dev/null
         - --http-address=0.0.0.0:4180

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/oidc-proxy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/oidc-proxy.yaml
@@ -25,21 +25,8 @@ data:
         ngx.exit(ngx.HTTP_FORBIDDEN)
     end
 
-    allowed = false
-    if res.id_token["https://k8s.integration.dsd.io/groups"] ~= nil then
-      for k, v in pairs(res.id_token["https://k8s.integration.dsd.io/groups"]) do
-          if v == "github:webops" then
-              allowed = true
-              break
-          end
-      end
-    end
-    if not allowed then
-      ngx.exit(ngx.HTTP_FORBIDDEN)
-    end
-
     ngx.log(ngx.DEBUG, "Authentication successful, setting Auth header...")
-    ngx.req.set_header("Authorization", "Bearer "..session.data.enc_id_token)
+
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
WHAT
Remove the webops team filter for AM, Prom and Grafana 

WHY 
In order to allow users to get useful metrics for the applications