### PR TITLE
Update makefile to use dockerhub tools image

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,12 +1,12 @@
-TOOLS_IMAGE := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools
 
 namespace-report.json: bin/namespace-reporter.rb namespaces/live-1.cloud-platform.service.justice.gov.uk/*/*.yaml
 	./bin/namespace-reporter.rb -o json -n '.*' > namespace-report.json
 
 # Create a new namespace
 namespace:
-	@echo "Authenticating to ECR & pulling Cloud Platform Tools docker image..."
-	@export AWS_PROFILE=moj-cp; ( $$(aws ecr get-login --no-include-email); docker pull $(TOOLS_IMAGE) > /dev/null )
+	@echo "Pulling Cloud Platform Tools docker image..."
+	@docker pull $(TOOLS_IMAGE) > /dev/null
 	@echo "Creating namespace..."
 	@docker run --rm -it -v $$(pwd):/app -w /app $(TOOLS_IMAGE) bash -c 'cd namespace-resources; terraform init; terraform apply -auto-approve'
 	@git status --untracked-files=all


### PR DESCRIPTION
This means there is no longer a requirement for the user to have
the AWS cli installed and configured, and no need to authenticate
to ECR in order to run `make namespace`