### PR TITLE
Increase formbuilder-services-dev requests.memory quota to 16Gi

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/03-resourcequota.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   hard:
     requests.cpu: 10000m
-    requests.memory: 8Gi
+    requests.memory: 16Gi
     limits.cpu: 20000m
     limits.memory: 64Gi


### PR DESCRIPTION
NB. limits.memory is set to 64Gi but appears to have no effect