### PR TITLE
Reduce request.limits resourcequota for PVB prod.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: prison-visits-booking-production
 spec:
   hard:
-    requests.cpu: 6000m
-    requests.memory: 12Gi
-    limits.cpu: 9000m
-    limits.memory: 15Gi
+    requests.cpu: 2000m
+    requests.memory: 5000Mi


### PR DESCRIPTION
These request limit values are based on amount of resources their
production namespace uses.

Also, remove the 'hard' limits from the namespace resourcequota, because they're not useful.