### PR TITLE
rework form builder route53 terraforms

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "main" {
-  name = "test.form.service.justice.gov.uk"
+  name = "form.service.justice.gov.uk"
 
   tags {
     business-unit          = "transformed-department"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/variables.tf
@@ -1,0 +1,15 @@
+variable "is-production" {
+  default = "true"
+}
+
+variable "environment-name" {
+  default = "live-production"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "infrastructure-support" {
+  default = "Form Builder form-builder-team@digital.justice.gov.uk"
+}


### PR DESCRIPTION
- I've reworked the missing route53 modules for form builder
- I've moved the namespaces so it seems more logical and closer to the certificates
- It's not tested so want a second pair of eyes