### PR TITLE
CircleCi Permissions - config maps

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-production/serviceaccount-circleci.yaml
@@ -14,6 +14,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - "configmaps"
       - "pods/portforward"
       - "deployment"
       - "secrets"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/serviceaccount-circleci.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/offender-management-staging/serviceaccount-circleci.yaml
@@ -14,6 +14,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - "configmaps"
       - "pods/portforward"
       - "deployment"
       - "secrets"


### PR DESCRIPTION
Allow CircleCI to deploy config maps for Offender Manager Staging & Production