### PR TITLE
Add member clusters output to cccd-dev redis cluster

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/redis.tf
@@ -28,6 +28,7 @@ resource "kubernetes_secret" "cccd_elasticache_redis" {
   data {
     primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
     auth_token               = "${module.cccd_elasticache_redis.auth_token}"
+    member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
     url                      = "redis://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
     unauthed_url             = "redis://${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }


### PR DESCRIPTION
previously had forgotten to jsonencode the value
resulting in apply pipeline error.

```
Error: Error running plan: 1 error occurred:
  * kubernetes_secret.cccd_elasticache_redis: data (member_clusters): '' expected type 'string', got unconvertible type '[]interface {}'
```