### PR TITLE
Change logging resourcequota and limit range

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/02-limitrange.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 100m
+      cpu: 300m
       memory: 500Mi
     defaultRequest:
       cpu: 10m

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
+      cpu: 100m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 400Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: logging
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 7500m
-    limits.memory: 15Gi
+    requests.cpu: 6000m
+    requests.memory: 12Gi


### PR DESCRIPTION
Due to a recent node scale out the daemonset for fluentd was failing due to resource limitations. This change will allow us to deploy the daemonset successfully.