### PR TITLE
Personal namespaces: use our resource defaults

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: becca-test-app-dev
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/el-demo-app-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/el-demo-app-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/el-demo-app-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/el-demo-app-dev/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: el-demo-app-dev
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/emile-sample-app-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/emile-sample-app-dev/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 2Gi
+      memory: 1000Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/emile-sample-app-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/emile-sample-app-dev/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: emile-sample-app-dev
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 8Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/gdavies-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/gdavies-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 16m
-      memory: 150Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/gdavies-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/gdavies-dev/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: gdavies-dev
 spec:
   hard:
-    requests.cpu: 1500m
-    requests.memory: 3Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 16m
-      memory: 150Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: jason-lab
 spec:
   hard:
-    requests.cpu: 1500m
-    requests.memory: 3Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: poornima-dev
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi


### PR DESCRIPTION
This commit changes the limitrange and resourcequota values for
all 'personal' namespaces to match our defaults, as set in the
templates in the namespace-resources folder.

'personal' namespaces were identified by looking for namespaces
whose names suggest that they belong to an individual, rather than
a service team.