### PR TITLE
Reduce cica-oas-basic-testing resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: cica-oas-basic-testing
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 250m
+    requests.memory: 5000Mi


### PR DESCRIPTION
* CPU to 250m
* Memory to 5000Mi

Memory is our default for new namespaces, 250m is double what the
total pods in the namespace are currently requesting