### PR TITLE
Update book-a-secure-move Github team owners

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-api-production
 subjects:
   - kind: Group
-    name: "github:pecs"
+    name: "github:book-a-secure-move"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-api-staging
 subjects:
   - kind: Group
-    name: "github:pecs"
+    name: "github:book-a-secure-move"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-production
 subjects:
   - kind: Group
-    name: "github:pecs"
+    name: "github:book-a-secure-move"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-staging
 subjects:
   - kind: Group
-    name: "github:pecs"
+    name: "github:book-a-secure-move"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
This updates the Book a Secure Move service to use RBAC on the `book-a-secure-move` team rather than `pecs` for consistency.

I'll delete the `pecs` team shortly.