### PR TITLE
Create new 'POSTGRES...' env vars that point to AWS Relation Database

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/rds-allocations-api.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/rds-allocations-api.tf
@@ -38,9 +38,13 @@ resource "kubernetes_secret" "allocation-rds" {
 
   data {
     rds_instance_endpoint = "${module.allocation-rds.rds_instance_endpoint}"
+    rds_instance_address  = "${module.allocation-rds.rds_instance_address}"
     database_name         = "${module.allocation-rds.database_name}"
     database_username     = "${module.allocation-rds.database_username}"
     database_password     = "${module.allocation-rds.database_password}"
-    rds_instance_address  = "${module.allocation-rds.rds_instance_address}"
+    postgres_name         = "${module.allocation-rds.database_name}"
+    postgres_host         = "${module.allocation-rds.rds_instance_address}"
+    postgres_user         = "${module.allocation-rds.database_username}"
+    postgres_password     = "${module.allocation-rds.database_password}"
   }
 }

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/rds-allocations-api.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/rds-allocations-api.tf
@@ -38,9 +38,13 @@ resource "kubernetes_secret" "allocation-rds" {
 
   data {
     rds_instance_endpoint = "${module.allocation-rds.rds_instance_endpoint}"
+    rds_instance_address  = "${module.allocation-rds.rds_instance_address}"
     database_name         = "${module.allocation-rds.database_name}"
     database_username     = "${module.allocation-rds.database_username}"
     database_password     = "${module.allocation-rds.database_password}"
-    rds_instance_address  = "${module.allocation-rds.rds_instance_address}"
+    postgres_name         = "${module.allocation-rds.database_name}"
+    postgres_host         = "${module.allocation-rds.rds_instance_address}"
+    postgres_user         = "${module.allocation-rds.database_username}"
+    postgres_password     = "${module.allocation-rds.database_password}"
   }
 }


### PR DESCRIPTION
- This PR creates new 'POSTGRES...' env vars that point to AWS Relation Database service. Using 'POSTGRES...' will bring about greater consistency across the Offender Management Allocation API application.

- Once connection to the database via the new env vars is made, then a follow up PR will be raised to remove unused database env vars.
