### PR TITLE
Reduce resource quotes for book-a-secure-move

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: hmpps-book-secure-move-api-production
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 50m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: hmpps-book-secure-move-api-staging
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 50m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-production
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 50m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-staging
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 50m
     requests.memory: 6Gi


### PR DESCRIPTION
@digitalronin pointed out that we're requesting 3 full CPUs for each service, but we're only using 0.04, so this PR frees up the remaining resource for other purposes.