### PR TITLE
CCCD Staging: Split SQS policy into separate step

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
@@ -24,15 +24,24 @@ module "claims_for_ccr" {
   }
   EOF
 
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
+  queue_url = "${module.claims_for_ccr.sqs_id}"
+
   policy = <<EOF
   {
     "Version": "2012-10-17",
-    "Id": "SQSDefaultPolicy",
+    "Id": "${module.claims_for_ccr.sqs_arn}/SQSDefaultPolicy",
     "Statement":
       [
         {
           "Effect": "Allow",
           "Principal": {"AWS": "*"},
+          "Resource": "${module.claims_for_ccr.sqs_arn}",
           "Action": "SQS:SendMessage",
           "Condition": 
             {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
@@ -53,11 +53,7 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
         }
       ]
   }
- EOF
-
-  providers = {
-    aws = "aws.london"
-  }
+  EOF
 }
 
 module "ccr_dead_letter_queue" {


### PR DESCRIPTION
This allows the queue and topic to be created before allowing
the topic to post to the queue

This could not be done in a single step as terraform
did not like setting a variable while creating it.

See https://www.terraform.io/docs/providers/aws/r/sqs_queue_policy.html