### PR TITLE
Remove ECR and secret

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/resources/main.tf
@@ -6,26 +6,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=2.0"
-
-  team_name = "laa-great-ideas"
-  repo_name = "laa-great-ideas"
-}
-
-resource "kubernetes_secret" "ecr-repo" {
-  metadata {
-    name      = "ecr-repo-laa-great-ideas"
-    namespace = "laa-great-ideas-staging"
-  }
-
-  data {
-    repo_url          = "${module.ecr-repo.repo_url}"
-    access_key_id     = "${module.ecr-repo.access_key_id}"
-    secret_access_key = "${module.ecr-repo.secret_access_key}"
-  }
-}
-
 variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 


### PR DESCRIPTION
We only need one ECR repo, and the namespace can access the existing
repo without the secret.