### PR TITLE
Upgrade cloud-platform-terraform module versions

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/resources/rds_instance.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/resources/rds_instance.tf
@@ -3,7 +3,7 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.4"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/resources/redis.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/resources/redis.tf
@@ -3,7 +3,7 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=2.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/publisher.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/publisher.tf
@@ -2,7 +2,7 @@
 # Publisher RDS
 
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/submitter.tf
@@ -2,7 +2,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-dev/resources/user-datastore.tf
@@ -1,7 +1,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=2.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-dev/resources/variables.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-dev/resources/variables.tf
@@ -2,6 +2,7 @@
 variable "environment-name" {
   default = "test-dev"
 }
+
 variable "team_name" {
   default = "formbuilder"
 }


### PR DESCRIPTION
This allows us to run the latest terraform version (0.11.11)
See https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/pull/9/commits/4ef00b926bc0e5c651201fbca249356b674d8391