### PR TITLE
Migrate court probation to live1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: court-probation-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "dev"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/application: "court-probation"
+    cloud-platform.justice.gov.uk/owner: "andy.marke@digital.justice.gov.uk: andy.marke@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/court-probation-service"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/01-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: court-probation-dev
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: court-probation-dev-admin
+  namespace: court-probation-dev
+subjects:
+  - kind: Group
+    name: "github:ndelius"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: circleci
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: court-probation-dev
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: court-probation-dev
+spec:
+  hard:
+    requests.cpu: 6000m
+    requests.memory: 12Gi
+    limits.cpu: 12000m
+    limits.memory: 24Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: court-probation-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: court-probation-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
@@ -39,7 +39,6 @@ module "ps_cps_pack_parser_ecr_credentials" {
   providers = {
     aws = "aws.london"
   }
-
 }
 
 resource "kubernetes_secret" "ps_cps_pack_parser_ecr_credentials" {
@@ -64,7 +63,6 @@ module "mock_cp_court_service_ecr_credentials" {
   providers = {
     aws = "aws.london"
   }
-
 }
 
 resource "kubernetes_secret" "mock_cp_court_service_ecr_credentials" {
@@ -89,7 +87,6 @@ module "court_list_service_ecr_credentials" {
   providers = {
     aws = "aws.london"
   }
-
 }
 
 resource "kubernetes_secret" "court_list_service_ecr_credentials" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
@@ -1,0 +1,107 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+module "court_probation_service_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.3"
+  repo_name = "court-probation-service"
+  team_name = "probation-services"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "court_probation_service_ecr_credentials" {
+  metadata {
+    name      = "court-probation-service-ecr-credentials"
+    namespace = "court-probation-dev"
+  }
+
+  data {
+    access_key_id     = "${module.court_probation_service_ecr_credentials.access_key_id}"
+    secret_access_key = "${module.court_probation_service_ecr_credentials.secret_access_key}"
+    repo_arn          = "${module.court_probation_service_ecr_credentials.repo_arn}"
+    repo_url          = "${module.court_probation_service_ecr_credentials.repo_url}"
+  }
+}
+
+module "ps_cps_pack_parser_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.3"
+  repo_name = "cps-pack-parser"
+  team_name = "probation-services"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+}
+
+resource "kubernetes_secret" "ps_cps_pack_parser_ecr_credentials" {
+  metadata {
+    name      = "ps-cps-pack-parser-ecr-credentials"
+    namespace = "court-probation-dev"
+  }
+
+  data {
+    access_key_id     = "${module.ps_cps_pack_parser_ecr_credentials.access_key_id}"
+    secret_access_key = "${module.ps_cps_pack_parser_ecr_credentials.secret_access_key}"
+    repo_arn          = "${module.ps_cps_pack_parser_ecr_credentials.repo_arn}"
+    repo_url          = "${module.ps_cps_pack_parser_ecr_credentials.repo_url}"
+  }
+}
+
+module "mock_cp_court_service_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.3"
+  repo_name = "mock-cp-court-service"
+  team_name = "probation-services"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+}
+
+resource "kubernetes_secret" "mock_cp_court_service_ecr_credentials" {
+  metadata {
+    name      = "mock-cp-court-service-ecr-credentials"
+    namespace = "court-probation-dev"
+  }
+
+  data {
+    access_key_id     = "${module.mock_cp_court_service_ecr_credentials.access_key_id}"
+    secret_access_key = "${module.mock_cp_court_service_ecr_credentials.secret_access_key}"
+    repo_arn          = "${module.mock_cp_court_service_ecr_credentials.repo_arn}"
+    repo_url          = "${module.mock_cp_court_service_ecr_credentials.repo_url}"
+  }
+}
+
+module "court_list_service_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.3"
+  repo_name = "court-list-service"
+  team_name = "probation-services"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+}
+
+resource "kubernetes_secret" "court_list_service_ecr_credentials" {
+  metadata {
+    name      = "court-list-service-ecr-credentials"
+    namespace = "court-probation-dev"
+  }
+
+  data {
+    access_key_id     = "${module.court_list_service_ecr_credentials.access_key_id}"
+    secret_access_key = "${module.court_list_service_ecr_credentials.secret_access_key}"
+    repo_arn          = "${module.court_list_service_ecr_credentials.repo_arn}"
+    repo_url          = "${module.court_list_service_ecr_credentials.repo_url}"
+  }
+}


### PR DESCRIPTION
copy from live0 with a couple of minor changes
- improve ecr repo names and use 3.3 of module
- Increase resources limit due to our image processing service require a lot of memory/cpu