### PR TITLE
add ECR repos & secrets for FormBuilder apps

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/publisher.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/publisher.tf
@@ -57,3 +57,63 @@ resource "kubernetes_secret" "publisher-elasticache" {
 
 ########################################################
 
+# Publisher ECR Repos
+module "ecr-repo-fb-publisher-base" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
+
+  team_name = "${var.team_name}"
+  repo_name = "fb-publisher-base"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-fb-publisher-base"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo-fb-publisher-base.repo_url}"
+    access_key_id     = "${module.ecr-repo-fb-publisher-base.access_key_id}"
+    secret_access_key = "${module.ecr-repo-fb-publisher-base.secret_access_key}"
+  }
+}
+
+module "ecr-repo-fb-publisher-web" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
+
+  team_name = "${var.team_name}"
+  repo_name = "fb-publisher-web"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-fb-publisher-web"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo-fb-publisher-web.repo_url}"
+    access_key_id     = "${module.ecr-repo-fb-publisher-web.access_key_id}"
+    secret_access_key = "${module.ecr-repo-fb-publisher-web.secret_access_key}"
+  }
+}
+
+module "ecr-repo-fb-publisher-worker" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
+
+  team_name = "${var.team_name}"
+  repo_name = "fb-publisher-worker"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-fb-publisher-worker"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo-fb-publisher-worker.repo_url}"
+    access_key_id     = "${module.ecr-repo-fb-publisher-worker.access_key_id}"
+    secret_access_key = "${module.ecr-repo-fb-publisher-worker.secret_access_key}"
+  }
+}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/service_token_cache.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/service_token_cache.tf
@@ -27,3 +27,23 @@ resource "kubernetes_secret" "service-token-cache-elasticache" {
 
 ########################################################
 
+# Service Token Cache ECR Repos
+module "ecr-repo-fb-service-token-cache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
+
+  team_name = "${var.team_name}"
+  repo_name = "fb-service-token-cache"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-fb-service-token-cache"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo-fb-service-token-cache.repo_url}"
+    access_key_id     = "${module.ecr-repo-fb-service-token-cache.access_key_id}"
+    secret_access_key = "${module.ecr-repo-fb-service-token-cache.secret_access_key}"
+  }
+}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/submitter.tf
@@ -57,3 +57,63 @@ resource "kubernetes_secret" "submitter-elasticache" {
 
 ########################################################
 
+# Submitter ECR Repos
+module "ecr-repo-fb-submitter-base" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
+
+  team_name = "${var.team_name}"
+  repo_name = "fb-submitter-base"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-fb-submitter-base"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo-fb-submitter-base.repo_url}"
+    access_key_id     = "${module.ecr-repo-fb-submitter-base.access_key_id}"
+    secret_access_key = "${module.ecr-repo-fb-submitter-base.secret_access_key}"
+  }
+}
+
+module "ecr-repo-fb-submitter-api" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
+
+  team_name = "${var.team_name}"
+  repo_name = "fb-submitter-api"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-fb-submitter-api"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo-fb-submitter-api.repo_url}"
+    access_key_id     = "${module.ecr-repo-fb-submitter-api.access_key_id}"
+    secret_access_key = "${module.ecr-repo-fb-submitter-api.secret_access_key}"
+  }
+}
+
+module "ecr-repo-fb-submitter-worker" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
+
+  team_name = "${var.team_name}"
+  repo_name = "fb-submitter-worker"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-fb-submitter-worker"
+    namespace = "formbuilder-platform-dev"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo-fb-submitter-worker.repo_url}"
+    access_key_id     = "${module.ecr-repo-fb-submitter-worker.access_key_id}"
+    secret_access_key = "${module.ecr-repo-fb-submitter-worker.secret_access_key}"
+  }
+}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/user-datastore.tf
@@ -27,33 +27,23 @@ resource "kubernetes_secret" "user-datastore-rds-instance" {
 
 ##################################################
 
-########################################################
-# User Datastore Elasticache Redis (service token cache)
-module "user-datastore-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=2.0"
+# User Datastore ECR Repos
+module "ecr-repo-fb-user-datastore-api" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
-
-  application            = "formbuilderuserdatastore"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  team_name = "${var.team_name}"
+  repo_name = "fb-user-datastore-api"
 }
 
-resource "kubernetes_secret" "user-datastore-elasticache" {
+resource "kubernetes_secret" "ecr-repo" {
   metadata {
-    name      = "elasticache-formbuilder-user-datastore-dev"
+    name      = "ecr-repo-fb-user-datastore-api"
     namespace = "formbuilder-platform-dev"
   }
 
   data {
-    primary_endpoint_address = "${module.user-datastore-elasticache.primary_endpoint_address}"
-    member_clusters          = "${jsonencode(module.user-datastore-elasticache.member_clusters)}"
-    auth_token               = "${module.user-datastore-elasticache.auth_token}"
+    repo_url          = "${module.ecr-repo-fb-user-datastore-api.repo_url}"
+    access_key_id     = "${module.ecr-repo-fb-user-datastore-api.access_key_id}"
+    secret_access_key = "${module.ecr-repo-fb-user-datastore-api.secret_access_key}"
   }
 }
-
-########################################################
-


### PR DESCRIPTION
Also remove Elasticache for fb-user-datastore, it's no longer needed since we factored-out the service token cache to a standalone microservice (fb-service-token-cache)