### PR TITLE
Reduce CPU default request to 10m for HMPPS

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-reports-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-reports-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 360m
       memory: 1024Mi
     defaultRequest:
-      cpu: 180m
+      cpu: 10m
       memory: 512Mi
     type: Container


### PR DESCRIPTION
HMPPS namespaces were created when our default
for defaultRequest.cpu was 180m

This is excessive because the containers in these
namespaces generally use around 1m CPU (this is
the case for most namespaces in the cluster) and 
it reduces the CPU available for other workloads.

Once this change is merged, and after the pods
running with the current 180m CPU request have
been cycled, subsequent PRs will reduce the
overall request size for the namespaces, which
will free up these resources.