### PR TITLE
Reduce cccd-production cpuRequest limitrange

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 2Gi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 1000Mi
     type: Container


### PR DESCRIPTION
#### What
Reduce cccd-production cpuRequest limitrange

#### Why
receiving the following with current settings:
```
Warning   FailedCreate        ReplicaSet   Error creating: pods "claim-for-crown-court-defence-845ff6bd95-j28ln" is forbidden: exceeded quota: namespace-quota, requested: requests.cpu=125m, used: requests.cpu=250m, limited: requests.cpu=300m
```

These changes bring cccd-production
inline with cccd-staging namespace
but will need reviewing inline with
current (template-deploy) production
version of CCCD.