### PR TITLE
Bump the namespace report image from 1.0 to 1.1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: usage-report
-          image: ministryofjustice/cloud-platform-namespace-usage-report:1.0
+          image: ministryofjustice/cloud-platform-namespace-usage-report:1.1
           env:
             - name: API_KEY
               valueFrom:


### PR DESCRIPTION
This version includes this fix:

https://github.com/ministryofjustice/cloud-platform-namespace-usage-report/commit/29a46515976cc155c82380809364174d961eb0e6