### PR TITLE
Increase default cpu and memory for cccd-api-sandbox

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 2Gi
     defaultRequest:
       cpu: 125m
       memory: 250Mi


### PR DESCRIPTION
The terraform template defaults were insufficient
and resulted in the unicorn server performing
SIGKILL, restarting the pod, when performing
even mundane tasks on the box - like `rake db:version`.