### PR TITLE
Fix namespace in track-a-query-dev namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-dev/resources/rds.tf
@@ -48,7 +48,7 @@ module "track_a_query_dev_rds" {
 resource "kubernetes_secret" "track_a_query_dev_rds" {
   metadata {
     name      = "example-team-rds-instance-output"
-    namespace = "my-namespace"
+    namespace = "track-a-query-dev"
   }
 
   data {


### PR DESCRIPTION
To fix a broken reference to a namespace that doesn't exist.