### PR TITLE
Changes made to all namespaces for formbuilder-publisher

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-integration/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-integration/02-limitrange.yaml
@@ -10,8 +10,8 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 300Mi
+      memory: 512Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 256Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/02-limitrange.yaml
@@ -10,8 +10,8 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 300Mi
+      memory: 512Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 256Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/03-resourcequota.yaml
@@ -10,5 +10,4 @@ spec:
   hard:
     requests.cpu: 4000m
     requests.memory: 8Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/02-limitrange.yaml
@@ -10,8 +10,8 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 300Mi
+      memory: 512Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 256Mi
     type: Container


### PR DESCRIPTION
Publisher services consume more memory than the other form builder namespaces.

formbuilder-publisher-test / integration / live
spec.limits.default.memory changed from 300Mi to 512Mi
spec.limits.default.defaultRequest.cpu changed from 100m to 10m
spec.limits.default.defaultRequest.memory change from 128m to 256m

formbuilder-publisher-live - removed spec.hard.limits.cpu and memory

