### PR TITLE
Reduce CPU requests for offender-management

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-management-preprod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 1000m
     requests.memory: 7500Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-management-production
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 1000m
     requests.memory: 7500Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-management-staging
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 1000m
     requests.memory: 7500Mi


### PR DESCRIPTION
The total of all the CPU requests for all pods in these namespaces is
800m in production, 600m in staging and 90m in preprod.  This will drop
to 90m in all 3 namespaces once all pods are restarted.

This change reduces the namespaces' CPU requests from 3000m to 1000m,
freeing up 4000m of unused CPU capacity. Although 1000m is much more
than should be required, I want all the namespaces to have the same
resourcequota, so that they all behave consistently wrt. scheduling
pods.

We can make a subsequent change to reduce the resourcequota further,
after all pods have been cycled and more resource can be reclaimed.