### PR TITLE
This PR adds several improvements to the namespace reporter script

### DIFF
--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -189,6 +189,22 @@ class Namespace
   end
 end
 
+def text_output(ns)
+  puts
+  puts "Namespace: #{ns[:name]}"
+  puts
+  puts "  Request limit:\tCPU: #{ns[:max_requests][:cpu]},\tMemory: #{ns[:max_requests][:memory]}"
+  puts "  Requested:\t\tCPU: #{ns[:resources_requested][:cpu]},\tMemory: #{ns[:resources_requested][:memory]}"
+  puts
+  puts "  Num. containers:\t#{ns[:container_count]}"
+  puts "  Req. per-container:\tCPU: #{ns[:default_request][:cpu]},\tMemory: #{ns[:default_request][:memory]}"
+  puts
+  puts "  Resources in-use:\tCPU: #{ns[:resources_used][:cpu]},\tMemory: #{ns[:resources_used][:memory]}"
+  puts
+  puts "CPU values are in millicores (m). Memory values are in mebibytes (Mi)."
+  puts
+end
+
 def parse_options
   options = {}
 
@@ -212,19 +228,5 @@ options = parse_options
 pattern = options.fetch(:namespace)
 
 Namespace.names(pattern).each do |name|
-  ns = Namespace.new(name).report
-
-  puts
-  puts "Namespace: #{ns[:name]}"
-  puts
-  puts "  Request limit:\tCPU: #{ns[:max_requests][:cpu]},\tMemory: #{ns[:max_requests][:memory]}"
-  puts "  Requested:\t\tCPU: #{ns[:resources_requested][:cpu]},\tMemory: #{ns[:resources_requested][:memory]}"
-  puts
-  puts "  Num. containers:\t#{ns[:container_count]}"
-  puts "  Req. per-container:\tCPU: #{ns[:default_request][:cpu]},\tMemory: #{ns[:default_request][:memory]}"
-  puts
-  puts "  Resources in-use:\tCPU: #{ns[:resources_used][:cpu]},\tMemory: #{ns[:resources_used][:memory]}"
-  puts
-  puts "CPU values are in millicores (m). Memory values are in mebibytes (Mi)."
-  puts
+  text_output(Namespace.new(name).report)
 end

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -8,18 +8,18 @@
 # Get results for all namespaces:
 #     ./bin/namespace-reporter.rb -n '.*' | tee namespace-report.txt
 #
+# Get results for all namespaces matching a string:
+#     ./bin/namespace-reporter.rb -n prison-visits
+#
+# Store data in a json file
+#     ./bin/namespace-reporter.rb -n '.*' -o json > namespaces.json
+#
+# Namespaces by number of containers
+#     cat namespaces.json | jq -r '.items[] | [.container_count, .name] | join(", ")' | sort -n
+#
 # Total count of containers:
-#     grep containers namespace-report.txt | sed 's/.*://' | paste -sd+ - | bc
+#     cat namespaces.json | jq '.items[].container_count' | paste -sd+ - | bc
 # https://stackoverflow.com/a/18141152/794111
-#
-# Total CPU used:
-#     grep in-use namespace-report.txt | sed 's/.*CPU: //' | sed 's/,.*//' | paste -sd+ - | bc
-#
-# Total Memory used:
-#     grep in-use namespace-report.txt | sed 's/.*Memory: //' | paste -sd+ - | bc
-#
-# Containers by namespace
-#     egrep '(containers|Namespace)' namespace-report.txt | sed 's/    / /g' | paste -s -d ' \n' - | sed 's/Namespace: //' | sed 's/\ *Num. containers:\ */, /' | sed 's/\(.*\), \(.*\)/\2, \1/' | sort -n
 
 require 'json'
 require 'optparse'

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -84,20 +84,18 @@ class Namespace
   end
 
   def from_limits(limits, value_type)
-    if limits.nil?
-      {
-        cpu: nil,
-        memory: nil
-      }
-    else
-      data = limits.dig("spec", "limits")[0]
-        .dig(value_type)
+    data = limits.dig("spec", "limits")[0]
+      .dig(value_type)
 
-      {
-        cpu: cpu_value(data.fetch("cpu", nil)),
-        memory: memory_value(data.fetch("memory", nil))
-      }
-    end
+    {
+      cpu: cpu_value(data.fetch("cpu", nil)),
+      memory: memory_value(data.fetch("memory", nil))
+    }
+  rescue
+    {
+      cpu: nil,
+      memory: nil
+    }
   end
 
   def limits

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -168,7 +168,7 @@ class Namespace
     case str
     when /^(\d+)$/
       $1.to_i / 1_000
-    when /^(\d+)k$/
+    when /^(\d+)k$/, /^(\d+)Ki$/
       $1.to_i / 1024
     when /^(\d+)m$/ # e.g. 6.4Gi in yaml => 6871947673600m in the JSON kubectl output
       $1.to_i / 1_000_000_000

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -215,8 +215,7 @@ def parse_options
       options[:namespace] = ns
     end
 
-    opts.on("-o", "--output FORMAT", "Output format (#{JSON_OUTPUT} | #{TEXT_OUTPUT})") do |fmt|
-      raise "Unknown output format #{fmt}" unless [TEXT_OUTPUT, JSON_OUTPUT].include?(fmt)
+    opts.on("-o", "--output [FORMAT]", [JSON_OUTPUT, TEXT_OUTPUT], "Output format (#{JSON_OUTPUT} | #{TEXT_OUTPUT})") do |fmt|
       options[:format] = fmt
     end
 

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -6,7 +6,7 @@
 # Usage tips:
 #
 # Get results for all namespaces:
-#     for ns in $(kubectl get ns | cut -f 1 -d\  | grep -v NAME); do ./bin/namespace-reporter.rb $ns; done | tee namespace-report.txt
+#     for ns in $(kubectl get ns | cut -f 1 -d\  | grep -v NAME); do ./bin/namespace-reporter.rb -n $ns; done | tee namespace-report.txt
 #
 # Total count of containers:
 #     grep containers namespace-report.txt | sed 's/.*://' | paste -sd+ - | bc
@@ -22,6 +22,7 @@
 #     egrep '(containers|Namespace)' namespace-report.txt | sed 's/    / /g' | paste -s -d ' \n' - | sed 's/Namespace: //' | sed 's/\ *Num. containers:\ */, /' | sed 's/\(.*\), \(.*\)/\2, \1/' | sort -n
 
 require 'json'
+require 'optparse'
 
 class Namespace
   attr_reader :name
@@ -182,14 +183,27 @@ class Namespace
   end
 end
 
+def parse_options
+  options = {}
+
+  OptionParser.new do |opts|
+    opts.on("-n", "--namespace NAMESPACE", "Namespace name (required)") do |ns|
+      options[:namespace] = ns
+    end
+
+    opts.on_tail("-h", "--help", "Show help message") do
+      puts opts
+      exit
+    end
+  end.parse!
+
+  options
+end
+
 ############################################################
 
-name = ARGV.shift
-
-if name.nil?
-  puts "USAGE: $0 [namespace name]"
-  exit
-end
+options = parse_options
+name = options.fetch(:namespace)
 
 ns = Namespace.new(name).report
 

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -6,7 +6,7 @@
 # Usage tips:
 #
 # Get results for all namespaces:
-#     for ns in $(kubectl get ns | cut -f 1 -d\  | grep -v NAME); do ./bin/namespace-reporter.rb -n $ns; done | tee namespace-report.txt
+#     for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}'); do ./bin/namespace-reporter.rb -n $ns; done | tee namespace-report.txt
 #
 # Total count of containers:
 #     grep containers namespace-report.txt | sed 's/.*://' | paste -sd+ - | bc

--- a/makefile
+++ b/makefile
@@ -1,0 +1,2 @@
+namespace-report.json: bin/namespace-reporter.rb namespaces/live-1.cloud-platform.service.justice.gov.uk/*/*.yaml
+	./bin/namespace-reporter.rb -o json -n '.*' > namespace-report.json


### PR DESCRIPTION
* Treat the supplied name as a pattern (e.g. get output for all the prison-visits namespaces at once)
* Add a `-o json` option for JSON output
* Handle memory values in the format 99999Ki
* Handle namespaces where the limits are not set (e.g. 'default')
* Update the usage tips at the top of the file

Note: This is a breaking change, in the sense that `./bin/namespace-reporter.rb foo` will not
work anymore. Now, it has to be `./bin/namespace-reporter.rb -n foo`