### PR TITLE
Increase monitoring namespace request CPU limit

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: monitoring
 spec:
   hard:
-    requests.cpu: 500m
+    requests.cpu: 2500m
     requests.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/03-resourcequota.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   hard:
     requests.cpu: 2500m
-    requests.memory: 12Gi
+    requests.memory: 18Gi


### PR DESCRIPTION
The total of all pod cpu requests is 2150, so a limit for the
namespace of 500 is much too low.