### PR TITLE
Add new postgresql role

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/c100-application-staging/resources/rds.tf
@@ -28,3 +28,45 @@ resource "kubernetes_secret" "rds-instance" {
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+
+########################################
+# postgres `analytics` unprivileged user
+########################################
+
+resource "random_string" "username" {
+  length  = 8
+  special = false
+}
+
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}
+
+provider "postgresql" {
+  alias    = "rds"
+  host     = "${module.rds-instance.rds_instance_address}"
+  port     = "${module.rds-instance.rds_instance_port}"
+  username = "${module.rds-instance.database_username}"
+  password = "${module.rds-instance.database_password}"
+  database = "${module.rds-instance.database_name}"
+}
+
+resource "postgresql_role" "analytics" {
+  provider = "postgresql.rds"
+  name     = "analytics${random_string.username.result}"
+  password = "${random_string.password.result}"
+  login    = true
+}
+
+resource "kubernetes_secret" "rds-instance-analytics" {
+  metadata {
+    name      = "rds-instance-analytics-c100-staging"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${postgresql_role.analytics.name}:${postgresql_role.analytics.password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
+  }
+}


### PR DESCRIPTION
The intended result of this, is to create a new role (postgres user, with ability to login to the DB) with separate credentials (but still randomly generated) to the main user.

This will expose a new secret with the connection string for this new user.