### PR TITLE
Align actual RDS version with manifest

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/resources/rds.tf
@@ -16,7 +16,7 @@ module "apply-for-legal-aid-rds" {
   environment-name       = "production"
   infrastructure-support = "apply@digtal.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "10.5"
+  db_engine_version      = "10.6"
   db_name                = "apply_for_legal_aid_production"
 }
 

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -16,7 +16,7 @@ module "apply-for-legal-aid-rds" {
   environment-name       = "staging"
   infrastructure-support = "apply@digtal.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "10.5"
+  db_engine_version      = "10.6"
   db_name                = "apply_for_legal_aid_staging"
 }
 


### PR DESCRIPTION
This is currently at 10.6 but the manifest shows 10.5. This commit will align both together and allow the pipeline to complete successfully. Please see build logs for more information: https://concourse.apps.cloud-platform-live-0.k8s.integration.dsd.io/teams/main/pipelines/build-environments/jobs/apply/builds/20598