### PR TITLE
Enable sync between template deploy s3 dev and cccd-dev s3

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
@@ -32,8 +32,7 @@ module "cccd_s3_bucket" {
     "Sid": "",
     "Effect": "Allow",
     "Action": [
-      "s3:GetObject",
-      "s3:CopyObject"
+      "s3:*"
     ],
     "Resource": [
       "$${bucket_arn}/*",

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
@@ -32,7 +32,8 @@ module "cccd_s3_bucket" {
     "Sid": "",
     "Effect": "Allow",
     "Action": [
-      "s3:GetObject"
+      "s3:GetObject",
+      "s3:CopyObject"
     ],
     "Resource": [
       "$${bucket_arn}/*",


### PR DESCRIPTION
The `aws s3 sync` command requires `s3:CopyObject` permissions
at least.

This must be applied here and on the dev bucket's bucket policy
inline with this change.

example output without this action permitted
```
copy failed: s3://adp-dev-documents/reports/management_information_20191008040001.csv to s3://cloud-platform-9266f53d509c18e49891086e2f27d82c/reports/management_information_20191008040001.csv An error occurred (AccessDenied) when calling the CopyObject operation: Access Denied
```