### PR TITLE
Reduce logging namespace CPU request to 3000m

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: logging
 spec:
   hard:
-    requests.cpu: 6000m
+    requests.cpu: 3000m
     requests.memory: 12Gi


### PR DESCRIPTION
The logging namespace uses less than 3000m CPU. This change
reduces the amount of CPU requested (i.e. reserved) from 6000m
to 3000m