### PR TITLE
Additional User Filestore S3 buckets for each environment

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-dev/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-production/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-staging/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-integration-staging/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+
+  team_name              = "${var.team_name}"
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  providers = {
+    aws = "aws.london"
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data {
+    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
+    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
+    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
+    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  }
+}


### PR DESCRIPTION
In order to support attachments for the HMCTS API integration, we need new
buckets with a shorter lifecycle policy.

Files will be encrypted with a different key than the existing bucket.
This key will then be passed on to our adapter to fetch and decrypt these files
on request from the Optics API.  We will use pre-signed URL's to fetch the
objects.