### PR TITLE
Updated business-unit for vv-myapp-dev

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/vv-myapp-dev/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/vv-myapp-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
+    cloud-platform.justice.gov.uk/business-unit: "cloud-platform-test"
     cloud-platform.justice.gov.uk/application: "app-test"
     cloud-platform.justice.gov.uk/owner: "vijay.veeranki: cloud-platform"
     cloud-platform.justice.gov.uk/source-code: "test"


### PR DESCRIPTION
This PR is to correct annotations in environments repo, updated business-unit for vv-myapp-dev to cloud-platform-test as all application monitoring for CP team is based on using the cloud_platform_justice_gov_uk_business_unit="cloud-platform" annotation.