### PR TITLE
Increase resource limit for OMIC prod & staging

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 200m
+      memory: 500Mi
     defaultRequest:
       cpu: 100m
-      memory: 128Mi
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: offender-management-production
 spec:
   hard:
-    requests.cpu: "4"
-    requests.memory: 8Gi
-    limits.cpu: "10"
-    limits.memory: 20Gi
+    requests.cpu: 3000m
+    requests.memory: 7500Mi
+    limits.cpu: 6000m
+    limits.memory: 15Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: offender-management-production
 spec:
   hard:
-    requests.cpu: 4000m
+    requests.cpu: "4"
     requests.memory: 8Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    limits.cpu: "10"
+    limits.memory: 20Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 200m
+      memory: 500Mi
     defaultRequest:
       cpu: 100m
-      memory: 128Mi
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: offender-management-staging
 spec:
   hard:
-    requests.cpu: 4000m
+    requests.cpu: "4"
     requests.memory: 8Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    limits.cpu: "10"
+    limits.memory: 20Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: offender-management-staging
 spec:
   hard:
-    requests.cpu: "4"
-    requests.memory: 8Gi
-    limits.cpu: "10"
-    limits.memory: 20Gi
+    requests.cpu: 3000m
+    requests.memory: 7500Mi
+    limits.cpu: 6000m
+    limits.memory: 15Gi


### PR DESCRIPTION
We have been experiencing an issue on staging where when we are trying
to deploy new code only 2 out of the 3 pods are successfully updated,
and means that we currently have to manually delete the 3rd pod to get
everything working properly.  Therefore we need to increase our
resource limit to avoid this issue moving forward.