### PR TITLE
formbuilder: add wildcard certs, one for each env

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-dev/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-dev/certificate.yaml
@@ -5,17 +5,17 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: tls-wildcard
-  namespace: formbuilder-services-live-production
+  namespace: formbuilder-services-integration-dev
 spec:
   secretName: tls-certificate
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: '*.form.service.justice.gov.uk'
+  commonName: '*.dev.integration.form.service.justice.gov.uk'
   acme:
     config:
     - domains:
-      - '*.form.service.justice.gov.uk'
+      - '*.dev.integration.form.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-staging/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-staging/certificate.yaml
@@ -5,17 +5,17 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: tls-wildcard
-  namespace: formbuilder-services-live-production
+  namespace: formbuilder-services-integration-staging
 spec:
   secretName: tls-certificate
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: '*.form.service.justice.gov.uk'
+  commonName: '*.staging.integration.form.service.justice.gov.uk'
   acme:
     config:
     - domains:
-      - '*.form.service.justice.gov.uk'
+      - '*.staging.integration.form.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/certificate.yaml
@@ -5,17 +5,17 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: tls-wildcard
-  namespace: formbuilder-services-live-production
+  namespace: formbuilder-services-live-dev
 spec:
   secretName: tls-certificate
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: '*.form.service.justice.gov.uk'
+  commonName: '*.dev.form.service.justice.gov.uk'
   acme:
     config:
     - domains:
-      - '*.form.service.justice.gov.uk'
+      - '*.dev.form.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-staging/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-staging/certificate.yaml
@@ -5,17 +5,17 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: tls-wildcard
-  namespace: formbuilder-services-live-production
+  namespace: formbuilder-services-live-staging
 spec:
   secretName: tls-certificate
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: '*.form.service.justice.gov.uk'
+  commonName: '*.staging.form.service.justice.gov.uk'
   acme:
     config:
     - domains:
-      - '*.form.service.justice.gov.uk'
+      - '*.staging.form.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/certificate.yaml
@@ -5,17 +5,17 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: tls-wildcard
-  namespace: formbuilder-services-live-production
+  namespace: formbuilder-services-test-dev
 spec:
   secretName: tls-certificate
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: '*.form.service.justice.gov.uk'
+  commonName: '*.dev.test.form.service.justice.gov.uk'
   acme:
     config:
     - domains:
-      - '*.form.service.justice.gov.uk'
+      - '*.dev.test.form.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-staging/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-staging/certificate.yaml
@@ -5,17 +5,17 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: tls-wildcard
-  namespace: formbuilder-services-live-production
+  namespace: formbuilder-services-test-staging
 spec:
   secretName: tls-certificate
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: '*.form.service.justice.gov.uk'
+  commonName: '*.staging.test.form.service.justice.gov.uk'
   acme:
     config:
     - domains:
-      - '*.form.service.justice.gov.uk'
+      - '*.staging.test.form.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform
 


### PR DESCRIPTION
we were planning on having one wildcard certificate for multiple (three) namespaces. however ingresses in different namespaces could not access the shared certificate. instead we have decided to give each of the 9 environments there own wildcard certificate.