### PR TITLE
court-probation-dev resource requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: court-probation-dev
 spec:
   hard:
-    requests.cpu: 6000m
-    requests.memory: 12Gi
+    requests.cpu: 300m
+    requests.memory: 5000Mi


### PR DESCRIPTION
* CPU: 6000m to 300m (double current total requested)
* memory: 12Gi to 5Gi (default for new namespaces)