### PR TITLE
increase ingress limits

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/02-limitrange.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 512m
+      memory: 1024Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 256m
+      memory: 512Mi
     type: Container

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/ingress-controllers/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ingress-controllers
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 6000m
+    requests.memory: 8Gi
+    limits.cpu: 12000m
+    limits.memory: 16Gi


### PR DESCRIPTION
**Why**
https://grafana.apps.cloud-platform-live-0.k8s.integration.dsd.io/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-compute-resources-pod?refresh=10s&orgId=1&var-datasource=Prometheus&var-namespace=ingress-controllers shows high res usage for both RAM&CPU