### PR TITLE
Mark cla-public and fala staging namespaces as is-production

### DIFF
--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-cla-public-staging/00-namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: laa-cla-public-staging
   labels:
-    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"

--- a/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging/00-namespace.yaml
+++ b/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging/00-namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: laa-fala-staging
   labels:
-    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"


### PR DESCRIPTION
To protect them when non-production environments are removed from live-0
The production namespaces for both are already marked as `in-production`