### PR TITLE
Reduce c100-application-metabase resource requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: c100-application-metabase
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 100m
+    requests.memory: 2Gi


### PR DESCRIPTION
The total of all the CPU requests for all pods in these namespaces is
20m. Memory requests total is 500Mi.

This change reduces the overall namespace requests from 3000m CPU
to 100m, and from 6Gi of memory to 2Gi.