### PR TITLE
Add elasticache to all cccd namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/elasticache.tf
@@ -1,0 +1,35 @@
+################################################################################
+# CCCD Application Elasticache for ReDiS
+# for sidekiq background job processing and internal API cache
+################################################################################
+
+module "cccd_elasticache_redis" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  application            = "${var.application}"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+
+  engine_version        = "4.0.10"
+  parameter_group_name  = "default.redis4.0"
+  number_cache_clusters = "2"
+  node_type             = "cache.t2.micro"
+}
+
+resource "kubernetes_secret" "cccd_elasticache_redis" {
+  metadata {
+    name      = "cccd-elasticache-redis"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
+    auth_token               = "${module.cccd_elasticache_redis.auth_token}"
+    member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
+    url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/main.tf
@@ -15,7 +15,3 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
-
-variable "cluster_name" {}
-
-variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/variables.tf
@@ -3,7 +3,7 @@ variable "application" {
 }
 
 variable "namespace" {
-  default = "cccd-staging"
+  default = "cccd-api-sandbox"
 }
 
 variable "business-unit" {
@@ -18,7 +18,7 @@ variable "team_name" {
 
 variable "environment-name" {
   description = "The type of environment you're deploying to."
-  default     = "staging"
+  default     = "api-sandbox"
 }
 
 variable "infrastructure-support" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
@@ -1,5 +1,6 @@
 ################################################################################
-# CCCD Application Elasticache for ReDiS (for sidekiq background job processing)
+# CCCD Application Elasticache for ReDiS
+# for sidekiq background job processing and internal API cache
 ################################################################################
 
 module "cccd_elasticache_redis" {
@@ -29,7 +30,6 @@ resource "kubernetes_secret" "cccd_elasticache_redis" {
     primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
     auth_token               = "${module.cccd_elasticache_redis.auth_token}"
     member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
-    url                      = "redis://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
-    unauthed_url             = "redis://${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
+    url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
@@ -1,0 +1,37 @@
+################################################################################
+# CCCD Application Elasticache for ReDiS
+# for sidekiq background job processing and internal API cache
+# Size: cache.t2.small (1vCPU, 1.55Gib, low/moderate)
+# https://aws.amazon.com/elasticache/pricing/
+################################################################################
+
+module "cccd_elasticache_redis" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  application            = "${var.application}"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+
+  engine_version        = "4.0.10"
+  parameter_group_name  = "default.redis4.0"
+  number_cache_clusters = "3"
+  node_type             = "cache.t2.small"
+}
+
+resource "kubernetes_secret" "cccd_elasticache_redis" {
+  metadata {
+    name      = "cccd-elasticache-redis"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
+    auth_token               = "${module.cccd_elasticache_redis.auth_token}"
+    member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
+    url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/rds.tf
@@ -1,14 +1,4 @@
 /*
- * When using this module through the cloud-platform-environments, the following
- * two variables are automatically supplied by the pipeline.
- *
- */
-
-variable "cluster_name" {}
-
-variable "cluster_state_bucket" {}
-
-/*
  * Make sure that you use the latest version of the module by changing the
  * `ref=` value in the `source` attribute to the latest version listed on the
  * releases page of this repository.

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/variables.tf
@@ -29,3 +29,12 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/elasticache.tf
@@ -1,0 +1,35 @@
+################################################################################
+# CCCD Application Elasticache for ReDiS
+# for sidekiq background job processing and internal API cache
+################################################################################
+
+module "cccd_elasticache_redis" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  application            = "${var.application}"
+  environment-name       = "${var.environment-name}"
+  is-production          = "${var.is-production}"
+  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = "${var.team_name}"
+
+  engine_version        = "4.0.10"
+  parameter_group_name  = "default.redis4.0"
+  number_cache_clusters = "3"
+  node_type             = "cache.t2.small"
+}
+
+resource "kubernetes_secret" "cccd_elasticache_redis" {
+  metadata {
+    name      = "cccd-elasticache-redis"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
+    auth_token               = "${module.cccd_elasticache_redis.auth_token}"
+    member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
+    url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
@@ -1,14 +1,4 @@
 /*
- * When using this module through the cloud-platform-environments, the following
- * two variables are automatically supplied by the pipeline.
- *
- */
-
-variable "cluster_name" {}
-
-variable "cluster_state_bucket" {}
-
-/*
  * Make sure that you use the latest version of the module by changing the
  * `ref=` value in the `source` attribute to the latest version listed on the
  * releases page of this repository.


### PR DESCRIPTION
#### What
amend cccd-dev terraform file name inline with conventions
add elastiche to api-sandbox, staging and production.

#### Why
Redis used for queuing email jobs and caching calls
to internal API.

TD elasticache uses an old node size of cache.m1.small in
production which most closely maps to cache.t2.small for
[current standard nodes](https://aws.amazon.com/elasticache/pricing/)