### PR TITLE
Add pingdom resource to CCCD staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
@@ -1,0 +1,22 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "pingdom" {}
+
+resource "pingdom_check" "claim-crown-court-defence-staging" {
+  type                     = "http"
+  name                     = "Claim for crown court defence staging - ping"
+  host                     = "staging.claim-crown-court-defence.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/ping"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_${var.business-unit},application_${var.application},component_ping,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_${var.application}"
+  probefilters             = "region:EU"
+  publicreport             = "true"
+  integrationids           = []
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
@@ -18,5 +18,5 @@ resource "pingdom_check" "claim-crown-court-defence-staging" {
   tags                     = "businessunit_${var.business-unit},application_${var.application},component_ping,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_${var.application}"
   probefilters             = "region:EU"
   publicreport             = "true"
-  integrationids           = []
+  integrationids           = [94703]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/variables.tf
@@ -1,0 +1,31 @@
+variable "application" {
+  default = "cccd"
+}
+
+variable "namespace" {
+  default = "cccd-staging"
+}
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "legal-aid-agency"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "laa-get-paid"
+}
+
+variable "environment-name" {
+  description = "The type of environment you're deploying to."
+  default     = "staging"
+}
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "crowncourtdefence@digtal.justice.gov.uk"
+}
+
+variable "is-production" {
+  default = "false"
+}


### PR DESCRIPTION
#### What
Add pingdom resource to CCCD staging

#### Why
To get failed ping response alerts in #laa-get-paid-alerts
channel

#### TODO

 - [x] [add pingdom/slack integration id](https://github.com/ministryofjustice/cloud-platform/issues/1155)