### PR TITLE
Increase limits.memory quota for laa-apply-for-legalaid-uat

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -8,4 +8,4 @@ spec:
     requests.cpu: 20000m
     requests.memory: 20Gi
     limits.cpu: 20000m
-    limits.memory: 20Gi
+    limits.memory: 30Gi


### PR DESCRIPTION
Each PR our team create boots its own UAT env and so we are struggling to stay within the quota at the moment