### PR TITLE
Change elasticsearch-curator filters

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/logging/elasticsearch-curator.yaml
@@ -26,8 +26,9 @@ spec:
                 --filter_list '[
                   {
                     "filtertype":"age",
-                    "source":"creation_date",
+                    "source":"name",
                     "direction":"older",
+                    "timestring": "%Y.%m.%d",
                     "unit":"days",
                     "unit_count":30
                   },


### PR DESCRIPTION
This changes the age filter to use the date from the index name, which produces the expected result.
See the documentation for more detail: https://www.elastic.co/guide/en/elasticsearch/client/curator/current/filtertype_age.html