### PR TITLE
namespace-details.rb: 'find_all' not 'filter'

### DIFF
--- a/bin/namespace-details.rb
+++ b/bin/namespace-details.rb
@@ -157,7 +157,7 @@ EOF
 
   def get_pods(data)
     data.dig("items")
-      .filter { |i| i.dig("kind") == "Pod" }
+      .find_all { |i| i.dig("kind") == "Pod" }
       .map { |pod| Pod.new(pod) }
   end
 


### PR DESCRIPTION
filter was introduced in ruby 2.6

find_all is a synonym, and works with earlier versions, so this
change makes it possible for people to run this script without
requiring them to install a later version of ruby.