### PR TITLE
Rename keys in laalaa rds secret data

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
@@ -26,11 +26,11 @@ resource "kubernetes_secret" "rds" {
   }
 
   data {
-    rds_instance_endpoint = "${module.rds.rds_instance_endpoint}"
-    database_name         = "${module.rds.database_name}"
-    database_username     = "${module.rds.database_username}"
-    database_password     = "${module.rds.database_password}"
-    rds_instance_address  = "${module.rds.rds_instance_address}"
-    rds_instance_port     = "${module.rds.rds_instance_port}"
+    endpoint = "${module.rds.rds_instance_endpoint}"
+    name     = "${module.rds.database_name}"
+    user     = "${module.rds.database_username}"
+    password = "${module.rds.database_password}"
+    host     = "${module.rds.rds_instance_address}"
+    port     = "${module.rds.rds_instance_port}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
@@ -19,9 +19,9 @@ module "rds" {
   db_name                = "laalaa"
 }
 
-resource "kubernetes_secret" "rds" {
+resource "kubernetes_secret" "db" {
   metadata {
-    name      = "rds"
+    name      = "db"
     namespace = "${var.namespace}"
   }
 


### PR DESCRIPTION
Given that they're within an `rds` secret, these data keys make more sense to us when consuming them during our deployment