### PR TITLE
Refine terraform plan censoring regex

### DIFF
--- a/bin/plan
+++ b/bin/plan
@@ -32,7 +32,7 @@ if [ -n "$changed_dirs" ]; then
           -var="cluster_name=${cluster%%.*}" \
           -var="cluster_state_bucket=${PIPELINE_CLUSTER_STATE_BUCKET}" \
           -var="cluster_state_key=${PIPELINE_CLUSTER_STATE_KEY_PREFIX}${cluster%%.*}/terraform.tfstate" \
-            | grep -vE '^\s{3}'
+            | grep -vE '^(\x1b\[0m)?\s{3,}'
       )
     fi
   done


### PR DESCRIPTION
The first 'attribute line' after a resource begins with `^[[0m` (a control character) so we need to account for that as well.

Connects to https://github.com/ministryofjustice/cloud-platform/issues/1004