### PR TITLE
Add cccd-dev redis url as secret data

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/redis.tf
@@ -27,5 +27,6 @@ resource "kubernetes_secret" "cccd_elasticache_redis" {
   data {
     primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
     auth_token               = "${module.cccd_elasticache_redis.auth_token}"
+    url                      = "redis://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379/0"
   }
 }


### PR DESCRIPTION
To simplify, hopefully, the connection
to the remote elasticache redis cluster.