### PR TITLE
Increase laa-fee-calculator-staging default resource limits

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/02-limitrange.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 50m
+      cpu: 1000m
       memory: 1250Mi
     defaultRequest:
       cpu: 10m


### PR DESCRIPTION
#### What
Increase laa-fee-calculator-staging default resource limits

#### Why
Inline with [laa-fee-calculator-production changes](https://github.com/ministryofjustice/cloud-platform-environments/pull/1118/files) for
the sake of parity.