### PR TITLE
add route53 for family mediator

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/route53.tf
@@ -1,0 +1,22 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = "familymediators.service.justice.gov.uk"
+
+  tags {
+    application            = "${var.application}"
+    is-production          = "${var.is-production}"
+    environment-name       = "${var.environment-name}"
+    owner                  = "${var.team_name}"
+    infrastructure-support = "${var.infrastructure-support}"
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  }
+}


### PR DESCRIPTION
- Added Route53 zone in family-mediator-api-production.
The zone had been created manually. 

A manual import is needed before merging this.