### PR TITLE
Add Family Mediators API namespaces to live-1 cluster

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: family-mediators-api-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/application: "Family Mediators API"
+    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/family-mediators-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: family-mediators-api-production-admin
+  namespace: family-mediators-api-production
+subjects:
+  - kind: Group
+    name: "github:family-justice"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: family-mediators-api-production
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: family-mediators-api-production
+spec:
+  hard:
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: family-mediators-api-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: family-mediators-api-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "${var.aws_region}"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
@@ -1,0 +1,28 @@
+############################################
+# Family Mediators API RDS (postgres engine)
+############################################
+
+module "rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "${var.application}"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "rds-instance" {
+  metadata {
+    name      = "rds-instance-family-mediators-api-production"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/variables.tf
@@ -1,0 +1,36 @@
+variable "team_name" {
+  default = "family-justice"
+}
+
+variable "environment-name" {
+  default = "production"
+}
+
+variable "is-production" {
+  default = "true"
+}
+
+variable "infrastructure-support" {
+  default = "Family Justice: family-justice-team@digital.justice.gov.uk"
+}
+
+variable "application" {
+  default = "Family Mediators API"
+}
+
+variable "namespace" {
+  default = "family-mediators-api-production"
+}
+
+variable "repo_name" {
+  default = "family-mediators-api"
+}
+
+variable "aws_region" {
+  default = "eu-west-2"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: family-mediators-api-production
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: family-mediators-api-production
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: family-mediators-api-production
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: family-mediators-api-production
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: family-mediators-api-staging
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/application: "Family Mediators API"
+    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/family-mediators-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: family-mediators-api-staging-admin
+  namespace: family-mediators-api-staging
+subjects:
+  - kind: Group
+    name: "github:family-justice"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: family-mediators-api-staging
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: family-mediators-api-staging
+spec:
+  hard:
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: family-mediators-api-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: family-mediators-api-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
@@ -1,0 +1,23 @@
+#####################################
+# Family Mediators API ECR repository
+#####################################
+
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
+
+  team_name = "${var.team_name}"
+  repo_name = "${var.repo_name}"
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-family-mediators-api"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo.repo_url}"
+    access_key_id     = "${module.ecr-repo.access_key_id}"
+    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "${var.aws_region}"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
@@ -1,0 +1,28 @@
+############################################
+# Family Mediators API RDS (postgres engine)
+############################################
+
+module "rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "${var.application}"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "rds-instance" {
+  metadata {
+    name      = "rds-instance-family-mediators-api-staging"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/variables.tf
@@ -1,0 +1,36 @@
+variable "team_name" {
+  default = "family-justice"
+}
+
+variable "environment-name" {
+  default = "staging"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "infrastructure-support" {
+  default = "Family Justice: family-justice-team@digital.justice.gov.uk"
+}
+
+variable "application" {
+  default = "Family Mediators API"
+}
+
+variable "namespace" {
+  default = "family-mediators-api-staging"
+}
+
+variable "repo_name" {
+  default = "family-mediators-api"
+}
+
+variable "aws_region" {
+  default = "eu-west-2"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: family-mediators-api-staging
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: family-mediators-api-staging
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: family-mediators-api-staging
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: family-mediators-api-staging
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Only AWS resources are ECR and RDS, both now on `eu-west-2` zone.

Using latest versions of the terraform modules.