### PR TITLE
Create Elasticache instance for offender-management

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/elasticache.cf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/elasticache.cf
@@ -1,0 +1,22 @@
+module "ec-cluster-offender-management-allocation-manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=2.1"
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "${var.team_name}"
+  application            = "offender-management-allocation-manager"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+}
+
+resource "kubernetes_secret" "ec-cluster-offender-management-allocation-manager-staging" {
+  metadata {
+    name      = "elasticache-offender-management-allocation-manager-token-cache-${var.environment-name}"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}"
+    auth_token               = "${module.ec-cluster-offender-management-allocation-manager.auth_token}"
+  }
+}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/variables.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/resources/variables.tf
@@ -1,0 +1,19 @@
+variable "environment-name" {
+  default = "production"
+}
+
+variable "team_name" {
+  default = "offender-management"
+}
+
+variable "is-production" {
+  default = "true"
+}
+
+variable "namespace" {
+  default = "offender-management-production"
+}
+
+variable "infrastructure-support" {
+  default = "omic@digtal.justice.gov.uk"
+}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/elasticache.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/elasticache.tf
@@ -1,0 +1,22 @@
+module "ec-cluster-offender-management-allocation-manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=2.1"
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "${var.team_name}"
+  application            = "offender-management-allocation-manager"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+}
+
+resource "kubernetes_secret" "ec-cluster-offender-management-allocation-manager-staging" {
+  metadata {
+    name      = "elasticache-offender-management-allocation-manager-token-cache-${var.environment-name}"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}"
+    auth_token               = "${module.ec-cluster-offender-management-allocation-manager.auth_token}"
+  }
+}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/variables.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/resources/variables.tf
@@ -1,0 +1,19 @@
+variable "environment-name" {
+  default = "staging"
+}
+
+variable "team_name" {
+  default = "offender-management"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "namespace" {
+  default = "offender-management-staging"
+}
+
+variable "infrastructure-support" {
+  default = "omic@digtal.justice.gov.uk"
+}


### PR DESCRIPTION
Adds elasticache to both the staging and production environment for the offender-management-allocation service.