### PR TITLE
Revisit elasticsearch-curator

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
@@ -3,78 +3,37 @@ kind: CronJob
 metadata:
   name: elasticsearch-curator-cronjob
   namespace: logging
-spec: 
+spec:
   schedule: "0 1 * * *"
-  jobTemplate: 
+  jobTemplate:
     spec:
       template:
         spec:
           restartPolicy: OnFailure
           containers:
-          - name: alpine
-            image: alpine
+          - name: curator
+            image: python:alpine
             command:
             - /bin/sh
             - -c
             - |
-              apk update
-              apk add --no-cache python3 
-              pip3 install --upgrade pip
-              pip3 install boto3 elasticsearch-curator requests_aws4auth elasticsearch
-              python3 /etc/es-curator/elasticsearch-curator
-            args:
-            - --config
-            - /etc/es-curator/elasticsearch-curator
-            volumeMounts:
-            - name: elasticsearch-curator-python
-              mountPath: /etc/es-curator
-          volumes:
-            - name: elasticsearch-curator-python
-              configMap:
-                name: elasticsearch-curator-python
-           
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: elasticsearch-curator-python
-  namespace: logging
-data:
-  elasticsearch-curator: |
-    #!/usr/bin/env python3
-
-    import boto3
-    from requests_aws4auth import AWS4Auth
-    from elasticsearch import Elasticsearch, RequestsHttpConnection
-    import curator
-
-    host = 'search-cloud-platform-live-7qrzc26xexgxtkt5qz72gt6cxa.eu-west-1.es.amazonaws.com' 
-    region = 'eu-west-1' 
-    service = 'es'
-    credentials = boto3.Session().get_credentials()
-    awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
-
-    es = Elasticsearch(
-        hosts = [{'host': host, 'port': 443}],
-        http_auth = awsauth,
-        use_ssl = True,
-        verify_certs = True,
-        connection_class = RequestsHttpConnection
-    )
-
-    index_list = curator.IndexList(es)
-
-    # Filters by age, anything with a time stamp older than 30 days in the index name.
-    index_list.filter_by_age(source='name', direction='older', timestring='%Y.%m.%d', unit='days', unit_count=30)
-
-    # Filters by naming prefix.
-    # index_list.filter_by_regex(kind='prefix', value='my-logs-2017')
-
-    # Filters by age, anything created more than one month ago.
-    # index_list.filter_by_age(source='creation_date', direction='older', unit='months', unit_count=1)
-
-    # Delete all indices in the filtered list.
-    try:
-      curator.DeleteIndices(index_list).do_action()
-    except:
-      print("index_list object is empty")
+              pip3 install elasticsearch-curator &&
+              curator_cli \
+                --host search-cloud-platform-live-7qrzc26xexgxtkt5qz72gt6cxa.eu-west-1.es.amazonaws.com \
+                --use_ssl \
+                --port 443 \
+                delete_indices \
+                --filter_list '[
+                  {
+                    "filtertype":"age",
+                    "source":"creation_date",
+                    "direction":"older",
+                    "unit":"days",
+                    "unit_count":30
+                  },
+                  {
+                    "filtertype":"pattern",
+                    "kind":"prefix",
+                    "value":"logstash"
+                  }
+                ]'


### PR DESCRIPTION
Instead of building on the curator library, we can just use the command line tool. It should make this a bit easier to
understand and modify in the future.