### PR TITLE
offender-management: extend circleci SA access

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/serviceaccount-circleci.yaml
@@ -37,13 +37,13 @@ rules:
       - "create"
       - "patch"
   - apiGroups:
-    - monitoring.coreos.com
+      - "monitoring.coreos.com"
     resources:
-    - service-monitor
-    - servicemonitors
-    - prometheusrules
+      - "service-monitor"
+      - "servicemonitors"
+      - "prometheusrules"
     verbs:
-    - '*'
+      - "*"
 
 ---
 kind: RoleBinding

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/serviceaccount-circleci.yaml
@@ -36,6 +36,14 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - service-monitor
+    - servicemonitors
+    - prometheusrules
+    verbs:
+    - '*'
 
 ---
 kind: RoleBinding

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/serviceaccount-circleci.yaml
@@ -37,13 +37,13 @@ rules:
       - "create"
       - "patch"
   - apiGroups:
-    - monitoring.coreos.com
+      - "monitoring.coreos.com"
     resources:
-    - service-monitor
-    - servicemonitors
-    - prometheusrules
+      - "service-monitor"
+      - "servicemonitors"
+      - "prometheusrules"
     verbs:
-    - '*'
+      - "*"
 
 ---
 kind: RoleBinding

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/serviceaccount-circleci.yaml
@@ -36,6 +36,14 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - service-monitor
+    - servicemonitors
+    - prometheusrules
+    verbs:
+    - '*'
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
circleci needs to be able to create ServiceMonitors