### PR TITLE
Install Kube-Ops on live1 Cluster

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-ops
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "live"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
+    cloud-platform.justice.gov.uk/application: "kube-ops"
+    cloud-platform.justice.gov.uk/owner: "cloud-platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/01-rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ops
+  namespace: kube-ops
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-ops
+  namespace: kube-ops
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods"]
+  verbs:
+    - list
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["nodes", "pods"]
+  verbs:
+    - get
+    - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-ops
+  namespace: kube-ops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-ops
+subjects:
+- kind: ServiceAccount
+  name: kube-ops
+  namespace: kube-ops

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: kube-ops
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: kube-ops
+spec:
+  hard:
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/04-networkpolicy.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: kube-ops
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: kube-ops
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: kube-ops
+spec:
+  podSelector:
+    matchLabels:
+      application: kube-ops
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-ops
+  namespace: kube-ops
+  labels:
+    application: kube-ops
+    version: v0.10
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-ops
+  template:
+    metadata:
+      labels:
+        application: kube-ops
+        version: v0.10
+    spec:
+      serviceAccount: kube-ops
+      containers:
+      - name: service
+        # see https://github.com/hjacobs/kube-ops-view/releases
+        image: hjacobs/kube-ops-view:0.10
+        env:
+          - name: APP_URL
+            value: "https://kube-ops.cloud-platform.service.justice.gov.uk/redirect_uri"
+          - name: AUTHORIZE_URL
+            value: "https://justice-cloud-platform.eu.auth0.com/authorize"
+          - name: ACCESS_TOKEN_URL
+            value: "https://justice-cloud-platform.eu.auth0.com/oauth/token"
+          - name: CREDENTIALS_DIR
+            value: "/etc/secrets"
+        args:
+        # remove this option to use built-in memory store
+        - --redis-url=redis://kube-ops-redis:6379
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+        volumeMounts:
+        - name: auth-secrets
+          mountPath: "/etc/secrets"
+          readOnly: true
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+      volumes:
+      - name: auth-secrets
+        secret:
+          secretName: kube-ops-oidc
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: kube-ops
+  namespace: kube-ops
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - hosts:
+    - kube-ops.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: kube-ops.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: kube-ops
+          servicePort: 8080

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/oidc-secret.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/oidc-secret.yaml
@@ -6,4 +6,4 @@ metadata:
 type: Opaque
 stringData:
   authcode-client-id: NEZpUULXq6rfGDBEixIzprF60RJlhnqj
-  authcode-client-secret: 39lINM-8WvI9ygBInnOcH20pn7eBdcMMR8PyPtdJSh10I-hlN0ckji91XjeEgJtI
+  authcode-client-secret:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/oidc-secret.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/oidc-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-ops-oidc
+  namespace: kube-ops
+type: Opaque
+stringData:
+  authcode-client-id: NEZpUULXq6rfGDBEixIzprF60RJlhnqj
+  authcode-client-secret: 39lINM-8WvI9ygBInnOcH20pn7eBdcMMR8PyPtdJSh10I-hlN0ckji91XjeEgJtI

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/redis-deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/redis-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: kube-ops-redis
+    version: v0.0.1
+  name: kube-ops-redis
+  namespace: kube-ops
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-ops-redis
+  template:
+    metadata:
+      labels:
+        application: kube-ops-redis
+        version: v0.0.1
+    spec:
+      containers:
+      - name: redis
+        image: redis:5-alpine
+        ports:
+        - containerPort: 6379
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 6379
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          # we need to use the "redis" uid
+          runAsUser: 100

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/redis-service.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/redis-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: kube-ops-redis
+  name: kube-ops-redis
+  namespace: kube-ops
+spec:
+  selector:
+    application: kube-ops-redis
+  type: ClusterIP
+  ports:
+  - port: 6379
+    protocol: TCP
+    targetPort: 6379

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/service.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-ops/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: kube-ops
+  name: kube-ops
+  namespace: kube-ops
+spec:
+  selector:
+    application: kube-ops
+  type: ClusterIP
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080


### PR DESCRIPTION
WHAT
Install kube-ops on live 1 cluster

WHY
kube-ops will be shown on tv screen in CP area for overall view of cluster 