### PR TITLE
Fb platform dev namespaces increase resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/03-resourcequota.yaml
@@ -8,5 +8,5 @@ metadata:
   namespace: formbuilder-platform-test-dev
 spec:
   hard:
-    requests.cpu: 320m
+    requests.cpu: 2000m
     requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/03-resourcequota.yaml
@@ -8,5 +8,5 @@ metadata:
   namespace: formbuilder-platform-test-dev
 spec:
   hard:
-    requests.cpu: 2000m
+    requests.cpu: 2500m
     requests.memory: 5000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-platform-test-production
 spec:
   hard:
-    requests.cpu: 2000m
+    requests.cpu: 2500m
     requests.memory: 5000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-platform-test-production
 spec:
   hard:
-    requests.cpu: 320m
+    requests.cpu: 2000m
     requests.memory: 5000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-platform-test-staging
 spec:
   hard:
-    requests.cpu: 320m
+    requests.cpu: 2000m
     requests.memory: 5000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-platform-test-staging
 spec:
   hard:
-    requests.cpu: 2000m
+    requests.cpu: 2500m
     requests.memory: 5000Mi
 


### PR DESCRIPTION
Temporary uplift of namespace cpu resources so we can reduce resources for the pods.