### PR TITLE
Add github action to reject bad YAML

### DIFF
--- a/.github/workflows/malformed-yaml.yml
+++ b/.github/workflows/malformed-yaml.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  reject-malformed-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: ministryofjustice/github-actions/malformed-yaml@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PRs like this one, containing malformed YAML, are hard to spot
by eye:
https://github.com/ministryofjustice/cloud-platform-environments/pull/1353

This commit adds a workflow which will attempt to parse every YAML file
included in a given PR. If any fail to parse, the action marks the PR as
bad and lists the failing files.