### PR TITLE
Bump RDS module version

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/rds.tf
@@ -3,7 +3,7 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
@@ -3,7 +3,7 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/main.tf
@@ -3,5 +3,10 @@ terraform {
 }
 
 provider "aws" {
-  region = "${var.aws_region}"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -13,6 +13,11 @@ module "rds-instance" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+  force_ssl              = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/variables.tf
@@ -26,10 +26,6 @@ variable "repo_name" {
   default = "family-mediators-api"
 }
 
-variable "aws_region" {
-  default = "eu-west-2"
-}
-
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {}
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/main.tf
@@ -3,15 +3,10 @@ terraform {
 }
 
 provider "aws" {
-  region = "${var.aws_region}"
+  region = "eu-west-2"
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
-}
-
-provider "aws" {
-  alias  = "ireland"
-  region = "eu-west-1"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -13,6 +13,11 @@ module "rds-instance" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+  force_ssl              = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/variables.tf
@@ -26,10 +26,6 @@ variable "repo_name" {
   default = "family-mediators-api"
 }
 
-variable "aws_region" {
-  default = "eu-west-2"
-}
-
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {}
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/main.tf
@@ -3,15 +3,10 @@ terraform {
 }
 
 provider "aws" {
-  region = "${var.aws_region}"
+  region = "eu-west-2"
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
-}
-
-provider "aws" {
-  alias  = "ireland"
-  region = "eu-west-1"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/variables.tf
@@ -30,10 +30,6 @@ variable "repo_name" {
   default = "pflr-cait"
 }
 
-variable "aws_region" {
-  default = "eu-west-2"
-}
-
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {}
 


### PR DESCRIPTION
Happy to use the defaults for `db_engine_version` and  `rds_family`, so we are not specifying these.

Cleanup of some remaining unused `var.aws_region`.