### PR TITLE
Increase default container CPU & memory limits

### DIFF
--- a/namespace-resources/02-limitrange.yaml
+++ b/namespace-resources/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 50m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
Containers can require a lot more resources when 
they start up than they do during normal operation
e.g. CCCD's containers use about 4m CPU most of
the time, but spike to nearly 1000m during startup

If the CPU limit is set too low in the limit range
the container can be throttled during startup.
This can make the startup process take so long
that the container fails its readiness probe, and
the cluster kills it and starts a new one, which
results in a crashloop.

This commit allows containers to spike to 1000m
CPU, and also increases the memory limit to 1Gi,
to avoid this problem.