### PR TITLE
Fix ES Curator

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+  labels:
+    component: logging
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
+    cloud-platform.justice.gov.uk/application: "Logging"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"
+    iam.amazonaws.com/permitted: ".*"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: logging
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 10000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
+    limits.cpu: 10000m
     limits.memory: 12Gi

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
@@ -8,6 +8,11 @@ spec:
   jobTemplate: 
     spec:
       template:
+        metadata:
+          labels:
+            application: live-es-cleanuper
+          annotations:
+            iam.amazonaws.com/role: elasticsearch-curator
         spec:
           restartPolicy: OnFailure
           containers:


### PR DESCRIPTION
**Why**
The cronjob defined in the namespace logging fails as it doesn't have an IAM role since KIAM