### PR TITLE
Add compiled postgres url to cccd-staging

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cccd-staging/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cccd-staging/resources/rds.tf
@@ -31,5 +31,7 @@ resource "kubernetes_secret" "cccd_staging_rds" {
     database_username     = "${module.cccd_staging_rds.database_username}"
     database_password     = "${module.cccd_staging_rds.database_password}"
     rds_instance_address  = "${module.cccd_staging_rds.rds_instance_address}"
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.cccd_staging_rds.database_username}:${module.cccd_staging_rds.database_password}@${module.cccd_staging_rds.rds_instance_endpoint}/${module.cccd_staging_rds.database_name}"
   }
 }

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cccd-staging/resources/rds.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/cccd-staging/resources/rds.tf
@@ -31,7 +31,6 @@ resource "kubernetes_secret" "cccd_staging_rds" {
     database_username     = "${module.cccd_staging_rds.database_username}"
     database_password     = "${module.cccd_staging_rds.database_password}"
     rds_instance_address  = "${module.cccd_staging_rds.rds_instance_address}"
-    # postgres://USER:PASSWORD@HOST:PORT/NAME
-    url = "postgres://${module.cccd_staging_rds.database_username}:${module.cccd_staging_rds.database_password}@${module.cccd_staging_rds.rds_instance_endpoint}/${module.cccd_staging_rds.database_name}"
+    url                   = "postgres://${module.cccd_staging_rds.database_username}:${module.cccd_staging_rds.database_password}@${module.cccd_staging_rds.rds_instance_endpoint}/${module.cccd_staging_rds.database_name}"
   }
 }


### PR DESCRIPTION
Using the cloud-platform-multi-container-demo-app configuration referenced  [here](https://github.com/ministryofjustice/cloud-platform-multi-container-demo-app/blob/5956b7588fba07bcbaabfeca12a453fe8198c056/kubernetes_deploy/rails-app-deployment.yaml#L22) and defined [here](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/davids-dummy-dev/resources/multicontainer-demo-app-rds.tf#L36)