### PR TITLE
Add laa-fee-calculator-production namespace, resources and certificate

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-fee-calculator-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "legal-aid-agency"
+    cloud-platform.justice.gov.uk/application: "LAA Fee Calculator"
+    cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-fee-calculator"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-fee-calculator-production-admin
+  namespace: laa-fee-calculator-production
+subjects:
+  - kind: Group
+    name: "github:crime-billing-online"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-fee-calculator-production
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-fee-calculator-production
+spec:
+  hard:
+    requests.cpu: 3000m
+    requests.memory: 6Gi
+    limits.cpu: 6000m
+    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-fee-calculator-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-fee-calculator-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: laa-fee-calculator-production-cert
+  namespace: laa-fee-calculator-production
+spec:
+  secretName: laa-fee-calculator-production-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 'laa-fee-calculator.service.justice.gov.uk'
+  acme:
+    config:
+    - domains:
+      - 'laa-fee-calculator.service.justice.gov.uk'
+      dns01:
+        provider: route53-cloud-platform

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/variables.tf
@@ -1,0 +1,44 @@
+variable "domain" {
+  default = "laa-fee-calculator.service.justice.gov.uk"
+}
+
+variable "application" {
+  default = "LAA Fee Calculator"
+}
+
+variable "namespace" {
+  default = "laa-fee-calculator-production"
+}
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "legal-aid-agency"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "crime-billing-online"
+}
+
+variable "environment-name" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "LAA get paid team: laa-get-paid@digital.justice.gov.uk"
+}
+
+variable "repo_name" {
+  default = "laa-fee-calculator"
+}
+
+variable "is-production" {
+  default = "true"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/variables.tf
@@ -17,7 +17,7 @@ variable "business-unit" {
 
 variable "team_name" {
   description = "The name of your development team"
-  default     = "crime-billing-online"
+  default     = "laa-get-paid"
 }
 
 variable "environment-name" {


### PR DESCRIPTION
#### What
Setup the laa fee calculator production API's resources

#### Why
We are going to run this production app in tandem
with currently used live-0 production app while we
rewire consumers. On the face of it only two components
make use of this API:

- https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence
- https://github.com/ministryofjustice/laa-fee-calculator-client

...and the app (former) uses the client gem (latter).

We also need to determine other users of the current API
by reviewing logs on the live-0 production instances.