### PR TITLE
Add rds instance terraform for cccd-api-sandbox

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/main.tf
@@ -15,3 +15,7 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
@@ -8,16 +8,16 @@
 module "cccd_rds" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "laa-get-paid"
-  business-unit          = "legal-aid-agency"
-  application            = "cccd"
-  is-production          = "false"
-  environment-name       = "api-sandbox"
-  infrastructure-support = "crowncourtdefence@digtal.justice.gov.uk"
-  db_engine_version = "9.6"
-  force_ssl              = "true"
+  cluster_name                = "${var.cluster_name}"
+  cluster_state_bucket        = "${var.cluster_state_bucket}"
+  team_name                   = "laa-get-paid"
+  business-unit               = "legal-aid-agency"
+  application                 = "cccd"
+  is-production               = "false"
+  environment-name            = "api-sandbox"
+  infrastructure-support      = "crowncourtdefence@digtal.justice.gov.uk"
+  db_engine_version           = "9.6"
+  force_ssl                   = "true"
   allow_major_version_upgrade = "true"
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
@@ -1,0 +1,42 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+
+module "cccd_rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "laa-get-paid"
+  business-unit          = "legal-aid-agency"
+  application            = "cccd"
+  is-production          = "false"
+  environment-name       = "api-sandbox"
+  infrastructure-support = "crowncourtdefence@digtal.justice.gov.uk"
+  db_engine_version = "9.6"
+  force_ssl              = "true"
+  allow_major_version_upgrade = "true"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "cccd_rds" {
+  metadata {
+    name      = "cccd-rds"
+    namespace = "cccd-api-sandbox"
+  }
+
+  data {
+    rds_instance_endpoint = "${module.cccd_rds.rds_instance_endpoint}"
+    database_name         = "${module.cccd_rds.database_name}"
+    database_username     = "${module.cccd_rds.database_username}"
+    database_password     = "${module.cccd_rds.database_password}"
+    rds_instance_address  = "${module.cccd_rds.rds_instance_address}"
+    url                   = "postgres://${module.cccd_rds.database_username}:${module.cccd_rds.database_password}@${module.cccd_rds.rds_instance_endpoint}/${module.cccd_rds.database_name}"
+  }
+}


### PR DESCRIPTION
To add postgres DB and Use latest ref and current (i.e. production) cccd db engine version.