### PR TITLE
Limit new namespaces to 50 pods

### DIFF
--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -5,5 +5,6 @@ metadata:
   namespace: ${namespace}
 spec:
   hard:
+    pods: "50"
     requests.cpu: 100m
     requests.memory: 5000Mi


### PR DESCRIPTION
We don't set hard limits for CPU and memory anymore. This leaves
us open to a risk that a namespace could spawn unlimited pods,
eventually crashing a worker node.

This change sets a default limit on the number of pods which can
be scheduled into a namespace, which should reduce this risk.