### PR TITLE
Reduce default resource quota and limit range values for new namespaces

### DIFF
--- a/namespace-resources/02-limitrange.yaml
+++ b/namespace-resources/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
+      cpu: 50m
       memory: 500Mi
     defaultRequest:
-      cpu: 16m
-      memory: 150Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 1500m
     requests.memory: 3Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: ${namespace}
 spec:
   hard:
-    requests.cpu: 1500m
-    requests.memory: 3Gi
+    requests.cpu: 100m
+    requests.memory: 1000Mi


### PR DESCRIPTION
This PR removes the 'limits' on namespace resource quotas, because they don't
do anything useful.

It also reduces the request limits values for namespaces, and the requests and
limits values which will apply to new containers, if users do not specify values
in their deployments.