### PR TITLE
Add more resources to fix failing deployments

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-apply-for-legalaid-uat
 spec:
   hard:
-    requests.cpu: 6000m
-    requests.memory: 12Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 10000m
+    requests.memory: 20Gi
+    limits.cpu: 10000m
+    limits.memory: 20Gi


### PR DESCRIPTION
Deployments are still failing after the previous resource increase. The limit still appears to be set to 6 uat deployments. This change should increase the number of deployments we can make simultaneously.