### PR TITLE
Reduce offender-categorisation ns CPU requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-categorisation-dev
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 600m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-categorisation-preprod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 600m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: offender-categorisation-prod
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 600m
     requests.memory: 6Gi


### PR DESCRIPTION
The total of all the CPU requests for all pods in these namespaces is
400m. This will drop to 60m once all pods are restarted, because some
pods are still running with the old limitrange CPU requests value of
180m rather than 10m.

This change reduces the namespaces' CPU requests from 3000m to 600m,
freeing up 7200m of unused CPU capacity.

We can make a subsequent change to reduce the resourcequota further,
after all pods have been cycled and more resource can be reclaimed.