### PR TITLE
Reduce concourse namespace resourcequota

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/concourse/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: concourse
 spec:
   hard:
-    requests.cpu: 4000m
-    requests.memory: 10Gi
+    requests.cpu: 1000m
+    requests.memory: 3Gi


### PR DESCRIPTION
Now that the pod resources requested by concourse have been
adjusted, we cna reduce the overall namespace resource requests

related to
https://github.com/ministryofjustice/cloud-platform-concourse/pull/103