### PR TITLE
Add Steve Lorek's test application (dev) to live cluster

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: steve-test-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "Dev"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Digital & Technology"
+    cloud-platform.justice.gov.uk/application: "Steve Lorek Test App"
+    cloud-platform.justice.gov.uk/owner: "Steve Lorek: steve.lorek@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/slorek/anagram_finder"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: steve-test-dev-admin
+  namespace: steve-test-dev
+subjects:
+  - kind: Group
+    name: "github:laa-technical-architects"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: steve-test-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: steve-test-dev
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/04-networkpolicy.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: steve-test-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: steve-test-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers


### PR DESCRIPTION
This is a new namespace just to enable me to test the usage and features of the cloud platform with a dummy application.

Note the repo for the application is not prepared for Docker/Kubernetes yet.