### PR TITLE
Reduce OPA limitrange default requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/opa/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/opa/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 80m
       memory: 400Mi
     defaultRequest:
-      cpu: 40m
-      memory: 200Mi
+      cpu: 4m
+      memory: 50Mi
     type: Container


### PR DESCRIPTION
* CPU: 40m -> 4m
* memory: 200Mi -> 50Mi

This is much closer to what the pods use in live-1