### PR TITLE
Reduce nomis-api namespaces CPU requests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: nomis-api-access-production
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 300m
+    requests.memory: 1Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: nomis-api-access-staging
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    requests.cpu: 300m
+    requests.memory: 1Gi


### PR DESCRIPTION
The total of all the CPU requests for all pods in these namespaces is
135m. This will fall to 20m when all pods are restarted. The mmemory
requests total is 350Mi.

This change reduces the overall namespace requests from 3000m CPU
to 300m, and from 6Gi of memory to 1Gi.