### PR TITLE
CPU requests: offender-case-notes namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-case-notes-dev
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 600m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-case-notes-preprod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 600m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-case-notes-prod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 600m
     requests.memory: 6Gi


### PR DESCRIPTION
The offender-case-notes namespaces are requesting 3000m CPU each,
but the max. sum of all pod requests is 560m (this would drop to
about 50m if all pods were cycled).

This commit reduced the namespace CPU request to 600m, freeing up
7200m of unused CPU.