### PR TITLE
Add configmaps access to circleci role for laa-cla-public namespaces

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/05-serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/05-serviceaccount-circleci.yaml
@@ -13,6 +13,7 @@ metadata:
 rules:
   - apiGroups:
       - ""
+      - "configmaps"
     resources:
       - "pods/portforward"
       - "deployment"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/05-serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/05-serviceaccount-circleci.yaml
@@ -13,8 +13,8 @@ metadata:
 rules:
   - apiGroups:
       - ""
-      - "configmaps"
     resources:
+      - "configmaps"
       - "pods/portforward"
       - "deployment"
       - "secrets"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/05-serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/05-serviceaccount-circleci.yaml
@@ -13,6 +13,7 @@ metadata:
 rules:
   - apiGroups:
       - ""
+      - "configmaps"
     resources:
       - "pods/portforward"
       - "deployment"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/05-serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/05-serviceaccount-circleci.yaml
@@ -13,8 +13,8 @@ metadata:
 rules:
   - apiGroups:
       - ""
-      - "configmaps"
     resources:
+      - "configmaps"
       - "pods/portforward"
       - "deployment"
       - "secrets"


### PR DESCRIPTION
This is required so that circleci is able to push up configmaps for the grafana dashboards