### PR TITLE
Removed resource aws_sqs_queue_policy to fix pipeline

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/messaging.tf
@@ -18,25 +18,27 @@ module "risk_profiler_change" {
   }
 }
 
-resource "aws_sqs_queue_policy" "risk_profiler_change_policy" {
-  queue_url = "${module.risk_profiler_change.sqs_id}"
+/*temp removed this to fix the pipeline*/
 
-  policy = <<EOF
-  {
-    "Version": "2012-10-17",
-    "Id": "${module.risk_profiler_change.sqs_arn}/SQSDefaultPolicy",
-    "Statement":
-      [
-        {
-          "Effect": "Allow",
-          "Principal": {"AWS": "*"},
-          "Resource": "${module.risk_profiler_change.sqs_arn}",
-          "Action": "SQS:SendMessage"
-        }
-      ]
-  }
-  EOF
-}
+# resource "aws_sqs_queue_policy" "risk_profiler_change_policy" {
+#   queue_url = "${module.risk_profiler_change.sqs_id}"
+
+#   policy = <<EOF
+#   {
+#     "Version": "2012-10-17",
+#     "Id": "${module.risk_profiler_change.sqs_arn}/SQSDefaultPolicy",
+#     "Statement":
+#       [
+#         {
+#           "Effect": "Allow",
+#           "Principal": {"AWS": "*"},
+#           "Resource": "${module.risk_profiler_change.sqs_arn}",
+#           "Action": "SQS:SendMessage"
+#         }
+#       ]
+#   }
+#   EOF
+# }
 
 module "risk_profiler_change_dead_letter_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"


### PR DESCRIPTION
Removed resource aws_sqs_queue_policy to fix pipeline

pipeline failing with reason:
` Error updating SQS attributes: AWS.SimpleQueueService.NonExistentQueue: The specified queue does not exist for this wsdl version.`