### PR TITLE
Align manifest with RDS version

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-staging/resources/main.tf
@@ -21,7 +21,7 @@ module "laa-great-ideas-rds" {
   environment-name       = "staging"
   infrastructure-support = "laa-great-ideas@digital.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "10.5"
+  db_engine_version      = "10.6"
   db_name                = "laa_great_ideas_db"
 }
 

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-uat/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-great-ideas-uat/resources/main.tf
@@ -41,7 +41,7 @@ module "laa-great-ideas-rds" {
   environment-name       = "uat"
   infrastructure-support = "laa-great-ideas@digital.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "10.5"
+  db_engine_version      = "10.6"
   db_name                = "laa_great_ideas_db"
 }
 


### PR DESCRIPTION
This is currently at 10.6 but the manifest shows 10.5. This commit will align both together and allow the pipeline to complete successfully. Please see build logs for more information: https://concourse.apps.cloud-platform-live-0.k8s.integration.dsd.io/teams/main/pipelines/build-environments/jobs/apply/builds/20698