### PR TITLE
Track A Query - add elasticache

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
@@ -12,15 +12,15 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "track_a_query_elasticache_redis" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
-  cluster_name                  = "${var.cluster_name}"
-  cluster_state_bucket          = "${var.cluster_state_bucket}"
-  team_name                     = "correspondence"
-  business-unit                 = "Central Digital"
-  application                   = "track-a-query"
-  is-production                 = "false"
-  environment-name              = "development"
-  infrastructure-support        = "mohammed.seedat@digtal.justice.gov.uk"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "correspondence"
+  business-unit          = "Central Digital"
+  application            = "track-a-query"
+  is-production          = "false"
+  environment-name       = "development"
+  infrastructure-support = "mohammed.seedat@digtal.justice.gov.uk"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
@@ -1,0 +1,31 @@
+################################################################################
+# Track a Query (Correspondence Tool Staff)
+# Application Elasticache for ReDiS (for sidekiq background job processing)
+#################################################################################
+
+module "track_a_query_elasticache_redis" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+
+  cluster_name                  = ""
+  cluster_state_bucket          = ""
+  team_name                     = "correspondence"
+  number_cache_clusters         = "3"
+  replication_group_description = "example description"
+  business-unit                 = "Central Digital"
+  application                   = "track-a-query"
+  is-production                 = "false"
+  environment-name              = "development"
+  infrastructure-support        = "mohammed.seedat@digtal.justice.gov.uk"
+}
+
+resource "kubernetes_secret" "track_a_query_elasticache_redis" {
+  metadata {
+    name      = "track-a-query-elasticache-redis"
+    namespace = "cts-prototype-dev-poc"
+  }
+
+  data {
+    primary_endpoint_address = "${module.track_a_query_elasticache_redis.primary_endpoint_address}"
+    auth_token               = "${module.track_a_query_elasticache_redis.auth_token}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
@@ -16,8 +16,6 @@ module "track_a_query_elasticache_redis" {
   cluster_name                  = "${var.cluster_name}"
   cluster_state_bucket          = "${var.cluster_state_bucket}"
   team_name                     = "correspondence"
-  number_cache_clusters         = "3"
-  replication_group_description = "example description"
   business-unit                 = "Central Digital"
   application                   = "track-a-query"
   is-production                 = "false"
@@ -37,7 +35,6 @@ resource "kubernetes_secret" "track_a_query_elasticache_redis" {
 
   data {
     primary_endpoint_address = "${module.track_a_query_elasticache_redis.primary_endpoint_address}"
-    member_clusters          = "${jsonencode(module.track_a_query_elasticache_redis.member_clusters)}"
     auth_token               = "${module.track_a_query_elasticache_redis.auth_token}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
@@ -3,11 +3,18 @@
 # Application Elasticache for ReDiS (for sidekiq background job processing)
 #################################################################################
 
-module "track_a_query_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ */
 
-  cluster_name                  = ""
-  cluster_state_bucket          = ""
+variable "cluster_name" {}
+variable "cluster_state_bucket" {}
+
+module "track_a_query_elasticache_redis" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  cluster_name                  = "${var.cluster_name}"
+  cluster_state_bucket          = "${var.cluster_state_bucket}"
   team_name                     = "correspondence"
   number_cache_clusters         = "3"
   replication_group_description = "example description"
@@ -16,16 +23,21 @@ module "track_a_query_elasticache_redis" {
   is-production                 = "false"
   environment-name              = "development"
   infrastructure-support        = "mohammed.seedat@digtal.justice.gov.uk"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "track_a_query_elasticache_redis" {
   metadata {
-    name      = "track-a-query-elasticache-redis"
+    name      = "track-a-query-elasticache-redis-output"
     namespace = "cts-prototype-dev-poc"
   }
 
   data {
     primary_endpoint_address = "${module.track_a_query_elasticache_redis.primary_endpoint_address}"
+    member_clusters          = "${jsonencode(module.track_a_query_elasticache_redis.member_clusters)}"
     auth_token               = "${module.track_a_query_elasticache_redis.auth_token}"
   }
 }


### PR DESCRIPTION
Enable redis cluster for use with Track a Query (Correspondence Tool Staff)