### PR TITLE
Remove tiller from cccd-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/01-rbac.yaml
@@ -11,23 +11,3 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tiller
-  namespace: cccd-dev
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: tiller
-  namespace: cccd-dev
-subjects:
-- kind: ServiceAccount
-  name: tiller
-  namespace: cccd-dev
-roleRef:
-  kind: ClusterRole
-  name: cluster-admin
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This is not used yet, we still use basic k8s
When we need Helm/Tiller this can be re-added