### PR TITLE
add route53 for prisoner-money

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/main.tf
@@ -3,6 +3,10 @@ terraform {
 }
 
 provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
@@ -1,0 +1,22 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = "prisoner-money.service.justice.gov.uk."
+
+  tags {
+    application            = "${var.application}"
+    is-production          = "${var.is-production}"
+    environment-name       = "${var.environment-name}"
+    owner                  = "${var.team_name}"
+    infrastructure-support = "${var.email}"
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    short_zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
@@ -10,7 +10,7 @@ resource "aws_route53_zone" "route53_zone" {
   }
 }
 
-resource "kubernetes_secret" "route53_zone_sec" {
+resource "kubernetes_secret" "route53_zone" {
   metadata {
     name      = "route53-zone-output"
     namespace = "${var.namespace}"


### PR DESCRIPTION
- Add route53 zone definition for prisoner-money.service.justice.gov.uk.

- This zone already exist and had been created manually. This change make it manageable through code.

- Add default terraform provider, on top of `aws.london`

A terraform import will be required, before this is merged.