### PR TITLE
add route53 zone for c100, long and short

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
@@ -1,0 +1,37 @@
+resource "aws_route53_zone" "route53_zone_short" {
+  name = "c100.service.justice.gov.uk"
+
+  tags {
+    application            = "${var.application}"
+    is-production          = "${var.is-production}"
+    environment-name       = "${var.environment-name}"
+    owner                  = "${var.team_name}"
+    infrastructure-support = "${var.infrastructure-support}"
+  }
+}
+
+resource "aws_route53_zone" "route53_zone_long" {
+  name = "apply-to-court-about-child-arrangements.service.justice.gov.uk"
+
+  tags {
+    application            = "${var.application}"
+    is-production          = "${var.is-production}"
+    environment-name       = "${var.environment-name}"
+    owner                  = "${var.team_name}"
+    infrastructure-support = "${var.infrastructure-support}"
+  }
+}
+
+
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    short_zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+    long_zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
@@ -22,8 +22,6 @@ resource "aws_route53_zone" "route53_zone_long" {
   }
 }
 
-
-
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
@@ -31,7 +29,7 @@ resource "kubernetes_secret" "route53_zone_sec" {
   }
 
   data {
-    short_zone_id = "${aws_route53_zone.route53_zone.zone_id}"
-    long_zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+    short_zone_id = "${aws_route53_zone.route53_zone_short.zone_id}"
+    long_zone_id  = "${aws_route53_zone.route53_zone_long.zone_id}"
   }
 }


### PR DESCRIPTION
- Added new route53 zones in c100-application-production.

- The two zones had been created manually, this PR configures it in the code.

A terraform import has to be ran before this can be merged.
