### PR TITLE
Add route53.tf file for apply for legal aid 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
@@ -14,10 +14,10 @@ resource "aws_route53_zone" "apply_for_legal_aid_route53_zone" {
 resource "kubernetes_secret" "apply_for_legal_aid_route_53_zone_sec" {
   metadata {
     name      = "apply-for-legal-aid-route53-zone-output"
-    namespace = "laa-apply-forlegalaid"
+    namespace = "laa-apply-for-legal-aid-production"
   }
 
   data {
-    zone_id   = "${aws_route53_zone.apply_for_legal_aid_route53_zone}"
+    zone_id   = "${aws_route53_zone.apply_for_legal_aid_route53_zone.zone_id}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
@@ -14,10 +14,10 @@ resource "aws_route53_zone" "apply_for_legal_aid_route53_zone" {
 resource "kubernetes_secret" "apply_for_legal_aid_route_53_zone_sec" {
   metadata {
     name      = "apply-for-legal-aid-route53-zone-output"
-    namespace = "laa-apply-for-legal-aid-production"
+    namespace = "laa-apply-for-legalaid-production"
   }
 
   data {
-    zone_id   = "${aws_route53_zone.apply_for_legal_aid_route53_zone.zone_id}"
+    zone_id = "${aws_route53_zone.apply_for_legal_aid_route53_zone.zone_id}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
@@ -1,23 +1,23 @@
 resource "aws_route53_zone" "apply_for_legal_aid_route53_zone" {
-  name = "staging.apply-for-legal-aid.service.justice.gov.uk"
+  name = "apply-for-legal-aid.service.justice.gov.uk"
 
   tags {
     business-unit          = "laa"
     application            = "laa-apply-for-legal-aid"
-    is-production          = "false"
-    environment-name       = "staging"
+    is-production          = "true"
+    environment-name       = "production"
     owner                  = "apply-for-legal-aid"
     infrastructure-support = "apply@digtal.justice.gov.uk"
   }
 }
 
-resource "kubernetes_secret" "apply_for_legal_aidroute_53_zone_sec" {
+resource "kubernetes_secret" "apply_for_legal_aid_route_53_zone_sec" {
   metadata {
     name      = "apply-for-legal-aid-route53-zone-output"
-    namespace = "laa-apply-forlegalaid-staging"
+    namespace = "laa-apply-forlegalaid"
   }
 
   data {
-    zone_id   = "${aws_route53_zone.example_team_route53_zone.zone_id}"
+    zone_id   = "${aws_route53_zone.apply_for_legal_aid_route53_zone}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "apply_for_legal_aid_route53_zone" {
+  name = "staging.apply-for-legal-aid.service.justice.gov.uk"
+
+  tags {
+    business-unit          = "laa"
+    application            = "laa-apply-for-legal-aid"
+    is-production          = "false"
+    environment-name       = "staging"
+    owner                  = "apply-for-legal-aid"
+    infrastructure-support = "apply@digtal.justice.gov.uk"
+  }
+}
+
+resource "kubernetes_secret" "apply_for_legal_aidroute_53_zone_sec" {
+  metadata {
+    name      = "apply-for-legal-aid-route53-zone-output"
+    namespace = "laa-apply-forlegalaid-staging"
+  }
+
+  data {
+    zone_id   = "${aws_route53_zone.example_team_route53_zone.zone_id}"
+  }
+}


### PR DESCRIPTION
Add a route53.tf file to set up a domain name for the production environment under the ```.service.justice.gov.uk``` domain.

The preferred names are:

production  ```apply-for-legal-aid.service.justice.gov.uk```

staging ```staging.apply-for-legal-aid.service.justice.gov.uk```

Would it be better to set the route53.tf on production and have a subdomain for staging?