### PR TITLE
Catch errors if branch already deleted

### DIFF
--- a/bin/delete-branch-after-merge.rb
+++ b/bin/delete-branch-after-merge.rb
@@ -7,4 +7,9 @@ require File.join(".", File.dirname(__FILE__), "lib", "github")
 
 puts "Merged PR: #{pr_number}"
 puts "Deleting branch: #{branch}"
-github.delete_branch(repo, branch)
+
+begin
+  github.delete_branch(repo, branch)
+rescue Octokit::UnprocessableEntity
+  puts "Branch not found; already deleted?"
+end


### PR DESCRIPTION
If the user deletes their branch when merging, then the branch
will be missing when this script tries to delete it. This will
raise an error, making it look like something was wrong.

This change swallows the relevant error, so that the action will
complete successfully.

This might sometimes swallow other errors that we would prefer to
see, so the rescue block dumps the error to stdout, so that it's
visible to anyone who views the action log via the github web UI.