### PR TITLE
changed resources for all formbuilder-publisher namespaces.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-integration/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-integration/02-limitrange.yaml
@@ -10,8 +10,8 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 300Mi
+      memory: 1000Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/02-limitrange.yaml
@@ -10,8 +10,8 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 300Mi
+      memory: 1000Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 250Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/03-resourcequota.yaml
@@ -10,5 +10,4 @@ spec:
   hard:
     requests.cpu: 4000m
     requests.memory: 8Gi
-    limits.cpu: 6000m
-    limits.memory: 12Gi
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/02-limitrange.yaml
@@ -10,8 +10,8 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 300Mi
+      memory: 1000Mi
     defaultRequest:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 250Mi
     type: Container


### PR DESCRIPTION
The publisher services use more memory.

formbuilder.publisher.test / integration / live
spec.limits.default.memory from 300Mi to 1000Mi
spec.limits.defaultRequest.cpu from 100m to 10m
spec.limits.defaultRequest.memory from 128Mi to 250Mi

spec.hard.limits removed from production-live.