### PR TITLE
Increase ResourceQuota requests for monitoring

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: monitoring
 spec:
   hard:
-    requests.cpu: 5000m
-    requests.memory: 12Gi
+    requests.cpu: 10000m
+    requests.memory: 24Gi
     limits.cpu: 10000m
     limits.memory: 24Gi


### PR DESCRIPTION
This brings limits and requests to the same level. We need to increase the requests so that we can allocate more
memory to prometheus, however, we do not really have a lot of burstable pods in this namespace so it makes sense to just
equalise the two values.