### PR TITLE
Switched env creation dir to live-1 and removed cluster var

### DIFF
--- a/namespace-resources/main.tf
+++ b/namespace-resources/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cluster = "${var.cluster}.k8s.integration.dsd.io"
+  cluster = "live-1.cloud-platform.service.justice.gov.uk"
 }
 
 data "template_file" "namespace" {

--- a/namespace-resources/variables.tf
+++ b/namespace-resources/variables.tf
@@ -1,8 +1,3 @@
-variable "cluster" {
-  description = "What cluster are you deploying your namespace. I.E cloud-platform-test-1 "
-  default     = "cloud-platform-live-0"
-}
-
 variable "namespace" {
   description = "Namespace you would like to create on cluster <application>-<environment>. I.E myapp-dev"
 }


### PR DESCRIPTION
This PR when merged will make changes to the `namespace-resources` Terraform so that the environment generation files are now inserted into the `live-1.cloud-platform.service.justice.gov.uk` dir.  