### PR TITLE
Move backend and AWS region to main.tf for 2 namespaces

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/rds-allocations-api.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/rds-allocations-api.tf
@@ -1,11 +1,3 @@
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 /*
  * When using this module through the cloud-platform-environments, the following
  * two variables are automatically supplied by the pipeline.

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/ecr-allocation-manager.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/ecr-allocation-manager.tf
@@ -1,11 +1,3 @@
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 module "ecr-repo-allocation-manager" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=1.0"
 

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}


### PR DESCRIPTION
This means that these are clearly defined once per namespace, rather than
being in files for other specific resources.

[As suggested](https://github.com/ministryofjustice/cloud-platform-environments/pull/340#issuecomment-454874137) by @razvan-moj 