### PR TITLE
test-1: consume PrometheusRules from any namespace

### DIFF
--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/kube-prometheus/values.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/kube-prometheus/values.yaml
@@ -331,7 +331,12 @@ prometheus:
   ## 2. If `matchExpressions` is used `rules.additionalLabels` must contain at least one label
   ##    from `matchExpressions` in order to be matched by Prometheus
   ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-  rulesSelector: {}
+  rulesSelector:
+    any: true
+
+  ruleNamespaceSelector:
+    any: true
+
    # rulesSelector: {
    #   matchExpressions: [{key: prometheus, operator: In, values: [example-rules, example-rules-2]}]
    # }

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/kube-prometheus/values.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/kube-prometheus/values.yaml
@@ -1,10 +1,31 @@
 # exporter-node configuration
 deployExporterNode: true
 
+exporter-node:
+  image:
+    repository: quay.io/prometheus/node-exporter
+    tag: v0.16.0
+
+deployKubeState: true
+
+exporter-kube-state:
+  kube_state_metrics:
+    image:
+      repository: gcr.io/google_containers/kube-state-metrics
+      tag: v1.4.0
+  addon_resizer:
+    image:
+      repository: gcr.io/google_containers/addon-resizer
+      tag: "1.8.3"
+
 # Grafana
 deployGrafana: true
 
 grafana:
+  image:
+    repository: grafana/grafana
+    tag: 5.3.1
+
   auth:
     anonymous:
       enabled: "false"
@@ -94,7 +115,7 @@ alertmanager:
   ##
   image:
     repository: quay.io/prometheus/alertmanager
-    tag: v0.14.0
+    tag: v0.15.2
 
   ingress:
     ## If true, Alertmanager Ingress will be created
@@ -229,7 +250,7 @@ prometheus:
   ##
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.2.1
+    tag: v2.4.3
 
   ingress:
     ## If true, Prometheus Ingress will be created

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/kube-prometheus/values.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/kube-prometheus/values.yaml
@@ -1,5 +1,5 @@
 # exporter-node configuration
-deployExporterNode: false
+deployExporterNode: true
 
 # Grafana
 deployGrafana: true

--- a/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/prometheus-operator/values.yaml
+++ b/namespaces/cloud-platform-test-1.k8s.integration.dsd.io/monitoring/helm/prometheus-operator/values.yaml
@@ -3,14 +3,14 @@ global:
   ##
   hyperkube:
     repository: quay.io/coreos/hyperkube
-    tag: v1.7.6_coreos.0
+    tag: v1.10.5_coreos.0
     pullPolicy: IfNotPresent
 
 ## Prometheus-config-reloader image to use for config and rule reloading
 ##
 prometheusConfigReloader:
   repository: quay.io/coreos/prometheus-config-reloader
-  tag: v0.20.0
+  tag: v0.24.0
 
 ## Configmap-reload image to use for reloading configmaps
 ##
@@ -22,7 +22,7 @@ configmapReload:
 ##
 image:
   repository: quay.io/coreos/prometheus-operator
-  tag: v0.20.0
+  tag: v0.24.0
   pullPolicy: IfNotPresent
 
 ## If enabled, prometheus-operator will create a service for scraping kubelets


### PR DESCRIPTION
Also, upgrade all kube-prometheus components (only the operator is strictly required to enable `PrometheusRules`).