### PR TITLE
Remove Tiller Service Accounts

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/01-rbac.yaml
@@ -11,23 +11,3 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tiller
-  namespace: hmcts-complaints-formbuilder-adapter-production
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: tiller
-  namespace: hmcts-complaints-formbuilder-adapter-production
-subjects:
-- kind: ServiceAccount
-  name: tiller
-  namespace: hmcts-complaints-formbuilder-adapter-production
-roleRef:
-  kind: ClusterRole
-  name: admin
-  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/01-rbac.yaml
@@ -11,23 +11,3 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tiller
-  namespace: hmcts-complaints-formbuilder-adapter-staging
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: tiller
-  namespace: hmcts-complaints-formbuilder-adapter-staging
-subjects:
-- kind: ServiceAccount
-  name: tiller
-  namespace: hmcts-complaints-formbuilder-adapter-staging
-roleRef:
-  kind: ClusterRole
-  name: admin
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
We only use `helm template` so don't need Tiller running on the server.