### PR TITLE
Removing namespace hard-limit

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/03-resourcequota.yaml
@@ -6,6 +6,5 @@ metadata:
 spec:
   hard:
     requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.memory: 12Gi
+    

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/03-resourcequota.yaml
@@ -6,6 +6,5 @@ metadata:
 spec:
   hard:
     requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.memory: 12Gi
+    


### PR DESCRIPTION
- Removing hard.limit of the c100 namespaces. 
- Bumping hard.request.memory to 12Gi