### PR TITLE
Reduce "Apply for legal aid" namespaces CPU allocation

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: laa-apply-for-legalaid-production
 spec:
   hard:
-    limits.cpu: "10"
-    limits.memory: 20Gi
-    requests.cpu: "4"
+    requests.cpu: 200m
     requests.memory: 8Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: laa-apply-for-legalaid-staging
 spec:
   hard:
-    limits.cpu: "10"
-    limits.memory: 20Gi
-    requests.cpu: "4"
+    requests.cpu: 200m
     requests.memory: 8Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: laa-apply-for-legalaid-uat
 spec:
   hard:
-    requests.cpu: 20000m
-    requests.memory: 20Gi
-    limits.cpu: 20000m
-    limits.memory: 30Gi
+    requests.cpu: 500m
+    requests.memory: 15Gi


### PR DESCRIPTION
Runtime CPU usage of each of the Apply-for-legal-aid namespaces stays
well under 100m (usually below 20m).
So allocating 4000m to 20000m for each namespace was an overkill.

The memory currently used by namespace is bellow 3Gi, and our containers
schedule memory is less than 5Gi, so setting an scheduled allocation of
 8Gi gives us space for even adding a new replica into the namespace.

 We normalized the namespace CPU and Memory allocation for staging and
 production.
 UAT though, as different branches get deployed in the same UAT
 namespace as different releases living together, has higher demands for
 CPU and Memory than the rest, especially when different developers are
 testing their work in parallel. This is the reason why UAT has higher
 CPU and Memory Allocation.

The limits.cpu and limits.memory are not used anymore in the defaults
and we removed them to align our configurations with Cloud Platform
current defaults/standards.

Our current allocation and resources consumption:

```
Namespace: laa-apply-for-legalaid-uat

  Request limit:	CPU: 20000,	Memory: 20000
  Requested:		CPU: 110,	Memory: 4864

  Num. containers:	11
  Req. per-container:	CPU: 10,	Memory: 512

  Resources in-use:	CPU: 27,	Memory: 2816
```

```
Namespace: laa-apply-for-legalaid-staging

  Request limit:	CPU: 4000,	Memory: 8000
  Requested:		CPU: 80,	Memory: 4672

  Num. containers:	9
  Req. per-container:	CPU: 10,	Memory: 512

  Resources in-use:	CPU: 16,	Memory: 2771
```

```
Namespace: laa-apply-for-legalaid-production

  Request limit:	CPU: 4000,	Memory: 8000
  Requested:		CPU: 80,	Memory: 4672

  Num. containers:	8
  Req. per-container:	CPU: 10,	Memory: 512

  Resources in-use:	CPU: 15,	Memory: 2791
```
