### PR TITLE
Reduce family-mediators-api namespaces CPU requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: family-mediators-api-production
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 500m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: family-mediators-api-staging
 spec:
   hard:
-    requests.cpu: 3000m
+    requests.cpu: 500m
     requests.memory: 6Gi


### PR DESCRIPTION
The total of all the CPU requests for all pods in these namespaces is
250m. This will fall to 20m once all pods are restarted.

This change reduces the overall namespace requests from 3000m CPU
to 500m, freeing up 5000m of unused CPU.