### PR TITLE
Update resource definitions for authorized-keys-provider

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/authorized-keys-provider/provider.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/authorized-keys-provider/provider.yaml
@@ -47,7 +47,7 @@ kind: Deployment
 metadata:
   labels:
     app: authorized-keys-provider
-  name: authorized-keys-provier
+  name: authorized-keys-provider
   namespace: authorized-keys-provider
 spec:
   replicas: 1
@@ -100,11 +100,11 @@ spec:
           done;
         resources:
           requests:
-            cpu: 1m
-            memory: 64Mi
+            cpu: 25m
+            memory: 256Mi
           limits:
-            cpu: 1m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
         volumeMounts:
         - name: python-key-provider
           mountPath: /usr/local/bin

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/authorized-keys-provider/resources/s3.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/authorized-keys-provider/resources/s3.tf
@@ -19,7 +19,7 @@ module "authorized-keys" {
   infrastructure-support = "platforms@digital.justice.gov.uk"
 }
 
-resource "kubernetes_secret" "example_s3_bucket_credentials" {
+resource "kubernetes_secret" "s3_bucket_credentials" {
   metadata {
     name      = "s3-bucket-authorized-keys"
     namespace = "authorized-keys-provider"


### PR DESCRIPTION
Although the Pod generally does not use a lot of resources (see requests), it will need to spike when it starts up and
installs a number of dependencies (see limits).