### PR TITLE
Enable creating namespace with `make namespace`

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,2 +1,12 @@
+TOOLS_IMAGE := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
+
 namespace-report.json: bin/namespace-reporter.rb namespaces/live-1.cloud-platform.service.justice.gov.uk/*/*.yaml
 	./bin/namespace-reporter.rb -o json -n '.*' > namespace-report.json
+
+# Create a new namespace
+namespace:
+	@echo "Authenticating to ECR & pulling Cloud Platform Tools docker image..."
+	@export AWS_PROFILE=moj-cp; ( $$(aws ecr get-login --no-include-email); docker pull $(TOOLS_IMAGE) > /dev/null )
+	@echo "Creating namespace..."
+	@docker run --rm -it -v $$(pwd):/app -w /app $(TOOLS_IMAGE) bash -c 'cd namespace-resources; terraform init; terraform apply -auto-approve'
+	@git status --untracked-files=all


### PR DESCRIPTION
This makefile target uses the cloud platform tools
image, so the user does not need to install 
terraform, although they do need to have a 
`moj-cp` AWS profile configured, and docker
installed.

This change, once merged, will be used as the
basis for a rewrite of the user guide article on
creating a new namespace.