### PR TITLE
Add elasticsearch-curator cronjob to live-1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/elasticsearch-curator.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/elasticsearch-curator.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: elasticsearch-curator-cronjob
+  namespace: logging
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: curator
+            image: python:alpine
+            command:
+            - /bin/sh
+            - -c
+            - |
+              pip3 install elasticsearch-curator &&
+              curator_cli \
+                --host search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com \
+                --use_ssl \
+                --port 443 \
+                delete_indices \
+                --filter_list '[
+                  {
+                    "filtertype":"age",
+                    "source":"name",
+                    "direction":"older",
+                    "timestring": "%Y.%m.%d",
+                    "unit":"days",
+                    "unit_count":30
+                  },
+                  {
+                    "filtertype":"pattern",
+                    "kind":"prefix",
+                    "value":"logstash"
+                  }
+                ]'


### PR DESCRIPTION
**Overview**
This PR will (when merged) create a cronjob on live-1 that will cleanup elasticsearch indices in live-1 older than 30 days. 