### PR TITLE
Track a Query - Add protocol to Redis URL

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/redis.tf
@@ -26,7 +26,7 @@ resource "kubernetes_secret" "track_a_query_elasticache_redis" {
   }
 
   data {
-    primary_endpoint_address = "${module.track_a_query_elasticache_redis.primary_endpoint_address}"
+    primary_endpoint_address = "redis://${module.track_a_query_elasticache_redis.primary_endpoint_address}:6379"
     auth_token               = "${module.track_a_query_elasticache_redis.auth_token}"
   }
 }


### PR DESCRIPTION
Redis URL in module output should have the `redis://` protocol in the URL for use in the consuming application.