### PR TITLE
Reduce pecs-move-platform-backend-staging requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: pecs-move-platform-backend-staging
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 750m
+    requests.memory: 5000Mi


### PR DESCRIPTION
* CPU to 750m (double current total requests)
* Memory to 5000Mi (default for new namespaces)