### PR TITLE
Pingdom Terraform state backend

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources/main.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "pingdom" {}

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources/pingdom.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/resources/pingdom.tf
@@ -1,5 +1,3 @@
-provider "pingdom" {}
-
 resource "pingdom_check" "cloud-platform-prometheus-live-0-healthcheck" {
   type                     = "http"
   name                     = "Prometheus - live-0 - cloud-platform - Healthcheck"


### PR DESCRIPTION
**Overview**
At the moment the `monitoring` namespace doesn't have a Terraform backend. This means the state is stored locally, causing duplicate results of newly created resources. 

This PR adds a `main.tf` to the `monitoring` namespace and moves the pingdom provider from `pingdom.tf` to `main.tf`