### PR TITLE
Set pvb prod ns limitrange to pvb staging values

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 1Gi
-    defaultRequest:
-      cpu: 250m
       memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
     type: Container


### PR DESCRIPTION
The limitrange values in production are causing PVB to hit quota
limits for their deployments. Their pods use far less resources
than they request, so this commit reduces the limitrange values
in their production namespace, to avoid this problem.

For more details:
https://mojdt.slack.com/archives/C57UPMZLY/p1563370094059800