### PR TITLE
Add concourse & concourse-main namespaces for live-1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: concourse
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
+    cloud-platform.justice.gov.uk/application: "Concourse CI"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-concourse"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: concourse
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: concourse
+spec:
+  hard:
+    requests.cpu: 6000m
+    requests.memory: 12Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/04-networkpolicy.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: concourse
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: concourse
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: concourse
+spec:
+  podSelector:
+    matchLabels:
+      app: concourse-web
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/monitoring.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/monitoring.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: concourse
+  namespace: concourse
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: concourse-web
+  namespaceSelector:
+    matchNames:
+      - concourse
+  endpoints:
+    - port: prometheus
+      interval: 30s


### PR DESCRIPTION
This allows us to start migrating pipelines onto the new concourse deployment on live-1