### PR TITLE
Flag laa-apply-for-legalaid namespaces as production

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-production/00-namespace.yaml
@@ -3,4 +3,10 @@ kind: Namespace
 metadata:
   name: laa-apply-for-legalaid-production
   labels:
-    name: laa-apply-for-legalaid-production
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-staging/00-namespace.yaml
@@ -3,4 +3,10 @@ kind: Namespace
 metadata:
   name: laa-apply-for-legalaid-staging
   labels:
-    name: laa-apply-for-legalaid-staging
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-uat/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-apply-for-legalaid-uat/00-namespace.yaml
@@ -3,10 +3,10 @@ kind: Namespace
 metadata:
   name: laa-apply-for-legalaid-uat
   labels:
-    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "uat"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "laa"
-    cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid-uat"
+    cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"


### PR DESCRIPTION
Marking our namespaces as `production` in order to give us more time to migrate them to `live-1`