### PR TITLE
Remove pry-byebug

### DIFF
--- a/bin/namespace-details.rb
+++ b/bin/namespace-details.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require "json"
-require "pry-byebug"
 
 module KubernetesValues
   def cpu_value(str)


### PR DESCRIPTION
This is not needed for normal operation, and removing the require
means the script doesn't need any custom libraries in order to run.