### PR TITLE
Add cccd s3 user-policies necessary for TD sync

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
@@ -25,7 +25,7 @@ module "cccd_s3_bucket" {
     ],
     "Resource": [
       "$${bucket_arn}",
-      "arn:aws:s3:::adp-staging-documents"
+      "arn:aws:s3:::adp-api-sandbox-documents"
     ]
   },
   {
@@ -36,7 +36,7 @@ module "cccd_s3_bucket" {
     ],
     "Resource": [
       "$${bucket_arn}/*",
-      "arn:aws:s3:::adp-staging-documents/*"
+      "arn:aws:s3:::adp-api-sandbox-documents/*"
     ]
   }
 ]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
@@ -11,6 +11,37 @@ module "cccd_s3_bucket" {
   providers = {
     aws = "aws.london"
   }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ],
+    "Resource": [
+      "$${bucket_arn}",
+      "arn:aws:s3:::adp-staging-documents"
+    ]
+  },
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:*"
+    ],
+    "Resource": [
+      "$${bucket_arn}/*",
+      "arn:aws:s3:::adp-staging-documents/*"
+    ]
+  }
+]
+}
+EOF
 }
 
 resource "kubernetes_secret" "cccd_s3_bucket" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
@@ -18,6 +18,37 @@ module "cccd_s3_bucket" {
   providers = {
     aws = "aws.london"
   }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ],
+    "Resource": [
+      "$${bucket_arn}",
+      "arn:aws:s3:::adp-staging-documents"
+    ]
+  },
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:*"
+    ],
+    "Resource": [
+      "$${bucket_arn}/*",
+      "arn:aws:s3:::adp-staging-documents/*"
+    ]
+  }
+]
+}
+EOF
 }
 
 resource "kubernetes_secret" "cccd_s3_bucket" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
@@ -32,7 +32,7 @@ module "cccd_s3_bucket" {
     ],
     "Resource": [
       "$${bucket_arn}",
-      "arn:aws:s3:::adp-staging-documents"
+      "arn:aws:s3:::adp-gamma-documents"
     ]
   },
   {
@@ -43,7 +43,7 @@ module "cccd_s3_bucket" {
     ],
     "Resource": [
       "$${bucket_arn}/*",
-      "arn:aws:s3:::adp-staging-documents/*"
+      "arn:aws:s3:::adp-gamma-documents/*"
     ]
   }
 ]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
@@ -11,6 +11,37 @@ module "cccd_s3_bucket" {
   providers = {
     aws = "aws.london"
   }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ],
+    "Resource": [
+      "$${bucket_arn}",
+      "arn:aws:s3:::adp-staging-documents"
+    ]
+  },
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:*"
+    ],
+    "Resource": [
+      "$${bucket_arn}/*",
+      "arn:aws:s3:::adp-staging-documents/*"
+    ]
+  }
+]
+}
+EOF
 }
 
 resource "kubernetes_secret" "cccd_s3_bucket" {


### PR DESCRIPTION
### What

Add s3 IAM user-policies to cccd-staging, api-sandbox
and production.

### Why

Enable live-1 (destination) s3 sync with
template-deploy (source) s3 bucket.

The Bucket policy of the source will
restrict permissions to ListBucket and
GetObject, which are the minimum required
for sync to work.