### PR TITLE
more resources for Prometheus operator

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1200m
+      memory: 12Gi
     defaultRequest:
       cpu: 10m
       memory: 100Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1200m
-      memory: 12Gi
+      cpu: 1600m
+      memory: 16Gi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
**Why**
`level=warn ts=2019-09-25T10:08:55.109237842Z caller=scrape.go:835 component="scrape manager" scrape_pool=monitoring/prometheus-operator-node-exporter/0 target=http://172.20.93.216:9100/metrics msg="append failed" err="write to WAL: log samples: write /prometheus/wal/00013884: cannot allocate memory"`

After increasing the limit, Prometheus operator pod stabilized at around 1000m CPU / 9000 Mi RAM
