### PR TITLE
Adjust LimitRange and ResourceQuota for a number of namespaces

### DIFF
--- a/namespace-resources/02-limitrange.yaml
+++ b/namespace-resources/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ${namespace}
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/audit/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/audit/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/audit/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/audit/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: audit
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/auth0-inactive-user-check-prod/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/auth0-inactive-user-check-prod/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/auth0-inactive-user-check-prod/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/auth0-inactive-user-check-prod/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: auth0-inactive-user-check-prod
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/authorized-keys-provider/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/authorized-keys-provider/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/authorized-keys-provider/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/authorized-keys-provider/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: authorized-keys-provider
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: c100-application-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/categorisation-tool-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/categorisation-tool-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/categorisation-tool-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/categorisation-tool-dev/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: categorisation-tool-dev
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cert-manager/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cert-manager/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cert-manager/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cert-manager/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cert-manager
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cica-development/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cica-development/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cica-development/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cica-development/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cica-development
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse-main/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse-main/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse-main/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse-main/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: concourse-main
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/concourse/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: concourse
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/custody-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/custody-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/custody-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/custody-dev/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: custody-dev
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-development/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: digicop-development
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-test/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-test/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-test/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/digicop-test/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: digicop-test
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: family-mediators-api-production
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: family-mediators-api-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/fj-cait-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/fj-cait-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/fj-cait-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/fj-cait-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: fj-cait-production
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/fj-cait-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/fj-cait-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/fj-cait-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/fj-cait-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: fj-cait-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ingress-controllers
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kube-ops/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kube-ops/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kube-ops/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kube-ops/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-ops
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kuberos/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kuberos/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kuberos/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/kuberos/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kuberos
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-backend-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-backend-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-backend-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-backend-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-cla-backend-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-frontend-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-frontend-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-frontend-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-frontend-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-cla-frontend-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-cla-public-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-fala-production
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-fala-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-fee-calculator-production
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-fee-calculator-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-great-ideas-production
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-great-ideas-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-uat/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-uat/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-uat/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-uat/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-great-ideas-uat
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-legal-adviser-api-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-legal-adviser-api-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-legal-adviser-api-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-legal-adviser-api-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-legal-adviser-api-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: logging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
-    limits.cpu: 12000m
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: monitoring
 spec:
   hard:
-    requests.cpu: 8000m
-    requests.memory: 16Gi
-    limits.cpu: 12000m
+    requests.cpu: 5000m
+    requests.memory: 12Gi
+    limits.cpu: 10000m
     limits.memory: 24Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/moving-people-safely-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/moving-people-safely-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/moving-people-safely-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/moving-people-safely-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: moving-people-safely-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/nick-sample-app-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/nick-sample-app-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/nick-sample-app-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/nick-sample-app-dev/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: nick-sample-app-dev
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/oa-test/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/oa-test/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/oa-test/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/oa-test/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: oa-test
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/pq-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/pq-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/pq-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/pq-dev/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: pq-dev
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/prisoner-categorisation-tool-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/prisoner-categorisation-tool-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/prisoner-categorisation-tool-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/prisoner-categorisation-tool-dev/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: prisoner-categorisation-tool-dev
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-development/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-development/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-development/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-development/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: reference-app-development
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: reference-app-production
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-staging/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-staging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/reference-app-staging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: reference-app-staging
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/steve-test-dev/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: steve-test-dev
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/support-labelling-webhook-production/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: support-labelling-webhook-production
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/vv-myapp-dev/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/vv-myapp-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/vv-myapp-dev/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/vv-myapp-dev/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: vv-myapp-dev
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/weekly-app-deploy-oa/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/weekly-app-deploy-oa/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 500Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 125m
+      memory: 250Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/weekly-app-deploy-oa/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/weekly-app-deploy-oa/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: weekly-app-deploy-oa
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
+    requests.cpu: 3000m
+    requests.memory: 6Gi
     limits.cpu: 6000m
     limits.memory: 12Gi


### PR DESCRIPTION
The previous default values for new namespaces were causing scheduling issues and were not properly thought out.
This PR introduces new defaults that should work for the majority of apps we host and should address the
overprovisioning of limits.