### PR TITLE
Fixing broken Terraform plan 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/resources/ecr.tf
@@ -3,6 +3,10 @@ module "ecr-repo" {
 
   team_name = "${var.team_name}"
   repo_name = "${var.repo_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "ecr-repo" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/resources/main.tf
@@ -5,3 +5,8 @@ terraform {
 provider "aws" {
   region = "${var.aws_region}"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/resources/rds.tf
@@ -13,7 +13,6 @@ module "rds-instance" {
   providers = {
     aws = "aws.london"
   }
-
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/resources/rds.tf
@@ -9,6 +9,11 @@ module "rds-instance" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {


### PR DESCRIPTION
It was brought to my attention that terraform plan was failing on the removal of the `pecs-move-platform-backend-staging`. Adding the commits in this PR will fix this and allow plan (and subsequently merge to master) to complete successfully. 