### PR TITLE
Remove fluentd-es ServiceMonitor

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/monitoring.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/monitoring.yaml
@@ -1,22 +1,5 @@
 ---
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: fluentd-es
-  namespace: logging
-spec:
-  jobLabel: app
-  selector:
-    matchLabels:
-      app: fluentd-es
-  namespaceSelector:
-    matchNames:
-      - logging
-  endpoints:
-    - port: metrics
-      interval: 30s
----
-apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: fluentd-es


### PR DESCRIPTION
This is now managed by the helm chart, see https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/309