### PR TITLE
Add an RDS instance for multi-container-demo app.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/david-helloworld-demo-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/david-helloworld-demo-dev/resources/rds.tf
@@ -15,7 +15,7 @@ variable "cluster_state_bucket" {}
  *
  */
 module "multi_container_demo_app_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "cloud-platform"
@@ -34,10 +34,10 @@ resource "kubernetes_secret" "multi_container_demo_rds" {
   }
 
   data {
-    rds_instance_endpoint = "${module.multi_container_demo_rds.rds_instance_endpoint}"
-    database_name         = "${module.multi_container_demo_rds.database_name}"
-    database_username     = "${module.multi_container_demo_rds.database_username}"
-    database_password     = "${module.multi_container_demo_rds.database_password}"
-    rds_instance_address  = "${module.multi_container_demo_rds.rds_instance_address}"
+    rds_instance_endpoint = "${module.multi_container_demo_app_rds.rds_instance_endpoint}"
+    database_name         = "${module.multi_container_demo_app_rds.database_name}"
+    database_username     = "${module.multi_container_demo_app_rds.database_username}"
+    database_password     = "${module.multi_container_demo_app_rds.database_password}"
+    rds_instance_address  = "${module.multi_container_demo_app_rds.rds_instance_address}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/david-helloworld-demo-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/david-helloworld-demo-dev/resources/rds.tf
@@ -29,7 +29,7 @@ module "multi_container_demo_app_rds" {
 
 resource "kubernetes_secret" "multi_container_demo_rds" {
   metadata {
-    name      = "multi_container_demo_rds"
+    name      = "multi-container-demo-rds"
     namespace = "david-helloworld-demo-dev"
   }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/david-helloworld-demo-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/david-helloworld-demo-dev/resources/rds.tf
@@ -1,0 +1,43 @@
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}
+
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "multi_container_demo_app_rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "cloud-platform"
+  business-unit          = "cloud-platform"
+  application            = "multi-container-demo-app"
+  is-production          = "false"
+  environment-name       = "development"
+  infrastructure-support = "david.salgado@digtal.justice.gov.uk"
+  aws_region             = "eu-west-2"
+}
+
+resource "kubernetes_secret" "multi_container_demo_rds" {
+  metadata {
+    name      = "multi_container_demo_rds"
+    namespace = "david-helloworld-demo-dev"
+  }
+
+  data {
+    rds_instance_endpoint = "${module.multi_container_demo_rds.rds_instance_endpoint}"
+    database_name         = "${module.multi_container_demo_rds.database_name}"
+    database_username     = "${module.multi_container_demo_rds.database_username}"
+    database_password     = "${module.multi_container_demo_rds.database_password}"
+    rds_instance_address  = "${module.multi_container_demo_rds.rds_instance_address}"
+  }
+}


### PR DESCRIPTION
This will be the datastore for a demo deployment of the multi-
container demo application, as per the walkthrough in the user
guide.