### PR TITLE
Resize pq namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: parliamentary-questions-development
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: parliamentary-questions-production
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 250m
-      memory: 500Mi
+      cpu: 1000m
+      memory: 1000Mi
     defaultRequest:
-      cpu: 125m
-      memory: 250Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/03-resourcequota.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: parliamentary-questions-staging
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+    requests.cpu: 100m
+    requests.memory: 5000Mi


### PR DESCRIPTION
This commit adjusts PQ namespaces' resource requests and limits

* removes the namespace hard limits
* reduces namespace request limits
* increases default container hard limits
* reduces default container request limits

Nick Preddy of the PQ team has given the green light for this change to go ahead.