### PR TITLE
Remove environment postfix from the secret

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/elasticache.tf
@@ -16,7 +16,7 @@ module "celery-broker" {
 
 resource "kubernetes_secret" "celery-broker" {
   metadata {
-    name      = "celery-broker-${var.environment-name}"
+    name      = "celery-broker"
     namespace = "${var.namespace}"
   }
 


### PR DESCRIPTION
A quick follow-up to #1182: the secret postfix is unnecessary as we already have "staging" in the namespace.