### PR TITLE
spec.hard.requests adjusted for all service namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-dev/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-services-integration-dev
 spec:
   hard:
-    requests.cpu: 8000m
-    requests.memory: 18Gi
+    requests.cpu: 2500m
+    requests.memory: 8000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-production/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-services-integration-production
 spec:
   hard:
-    requests.cpu: 500m
-    requests.memory: 6.4Gi
+    requests.cpu: 2500m
+    requests.memory: 8000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-integration-staging/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-services-integration-staging
 spec:
   hard:
-    requests.cpu: 500m
-    requests.memory: 6.4Gi
+    requests.cpu: 2500m
+    requests.memory: 8000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-services-live-dev
 spec:
   hard:
-    requests.cpu: 1000m
-    requests.memory: 12.8Gi
+    requests.cpu: 2500m
+    requests.memory: 12000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/03-resourcequota.yaml
@@ -8,5 +8,5 @@ metadata:
   namespace: formbuilder-services-live-production
 spec:
   hard:
-    requests.cpu: 8000m
-    requests.memory: 12Gi
+    requests.cpu: 2500m
+    requests.memory: 8000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-staging/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-services-live-staging
 spec:
   hard:
-    requests.cpu: 500m
-    requests.memory: 6.4Gi
+    requests.cpu: 2500m
+    requests.memory: 8000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-services-test-dev
 spec:
   hard:
-    requests.cpu: 800m
-    requests.memory: 9000Mi
+    requests.cpu: 2500m
+    requests.memory: 8000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-services-test-production
 spec:
   hard:
-    requests.cpu: 500m
-    requests.memory: 5500Mi
+    requests.cpu: 2500m
+    requests.memory: 8000Mi
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-staging/03-resourcequota.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: formbuilder-services-test-staging
 spec:
   hard:
-    requests.cpu: 350m
-    requests.memory: 4000Mi
+    requests.cpu: 2500m
+    requests.memory: 8000Mi
 


### PR DESCRIPTION
Made the spec.hard.requests standard across all names spaces (except live.dev). The Service namespaces hold the running forms and therefore need larger overhead due to the form having elevated default resources for live forms (and testing).