### PR TITLE
fix to use shas instead of using branch while doing git diff

### DIFF
--- a/bin/plan
+++ b/bin/plan
@@ -13,7 +13,7 @@ log() {
   echo -e "${_fg}>>> ${@}\033[0m"
 }
 
-changed_dirs=$(git diff --no-commit-id --name-only -r master..HEAD^ |awk 'BEGIN{FS=OFS="/"}/\/resources\//{NF-=1; print $3}' | sort | uniq)
+changed_dirs=$(git diff-tree --no-commit-id --name-only -r $master_base_sha $branch_head_sha | awk 'BEGIN{FS=OFS="/"}/\/resources\//{NF-=1; print $3}' | sort | uniq)
 
 for _c in namespaces/*; do
   cluster="$(basename ${_c})"


### PR DESCRIPTION
Exported branch and master Shas while running plan pipeline, this change is to pick those Shas and use it in the git diff so it can check all the commits in the PR raised.