### PR TITLE
Update money-to-prisoners namespaces with latest terraform resource versions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/02-limitrange.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: money-to-prisoners-prod
 spec:
   limits:
-  - default:
-      cpu: 250m
-      memory: 500Mi
-    defaultRequest:
-      cpu: 125m
-      memory: 250Mi
-    type: Container
+    - default:
+        cpu: 250m
+        memory: 500Mi
+      defaultRequest:
+        cpu: 125m
+        memory: 250Mi
+      type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/04-networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - podSelector: {}
+    - from:
+        - podSelector: {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -19,9 +19,9 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          component: ingress-controllers
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/05-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/05-service-account.yaml
@@ -32,9 +32,9 @@ metadata:
   name: pod-internal
   namespace: money-to-prisoners-prod
 subjects:
-- kind: ServiceAccount
-  name: pod-internal
-  namespace: money-to-prisoners-prod
+  - kind: ServiceAccount
+    name: pod-internal
+    namespace: money-to-prisoners-prod
 roleRef:
   kind: Role
   name: pod-internal

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/ecr.tf
@@ -1,10 +1,15 @@
 # https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials
 
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.3"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.application}"
+  providers = {
+    aws = "aws.london"
+  }
+
+  team_name     = "${var.team_name}"
+  repo_name     = "${var.application}"
+  enable_policy = false
 }
 
 resource "kubernetes_secret" "ecr" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/main.tf
@@ -3,6 +3,7 @@ terraform {
 }
 
 provider "aws" {
+  alias  = "london"
   region = "eu-west-2"
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/02-limitrange.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: money-to-prisoners-test
 spec:
   limits:
-  - default:
-      cpu: 250m
-      memory: 500Mi
-    defaultRequest:
-      cpu: 125m
-      memory: 250Mi
-    type: Container
+    - default:
+        cpu: 250m
+        memory: 500Mi
+      defaultRequest:
+        cpu: 125m
+        memory: 250Mi
+      type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/04-networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - podSelector: {}
+    - from:
+        - podSelector: {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -19,9 +19,9 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          component: ingress-controllers
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/05-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/05-service-account.yaml
@@ -32,9 +32,9 @@ metadata:
   name: pod-internal
   namespace: money-to-prisoners-test
 subjects:
-- kind: ServiceAccount
-  name: pod-internal
-  namespace: money-to-prisoners-test
+  - kind: ServiceAccount
+    name: pod-internal
+    namespace: money-to-prisoners-test
 roleRef:
   kind: Role
   name: pod-internal

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/main.tf
@@ -3,6 +3,7 @@ terraform {
 }
 
 provider "aws" {
+  alias  = "london"
   region = "eu-west-2"
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -4,7 +4,11 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
+
+  providers = {
+    aws = "aws.london"
+  }
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"


### PR DESCRIPTION
and disable ECR lifecycle policy
c.f. [Issue 839](https://github.com/ministryofjustice/cloud-platform/issues/839)