### PR TITLE
formbuilder. add service account to role

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-dev/01-rbac.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/formbuilder-platform-test-dev/01-rbac.yaml
@@ -12,6 +12,9 @@ subjects:
   - kind: Group
     name: "github:form-builder"
     apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-test-dev
+    namespace: formbuilder-platform-test-dev
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
- the service account already has access to out service namespace which we use to fetch info.
- we want to do the same but for platform namespace too