### PR TITLE
Create namespace for prod version of support app

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: support-labelling-webhook-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "support-labelling-webhook"
+    cloud-platform.justice.gov.uk/owner: "cloud-platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-support-labelling-webhook"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: support-labelling-webhook-production-admin
+  namespace: support-labelling-webhook-production
+subjects:
+  - kind: Group
+    name: "github:cloud-platform"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: support-labelling-webhook-production
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: support-labelling-webhook-production
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: support-labelling-webhook-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: support-labelling-webhook-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers


### PR DESCRIPTION
The support labelling webhook currently only has a dev site (which is
essentially the live version of the webhook). This creates a prod
namespace so that in the future no one gets confused and deletes the dev
one.