### PR TITLE
Adjust resources on grafana-dashboard-aggregator

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml
@@ -183,11 +183,11 @@ spec:
           done;
         resources:
           requests:
-            cpu: 1m
-            memory: 32Mi
+            cpu: 10m
+            memory: 64Mi
           limits:
-            cpu: 1m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
         volumeMounts:
         - name: grafana-dashboard-aggregator
           mountPath: /var/run/bin


### PR DESCRIPTION
Previously, it was struggling to complete requests and getting killed ofter. This chang makes it more responsive and
allows it to complete the aggregation.