### PR TITLE
Annotate monitoring and logging ns to have workloads in master node

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-system
-annotations:
-  openpolicyagent.org/webhook: "ignore"
+  annotations:
+    openpolicyagent.org/webhook: "ignore"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/00-namespace.yaml
@@ -12,3 +12,4 @@ metadata:
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"
     iam.amazonaws.com/permitted: ".*"
+    cloud-platform.justice.gov.uk/can-tolerate-master-taints: "true"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/00-namespace.yaml
@@ -12,3 +12,4 @@ metadata:
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"
     iam.amazonaws.com/permitted: ".*"
+    cloud-platform.justice.gov.uk/can-tolerate-master-taints: "true"


### PR DESCRIPTION
What:
Annotate monitoring and logging namespaces with cloud-platform.justice.gov.uk/can-tolerate-master-taints

Why: so when the OPA policy for pod toleration is applied, these namespaces are allowed to schedule pods on master node

Related to: https://github.com/ministryofjustice/cloud-platform/issues/1028