### PR TITLE
Change laalaa database url to use postgis://

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
@@ -32,6 +32,6 @@ resource "kubernetes_secret" "db" {
     password = "${module.rds.database_password}"
     host     = "${module.rds.rds_instance_address}"
     port     = "${module.rds.rds_instance_port}"
-    url      = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+    url      = "postgis://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
   }
 }


### PR DESCRIPTION
Apologies. Think I need the postgis protocol, so that `dj-database-url` correctly sets the database engine type when we configure the app