### PR TITLE
Reduce dps-welcome-(dev|prod) CPU requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-dev/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: dps-welcome-dev
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 300m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: dps-welcome-prod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 300m
     requests.memory: 6Gi


### PR DESCRIPTION
The total of all the CPU requests for all pods in these namespaces
is 190m. This will drop to 20m after all pods are restarted.

This change reduces the namespaces' CPU requests from 3000m to
300m, freeing up 5400m of unused CPU capacity.