### PR TITLE
Add kubewatch namespace to Apply LAA 

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-kubewatch/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-kubewatch/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-apply-for-legalaid-kubewatch
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/application: "kubewatch"
+    cloud-platform.justice.gov.uk/owner: "Sergio Marques: sergio.marques@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/bitnami-labs/kubewatch"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-kubewatch/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-kubewatch/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-apply-for-legalaid-kubewatch
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-kubewatch/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-kubewatch/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-apply-for-legalaid-kubewatch
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 1Gi
+    limits.cpu: 6000m
+    limits.memory: 2Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-kubewatch/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-kubewatch/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-apply-for-legalaid-kubewatch
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-apply-for-legalaid-kubewatch
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ **DO NOT MERGE** ⚠️ ⚠️ ⚠️ 

To deploy [kubewatch](https://github.com/bitnami-labs/kubewatch) so that we can monitor k8s deploys, etc.

**QUESTIONS:**

* According to the setup instructions we need to run something like this in order to deploy it:

```
helm install kubewatch stable/kubewatch --set='rbac.create=true,slack.channel=#YOUR_CHANNEL,slack.token=xoxb-YOUR_TOKEN,resourcesToWatch.pod=true,resourcesToWatch.daemonset=true'
```

(or use a configuration file). 

**Where are we supposed to keep these configurations? Are we expected to create a MOJ github repo just to hold this?**