### PR TITLE
Book a secure move – rename team for ECR registry to match GH team

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
@@ -1,5 +1,5 @@
 variable "team_name" {
-  default = "pecs"
+  default = "book-a-secure-move"
 }
 
 variable "environment-name" {
@@ -11,7 +11,7 @@ variable "is-production" {
 }
 
 variable "infrastructure-support" {
-  default = "PECS: pecs-team@digital.justice.gov.uk"
+  default = "bookasecuremove@digital.justice.gov.uk"
 }
 
 variable "application" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/variables.tf
@@ -1,5 +1,5 @@
 variable "team_name" {
-  default = "pecs"
+  default = "book-a-secure-move"
 }
 
 variable "environment-name" {
@@ -11,7 +11,7 @@ variable "is-production" {
 }
 
 variable "infrastructure-support" {
-  default = "PECS: pecs-team@digital.justice.gov.uk"
+  default = "bookasecuremove@digital.justice.gov.uk"
 }
 
 variable "application" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/variables.tf
@@ -1,5 +1,5 @@
 variable "team_name" {
-  default = "pecs"
+  default = "book-a-secure-move"
 }
 
 variable "environment-name" {
@@ -11,7 +11,7 @@ variable "is-production" {
 }
 
 variable "infrastructure-support" {
-  default = "PECS: pecs-team@digital.justice.gov.uk"
+  default = "bookasecuremove@digital.justice.gov.uk"
 }
 
 variable "application" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/variables.tf
@@ -1,5 +1,5 @@
 variable "team_name" {
-  default = "pecs"
+  default = "book-a-secure-move"
 }
 
 variable "environment-name" {
@@ -11,7 +11,7 @@ variable "is-production" {
 }
 
 variable "infrastructure-support" {
-  default = "PECS: pecs-team@digital.justice.gov.uk"
+  default = "bookasecuremove@digital.justice.gov.uk"
 }
 
 variable "application" {


### PR DESCRIPTION
Following our previous PRs our CI started failing. This PR brings the ECR team name in line with the GitHub team specified in RBAC.