### PR TITLE
Output the exception, if branch delete fails

### DIFF
--- a/bin/delete-branch-after-merge.rb
+++ b/bin/delete-branch-after-merge.rb
@@ -10,6 +10,7 @@ puts "Deleting branch: #{branch}"
 
 begin
   github.delete_branch(repo, branch)
-rescue Octokit::UnprocessableEntity
+rescue Octokit::UnprocessableEntity => e
   puts "Branch not found; already deleted?"
+  pp e
 end


### PR DESCRIPTION
This should have gone in as part of the last PR.
If the branch delete fails, it might be useful to
see the details of the error, in case it's not
because the user deleted the branch before the
action could do so.