### PR TITLE
Create `resources/main.tf` for every new namespace

### DIFF
--- a/namespace-resources/main-tf.template
+++ b/namespace-resources/main-tf.template
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}

--- a/namespace-resources/main.tf
+++ b/namespace-resources/main.tf
@@ -74,3 +74,12 @@ resource "local_file" "04-networkpolicy" {
   content  = "${data.template_file.networkpolicy.rendered}"
   filename = "../namespaces/${local.cluster}/${var.namespace}/04-networkpolicy.yaml"
 }
+
+data "template_file" "resources-main-tf" {
+  template = "${file("${path.module}/main-tf.template")}"
+}
+
+resource "local_file" "resources-main-tf" {
+  content  = "${data.template_file.resources-main-tf.rendered}"
+  filename = "../namespaces/${local.cluster}/${var.namespace}/resources/main.tf"
+}


### PR DESCRIPTION
This will ensure users start with a viable
`main.tf` file, which defines all the required
terraform providers, before they try to create any
AWS resources (via terraform).

This may have the unwanted side-effect of slowing
down the Concourse pipeline, if there are a lot of
namespaces which do not have any AWS resources.
The vast majority of namespaces which are actually
being used *will* have some AWS resources, so if
this slowdown is a problem, efforts should focus
on identifying and removing unused test/dev
namespaces.

fixes https://github.com/ministryofjustice/cloud-platform/issues/868