### PR TITLE
Introduce grafana-dashboard-aggregator

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml
@@ -1,0 +1,170 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-dashboard-aggregator
+  namespace: monitoring
+  labels:
+    k8s-app: grafana-dashboard-aggregator
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-platform:grafana-dashboard-aggregator
+  namespace: monitoring
+  labels:
+    k8s-app: grafana-dashboard-aggregator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "create"
+  - "patch"
+  - "update"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-platform:grafana-dashboard-aggregator
+  namespace: monitoring
+  labels:
+    k8s-app: grafana-dashboard-aggregator
+subjects:
+- kind: ServiceAccount
+  name: grafana-dashboard-aggregator
+  namespace: monitoring
+roleRef:
+  kind: Role
+  name: cloud-platform:grafana-dashboard-aggregator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-platform:grafana-dashboard-aggregator
+  labels:
+    k8s-app: grafana-dashboard-aggregator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-platform:grafana-dashboard-aggregator
+  labels:
+    k8s-app: grafana-dashboard-aggregator
+subjects:
+- kind: ServiceAccount
+  name: grafana-dashboard-aggregator
+  namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: cloud-platform:grafana-dashboard-aggregator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-aggregator
+  namespace: monitoring
+data:
+  grafana-dashboard-aggregator: |
+    #!/bin/bash
+
+    set -o errexit
+    set -o pipefail
+
+    data=""
+    while read -r c; do
+      ns=${c%%[[:space:]]*}
+      cm=${c##*[[:space:]]}
+      echo "[$(date -uIseconds)] found configmap ${ns}/${cm}"
+      #
+      # The JSON string exported from a Grafana dashboard cannot be used as-is on the
+      #  Grafana API. Instead, it needs to be wrapped into another object. See the
+      #  docs: http://docs.grafana.org/http_api/dashboard/#create-update-dashboard
+      #
+      # This is all achieved with `jq`. The query itself is perhaps a bit too long
+      #  so the section below is an attempt to explain how it works:
+      #
+      # // infers the `inputs` array from the exported dashboard's `__inputs`
+      # def set_inputs: [.["__inputs"][] | del(.description, .label, .pluginName) + {"value": .label | ascii_downcase}];
+      # // as per the doc above
+      # def wrap_dashboard: {"dashboard": ., "inputs": . | set_inputs};
+      # [
+      #   // foreach of the keys in the ConfigMap
+      #   .data | . as $x | keys[] |
+      #   // prefix its key and wrap the dashboard object
+      #   {("'${ns}'-'${cm}'-" + .): $x[.] | fromjson | wrap_dashboard | tojson}
+      #   // concatenate the produced objects
+      # ] | add
+      #
+      data=${data}$(kubectl -n${ns} get configmap ${cm} --export -o json | jq -c 'def set_inputs: [.["__inputs"][] | del(.description, .label, .pluginName) + {"value": .label | ascii_downcase}]; def wrap_dashboard: {"dashboard": ., "inputs": . | set_inputs}; [.data | . as $x | keys[] | {("'${ns}'-'${cm}'-" + .): $x[.] | fromjson | wrap_dashboard | tojson}] | add'),
+    done <<< "$(kubectl get configmaps \
+      --all-namespaces \
+      -lcloud-platform.justice.gov.uk/grafana-dashboard \
+      --no-headers \
+      -o custom-columns=:.metadata.namespace,:metadata.name)"
+
+    echo "[$(date -uIseconds)] applying aggregate configmap"
+
+    kubectl apply -f - <<EOS
+    {
+      "apiVersion": "v1",
+      "data": $(echo "[${data}{}]" | jq 'add'),
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "grafana-user-dashboards",
+        "namespace": "monitoring"
+      }
+    }
+    EOS
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana-dashboard-aggregator
+  name: grafana-dashboard-aggregator
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana-dashboard-aggregator
+  template:
+    metadata:
+      labels:
+        app: grafana-dashboard-aggregator
+    spec:
+      serviceAccountName: grafana-dashboard-aggregator
+      containers:
+      - name: aggregator
+        image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
+        command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache bash
+          while true; do
+            /var/run/bin/grafana-dashboard-aggregator
+            sleep 60
+          done;
+        volumeMounts:
+        - name: grafana-dashboard-aggregator
+          mountPath: /var/run/bin
+          readOnly: true
+      volumes:
+      - name: grafana-dashboard-aggregator
+        configMap:
+          name: grafana-dashboard-aggregator
+          defaultMode: 0755

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml
@@ -84,9 +84,20 @@ data:
 
     data=""
     while read -r c; do
-      ns=${c%%[[:space:]]*}
-      cm=${c##*[[:space:]]}
+      ns="${c%%[[:space:]]*}"
+      cm="${c##*[[:space:]]}"
       echo "[$(date -uIseconds)] found configmap ${ns}/${cm}"
+
+      # Construct new names and uids for all dashboards in this configmap
+      names="$(kubectl -n${ns} get configmap ${cm} --export -o json | jq -rc '.data | keys[]')"
+      ids="{"
+      for d in ${names}; do
+        name="${ns}-${cm}-${d}"
+        uid="$(echo -n ${name} | gsha1sum)"
+        ids="${ids}\"${d}\":{\"name\":\"${name}\",\"uid\":\"${uid%%[[:space:]]*}\"},"
+      done
+      ids="${ids}\"\":null}"
+
       #
       # The JSON string exported from a Grafana dashboard cannot be used as-is on the
       #  Grafana API. Instead, it needs to be wrapped into another object. See the
@@ -95,19 +106,22 @@ data:
       # This is all achieved with `jq`. The query itself is perhaps a bit too long
       #  so the section below is an attempt to explain how it works:
       #
-      # // infers the `inputs` array from the exported dashboard's `__inputs`
-      # def set_inputs: [.["__inputs"][] | del(.description, .label, .pluginName) + {"value": .label | ascii_downcase}];
-      # // as per the doc above
-      # def wrap_dashboard: {"dashboard": ., "inputs": . | set_inputs};
-      # [
-      #   // foreach of the keys in the ConfigMap
-      #   .data | . as $x | keys[] |
-      #   // prefix its key and wrap the dashboard object
-      #   {("'${ns}'-'${cm}'-" + .): $x[.] | fromjson | wrap_dashboard | tojson}
-      #   // concatenate the produced objects
-      # ] | add
-      #
-      data=${data}$(kubectl -n${ns} get configmap ${cm} --export -o json | jq -c 'def set_inputs: [.["__inputs"][] | del(.description, .label, .pluginName) + {"value": .label | ascii_downcase}]; def wrap_dashboard: {"dashboard": ., "inputs": . | set_inputs}; [.data | . as $x | keys[] | {("'${ns}'-'${cm}'-" + .): $x[.] | fromjson | wrap_dashboard | tojson}] | add'),
+      data=${data},$(kubectl -n${ns} get configmap ${cm} --export -o json | jq -c '
+        # infers the `inputs` array from `__inputs` of the exported dashboard
+        def set_inputs: [.["__inputs"][] | del(.description, .label, .pluginName) + {"value": .label | ascii_downcase}];
+        # wraps the dashboard and fixes the id and uid properties
+        def wrap_dashboard(u): {"dashboard": (. | del(.id) + {uid: u}), "inputs": . | set_inputs};
+        # inject the generated names and uids
+        '"${ids}"' as $ids |
+        [
+          # foreach of the keys in the ConfigMap
+          .data | . as $x | keys[] |
+          # wrap the dashboard
+          $ids[.] as $i | {($i.name): $x[.] | fromjson | wrap_dashboard($i.uid) | tojson}
+        # and concatenate the resulting array
+        ] | add'
+      )
+
     done <<< "$(kubectl get configmaps \
       --all-namespaces \
       -lcloud-platform.justice.gov.uk/grafana-dashboard \
@@ -119,7 +133,7 @@ data:
     kubectl apply -f - <<EOS
     {
       "apiVersion": "v1",
-      "data": $(echo "[${data}{}]" | jq 'add'),
+      "data": $(echo "[{}${data}]" | jq 'add'),
       "kind": "ConfigMap",
       "metadata": {
         "name": "grafana-user-dashboards",

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml
@@ -93,7 +93,7 @@ data:
       ids="{"
       for d in ${names}; do
         name="${ns}-${cm}-${d}"
-        uid="$(echo -n ${name} | gsha1sum)"
+        uid="$(echo -n ${name} | sha1sum)"
         ids="${ids}\"${d}\":{\"name\":\"${name}\",\"uid\":\"${uid%%[[:space:]]*}\"},"
       done
       ids="${ids}\"\":null}"

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/kube-prometheus/values.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/kube-prometheus/values.yaml
@@ -17,6 +17,9 @@ grafana:
     hosts:
       - grafana.apps.cloud-platform-test-1.k8s.integration.dsd.io
 
+  serverDashboardConfigmaps:
+    - grafana-user-dashboards
+
   extraVars:
     - name: GF_SERVER_ROOT_URL
       value: "https://grafana.apps.cloud-platform-test-1.k8s.integration.dsd.io"


### PR DESCRIPTION
This service aggregates user-created dashboards discovered in ConfigMaps into a single ConfigMap in the monitoring namespace that grafana has been configured to use as a source.

Connects to https://github.com/ministryofjustice/cloud-platform/issues/445