### PR TITLE
Adjust formbuilder environment quotas

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 30m
+      cpu: 150m
       memory: 300Mi
     defaultRequest:
-      cpu: 30m
+      cpu: 10m
       memory: 128Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-dev/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: formbuilder-services-dev
 spec:
   hard:
-    requests.cpu: 10000m
-    requests.memory: 16Gi
-    limits.cpu: 20000m
-    limits.memory: 64Gi
+    requests.cpu: 1000m
+    requests.memory: 12.8Gi
+    limits.cpu: 15000m
+    limits.memory: 30Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 30m
+      cpu: 150m
       memory: 300Mi
     defaultRequest:
-      cpu: 30m
+      cpu: 10m
       memory: 128Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: formbuilder-services-production
 spec:
   hard:
-    requests.cpu: 10000m
-    requests.memory: 16Gi
-    limits.cpu: 20000m
-    limits.memory: 64Gi
+    requests.cpu: 500m
+    requests.memory: 6.4Gi
+    limits.cpu: 7500m
+    limits.memory: 15Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 30m
+      cpu: 150m
       memory: 300Mi
     defaultRequest:
-      cpu: 30m
+      cpu: 10m
       memory: 128Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-services-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: formbuilder-services-staging
 spec:
   hard:
-    requests.cpu: 10000m
-    requests.memory: 16Gi
-    limits.cpu: 20000m
-    limits.memory: 64Gi
+    requests.cpu: 500m
+    requests.memory: 6.4Gi
+    limits.cpu: 7500m
+    limits.memory: 15Gi


### PR DESCRIPTION
To provide:

* Dev - 100 forms
* Staging/Production - 50 forms

Using the following limit ranges

* cpu - request: 10m, limit: 150m
* memory: - request: 128Mi, limit: 300Mi