### PR TITLE
LGA-288: Reduce default cla-public production limits

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-production/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 250m
+      memory: 512Mi
     defaultRequest:
       cpu: 100m
       memory: 128Mi


### PR DESCRIPTION
Our monitoring identified that our maximum memory usage for these pods was 126MiB since Christmas Eve 2018.

Similarly, our highest CPU spike was 59 millicpu.

We propose to scale memory down to 512Mi and CPU down to 250m. This will give us 24 pods to scale up, if necessary.