### PR TITLE
Downgrade cccd-dev rds instance to postgres 9.6

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/main.tf
@@ -17,7 +17,3 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
-
-variable "cluster_name" {}
-
-variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds.tf
@@ -1,4 +1,14 @@
 /*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}
+
+/*
  * Make sure that you use the latest version of the module by changing the
  * `ref=` value in the `source` attribute to the latest version listed on the
  * releases page of this repository.
@@ -6,19 +16,23 @@
  */
 
 module "cccd_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
-
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "laa-get-paid"
-  business-unit          = "legal-aid-agency"
-  application            = "cccd"
-  is-production          = "false"
-  environment-name       = "dev"
-  infrastructure-support = "crowncourtdefence@digtal.justice.gov.uk"
-  db_engine_version      = "10.6"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
+  cluster_name                = "${var.cluster_name}"
+  cluster_state_bucket        = "${var.cluster_state_bucket}"
+  team_name                   = "${var.team_name}"
+  business-unit               = "${var.business-unit}"
+  application                 = "${var.application}"
+  is-production               = "${var.is-production}"
+  environment-name            = "${var.environment-name}"
+  infrastructure-support      = "${var.infrastructure-support}"
+  db_allocated_storage        = "50"
+  db_instance_class           = "db.t3.small"
+  db_engine_version           = "9.6"
+  rds_family                  = "postgres9.6"
+  allow_major_version_upgrade = "true"
 
   providers = {
+    # Can be either "aws.london" or "aws.ireland"
     aws = "aws.london"
   }
 }
@@ -26,7 +40,7 @@ module "cccd_rds" {
 resource "kubernetes_secret" "cccd_rds" {
   metadata {
     name      = "cccd-rds"
-    namespace = "cccd-dev"
+    namespace = "${var.namespace}"
   }
 
   data {


### PR DESCRIPTION
#### What
Postgres 10.6 --> 9.6

Also:
 - update the terraform template
 - specify instance class to be small

#### Why
This downgrade of the rds instance is in line with both
live-1 cccd-production, cccd-api-sandbox and cccd-staging
as well as all current CCCD Template deploy environments.
The downgrade is to remove potential unknowns from any
migration of the current production databases (TD).

Can be upgraded after migration to live-1.