### PR TITLE
Update fee-calculator labels

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-production/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-production/00-namespace.yaml
@@ -2,3 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: laa-fee-calculator-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "laa-get-paid"
+    cloud-platform.justice.gov.uk/application: "LAA Fee Calculator"
+    cloud-platform.justice.gov.uk/owner: "laa-get-paid: crowncourtdefence@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-fee-calculator"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-staging/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fee-calculator-staging/00-namespace.yaml
@@ -2,3 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: laa-fee-calculator-staging
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "laa-get-paid"
+    cloud-platform.justice.gov.uk/application: "LAA Fee Calculator"
+    cloud-platform.justice.gov.uk/owner: "laa-get-paid: crowncourtdefence@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-fee-calculator"


### PR DESCRIPTION
Due to the pending migration from live-0 > live-1 these two environments
need to remain, together, in the live-1 environment until the application
has been prepared for migration