### PR TITLE
Remove custom Prometheus alert from PVB & MOIC

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/prometheus-custom-alerts-moic-preprod.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/prometheus-custom-alerts-moic-preprod.yaml
@@ -7,14 +7,6 @@ spec:
   groups:
   - name: moic-preprod
     rules:
-    - alert: KubePodNotReady
-      annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 5 minutes
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"^(Running|Completed)$", namespace="offender-management-preprod"}) > 0
-      for: 5m
-      labels:
-        severity: moic
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/prometheus-custom-alerts-moic-production.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/prometheus-custom-alerts-moic-production.yaml
@@ -7,14 +7,6 @@ spec:
   groups:
   - name: moic-production
     rules:
-    - alert: KubePodNotReady
-      annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 5 minutes
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"^(Running|Completed)$", namespace="offender-management-production"}) > 0
-      for: 5m
-      labels:
-        severity: moic
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/prometheus-custom-alerts-moic-staging.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/prometheus-custom-alerts-moic-staging.yaml
@@ -7,14 +7,6 @@ spec:
   groups:
   - name: moic-staging
     rules:
-    - alert: KubePodNotReady
-      annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 5 minutes
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"^(Running|Completed)$", namespace="offender-management-staging"}) > 0
-      for: 5m
-      labels:
-        severity: moic
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/prometheus-custom-alerts-pvb-production.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/prometheus-custom-alerts-pvb-production.yaml
@@ -7,14 +7,6 @@ spec:
   groups:
   - name: pvb-production
     rules:
-    - alert: KubePodNotReady
-      annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 2 minutes
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Completed", namespace="prison-visits-booking-production"}) > 0
-      for: 2m
-      labels:
-        severity: Prison Visits Booking / PVB
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/prometheus-custom-alerts-pvb-staging.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/prometheus-custom-alerts-pvb-staging.yaml
@@ -7,14 +7,6 @@ spec:
   groups:
   - name: pvb-staging
     rules:
-    - alert: KubePodNotReady
-      annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 2 minutes
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Completed", namespace="prison-visits-booking-staging"}) > 0
-      for: 2m
-      labels:
-        severity: Prison Visits Booking / PVB
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively


### PR DESCRIPTION
The KubePodNotReady alert is not working as intended and is causing a
huge amount of noise in our alerts channels for PVB & MOIC so we are
going to remove it.