### PR TITLE
Reduce CPU request limits for whereabouts API

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: whereabouts-api-dev
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 300m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: whereabouts-api-preprod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 300m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: whereabouts-api-prod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 300m
     requests.memory: 6Gi


### PR DESCRIPTION
The whereabouts API namespaces are requesting less than 200m CPU
(the total of all requests for all pods in the namespaces), but
the namespaces have a request limit of 3000m.

This change reduces the CPU request limit of each namespace to
300m, which will free up 8100m of CPU in the cluster which is
currently not being used.

I have run this change past Matt Whittaker, who is happy for us to go ahead with it.

