### PR TITLE
Concourse namespace: reduce resource allocation

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 5000Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: concourse
 spec:
   hard:
-    requests.cpu: 6000m
+    requests.cpu: 2500m
     requests.memory: 12Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi


### PR DESCRIPTION
* limitrange

Increase the hard limit for CPU and memory. We already have pods in the
concourse namespace using 820m and 2020Mi, so these container limits are
too low.

Reduce defaultRequest to 10m/100Mi - 2 out of 3 containers in the
namespace only use 13m CPU, so there's no need to reserve 125m.
Similarly, memory doesn't need to be set aside, as long as the
containers can use as much as they need.

* resourcequota

The total of all CPU requests in the namespace is 2100m, so this change
reduces the requested CPU from 6000m to 2500m

Memory requested is just over 8Gi, so I've left the request for 12Gi as
is.

After all the pods are cycled, with the new limitrange values, we may be
able to reduce the resourcequota further.