### PR TITLE
Update cccd-staging rds name

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
@@ -25,7 +25,7 @@ module "cccd_rds" {
 
 resource "kubernetes_secret" "cccd_rds" {
   metadata {
-    name      = "cccd-staging-rds"
+    name      = "cccd-rds"
     namespace = "cccd-staging"
   }
 


### PR DESCRIPTION
The environment name was left in the metadata name by mistake