### PR TITLE
Migration of namespace: live0_to_live1 in to live1 cluster

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: live0-to-live1
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "live1-dev"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "cp-live1"
+    cloud-platform.justice.gov.uk/application: "app-live0"
+    cloud-platform.justice.gov.uk/owner: "vijay.veeranki: cloud-platform"
+    cloud-platform.justice.gov.uk/source-code: "test-live1"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/01-rbac.yaml
@@ -1,0 +1,34 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: live0-to-live1-admin
+  namespace: live0-to-live1
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: live0-to-live1
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: tiller
+  namespace: live0-to-live1
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: live0-to-live1
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: live0-to-live1
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: live0-to-live1
+spec:
+  hard:
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: live0-to-live1
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: live0-to-live1
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/05-serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: live0-to-live1
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: live0-to-live1
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: live0-to-live1
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: live0-to-live1
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/ecr.tf
@@ -1,0 +1,24 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr_live0_to_live1" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
+  repo_name = "ecr-live0-to-live1"
+  team_name = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "sec-ecr_live0_to_live1" {
+  metadata {
+    name      = "ecr-live0-to-live1-migration"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    repo_url          = "${module.ecr_live0_to_live1.repo_url}"
+    access_key_id     = "${module.ecr_live0_to_live1.access_key_id}"
+    secret_access_key = "${module.ecr_live0_to_live1.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/elasticache.tf
@@ -1,0 +1,22 @@
+module "ec_live0_to_live1_migration" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "${var.team_name}"
+  application            = "${var.application}"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+}
+
+resource "kubernetes_secret" "ec_sec_live0_to_live1_migration" {
+  metadata {
+    name      = "ec-live0-to-live1-migration-${var.environment-name}"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.ec_live0_to_live1_migration.primary_endpoint_address}"
+    auth_token               = "${module.ec_live0_to_live1_migration.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "${var.aws_region}"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/rds-live0.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/rds-live0.tf
@@ -1,0 +1,33 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "live0_migration_rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "${var.team_name}"
+  business-unit          = "${var.business_unit}"
+  application            = "${var.application}"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+}
+
+resource "kubernetes_secret" "live0_migration_rds" {
+  metadata {
+    name      = "live0-migration-rds-instance-output"
+    namespace = "live0-to-live1"
+  }
+
+  data {
+    rds_instance_endpoint = "${module.live0_migration_rds.rds_instance_endpoint}"
+    rds_instance_address  = "${module.live0_migration_rds.rds_instance_address}"
+    database_name         = "${module.live0_migration_rds.database_name}"
+    database_username     = "${module.live0_migration_rds.database_username}"
+    database_password     = "${module.live0_migration_rds.database_password}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/s3.tf
@@ -1,0 +1,26 @@
+module "live0_to_live1_migration_s3_bucket" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.1"
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "${var.business_unit}"
+  application            = "${var.application}"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+  aws-s3-region          = "${var.aws_region}"
+}
+
+resource "kubernetes_secret" "live0_to_live1_migration_s3_bucket" {
+  metadata {
+    name      = "sec-live0-to-live1-migration-s3-bucket"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    access_key_id     = "${module.live0_to_live1_migration_s3_bucket.access_key_id}"
+    secret_access_key = "${module.live0_to_live1_migration_s3_bucket.secret_access_key}"
+    bucket_arn        = "${module.live0_to_live1_migration_s3_bucket.bucket_arn}"
+    bucket_name       = "${module.live0_to_live1_migration_s3_bucket.bucket_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/live0-to-live1/resources/variables.tf
@@ -1,0 +1,36 @@
+variable "environment-name" {
+  default = "live1-dev"
+}
+
+variable "team_name" {
+  default = "team-webops"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "namespace" {
+  default = "live0-to-live1"
+}
+
+variable "infrastructure-support" {
+  default = "webops@digtal.justice.gov.uk"
+}
+
+variable "aws_region" {
+  default = "eu-west-2"
+}
+
+variable "business_unit" {
+  default = "cp-live1"
+}
+
+variable "application" {
+  default = "app-live1"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}


### PR DESCRIPTION
This is to test migration from live0 to live1 #779
Updated modules to use the latest version.