### PR TITLE
Reduce default request values for new namespaces

### DIFF
--- a/namespace-resources/02-limitrange.yaml
+++ b/namespace-resources/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 12m
+      cpu: 16m
       memory: 150Mi
     type: Container

--- a/namespace-resources/02-limitrange.yaml
+++ b/namespace-resources/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 12m
+      memory: 150Mi
     type: Container


### PR DESCRIPTION
Averaged across the whole cluster, containers use
8m CPU, and 128Mi Memory. 

The defaultRequest values are the resources the
scheduler will *reserve* for every container in a 
pod. If these values are much higher than what
containers will actually use, the cluster will run
out of capacity much sooner than it should.

NB: This commit only changes the *request* value,
not the limits on how much resource a container
is actually allowed to consume.