### PR TITLE
Bump disclosure checker module versions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
@@ -3,10 +3,14 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.3"
 
   team_name = "${var.team_name}"
   repo_name = "${var.repo_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "ecr-repo" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/main.tf
@@ -3,5 +3,10 @@ terraform {
 }
 
 provider "aws" {
-  region = "${var.aws_region}"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -13,6 +13,11 @@ module "rds-instance" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+  force_ssl              = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/variables.tf
@@ -26,10 +26,6 @@ variable "repo_name" {
   default = "disclosure-checker"
 }
 
-variable "aws_region" {
-  default = "eu-west-2"
-}
-
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {}
 


### PR DESCRIPTION
* Bump the RDS and ECR modules to the latest versions.
* Using the new providers mechanism.
* Force SSL in RDS module.

Note: ECR module bumped only to 3.3 and not 3.4 because latest version doesn't work until the providers mechanism is in place.