### PR TITLE
Reduce resources allocated to concourse-main

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse-main/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse-main/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse-main/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse-main/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: concourse-main
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 1m
+    requests.memory: 1Mi


### PR DESCRIPTION
This namespace only exists to host secrets for concourse - no
pods actually run in it. So, we don't need to set aside 3 CPUs
and 6G of memory for it.