### PR TITLE
Remove rds-test resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/rds-test/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/rds-test/resources/main.tf
@@ -1,8 +1,0 @@
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  alias  = "london"
-  region = "eu-west-2"
-}


### PR DESCRIPTION
The current pipeline breaks if no manifest files are left in the directory.

Related to #734 

See https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/build-environments/jobs/apply-live-1/builds/2180