### PR TITLE
Remove leftover main.tf files from fb pentest ns

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/main.tf
@@ -1,8 +1,0 @@
-# auto-generated from fb-cloud-platforms-environments
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  region = "eu-west-2"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-production/resources/main.tf
@@ -1,8 +1,0 @@
-# auto-generated from fb-cloud-platforms-environments
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  region = "eu-west-2"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-staging/resources/main.tf
@@ -1,8 +1,0 @@
-# auto-generated from fb-cloud-platforms-environments
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  region = "eu-west-2"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/main.tf
@@ -1,8 +1,0 @@
-# auto-generated from fb-cloud-platforms-environments
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  region = "eu-west-2"
-}


### PR DESCRIPTION
These namespaces have all had their AWS resources
deleted, and been removed from the cluster.
This commit removes leftover main.tf files which
are no longer required, and the directories
themselves.