### PR TITLE
Copy laa-apply-for-legalaid namespaces and resources to live-1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-apply-for-legalaid-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-apply-for-legalaid-production
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-apply-for-legalaid-production
+spec:
+  hard:
+    limits.cpu: "10"
+    limits.memory: 20Gi
+    requests.cpu: "4"
+    requests.memory: 8Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-apply-for-legalaid-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-apply-for-legalaid-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/rbac.yaml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-apply-for-legalaid-production-admin
+  namespace: laa-apply-for-legalaid-production
+subjects:
+  - kind: Group
+    name: "github:laa-apply-for-legal-aid"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
@@ -1,0 +1,49 @@
+module "ecr-repo-applyforlegalaid-service" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+
+  team_name = "laa-apply-for-legal-aid"
+  repo_name = "applyforlegalaid-service"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "ecr-repo-applyforlegalaid-service" {
+  metadata {
+    name      = "ecr-repo-applyforlegalaid-service"
+    namespace = "laa-apply-for-legalaid-production"
+  }
+
+  data {
+    repo_arn          = "${module.ecr-repo-applyforlegalaid-service.repo_arn}"
+    repo_url          = "${module.ecr-repo-applyforlegalaid-service.repo_url}"
+    access_key_id     = "${module.ecr-repo-applyforlegalaid-service.access_key_id}"
+    secret_access_key = "${module.ecr-repo-applyforlegalaid-service.secret_access_key}"
+  }
+}
+
+module "ecr-repo-clamav" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+
+  team_name = "laa-apply-for-legal-aid"
+  repo_name = "clamav"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "ecr-repo-clamav" {
+  metadata {
+    name      = "ecr-repo-clamav"
+    namespace = "laa-apply-for-legalaid-production"
+  }
+
+  data {
+    repo_arn          = "${module.ecr-repo-clamav.repo_arn}"
+    repo_url          = "${module.ecr-repo-clamav.repo_url}"
+    access_key_id     = "${module.ecr-repo-clamav.access_key_id}"
+    secret_access_key = "${module.ecr-repo-clamav.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
@@ -1,0 +1,35 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "apply-for-legal-aid-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "apply-for-legal-aid"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "true"
+  environment-name       = "production"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
+  metadata {
+    name      = "apply-for-legal-aid-elasticache-instance-output"
+    namespace = "laa-apply-for-legalaid-production"
+  }
+
+  data {
+    primary_endpoint_address = "${module.apply-for-legal-aid-elasticache.primary_endpoint_address}"
+    member_clusters          = "${jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)}"
+    auth_token               = "${module.apply-for-legal-aid-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in London
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in Ireland
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
@@ -1,0 +1,43 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "apply-for-legal-aid-rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "apply-for-legal-aid"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "true"
+  environment-name       = "production"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+  db_engine              = "postgres"
+  db_engine_version      = "11.4"
+  db_name                = "apply_for_legal_aid_production"
+  rds_family             = "postgres11"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-rds" {
+  metadata {
+    name      = "apply-for-legal-aid-rds-instance-output"
+    namespace = "laa-apply-for-legalaid-production"
+  }
+
+  data {
+    rds_instance_endpoint = "${module.apply-for-legal-aid-rds.rds_instance_endpoint}"
+    database_name         = "${module.apply-for-legal-aid-rds.database_name}"
+    database_username     = "${module.apply-for-legal-aid-rds.database_username}"
+    database_password     = "${module.apply-for-legal-aid-rds.database_password}"
+    rds_instance_address  = "${module.apply-for-legal-aid-rds.rds_instance_address}"
+
+    url = "postgres://${module.apply-for-legal-aid-rds.database_username}:${module.apply-for-legal-aid-rds.database_password}@${module.apply-for-legal-aid-rds.rds_instance_endpoint}/${module.apply-for-legal-aid-rds.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
@@ -1,0 +1,28 @@
+module "authorized-keys" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+
+  team_name              = "apply-for-legal-aid"
+  acl                    = "private"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "true"
+  environment-name       = "production"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
+  metadata {
+    name      = "apply-for-legal-aid-s3-instance-output"
+    namespace = "laa-apply-for-legalaid-production"
+  }
+
+  data {
+    bucket_name       = "${module.authorized-keys.bucket_name}"
+    access_key_id     = "${module.authorized-keys.access_key_id}"
+    secret_access_key = "${module.authorized-keys.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/serviceaccount-admin.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/serviceaccount-admin.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: serviceaccount-admin
+  namespace: laa-apply-for-legalaid-production
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: laa-apply-for-legalaid-production
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-production
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-production
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-production
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-apply-for-legalaid-production
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-apply-for-legalaid-staging
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-apply-for-legalaid-staging
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 100m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-apply-for-legalaid-staging
+spec:
+  hard:
+    limits.cpu: "10"
+    limits.memory: 20Gi
+    requests.cpu: "4"
+    requests.memory: 8Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-apply-for-legalaid-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-apply-for-legalaid-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-apply-for-legalaid-staging-admin
+  namespace: laa-apply-for-legalaid-staging
+subjects:
+  - kind: Group
+    name: "github:laa-apply-for-legal-aid"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
@@ -1,0 +1,35 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "apply-for-legal-aid-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "apply-for-legal-aid"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "false"
+  environment-name       = "staging"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
+  metadata {
+    name      = "apply-for-legal-aid-elasticache-instance-output"
+    namespace = "laa-apply-for-legalaid-staging"
+  }
+
+  data {
+    primary_endpoint_address = "${module.apply-for-legal-aid-elasticache.primary_endpoint_address}"
+    member_clusters          = "${jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)}"
+    auth_token               = "${module.apply-for-legal-aid-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in London
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in Ireland
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -1,0 +1,43 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "apply-for-legal-aid-rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "apply-for-legal-aid"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "false"
+  environment-name       = "staging"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+  db_engine              = "postgres"
+  db_engine_version      = "11.4"
+  db_name                = "apply_for_legal_aid_staging"
+  rds_family             = "postgres11"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-rds" {
+  metadata {
+    name      = "apply-for-legal-aid-rds-instance-output"
+    namespace = "laa-apply-for-legalaid-staging"
+  }
+
+  data {
+    rds_instance_endpoint = "${module.apply-for-legal-aid-rds.rds_instance_endpoint}"
+    database_name         = "${module.apply-for-legal-aid-rds.database_name}"
+    database_username     = "${module.apply-for-legal-aid-rds.database_username}"
+    database_password     = "${module.apply-for-legal-aid-rds.database_password}"
+    rds_instance_address  = "${module.apply-for-legal-aid-rds.rds_instance_address}"
+
+    url = "postgres://${module.apply-for-legal-aid-rds.database_username}:${module.apply-for-legal-aid-rds.database_password}@${module.apply-for-legal-aid-rds.rds_instance_endpoint}/${module.apply-for-legal-aid-rds.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
@@ -1,0 +1,28 @@
+module "authorized-keys" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+
+  team_name              = "apply-for-legal-aid"
+  acl                    = "private"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "false"
+  environment-name       = "staging"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
+  metadata {
+    name      = "apply-for-legal-aid-s3-instance-output"
+    namespace = "laa-apply-for-legalaid-staging"
+  }
+
+  data {
+    bucket_name       = "${module.authorized-keys.bucket_name}"
+    access_key_id     = "${module.authorized-keys.access_key_id}"
+    secret_access_key = "${module.authorized-keys.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/serviceaccount-admin.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/serviceaccount-admin.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: serviceaccount-admin
+  namespace: laa-apply-for-legalaid-staging
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: laa-apply-for-legalaid-staging
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+  

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-staging
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-staging
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-staging
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-apply-for-legalaid-staging
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-apply-for-legalaid-uat
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "uat"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-apply-for-legalaid-uat-admin
+  namespace: laa-apply-for-legalaid-uat
+subjects:
+  - kind: Group
+    name: "github:laa-apply-for-legal-aid"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-apply-for-legalaid-uat
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 200m
+      memory: 256Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-apply-for-legalaid-uat
+spec:
+  hard:
+    requests.cpu: 20000m
+    requests.memory: 20Gi
+    limits.cpu: 20000m
+    limits.memory: 30Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-apply-for-legalaid-uat
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-apply-for-legalaid-uat
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
@@ -1,0 +1,35 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "apply-for-legal-aid-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "apply-for-legal-aid"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "false"
+  environment-name       = "uat"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
+  metadata {
+    name      = "apply-for-legal-aid-elasticache-instance-output"
+    namespace = "laa-apply-for-legalaid-uat"
+  }
+
+  data {
+    primary_endpoint_address = "${module.apply-for-legal-aid-elasticache.primary_endpoint_address}"
+    member_clusters          = "${jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)}"
+    auth_token               = "${module.apply-for-legal-aid-elasticache.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in London
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in Ireland
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,0 +1,28 @@
+module "authorized-keys" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+
+  team_name              = "apply-for-legal-aid"
+  acl                    = "private"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "false"
+  environment-name       = "uat"
+  infrastructure-support = "apply@digtal.justice.gov.uk"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
+  metadata {
+    name      = "apply-for-legal-aid-s3-instance-output"
+    namespace = "laa-apply-for-legalaid-uat"
+  }
+
+  data {
+    bucket_name       = "${module.authorized-keys.bucket_name}"
+    access_key_id     = "${module.authorized-keys.access_key_id}"
+    secret_access_key = "${module.authorized-keys.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-admin.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-admin.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: serviceaccount-admin
+  namespace: laa-apply-for-legalaid-uat
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: laa-apply-for-legalaid-uat
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-uat
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-uat
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-uat
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-apply-for-legalaid-uat
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Copy UAT, staging and prod namespaces of `laa-apply-for-legalaid` to live-1

It's almost an identical copy except for these:
- added the `aws.london` bit
- used the latest terraform source versions
- bumped version of RDS to the latest PostgreSQL and added the database `url` secret

Summary:
- 3 namespaces : uat, staging, prod
- They all have elasticache and s3 resources
- prod and staging have also rds resources
- prod has ecr resource
