### PR TITLE
Add open network policy to kube-system and ingress-controllers namespace

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/04-networkpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all
+  namespace: ingress-controllers
+spec:
+  podSelector: {}
+  ingress:
+  - {}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kube-system/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kube-system/04-networkpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all
+  namespace: ingress-controllers
+spec:
+  podSelector: {}
+  ingress:
+  - {}

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/ingress-controllers/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/ingress-controllers/04-networkpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all
+  namespace: ingress-controllers
+spec:
+  podSelector: {}
+  ingress:
+  - {}

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/kube-system/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/kube-system/04-networkpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/371

**WHAT**
An `allow all` network policy that enables a blank network policy to be applied to the `kube-system` and `ingress-controllers` namespaces on both live-0 and test-1.

**WHY**
It has been decided that we will open these namespaces to all ingress traffic. 