### PR TITLE
Enable GH action on PRs

### DIFF
--- a/.github/slack.workflow
+++ b/.github/slack.workflow
@@ -1,0 +1,10 @@
+workflow "New workflow" {
+  on = "pull_request"
+  resolves = ["Notify #ask-cloud-platforms"]
+}
+
+action "Notify #ask-cloud-platforms" {
+  uses = "Ilshidur/action-slack@2a8ddb6db23f71a413f9958ae75bbc32bbaa6385"
+  secrets = ["SLACK_WEBHOOK"]
+  args = "New PR opened: <{{ EVENT_PAYLOAD.pull_request.url }}|\\#{{ EVENT_PAYLOAD.pull_request.number }}>"
+}


### PR DESCRIPTION
This change will enable us to remove standard and noisy github integration with slack, and replace it with targeted information about the actions.