### PR TITLE
Remove RDS minor version

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/rds-allocations-api.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/rds-allocations-api.tf
@@ -26,7 +26,7 @@ module "allocation-rds" {
   environment-name       = "production"
   infrastructure-support = "omic@digital.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "10.5"
+  db_engine_version      = "10"
   db_name                = "allocations"
 }
 


### PR DESCRIPTION
To match the RDS version in live we have removed the minor version pin. This will follow the module best practice.