### PR TITLE
Update the ecr credentials for cccd-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
@@ -6,22 +6,22 @@ provider "aws" {
   region = "eu-west-2"
 }
 
-module "cbo_ecr_credentials" {
+module "cccd_ecr_credentials" {
   source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
-  repo_name = "claim-for-crown-court-defence"
-  team_name = "crime-billing-online"
+  repo_name = "cccd"
+  team_name = "laa-get-paid"
 }
 
-resource "kubernetes_secret" "cbo_ecr_credentials" {
+resource "kubernetes_secret" "cccd_ecr_credentials" {
   metadata {
-    name      = "cbo-credentials-output"
+    name      = "cccd-ecr-credentials-output"
     namespace = "cccd-dev"
   }
 
   data {
-    access_key_id     = "${module.cbo_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.cbo_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.cbo_ecr_credentials.repo_arn}"
-    repo_url          = "${module.cbo_ecr_credentials.repo_url}"
+    access_key_id     = "${module.cccd_ecr_credentials.access_key_id}"
+    secret_access_key = "${module.cccd_ecr_credentials.secret_access_key}"
+    repo_arn          = "${module.cccd_ecr_credentials.repo_arn}"
+    repo_url          = "${module.cccd_ecr_credentials.repo_url}"
   }
 }


### PR DESCRIPTION
We are trying to standardise tour internal naming convention and these had diverged