### PR TITLE
Reduce CPU requests for legal adviser namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: laa-legal-adviser-api-production
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 500m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: laa-legal-adviser-api-staging
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 500m
     requests.memory: 6Gi


### PR DESCRIPTION
The max total of all pods' CPU requests in these two namespaces is 375m
(this will drop to 30m when the pods are restarted, and the new
limitrange values take effect). However, the namespaces request 3000m of
CPU each.

This change reduces the cpu requested by each namespace to 500m, freeing
up 5500m of unused CPU capacity.