### PR TITLE
Reduce limitrange request values in old namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
         cpu: 250m
         memory: 500Mi
       defaultRequest:
-        cpu: 125m
+        cpu: 10m
         memory: 250Mi
       type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
         memory: 500Mi
       defaultRequest:
         cpu: 10m
-        memory: 250Mi
+        memory: 100Mi
       type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
         cpu: 250m
         memory: 500Mi
       defaultRequest:
-        cpu: 125m
+        cpu: 10m
         memory: 250Mi
       type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
         memory: 500Mi
       defaultRequest:
         cpu: 10m
-        memory: 250Mi
+        memory: 100Mi
       type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-production/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 750Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 750Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 750Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 250m
       memory: 500Mi
     defaultRequest:
-      cpu: 125m
+      cpu: 10m
       memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/02-limitrange.yaml
@@ -10,5 +10,5 @@ spec:
       memory: 500Mi
     defaultRequest:
       cpu: 10m
-      memory: 250Mi
+      memory: 100Mi
     type: Container


### PR DESCRIPTION
Where namespaces were using our older limitrange template
defaultRequest values of 100m CPU and 250Mi, this PR
alters all of them to use our new defaultRequest values of
10m and 100Mi.

This will only affect pods which are scheduled after this
PR is merged, and it should not make any practical
difference to teams' ability to schedule pods into their
namespaces.

The only affect should be that new containers request
(i.e. reserve) less CPU and memory than before. They can
still *use* more than these request values, if they need
it, because the hard limits are not affected by this change