### PR TITLE
Add LAA Service Improvement team namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-get-access-service-improvement
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "team"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/application: "laa-get-access-service-improvement"
+    cloud-platform.justice.gov.uk/owner: "LAA Get Access Service Improvement: get-access-service-improvement@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "none"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-get-access-service-improvement-admin
+  namespace: laa-get-access-service-improvement
+subjects:
+  - kind: Group
+    name: "github:laa-get-access-service-improvement"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-get-access-service-improvement
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-get-access-service-improvement
+spec:
+  hard:
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-get-access-service-improvement
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-get-access-service-improvement
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers


### PR DESCRIPTION
We plan to use this namespace to store team-related artefacts (mainly secrets) and helper applications used for day-to-day development and support.

cc @ministryofjustice/laa-get-access-service-improvement 