### PR TITLE
more CPU for Concourse

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 5000Mi
+      cpu: 2000m
+      memory: 4000Mi
     defaultRequest:
-      cpu: 10m
+      cpu: 100m
       memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: concourse
 spec:
   hard:
-    requests.cpu: 2500m
-    requests.memory: 12Gi
+    requests.cpu: 4000m
+    requests.memory: 10Gi


### PR DESCRIPTION
**Why**
`top pod` and speed of pipeline shows a slowdown