### PR TITLE
Decrease default limits for CPU and memory

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 125m
+      memory: 250Mi
     defaultRequest:
       cpu: 125m
       memory: 250Mi


### PR DESCRIPTION
This change was made because PVB were unable to increase the number
of replicas for their staff app. deployment from 3 to 5. By making
this change, we believe enough reserved capacity was freed up to
allow the extra pods to run. So, this commit makes the change
permanent.