### PR TITLE
Reduce "Apply for legal aid" containers CPU allocation

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 2Gi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 2Gi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 2Gi
     defaultRequest:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 10m
+      memory: 512Mi
     type: Container


### PR DESCRIPTION
Runtime CPU usage of each of the Apply-for-legal-aid containers stays
under 10m. So allocating 100m for each was an overkill.
We increased the memory allocation per container as some of our
containers use between 256Mi and 900Mi, while others use less than
100Mi.

We normalized the container CPU and Memory allocation for the three
environments/namespaces: UAT, Staging and Production so we have the
same resources everywhere.