### PR TITLE
Revert "Reduce "Apply for legal aid" namespaces CPU allocation"

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/03-resourcequota.yaml
@@ -5,5 +5,7 @@ metadata:
   namespace: laa-apply-for-legalaid-production
 spec:
   hard:
-    requests.cpu: 100m
-    requests.memory: 6Gi
+    limits.cpu: "10"
+    limits.memory: 20Gi
+    requests.cpu: "4"
+    requests.memory: 8Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/03-resourcequota.yaml
@@ -5,5 +5,7 @@ metadata:
   namespace: laa-apply-for-legalaid-staging
 spec:
   hard:
-    requests.cpu: 100m
-    requests.memory: 6Gi
+    limits.cpu: "10"
+    limits.memory: 20Gi
+    requests.cpu: "4"
+    requests.memory: 8Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -5,5 +5,7 @@ metadata:
   namespace: laa-apply-for-legalaid-uat
 spec:
   hard:
-    requests.cpu: 100m
-    requests.memory: 6Gi
+    requests.cpu: 20000m
+    requests.memory: 20Gi
+    limits.cpu: 20000m
+    limits.memory: 30Gi


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-environments#1168

We were actually allocating more CPU per pod than the Namespace Allocation we set up, so started getting alerts like: 

"Alert: Namespace laa-apply-for-legalaid-production is using 170% of its requests.cpu "

Reverting the reduction, will adjust accordingly and re-open the PR.