### PR TITLE
Route53 moic

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_zone" "route53_zone_short" {
+resource "aws_route53_zone" "route53_zone" {
   name = "moic.service.justice.gov.uk"
 
   tags {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
@@ -1,0 +1,22 @@
+resource "aws_route53_zone" "route53_zone_short" {
+  name = "moic.service.justice.gov.uk"
+
+  tags {
+    application            = "${var.application}"
+    is-production          = "${var.is-production}"
+    environment-name       = "${var.environment-name}"
+    owner                  = "${var.team_name}"
+    infrastructure-support = "${var.infrastructure-support}"
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    short_zone_id = "${aws_route53_zone.route53_zone_short.zone_id}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
@@ -2,7 +2,7 @@ resource "aws_route53_zone" "route53_zone" {
   name = "moic.service.justice.gov.uk"
 
   tags {
-    application            = "${var.application}"
+    application            = "MOIC"
     is-production          = "${var.is-production}"
     environment-name       = "${var.environment-name}"
     owner                  = "${var.team_name}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
@@ -17,6 +17,6 @@ resource "kubernetes_secret" "route53_zone_sec" {
   }
 
   data {
-    short_zone_id = "${aws_route53_zone.route53_zone_short.zone_id}"
+    short_zone_id = "${aws_route53_zone.route53_zone.zone_id}"
   }
 }


### PR DESCRIPTION
- Add route53 zone for moic.service.justice.gov.uk

- The zone exists already, but was created manually. This change brings it into the code .

A terraform import is needed before we can merge this.