### PR TITLE
Allocate 5Gi memory request.limits to namespaces

### DIFF
--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   hard:
     requests.cpu: 100m
-    requests.memory: 1000Mi
+    requests.memory: 5000Mi


### PR DESCRIPTION
Based on PVB prod namespace resizing, it's hard to predict in
advance how much memory a namespace will need, especially for
short-lived jobs.
This change should give developers more room to play with, although
they will still need to increase this limit for production namespaces