### PR TITLE
shorter kibana ingress

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/kibana-oauth2-proxy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/kibana-oauth2-proxy.yaml
@@ -100,9 +100,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - kibana.apps.live-1.cloud-platform.service.justice.gov.uk
+    - kibana.cloud-platform.service.justice.gov.uk
   rules:
-    - host: kibana.apps.live-1.cloud-platform.service.justice.gov.uk
+    - host: kibana.cloud-platform.service.justice.gov.uk
       http:
         paths:
           - path: /


### PR DESCRIPTION
**Why**
We don't want the main monitoring/login page address to change when we switch clusters

