### PR TITLE
Reduce "Apply for legal aid" namespaces CPU allocation

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: laa-apply-for-legalaid-production
 spec:
   hard:
-    limits.cpu: "10"
-    limits.memory: 20Gi
-    requests.cpu: "4"
-    requests.memory: 8Gi
+    requests.cpu: 100m
+    requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: laa-apply-for-legalaid-staging
 spec:
   hard:
-    limits.cpu: "10"
-    limits.memory: 20Gi
-    requests.cpu: "4"
-    requests.memory: 8Gi
+    requests.cpu: 100m
+    requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: laa-apply-for-legalaid-uat
 spec:
   hard:
-    requests.cpu: 20000m
-    requests.memory: 20Gi
-    limits.cpu: 20000m
-    limits.memory: 30Gi
+    requests.cpu: 100m
+    requests.memory: 6Gi


### PR DESCRIPTION
Runtime CPU usage of each of the Apply-for-legal-aid namespaces stays
well under 100m (usually below 20m).
So allocating 4000m to 20000m for each namespace was an overkill.

The memory currently used by namespace is bellow 3Gi, so setting an
scheduled allocation of 6Gi gives us space for even a replica of all the
containers in the namespace.

We normalized the namespace CPU and Memory allocation for the three
environments/namespaces: UAT, Staging and Production so we have the
same resources everywhere.

The limits.cpu and limits.memory are not used anymore in the defaults
and we removed them to align our configurations with Cloud Platform
current defaults/standards.