### PR TITLE
Add certificate for hmpps-book-secure-move-frontend-production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: hmpps-book-secure-move-frontend-production-cert
+  namespace: hmpps-book-secure-move-frontend-production
+spec:
+  secretName: hmpps-book-secure-move-frontend-production-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 'bookasecuremove.service.justice.gov.uk'
+  acme:
+    config:
+    - domains:
+      - 'bookasecuremove.service.justice.gov.uk'
+      dns01:
+        provider: route53-cloud-platform


### PR DESCRIPTION
For the frontend server we are using hostname `bookasecuremove.service.justice.gov.uk`

