### PR TITLE
Fix incorrect RBAC group

### DIFF
--- a/namespace-resources/01-rbac.yaml
+++ b/namespace-resources/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ${namespace}
 subjects:
   - kind: Group
-    name: "github:${github_team}"
+    name: "github:${lower(github_team)}"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cica-development/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cica-development/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cica-development
 subjects:
   - kind: Group
-    name: "github:CICA"
+    name: "github:cica"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Github team names appear in lowercase in the OIDC claim. Fix for cica-development and enforce through the template.