### PR TITLE
add RDS, Elasticache and ServiceAccount for fb-submitter

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/submitter.tf
@@ -56,3 +56,4 @@ resource "kubernetes_secret" "submitter-elasticache" {
 }
 
 ########################################################
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/submitter.tf
@@ -1,0 +1,58 @@
+##################################################
+# Publisher RDS
+
+module "submitter-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "2"
+  application                = "formbuildersubmitter"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-submitter-dev"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
+  }
+}
+
+##################################################
+
+########################################################
+# Publisher Elasticache Redis (for resque + job logging)
+module "submitter-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=2.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuildersubmitter"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-submitter-dev"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    primary_endpoint_address = "${module.submitter-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.submitter-elasticache.auth_token}"
+  }
+}
+
+########################################################

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/submitter-workers-service-account.yml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/submitter-workers-service-account.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-submitter-workers-dev
+  namespace: formbuilder-platform-dev

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/submitter.tf
@@ -56,3 +56,4 @@ resource "kubernetes_secret" "submitter-elasticache" {
 }
 
 ########################################################
+

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/submitter.tf
@@ -1,0 +1,58 @@
+##################################################
+# Publisher RDS
+
+module "submitter-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "2"
+  application                = "formbuildersubmitter"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-submitter-staging"
+    namespace = "formbuilder-platform-staging"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
+  }
+}
+
+##################################################
+
+########################################################
+# Publisher Elasticache Redis (for resque + job logging)
+module "submitter-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=2.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuildersubmitter"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-submitter-staging"
+    namespace = "formbuilder-platform-staging"
+  }
+
+  data {
+    primary_endpoint_address = "${module.submitter-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.submitter-elasticache.auth_token}"
+  }
+}
+
+########################################################

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/submitter-service-account.yml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/submitter-service-account.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-submitter-workers-staging
+  namespace: formbuilder-platform-staging


### PR DESCRIPTION
We're deploying a new FormBuilder component (fb-submitter) which needs an RDS instance, Elasticache Redis and a ServiceAccount

This PR adds the above