### PR TITLE
Add pod-internal service accounts for money-to-prisoners

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/money-to-prisoners-prod/05-service-account.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/money-to-prisoners-prod/05-service-account.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-internal
+  namespace: money-to-prisoners-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: pod-internal
+  namespace: money-to-prisoners-prod
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - deployment
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: pod-internal
+  namespace: money-to-prisoners-prod
+subjects:
+- kind: ServiceAccount
+  name: pod-internal
+  namespace: money-to-prisoners-prod
+roleRef:
+  kind: Role
+  name: pod-internal
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/money-to-prisoners-prod/README.md
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/money-to-prisoners-prod/README.md
@@ -15,4 +15,4 @@ Architecture
 Deployment pipeline
 -------------------
 
-See https://github.com/ministryofjustice/money-to-prisoners-deploy
+See [money-to-prisoners-deploy](https://github.com/ministryofjustice/money-to-prisoners-deploy)

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/money-to-prisoners-test/05-service-account.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/money-to-prisoners-test/05-service-account.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-internal
+  namespace: money-to-prisoners-test
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: pod-internal
+  namespace: money-to-prisoners-test
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - deployment
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: pod-internal
+  namespace: money-to-prisoners-test
+subjects:
+- kind: ServiceAccount
+  name: pod-internal
+  namespace: money-to-prisoners-test
+roleRef:
+  kind: Role
+  name: pod-internal
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
the idea is to allow pods to use the k8s api to determine what other pods/replicas exists