### PR TITLE
Namespaces for formbuilder platform pentest environment

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-platform/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-platform-pentest-dev
+  labels:
+    # for fb's own purposes
+    name: formbuilder-platform-pentest-dev
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest-dev"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-platform"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/01-rbac.yaml
@@ -1,0 +1,27 @@
+---
+# Source: formbuilder-platform/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-pentest-dev-admins
+  namespace: formbuilder-platform-pentest-dev
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-pentest-dev
+    namespace: formbuilder-platform-pentest-dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+# Further roles defined in:
+# - service-token-cache-service-account.yaml
+# - submitter-workers-service-account.yaml
+# - user-datastore-service-account.yaml
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-platform/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-platform-pentest-dev
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/03-resourcequota.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-platform/templates/03-resourcequota.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-platform-pentest-dev
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-platform/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-platform-pentest-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-platform-pentest-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/av-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/av-service-account.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-platform/templates/av-service-account.yaml
+---
+# Source: formbuilder-platform/templates/user-filestore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user filestore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-test-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-av-pentest-dev
+  namespace: formbuilder-platform-pentest-dev
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/main.tf
@@ -1,0 +1,8 @@
+# auto-generated from fb-cloud-platforms-environments
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/service_token_cache.tf
@@ -1,0 +1,27 @@
+# auto-generated from fb-cloud-platforms-environments
+########################################################
+# Service Token Cache Elasticache Redis (for resque + job logging)
+module "service-token-cache-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuilderservice-token-cache"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "service-token-cache-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-service-token-cache-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.service-token-cache-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.service-token-cache-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/submitter.tf
@@ -1,0 +1,57 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# Submitter RDS
+
+module "submitter-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "${var.db_backup_retention_period_submitter}"
+  application                = "formbuildersubmitter"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-submitter-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
+  }
+}
+
+##################################################
+
+########################################################
+# Submitter Elasticache Redis (for resque + job logging)
+module "submitter-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuildersubmitter"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-submitter-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.submitter-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.submitter-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-datastore.tf
@@ -1,0 +1,27 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# User Datastore RDS
+module "user-datastore-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "${var.db_backup_retention_period_user_datastore}"
+  application                = "formbuilderuserdatastore"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "user-datastore-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-user-datastore-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-filestore.tf
@@ -1,0 +1,29 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# User Filestore S3
+module "user-filestore-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.0"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+}
+
+resource "kubernetes_secret" "user-filestore-s3-bucket" {
+  metadata {
+    name      = "s3-formbuilder-user-filestore-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.user-filestore-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.user-filestore-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.user-filestore-s3-bucket.bucket_name}"
+    secret_access_key = "${module.user-filestore-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/variables.tf
@@ -1,0 +1,29 @@
+# auto-generated from fb-cloud-platforms-environments
+variable "environment-name" {
+  default = "pentest-dev"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "db_backup_retention_period_submitter" {
+  default = "2"
+}
+
+variable "db_backup_retention_period_user_datastore" {
+  default = "2"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "infrastructure-support" {
+  default = "Form Builder form-builder-team@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/service-token-cache-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/service-token-cache-service-account.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/service-token-cache-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-service-token-cache-pentest-dev
+  namespace: formbuilder-platform-pentest-dev

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/submitter-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/submitter-workers-service-account.yaml
@@ -1,0 +1,8 @@
+---
+# Source: formbuilder-platform/templates/submitter-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-submitter-workers-pentest-dev
+  namespace: formbuilder-platform-pentest-dev

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/user-datastore-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/user-datastore-service-account.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/user-datastore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-user-datastore-pentest-dev
+  namespace: formbuilder-platform-pentest-dev

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/user-filestore-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/user-filestore-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-platform/templates/user-filestore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user filestore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-user-filestore-pentest-dev
+  namespace: formbuilder-platform-pentest-dev
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-platform/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-platform-pentest-production
+  labels:
+    # for fb's own purposes
+    name: formbuilder-platform-pentest-production
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest-production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-platform"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/01-rbac.yaml
@@ -1,0 +1,27 @@
+---
+# Source: formbuilder-platform/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-pentest-production-admins
+  namespace: formbuilder-platform-pentest-production
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-pentest-production
+    namespace: formbuilder-platform-pentest-production
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+# Further roles defined in:
+# - service-token-cache-service-account.yaml
+# - submitter-workers-service-account.yaml
+# - user-datastore-service-account.yaml
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-platform/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-platform-pentest-production
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/03-resourcequota.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-platform/templates/03-resourcequota.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-platform-pentest-production
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-platform/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-platform-pentest-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-platform-pentest-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/av-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/av-service-account.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-platform/templates/av-service-account.yaml
+---
+# Source: formbuilder-platform/templates/user-filestore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user filestore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-test-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-av-pentest-production
+  namespace: formbuilder-platform-pentest-production
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/main.tf
@@ -1,0 +1,8 @@
+# auto-generated from fb-cloud-platforms-environments
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/service_token_cache.tf
@@ -1,0 +1,27 @@
+# auto-generated from fb-cloud-platforms-environments
+########################################################
+# Service Token Cache Elasticache Redis (for resque + job logging)
+module "service-token-cache-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuilderservice-token-cache"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "service-token-cache-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-service-token-cache-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.service-token-cache-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.service-token-cache-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/submitter.tf
@@ -1,0 +1,57 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# Submitter RDS
+
+module "submitter-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "${var.db_backup_retention_period_submitter}"
+  application                = "formbuildersubmitter"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-submitter-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
+  }
+}
+
+##################################################
+
+########################################################
+# Submitter Elasticache Redis (for resque + job logging)
+module "submitter-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuildersubmitter"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-submitter-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.submitter-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.submitter-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/user-datastore.tf
@@ -1,0 +1,27 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# User Datastore RDS
+module "user-datastore-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "${var.db_backup_retention_period_user_datastore}"
+  application                = "formbuilderuserdatastore"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "user-datastore-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-user-datastore-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/user-filestore.tf
@@ -1,0 +1,29 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# User Filestore S3
+module "user-filestore-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.0"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+}
+
+resource "kubernetes_secret" "user-filestore-s3-bucket" {
+  metadata {
+    name      = "s3-formbuilder-user-filestore-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.user-filestore-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.user-filestore-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.user-filestore-s3-bucket.bucket_name}"
+    secret_access_key = "${module.user-filestore-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/variables.tf
@@ -1,0 +1,29 @@
+# auto-generated from fb-cloud-platforms-environments
+variable "environment-name" {
+  default = "pentest-production"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "db_backup_retention_period_submitter" {
+  default = "2"
+}
+
+variable "db_backup_retention_period_user_datastore" {
+  default = "2"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "infrastructure-support" {
+  default = "Form Builder form-builder-team@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/service-token-cache-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/service-token-cache-service-account.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/service-token-cache-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-production namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-service-token-cache-pentest-production
+  namespace: formbuilder-platform-pentest-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/submitter-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/submitter-workers-service-account.yaml
@@ -1,0 +1,8 @@
+---
+# Source: formbuilder-platform/templates/submitter-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-submitter-workers-pentest-production
+  namespace: formbuilder-platform-pentest-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/user-datastore-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/user-datastore-service-account.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/user-datastore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-production namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-user-datastore-pentest-production
+  namespace: formbuilder-platform-pentest-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/user-filestore-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/user-filestore-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-platform/templates/user-filestore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user filestore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-production namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-user-filestore-pentest-production
+  namespace: formbuilder-platform-pentest-production
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-platform/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-platform-pentest-staging
+  labels:
+    # for fb's own purposes
+    name: formbuilder-platform-pentest-staging
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest-staging"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-platform"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/01-rbac.yaml
@@ -1,0 +1,27 @@
+---
+# Source: formbuilder-platform/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-pentest-staging-admins
+  namespace: formbuilder-platform-pentest-staging
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-pentest-staging
+    namespace: formbuilder-platform-pentest-staging
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+# Further roles defined in:
+# - service-token-cache-service-account.yaml
+# - submitter-workers-service-account.yaml
+# - user-datastore-service-account.yaml
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-platform/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-platform-pentest-staging
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/03-resourcequota.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-platform/templates/03-resourcequota.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-platform-pentest-staging
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-platform/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-platform-pentest-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-platform-pentest-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/av-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/av-service-account.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-platform/templates/av-service-account.yaml
+---
+# Source: formbuilder-platform/templates/user-filestore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user filestore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-test-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-av-pentest-staging
+  namespace: formbuilder-platform-pentest-staging
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/main.tf
@@ -1,0 +1,8 @@
+# auto-generated from fb-cloud-platforms-environments
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/service_token_cache.tf
@@ -1,0 +1,27 @@
+# auto-generated from fb-cloud-platforms-environments
+########################################################
+# Service Token Cache Elasticache Redis (for resque + job logging)
+module "service-token-cache-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuilderservice-token-cache"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "service-token-cache-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-service-token-cache-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.service-token-cache-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.service-token-cache-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/submitter.tf
@@ -1,0 +1,57 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# Submitter RDS
+
+module "submitter-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "${var.db_backup_retention_period_submitter}"
+  application                = "formbuildersubmitter"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-submitter-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
+  }
+}
+
+##################################################
+
+########################################################
+# Submitter Elasticache Redis (for resque + job logging)
+module "submitter-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuildersubmitter"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "submitter-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-submitter-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.submitter-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.submitter-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/user-datastore.tf
@@ -1,0 +1,27 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# User Datastore RDS
+module "user-datastore-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "${var.db_backup_retention_period_user_datastore}"
+  application                = "formbuilderuserdatastore"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "user-datastore-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-user-datastore-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/user-filestore.tf
@@ -1,0 +1,29 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# User Filestore S3
+module "user-filestore-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.0"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+}
+
+resource "kubernetes_secret" "user-filestore-s3-bucket" {
+  metadata {
+    name      = "s3-formbuilder-user-filestore-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.user-filestore-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.user-filestore-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.user-filestore-s3-bucket.bucket_name}"
+    secret_access_key = "${module.user-filestore-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/variables.tf
@@ -1,0 +1,29 @@
+# auto-generated from fb-cloud-platforms-environments
+variable "environment-name" {
+  default = "pentest-staging"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "db_backup_retention_period_submitter" {
+  default = "2"
+}
+
+variable "db_backup_retention_period_user_datastore" {
+  default = "2"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "infrastructure-support" {
+  default = "Form Builder form-builder-team@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/service-token-cache-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/service-token-cache-service-account.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/service-token-cache-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-staging namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-service-token-cache-pentest-staging
+  namespace: formbuilder-platform-pentest-staging

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/submitter-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/submitter-workers-service-account.yaml
@@ -1,0 +1,8 @@
+---
+# Source: formbuilder-platform/templates/submitter-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-submitter-workers-pentest-staging
+  namespace: formbuilder-platform-pentest-staging

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/user-datastore-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/user-datastore-service-account.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/user-datastore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-staging namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-user-datastore-pentest-staging
+  namespace: formbuilder-platform-pentest-staging

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/user-filestore-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/user-filestore-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-platform/templates/user-filestore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user filestore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-staging namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-user-filestore-pentest-staging
+  namespace: formbuilder-platform-pentest-staging
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-publisher/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-publisher-pentest
+  labels:
+    # for fb's own purposes
+    name: formbuilder-publisher-pentest
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-publisher"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/fb-publisher"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/01-rbac.yaml
@@ -1,0 +1,21 @@
+---
+# Source: formbuilder-publisher/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-publisher-pentest-admins
+  namespace: formbuilder-publisher-pentest
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+# Further roles defined in:
+# - publisher-workers-service-account.yaml

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-publisher/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-publisher-pentest
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/03-resourcequota.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-publisher/templates/03-resourcequota.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-publisher-pentest
+spec:
+  hard:
+    requests.cpu: 4000m
+    requests.memory: 8Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-publisher/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-publisher-pentest
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-publisher-pentest
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/publisher-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/publisher-workers-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-publisher/templates/publisher-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the publisher worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-pentest-(deploymentEnvironment)
+# namespaces so that they can deploy services there
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-publisher-workers-pentest
+  namespace: formbuilder-publisher-pentest

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/main.tf
@@ -1,0 +1,8 @@
+# auto-generated from fb-cloud-platforms-environments
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/publisher.tf
@@ -1,0 +1,57 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# Publisher RDS
+
+module "publisher-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+
+  cluster_name               = "${var.cluster_name}"
+  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  db_backup_retention_period = "${var.db_backup_retention_period}"
+  application                = "formbuilderpublisher"
+  environment-name           = "${var.environment-name}"
+  is-production              = "${var.is-production}"
+  infrastructure-support     = "${var.infrastructure-support}"
+  team_name                  = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "publisher-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-publisher-${var.environment-name}"
+    namespace = "formbuilder-publisher-${var.environment-name}"
+  }
+
+  data {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.publisher-rds-instance.database_username}:${module.publisher-rds-instance.database_password}@${module.publisher-rds-instance.rds_instance_endpoint}/${module.publisher-rds-instance.database_name}"
+  }
+}
+
+##################################################
+
+########################################################
+# Publisher Elasticache Redis (for resque + job logging)
+module "publisher-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+
+  cluster_name         = "${var.cluster_name}"
+  cluster_state_bucket = "${var.cluster_state_bucket}"
+
+  application            = "formbuilderpublisher"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+}
+
+resource "kubernetes_secret" "publisher-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-publisher-${var.environment-name}"
+    namespace = "formbuilder-publisher-${var.environment-name}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.publisher-elasticache.primary_endpoint_address}"
+    auth_token               = "${module.publisher-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/variables.tf
@@ -1,0 +1,25 @@
+# auto-generated from fb-cloud-platforms-environments
+variable "environment-name" {
+  default = "pentest"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "db_backup_retention_period" {
+  default = "2"
+}
+
+variable "infrastructure-support" {
+  default = "Form Builder form-builder-team@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-services/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-services-pentest-dev
+  labels:
+    # for fb's own purposes
+    name: formbuilder-services-pentest-dev
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest-dev"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-services"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/01-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: formbuilder-services/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-pentest-dev-admins
+  namespace: formbuilder-services-pentest-dev
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+# Bind admin role for namespace to team group & publisher ServiceAccount
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-pentest-dev-service-account
+  namespace: formbuilder-services-pentest-dev
+subjects:
+  # allow platformenv Publisher to deploy to this deploymentenv
+  - kind: ServiceAccount
+    name: formbuilder-publisher-workers-pentest
+    namespace: formbuilder-publisher-pentest
+  # ...but only the dev service token cache can read the dev
+  # service tokens
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-pentest-dev
+    namespace: formbuilder-platform-pentest-dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-services/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-services-pentest-dev
+spec:
+  limits:
+  - default:
+      cpu: 150m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/03-resourcequota.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-services/templates/03-resourcequota.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-services-pentest-dev
+spec:
+  hard:
+    requests.cpu: 500m
+    requests.memory: 6.4Gi
+    limits.cpu: 7500m
+    limits.memory: 15Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-services/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-services-pentest-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-services-pentest-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/certificate.yaml
@@ -1,0 +1,21 @@
+---
+# Source: formbuilder-services/templates/certificate.yaml
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: tls-wildcard
+  namespace: formbuilder-services-pentest-dev
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: '*.dev.pentest.form.service.justice.gov.uk'
+  acme:
+    config:
+    - domains:
+      - '*.dev.pentest.form.service.justice.gov.uk'
+      dns01:
+        provider: route53-cloud-platform
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-services/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-services-pentest-production
+  labels:
+    # for fb's own purposes
+    name: formbuilder-services-pentest-production
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest-production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-services"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/01-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: formbuilder-services/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-pentest-production-admins
+  namespace: formbuilder-services-pentest-production
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+# Bind admin role for namespace to team group & publisher ServiceAccount
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-pentest-production-service-account
+  namespace: formbuilder-services-pentest-production
+subjects:
+  # allow platformenv Publisher to deploy to this deploymentenv
+  - kind: ServiceAccount
+    name: formbuilder-publisher-workers-pentest
+    namespace: formbuilder-publisher-pentest
+  # ...but only the dev service token cache can read the dev
+  # service tokens
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-pentest-production
+    namespace: formbuilder-platform-pentest-production
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-services/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-services-pentest-production
+spec:
+  limits:
+  - default:
+      cpu: 150m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/03-resourcequota.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-services/templates/03-resourcequota.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-services-pentest-production
+spec:
+  hard:
+    requests.cpu: 500m
+    requests.memory: 6.4Gi
+    limits.cpu: 7500m
+    limits.memory: 15Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-services/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-services-pentest-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-services-pentest-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/certificate.yaml
@@ -1,0 +1,21 @@
+---
+# Source: formbuilder-services/templates/certificate.yaml
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: tls-wildcard
+  namespace: formbuilder-services-pentest-production
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: '*.pentest.form.service.justice.gov.uk'
+  acme:
+    config:
+    - domains:
+      - '*.pentest.form.service.justice.gov.uk'
+      dns01:
+        provider: route53-cloud-platform
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-services/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-services-pentest-staging
+  labels:
+    # for fb's own purposes
+    name: formbuilder-services-pentest-staging
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest-staging"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-services"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/01-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: formbuilder-services/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-pentest-staging-admins
+  namespace: formbuilder-services-pentest-staging
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+# Bind admin role for namespace to team group & publisher ServiceAccount
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-pentest-staging-service-account
+  namespace: formbuilder-services-pentest-staging
+subjects:
+  # allow platformenv Publisher to deploy to this deploymentenv
+  - kind: ServiceAccount
+    name: formbuilder-publisher-workers-pentest
+    namespace: formbuilder-publisher-pentest
+  # ...but only the dev service token cache can read the dev
+  # service tokens
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-pentest-staging
+    namespace: formbuilder-platform-pentest-staging
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-services/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-services-pentest-staging
+spec:
+  limits:
+  - default:
+      cpu: 150m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/03-resourcequota.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-services/templates/03-resourcequota.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-services-pentest-staging
+spec:
+  hard:
+    requests.cpu: 500m
+    requests.memory: 6.4Gi
+    limits.cpu: 7500m
+    limits.memory: 15Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-services/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-services-pentest-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-services-pentest-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/certificate.yaml
@@ -1,0 +1,21 @@
+---
+# Source: formbuilder-services/templates/certificate.yaml
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: tls-wildcard
+  namespace: formbuilder-services-pentest-staging
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: '*.staging.pentest.form.service.justice.gov.uk'
+  acme:
+    config:
+    - domains:
+      - '*.staging.pentest.form.service.justice.gov.uk'
+      dns01:
+        provider: route53-cloud-platform
+


### PR DESCRIPTION
Generated files for building a full FormBuilder environment to be used for pentesting.
Namespaces are:
1. namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/
2. namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/
3. namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/
4. namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/
5. namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/
6. namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/
7. namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-staging/