### PR TITLE
Increase the default resource limits for fee-calc

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 1250Mi
     defaultRequest:
       cpu: 10m
       memory: 250Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 50m
-      memory: 1250Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
       cpu: 10m
       memory: 250Mi


### PR DESCRIPTION
They are seeing sentry issues with failing health checks, and I
can see 'Readiness probe failed' kubernetes events.

I believe the container is sometimes being starved of CPU,
probably at launch time, causing startup to take too long, and
the readiness probe to fail.

This change allows the container to burst CPU usage much higher,
which should avoid this problem.