### PR TITLE
 Renamed ECR to avoid conflict

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/dummy-app-dev/resources/ecr.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/dummy-app-dev/resources/ecr.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "example_team_ecr_credentials" {
   source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=2.0"
-  repo_name = "dummy-app"
+  repo_name = "dummy-app-mourad"
   team_name = "cloud-platform-test"
 }
 


### PR DESCRIPTION
 Renamed ECR to avoid conflict, from dummy-app to dummy-app-mourad