### PR TITLE
Prison Visits Booking Allow CircleCI to deploy Kubernetes cron jobs

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/prison-visits-booking-staging/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/prison-visits-booking-staging/serviceaccount-circleci.yaml
@@ -15,6 +15,7 @@ rules:
       - ""
     resources:
       - "configmaps"
+      - "cronjobs"
       - "pods/portforward"
       - "deployment"
       - "secrets"


### PR DESCRIPTION
CircleCI is not allowed to deploy Kubernetes cronjobs and is sad 😭 
Let CircleCi deploy cronjobs

```
"./deploy/staging/cronjob.yaml": cronjobs.batch "delete-load-test-data" is forbidden: User "system:serviceaccount:prison-visits-booking-staging:circleci" cannot get cronjobs.batch in the namespace "prison-visits-booking-staging"
```