### PR TITLE
Add certificate for domain name

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: apply-for-legal-aid-domain
+  namespace: laa-apply-for-legal-aid-staging
+spec:
+  secretName: apply-for-legal-aid-tls-certificate-domain
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 'staging.apply-for-legal-aid.service.justice.gov.uk'
+  acme:
+    config:
+    - domains:
+      - 'staging.apply-for-legal-aid.service.justice.gov.uk'
+      dns01:
+        provider: route53-cloud-platform


### PR DESCRIPTION
Need to create a certificate for new domain ```apply-for-legal-aid.service.justice.gov.uk```

however this is on staging as we require ```staging.apply-for-legal-aid.service.justice.gov.uk``` as a subdomain.

Not sure if this is the correct way, i.e should I be creating one certificate under ```apply-for-legal-aid.service.justice.gov.uk``` and this would also cover any subdomains?
