### PR TITLE
Correct the namespace name in certificate file

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: apply-for-legal-aid-domain
-  namespace: laa-apply-for-legal-aid-staging
+  namespace: laa-apply-for-legalaid-staging
 spec:
   secretName: apply-for-legal-aid-tls-certificate-domain
   issuerRef:


### PR DESCRIPTION
The namespace was provided was incorrect

    laa-apply-for-legal-aid-staging -> laa-apply-for-legalaid-staging

i.e. remove extraneous dash in 'legal-aid'