### PR TITLE
Add rds to laa apply for legalaid staging and production

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/resources/rds.tf
@@ -1,11 +1,3 @@
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 /*
  * When using this module through the cloud-platform-environments, the following
  * two variables are automatically supplied by the pipeline.
@@ -30,8 +22,8 @@ module "apply-for-legal-aid-rds" {
   team_name              = "apply-for-legal-aid"
   business-unit          = "laa"
   application            = "laa-apply-for-legal-aid"
-  is-production          = "false"
-  environment-name       = "staging"
+  is-production          = "true"
+  environment-name       = "production"
   infrastructure-support = "apply@digtal.justice.gov.uk"
   db_engine              = "postgres"
   db_engine_version      = "10.5"
@@ -41,7 +33,7 @@ module "apply-for-legal-aid-rds" {
 resource "kubernetes_secret" "apply-for-legal-aid-rds" {
   metadata {
     name      = "apply-for-legal-aid-rds-instance-output"
-    namespace = "laa-apply-for-legalaid-staging"
+    namespace = "laa-apply-for-legalaid-production"
   }
 
   data {

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/resources/rds.tf
@@ -15,7 +15,7 @@ variable "cluster_state_bucket" {}
  *
  */
 module "apply-for-legal-aid-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -1,0 +1,54 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}
+
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "apply-for-legal-aid-rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.3"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "apply-for-legal-aid"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "false"
+  environment-name       = "staging"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+  db_engine              = "postgres"
+  db_engine_version      = "10.5"
+  db_name                = "apply-for-legal-aid"
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-rds" {
+  metadata {
+    name      = "apply-for-legal-aid-rds-instance-output"
+    namespace = "laa-apply-for-legalaid-staging"
+  }
+
+  data {
+    rds_instance_endpoint = "${module.apply-for-legal-aid-rds.rds_instance_endpoint}"
+    database_name         = "${module.apply-for-legal-aid-rds.database_name}"
+    database_username     = "${module.apply-for-legal-aid-rds.database_username}"
+    database_password     = "${module.apply-for-legal-aid-rds.database_password}"
+    rds_instance_address	= "${module.apply-for-legal-aid-rds.rds_instance_address}"
+  }
+}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -23,7 +23,7 @@ variable "cluster_state_bucket" {}
  *
  */
 module "apply-for-legal-aid-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"


### PR DESCRIPTION
Add /resources/rds.tf to staging and production namespaces to create RDS databases for the service.