### PR TITLE
curator ignore empty test

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/elasticsearch-curator.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/elasticsearch-curator.yaml
@@ -43,6 +43,7 @@ spec:
                 --use_ssl \
                 --port 443 \
                 delete_indices \
+                --ignore_empty_list \
                 --filter_list '[
                   {
                     "filtertype":"age",


### PR DESCRIPTION
**Why**
fails if the test ES cluster doesn't have any entries