### PR TITLE
Reduce resources reserved for monitoring namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: monitoring
 spec:
   hard:
-    requests.cpu: 10000m
-    requests.memory: 24Gi
-    limits.cpu: 10000m
-    limits.memory: 24Gi
+    requests.cpu: 500m
+    requests.memory: 12Gi


### PR DESCRIPTION
* Reduce limitrange requests from 125m/250Mi to
10m/100Mi

This change will not have any effect, because all
the pods in the monitoring namespace seem to have
sensible resource values set via the helm chart, 
so these defaults won't be used. But, this change
is worth making in case we add any pods to the
namespace in future, without specifying limits.

* Remove the 'hard limit' on the namespace
* Reduce the request limit from 10000m/24Gi to
500m/12Gi

These changes bring the namespace closer into line
with our defaults for all namespaces, and better
reflect what the monitoring namespace actually
uses.