### PR TITLE
formbuilder force_ssl on datastore rds instances

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-dev/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-dev/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -12,6 +12,11 @@ module "user-datastore-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  force_ssl                  = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "user-datastore-rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-production/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-production/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-production/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -12,6 +12,11 @@ module "user-datastore-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  force_ssl                  = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "user-datastore-rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-staging/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-staging/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-staging/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -12,6 +12,11 @@ module "user-datastore-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  force_ssl                  = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "user-datastore-rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -12,6 +12,11 @@ module "user-datastore-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  force_ssl                  = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "user-datastore-rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -12,6 +12,11 @@ module "user-datastore-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  force_ssl                  = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "user-datastore-rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -12,6 +12,11 @@ module "user-datastore-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  force_ssl                  = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "user-datastore-rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -12,6 +12,11 @@ module "user-datastore-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  force_ssl                  = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "user-datastore-rds-instance" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/user-datastore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Datastore RDS
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -12,6 +12,11 @@ module "user-datastore-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  force_ssl                  = true
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "user-datastore-rds-instance" {


### PR DESCRIPTION
- this is similar to https://github.com/ministryofjustice/cloud-platform-environments/pull/1045 except for different application hence different rds instances