### PR TITLE
Add get verb to MTP Test for circleci service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/06-service-account-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/06-service-account-circleci.yaml
@@ -22,6 +22,7 @@ rules:
     resources:
       - deployments
     verbs:
+      - get
       - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
This is because if you want to "patch deployments" you need "get" as well.