### PR TITLE
Reduce resourcequota for disclosure-checker-prod

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: disclosure-checker-production
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 600m
+    requests.memory: 5000Mi


### PR DESCRIPTION
The disclosure-checker-production namespace is using 270m CPU and
1200Mi of memory.

This change reduces the CPU request limit from 3000m to 600m, and
the memory request limit from 6000Mi to 5000Mi.

This brings the production namespace into line with the staging
namespace, and frees up 2400m of CPU which is not currently
being used.

I've run this past Jesus Laiz, who is happy for us to go ahead.
