### PR TITLE
Reduce use of force namespaces CPU requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: use-of-force-dev
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 300m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: use-of-force-preprod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 300m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: use-of-force-prod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 300m
     requests.memory: 6Gi


### PR DESCRIPTION
The use-of-force-(dev|preprod|prod) namespaces request 3000m CPU
each. The total CPU requested by all pods in those namespaces is
190m each.

This change reduces the CPU requested for each namespace from
3000m to 300m, freeing up 8100m of unused CPU.