### PR TITLE
Removing conflicts for logging namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/00-namespace.yaml
@@ -4,12 +4,9 @@ metadata:
   name: logging
   labels:
     component: logging
-    cloud-platform.justice.gov.uk/is-production: "true"
-    cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
     cloud-platform.justice.gov.uk/application: "Logging"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"
     iam.amazonaws.com/permitted: ".*"
     cloud-platform.justice.gov.uk/can-tolerate-master-taints: "true"


### PR DESCRIPTION
What:
Synching labels and annotations for logging namespace with infrastructure repo

Why:
The namespace creation is moved to infrastructure repo but when the pipeline run for live-1, it overwrites the labels and annotations creating conflicts whenever doing terraform plan on live-1.
