### PR TITLE
Track a Query - Add simple S3 bucket to terraform config

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
@@ -1,0 +1,33 @@
+################################################################################
+# Track a Query (Correspondence Tool Staff)
+# S3 Bucket for file uploads
+#################################################################################
+
+module "track_a_query_s3" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "correspondence"
+  business-unit          = "Central Digital"
+  application            = "track-a-query"
+  is-production          = "false"
+  environment-name       = "development"
+  infrastructure-support = "mohammed.seedat@digtal.justice.gov.uk"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "track_a_query_s3" {
+  metadata {
+    name      = "track-a-query-s3-output"
+    namespace = "cts-prototype-dev-poc"
+  }
+
+  data {
+    access_key_id     = "${module.track_a_query_s3.access_key_id}"
+    secret_access_key = "${module.track_a_query_s3.secret_access_key}"
+    bucket_arn        = "${module.track_a_query_s3.bucket_arn}"
+    bucket_name       = "${module.track_a_query_s3.bucket_name}"
+  }
+}


### PR DESCRIPTION
Correspondence Tool Staff requires an S3 bucket to operate