### PR TITLE
Formbuilder circleci deployment

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/circleci-service-account.yaml
@@ -1,0 +1,26 @@
+---
+# Source: formbuilder-platform/templates/circleci-service-account.yaml
+---
+# Source: formbuilder-platform/templates/circleci-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# This service account allows circleci to deploy into this environment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-platform-test-dev
+  namespace: formbuilder-platform-test-dev
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-platform-test-dev
+  namespace: formbuilder-platform-test-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-platform-test-dev
+  namespace: formbuilder-platform-test-dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/circleci-service-account.yaml
@@ -1,0 +1,26 @@
+---
+# Source: formbuilder-platform/templates/circleci-service-account.yaml
+---
+# Source: formbuilder-platform/templates/circleci-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# This service account allows circleci to deploy into this environment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-platform-test-production
+  namespace: formbuilder-platform-test-production
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-platform-test-production
+  namespace: formbuilder-platform-test-production
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-platform-test-production
+  namespace: formbuilder-platform-test-production
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/circleci-service-account.yaml
@@ -1,0 +1,26 @@
+---
+# Source: formbuilder-platform/templates/circleci-service-account.yaml
+---
+# Source: formbuilder-platform/templates/circleci-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# This service account allows circleci to deploy into this environment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-platform-test-staging
+  namespace: formbuilder-platform-test-staging
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-platform-test-staging
+  namespace: formbuilder-platform-test-staging
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-platform-test-staging
+  namespace: formbuilder-platform-test-staging
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/serviceaccount-circleci.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-repos
+  namespace: formbuilder-repos
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-repos
+  namespace: formbuilder-repos
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-repos
+  namespace: formbuilder-repos
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-repos
+  namespace: formbuilder-repos
+roleRef:
+  kind: Role
+  name: circleci-formbuilder-repos
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This allows CircleCI to push docker images to our ECR and deploy those images to kubernetes to our test environments