### PR TITLE
Update RDS module version to 3.1

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/categorisation-tool-dev/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/categorisation-tool-dev/resources/user-datastore.tf
@@ -7,7 +7,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "categorisation_tool_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-production/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-production/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-staging/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/family-mediators-api-staging/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-dev/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-dev/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-dev/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-dev/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-production/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-production/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-production/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-production/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-staging/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-staging/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-staging/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-integration-staging/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-dev/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-production/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-production/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-staging/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-staging/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-staging/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-live-staging/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-production/resources/publisher.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-production/resources/publisher.tf
@@ -2,7 +2,7 @@
 # Publisher RDS
 
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-production/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-production/resources/submitter.tf
@@ -2,7 +2,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-production/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-production/resources/user-datastore.tf
@@ -1,7 +1,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/publisher.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/publisher.tf
@@ -2,7 +2,7 @@
 # Publisher RDS
 
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/submitter.tf
@@ -2,7 +2,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-staging/resources/user-datastore.tf
@@ -1,7 +1,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-dev/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-production/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-production/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-production/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-production/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-staging/resources/submitter.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-staging/resources/submitter.tf
@@ -3,7 +3,7 @@
 # Submitter RDS
 
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-staging/resources/user-datastore.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-staging/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-publisher-integration/resources/publisher.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-publisher-integration/resources/publisher.tf
@@ -3,7 +3,7 @@
 # Publisher RDS
 
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-publisher-live/resources/publisher.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-publisher-live/resources/publisher.tf
@@ -3,7 +3,7 @@
 # Publisher RDS
 
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-publisher-test/resources/publisher.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-publisher-test/resources/publisher.tf
@@ -3,7 +3,7 @@
 # Publisher RDS
 
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/resources/main.tf
@@ -30,7 +30,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "laa-great-ideas-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-uat/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-uat/resources/main.tf
@@ -30,7 +30,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "laa-great-ideas-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/money-to-prisoners-test/resources/rds.tf
@@ -4,7 +4,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/rds-allocations-api.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/rds-allocations-api.tf
@@ -15,7 +15,7 @@ variable "cluster_state_bucket" {}
  *
  */
 module "allocation-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/rds-allocations-api.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/rds-allocations-api.tf
@@ -15,7 +15,7 @@ variable "cluster_state_bucket" {}
  *
  */
 module "allocation-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/pq-dev/resources/rds_instance.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/pq-dev/resources/rds_instance.tf
@@ -3,7 +3,7 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"


### PR DESCRIPTION
This fixes an issue with terraform trying to downgrade when an automatic minor version upgrade has been performed.

There's a [single change](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/compare/3.1..3.0#diff-c9ac8098c5ea9d3e6a9a596ff0c512a4) in this version.