### PR TITLE
Add CAIT namespaces to live-1 cluster

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fj-cait-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/application: "Get help with child arrangements"
+    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pflr-cait"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fj-cait-production-admin
+  namespace: fj-cait-production
+subjects:
+  - kind: Group
+    name: "github:family-justice"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: fj-cait-production
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: fj-cait-production
+spec:
+  hard:
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: fj-cait-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: fj-cait-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: fj-cait-production
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: fj-cait-production
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: fj-cait-production
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: fj-cait-production
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fj-cait-staging
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/application: "Get help with child arrangements"
+    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pflr-cait"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fj-cait-staging-admin
+  namespace: fj-cait-staging
+subjects:
+  - kind: Group
+    name: "github:family-justice"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: fj-cait-staging
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: fj-cait-staging
+spec:
+  hard:
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: fj-cait-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: fj-cait-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ecr.tf
@@ -1,0 +1,23 @@
+####################################
+# Family Justice CAIT ECR repository
+####################################
+
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
+
+  team_name = "${var.team_name}"
+  repo_name = "${var.repo_name}"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-fj-cait"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo.repo_url}"
+    access_key_id     = "${module.ecr-repo.access_key_id}"
+    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "${var.aws_region}"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/variables.tf
@@ -1,0 +1,40 @@
+variable "team_name" {
+  default = "family-justice"
+}
+
+variable "db_backup_retention_period" {
+  default = "2"
+}
+
+variable "environment-name" {
+  default = "staging"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "infrastructure-support" {
+  default = "Family Justice: family-justice-team@digital.justice.gov.uk"
+}
+
+variable "application" {
+  default = "Get help with child arrangements"
+}
+
+variable "namespace" {
+  default = "fj-cait-staging"
+}
+
+variable "repo_name" {
+  default = "pflr-cait"
+}
+
+variable "aws_region" {
+  default = "eu-west-2"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: fj-cait-staging
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: fj-cait-staging
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: fj-cait-staging
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: fj-cait-staging
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Basically copy/paste from what we already had on `live-0`, but changing the `aws_region` to be `eu-west-2`.

This service doesn't have a database, so the only resource needed is the ECR repo (created once, on staging namespace).

If there is anything else required, please let us know.