### PR TITLE
Expand namespace to another Get Access team

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:laa-get-access-service-improvement"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:laa-get-access-data-and-reporting"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
The @ministryofjustice/laa-get-access-data-and-reporting team has been created recently and the resources in this namespace will be shared between these two teams.

The intention of this pull request is to assign the admin role to both of these GitHub teams.