### PR TITLE
Add a script to report namespace usage down to container-level

### DIFF
--- a/bin/namespace-details.rb
+++ b/bin/namespace-details.rb
@@ -181,6 +181,7 @@ class Container
   def initialize(args)
     @name = args.fetch(:name)
     @requests = args.fetch(:requests)
+    @used = { "cpu" => "0m", "memory" => "0Mi" }
   end
 
   def to_s

--- a/bin/namespace-details.rb
+++ b/bin/namespace-details.rb
@@ -5,7 +5,6 @@ require "pry-byebug"
 
 # TODO: show namespace defaults (limit range)
 # TODO: show totals (requested, used)
-# TODO: pretty output
 
 module KubernetesValues
   def cpu_value(str)
@@ -56,6 +55,14 @@ class Namespace
     self
   end
 
+  def to_s
+    <<EOF
+NAMESPACE: #{name}
+PODS:
+#{pods.map(&:to_s).join("\n")}
+EOF
+  end
+
   private
 
   def add_usage_data
@@ -88,6 +95,14 @@ class Container
     @requests = args.fetch(:requests)
   end
 
+  def to_s
+    <<EOF
+    #{name}
+      requested (cpu, memory):\t#{req_cpu}\t#{req_mem}
+      used (cpu, memory):\t#{used_cpu}\t#{used_mem}
+EOF
+  end
+
   private
 
   def req_mem
@@ -115,6 +130,13 @@ class Pod
     @containers = get_containers(data)
   end
 
+  def to_s
+    <<EOF
+  POD: #{name}
+#{containers.map(&:to_s).join("\n")}
+EOF
+  end
+
   private
 
   def get_containers(data)
@@ -130,7 +152,7 @@ end
 
 def main(namespace)
   usage if namespace.nil?
-  pp Namespace.new(namespace).get_data
+  puts Namespace.new(namespace).get_data
 end
 
 def usage

--- a/bin/namespace-details.rb
+++ b/bin/namespace-details.rb
@@ -205,7 +205,7 @@ class Pod
 
   def to_s
     <<EOF
-  POD: #{name}
+  #{name}
 #{containers.map(&:to_s).join("\n")}
 EOF
   end

--- a/bin/namespace-details.rb
+++ b/bin/namespace-details.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "pry-byebug"
+
+class Pod
+  attr_reader :name, :containers
+
+  def initialize(args)
+    @name = args.fetch(:name)
+    @containers = args.fetch(:containers)
+  end
+end
+
+class Container
+  attr_reader :name, :requests
+
+  def initialize(args)
+    @name = args.fetch(:name)
+    @requests = args.fetch(:requests)
+  end
+end
+
+def main(namespace)
+  usage if namespace.nil?
+
+  data = JSON.parse `kubectl -n #{namespace} get all -o json`
+  pp pods(data)
+end
+
+def pods(data)
+  pods = data.dig("items").filter { |i| i.dig("kind") == "Pod" }
+
+  pods.map do |pod|
+    name = pod.dig("metadata", "name")
+    Pod.new(name: name, containers: containers(pod))
+  end
+end
+
+def containers(pod)
+  pod.dig("spec", "containers").map do |c|
+    name = c.dig("name")
+    requests = c.dig("resources", "requests")
+    Container.new(name: name, requests: requests)
+  end
+end
+
+def usage
+  puts <<EOF
+
+Usage: #{$0} [namespace name]
+
+EOF
+  exit
+end
+
+main ARGV.shift

--- a/bin/namespace-details.rb
+++ b/bin/namespace-details.rb
@@ -11,6 +11,10 @@ class Pod
     @containers = args.fetch(:containers)
   end
 end
+# TODO: show actual resource usage: kubectl -n court-probation-dev top pods --containers --no-headers
+# TODO: show namespace defaults (limit range)
+# TODO: show totals (requested, used)
+# TODO: pretty output
 
 class Container
   attr_reader :name, :requests

--- a/bin/namespace-details.rb
+++ b/bin/namespace-details.rb
@@ -37,11 +37,25 @@ module KubernetesValues
   end
 end
 
+module FormatOutput
+
+  private
+
+  def format_line(title, col1, col2)
+    [
+      title.ljust(40),
+      col1.to_s.ljust(10),
+      col2.to_s.ljust(10),
+    ].join
+  end
+end
+
 
 class Namespace
   attr_reader :name, :pods, :hard, :request, :used, :limitrange
 
   include KubernetesValues
+  include FormatOutput
 
   def initialize(name)
     @name = name
@@ -59,10 +73,10 @@ class Namespace
   def to_s
     <<EOF
 NAMESPACE: #{name}
-  hard limit (cpu, memory):\t#{hard_cpu}\t#{hard_mem}
-  request limit (cpu, memory):\t#{req_cpu}\t#{req_mem}
-  used (cpu, memory):\t\t#{used_cpu}\t#{used_mem}
-  per-container\n  request (cpu, memory):\t#{limit_cpu}\t#{limit_mem}
+  #{format_line("hard limit (cpu, memory):", hard_cpu, hard_mem)}
+  #{format_line("request limit (cpu, memory):", req_cpu, req_mem)}
+  #{format_line("used (cpu, memory):", used_cpu, used_mem)}
+  #{format_line("per-container request (cpu, memory):", limit_cpu, limit_mem)}
 
 PODS:
 #{pods.map(&:to_s).join("\n")}
@@ -162,6 +176,7 @@ class Container
   attr_accessor :used
 
   include KubernetesValues
+  include FormatOutput
 
   def initialize(args)
     @name = args.fetch(:name)
@@ -171,8 +186,8 @@ class Container
   def to_s
     <<EOF
     #{name}
-      requested (cpu, memory):\t#{req_cpu}\t#{req_mem}
-      used (cpu, memory):\t#{used_cpu}\t#{used_mem}
+      #{format_line("requested (cpu, memory):", req_cpu, req_mem)}
+      #{format_line("used (cpu, memory):", used_cpu, used_mem)}
 EOF
   end
 


### PR DESCRIPTION
This script outputs the overall namespace resource requests and usage,
and print out details of how much each running container is requesting
and using.

This will be used to generate reports to send to responsible parties
whose namespace resources need adjusting.