### PR TITLE
Create a namespace for the namespace usage report

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-usage-report
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "Cloud platform namespace usage report"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-namespace-usage-report"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: namespace-usage-report-admin
+  namespace: namespace-usage-report
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: namespace-usage-report
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: namespace-usage-report
+spec:
+  hard:
+    requests.cpu: 100m
+    requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: namespace-usage-report
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: namespace-usage-report
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/resources/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}


### PR DESCRIPTION
This namespace will host a single pod, with a container running
the sinatra application that displays information about namespace
utilisation.