### PR TITLE
Add configmaps access to circleci role for laa-fala namespaces

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-production/05-serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-production/05-serviceaccount-circleci.yaml
@@ -14,6 +14,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - "configmaps"
       - "pods/portforward"
       - "deployment"
       - "secrets"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging/05-serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging/05-serviceaccount-circleci.yaml
@@ -14,6 +14,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - "configmaps"
       - "pods/portforward"
       - "deployment"
       - "secrets"


### PR DESCRIPTION
This is required so that circleci is able to push up configmaps for the grafana dashboards