### PR TITLE
Smoke test for checking namespace functionality in cluster.

### DIFF
--- a/bin/ns-smoke
+++ b/bin/ns-smoke
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+namespace="$1"
+github_team="$2"
+
+if kubectl auth can-i get namespace --namespace "${namespace}" --as=test --as-group=github:"${github_team}" | grep  -q "yes"; then
+    echo "namespace exists"
+else
+    echo "namespace does not exist or you do not have access"
+fi


### PR DESCRIPTION
Work in Progress as still testing the kubectl auth can-i
Plus can only find two groups (could be wrong) in our cluster, webops and laa-developers so need more testing. Both work as expected but need more testing.

***Why***
When namespace is created in cluster, we need to test that its created and can be accessed.

***What***

This is a bash script to check that the namespace can be accessed by the github team who will need to have access to it.

Reason its a Work in Progress is, i am having issues with understanding how the permissions is working. Groups are the github group and by default should not have particular permissions on our cluster (could be wrong), but gains permissions via rolebinding and clusterrolebinding. However we are not testing the rolebinding or clusterrolebinding here, so not really understanding how this works.