### PR TITLE
Save Route53 zone name servers into kubernetes secret

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
@@ -18,6 +18,7 @@ resource "kubernetes_secret" "app_domain" {
 
   data {
     short_zone_id = "${aws_route53_zone.app_domain.zone_id}"
+    name_servers  = "${join("\n", aws_route53_zone.app_domain.name_servers)}"
   }
 }
 
@@ -73,6 +74,7 @@ resource "kubernetes_secret" "send_money" {
 
   data {
     short_zone_id = "${aws_route53_zone.send_money.zone_id}"
+    name_servers  = "${join("\n", aws_route53_zone.send_money.name_servers)}"
   }
 }
 
@@ -206,6 +208,7 @@ resource "kubernetes_secret" "start_page" {
 
   data {
     short_zone_id = "${aws_route53_zone.start_page.zone_id}"
+    name_servers  = "${join("\n", aws_route53_zone.start_page.name_servers)}"
   }
 }
 


### PR DESCRIPTION
this is a bit of an experiment. i'm hoping that knowing the name servers for these new zones will allow us to check that things were correctly copied from the DSD account and will work properly once delegated instead to the CP account.

is the kubernetes secret used for anything special within cloud platform? is it ok to add/change keys here?