### PR TITLE
Add a github actions workflow deleting branches

### DIFF
--- a/.github/workflows/delete-branch-after-merge.yml
+++ b/.github/workflows/delete-branch-after-merge.yml
@@ -1,0 +1,22 @@
+name: Delete branch on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: ministryofjustice/cloud-platform-tools:1.4-test
+
+    steps:
+      - uses: actions/checkout@master
+      - run: gem install octokit
+      - name: Delete branch after merge
+        if: github.event.pull_request.merged == true
+        run: ruby bin/delete-branch-after-merge.rb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-branch-after-merge.yml
+++ b/.github/workflows/delete-branch-after-merge.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ministryofjustice/cloud-platform-tools:1.4-test
+      image: ministryofjustice/cloud-platform-tools:1.4
 
     steps:
       - uses: actions/checkout@master

--- a/bin/delete-branch-after-merge.rb
+++ b/bin/delete-branch-after-merge.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "octokit"
+
+def github_client
+  unless ENV.key?("GITHUB_TOKEN")
+    raise "No GITHUB_TOKEN env var found. Please make this available via the github actions workflow\nhttps://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret"
+  end
+
+  @client ||= Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+end
+
+def event
+  unless ENV.key?("GITHUB_EVENT_PATH")
+    raise "No GITHUB_EVENT_PATH env var found. This script is designed to run via github actions, which will provide the github event via this env var."
+  end
+
+  @evt ||= JSON.parse File.read(ENV["GITHUB_EVENT_PATH"])
+end
+
+def repo
+  name = event.dig("repository", "name")
+  owner = event.dig("repository", "owner", "login")
+  [owner, name].join("/")
+end
+
+def pr_number
+  event.dig("pull_request", "number")
+end
+
+def branch
+  event.dig("pull_request", "head", "ref")
+end
+
+############################################################
+
+puts "Merged PR: #{pr_number}"
+puts "Deleting branch: #{branch}"
+github_client.delete_branch(repo, branch)


### PR DESCRIPTION
Merging a PR will trigger the workflow, which will
find the branch the PR relates to, and delete it.
If the user has already deleted the branch, this
workflow will show an error, but nothing terrible
will happen.

It's not strictly necessary to use the tools image
for this. A lighter-weight ruby image would work,
but we'll need the tools image for some workflows,
so it seems simpler to just use it everywhere, 
even if that makes workflows run a little slower
than they could.