### PR TITLE
Annotate OPA and kube-system namespace so OPA ignore decisions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-system
+annotations:
+  openpolicyagent.org/webhook: "ignore"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/opa/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/opa/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "OPA"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-infrastructure"
+    openpolicyagent.org/webhook: "ignore"


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/1028

Why: OPA policy to block Pods which has tolerations stopped OPA to make decisions because the OPA pod were also blocked from creating which created a loop. Hence, Ignore OPA and kube-system from OPA policy decisions.

Ref: https://www.openpolicyagent.org/docs/latest/kubernetes-debugging/#ensure-the-webhook-is-configured-for-the-proper-namespaces



