### PR TITLE
increase rds storage size

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/rds-test/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/rds-test/resources/main.tf
@@ -33,7 +33,7 @@ module "example_team_rds" {
   environment-name       = "rds-test"
   infrastructure-support = "oliver.anwyll@digtal.justice.gov.uk"
   aws_region             = "eu-west-2"
-  db_allocated_storage   = "50"
+  db_allocated_storage   = "90"
 }
 
 resource "kubernetes_secret" "example_team_rds" {


### PR DESCRIPTION
**WHY**
To increase the RDS storage size after the 6-hour wait limitation. 