### PR TITLE
Add cccd-production namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cccd-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "legal-aid-agency"
+    cloud-platform.justice.gov.uk/application: "cccd"
+    cloud-platform.justice.gov.uk/owner: "LAA get paid team: crowncourtdefence@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cccd-production-admin
+  namespace: cccd-production
+subjects:
+  - kind: Group
+    name: "github:crime-billing-online"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: cccd-production
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 125m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: cccd-production
+spec:
+  hard:
+    requests.cpu: 300m
+    requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: cccd-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: cccd-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/variables.tf
@@ -1,0 +1,31 @@
+variable "application" {
+  default = "cccd"
+}
+
+variable "namespace" {
+  default = "cccd-production"
+}
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "legal-aid-agency"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "laa-get-paid"
+}
+
+variable "environment-name" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "crowncourtdefence@digtal.justice.gov.uk"
+}
+
+variable "is-production" {
+  default = "true"
+}


### PR DESCRIPTION
#### What
Add cccd-production namespace

#### Why
migration to live-1. This namespace is
initially to be used for testing RDS and
s3 migration.