### PR TITLE
Remove CPU & memory hard limits from namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 6000m
     requests.memory: 12Gi
-    limits.cpu: 12000m
-    limits.memory: 24Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-dev/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kuberos/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kuberos/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 20m
     requests.memory: 400Mi
-    limits.cpu: 40m
-    limits.memory: 800Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 15000m
-    limits.memory: 30Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 15000m
-    limits.memory: 30Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-production/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-reports-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-reports-dev/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/03-resourcequota.yaml
@@ -7,5 +7,3 @@ spec:
   hard:
     requests.cpu: 3000m
     requests.memory: 6Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi


### PR DESCRIPTION
We no longer set hard limits on new namespaces.
This change removes any existing hard limits on
namespaces.

This change should have no visible impact.

NB: formbuilder namespaces are excluded from this
change, because they are in the process of
changing their resource limits for all their 
namespaces, and I don't want to confuse things