### PR TITLE
Increase resource request limits for PVB staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: prison-visits-booking-staging
 spec:
   hard:
-    requests.cpu: 300m
-    requests.memory: 7500Mi
+    requests.cpu: 600m
+    requests.memory: 8500Mi


### PR DESCRIPTION
They have some cron jobs, so they need some
'headroom' in their CPU and memory resource quotas