### PR TITLE
formbuilder upgrade non-prod postgres 10.6 => 10.9

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/main.tf
@@ -6,3 +6,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
@@ -3,7 +3,7 @@
 # Publisher RDS
 
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.4"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
@@ -13,6 +13,11 @@ module "publisher-rds-instance" {
   is-production              = "${var.is-production}"
   infrastructure-support     = "${var.infrastructure-support}"
   team_name                  = "${var.team_name}"
+  db_engine_version          = "10.9"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "publisher-rds-instance" {


### PR DESCRIPTION
- I am aware rds module 4.5 and postgres 10.10 are available but have to chosen these numbers so we can have parity across the many moving form builder parts
- these changes affect non-production environments