### PR TITLE
Halve the requests limits for new namespaces

### DIFF
--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ${namespace}
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 1500m
+    requests.memory: 3Gi
     limits.cpu: 6000m
     limits.memory: 12Gi


### PR DESCRIPTION
Change #1012 reduced the resources that will be
reserved for every container in a namespace.

Having reduced those values, we should be able to
reduce the overall resources that will be reserved
for the namespaces as a whole.

This commit reduces those values by half, which is
a conservative change.

Looking at our actual usage, out of 114 namespaces
in live-1, 103 are using less than 2Gi of memory,
and 107 are using less than 100m of CPU.

NB: This only puts a limit on the resources the
cluster will reserve for a namespace. It does not
prevent the namespace from *consuming* more than
this.

Relates to #1012
Relates to https://github.com/ministryofjustice/cloud-platform/issues/1094
Closes https://github.com/ministryofjustice/cloud-platform/issues/1093