### PR TITLE
Reduce fj-cait resource requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: fj-cait-production
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 100m
+    requests.memory: 1Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: fj-cait-staging
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 100m
+    requests.memory: 1Gi


### PR DESCRIPTION
The fj-cait-(production|staging) namespaces are requesting 3000m
CPU and 6000Mi of memory.

The total requests for all pods in those namespaces is 50m CPU and
600Mi of memory.

This change reduces the requests for those namespaces to 100m CPU
and 1000Mi of memory.

This change should have no impact at all on the service. It does
not limit the resources available to the namespace, it just
changes the information provided to the scheduler in order to
help it decide where to schedule these namespaces' workloads.

This frees up 5800m CPU and 10Gi of memory which were not being
used, making them available to the cluster.