### PR TITLE
Upgrade PVB RDS Postgres to 9.6

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/rds-prison-visits.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/rds-prison-visits.tf
@@ -26,7 +26,7 @@ module "prison-visits-rds" {
   environment-name       = "staging"
   infrastructure-support = "pvb-technical-support@digtal.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "9.4"
+  db_engine_version      = "9.6"
   db_name                = "visits"
   aws_region             = "eu-west-2"
 }


### PR DESCRIPTION
Following a discussion with CP we are going to upgrade Postgres 9.6 on
staging and experiment/test both migrating the data from the current db
& upgrading the version as Postgres 9.4 stops being supported early next
year.