### PR TITLE
Reduce claim-criminal-injuries-compensation-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: claim-criminal-injuries-compensation-dev
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 600m
+    requests.memory: 5000Mi


### PR DESCRIPTION
* CPU to 600m (double total requests)
* memory to 5000Mi (default for new namespaces)