### PR TITLE
Move `auto-approve` flag to the end of the command

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -28,10 +28,10 @@ for _f in namespaces/${cluster}/*; do
           -backend-config="key=${PIPELINE_STATE_KEY_PREFIX}${cluster}/${namespace}/terraform.tfstate" \
           -backend-config="region=${PIPELINE_STATE_REGION}"
         terraform apply \
-          -auto-approve \
           -var="cluster_name=${cluster%%.*}" \
           -var="cluster_state_bucket=${PIPELINE_CLUSTER_STATE_BUCKET}" \
-          -var="cluster_state_key=${PIPELINE_CLUSTER_STATE_KEY_PREFIX}${cluster%%.*}/terraform.tfstate"
+          -var="cluster_state_key=${PIPELINE_CLUSTER_STATE_KEY_PREFIX}${cluster%%.*}/terraform.tfstate" \
+          -auto-approve
       )
     fi
   fi


### PR DESCRIPTION
This change has no functional effect, but it makes
it easier to grab the part of the command you need
when doing a manual apply on a namespace, without
including the dangerous `auto-approve` flag