### PR TITLE
Add ecr to new laa-legal-adviser-api namespace

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-legal-adviser-api-staging/resources/ecr.tf
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-legal-adviser-api-staging/resources/ecr.tf
@@ -7,7 +7,7 @@ provider "aws" {
 }
 
 module "ecr-repo-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
 
   team_name = "laa-get-access"
   repo_name = "laa-legal-adviser-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
@@ -1,0 +1,27 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "ecr-repo-api" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=2.1"
+
+  team_name = "laa-get-access"
+  repo_name = "laa-legal-adviser-api"
+}
+
+resource "kubernetes_secret" "ecr-repo-api" {
+  metadata {
+    name      = "ecr-repo-laa-legal-adviser-api"
+    namespace = "laa-legal-adviser-api-staging"
+  }
+
+  data {
+    repo_url          = "${module.ecr-repo-api.repo_url}"
+    access_key_id     = "${module.ecr-repo-api.access_key_id}"
+    secret_access_key = "${module.ecr-repo-api.secret_access_key}"
+  }
+}


### PR DESCRIPTION
This ecr.tf is just a copy of the one that's in the staging namespace on live-0

I know it won't need to go in more than one namespace dir in the end, but I thought it best to add it to this dir as we're going to be cleaning the live-0 one up soon, but apologies if I've misunderstood.