### PR TITLE
Update CCCD namespace

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cccd-dev/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cccd-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cccd-dev
 subjects:
   - kind: Group
-    name: "crime-billing-online"
+    name: "github:crime-billing-online"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Replace github prefix on team name
This was accidentally deleted when the team name was replaced