### PR TITLE
Track a Query - add demo S3 bucket access to Template Deploy

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/s3.tf
@@ -16,6 +16,37 @@ module "track_a_query_s3" {
   providers = {
     aws = "aws.london"
   }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ],
+    "Resource": [
+      "$${bucket_arn}",
+      "arn:aws:s3:::correspondence-staff-case-uploads-demo"
+    ]
+  },
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:*"
+    ],
+    "Resource": [
+      "$${bucket_arn}/*",
+      "arn:aws:s3:::correspondence-staff-case-uploads-demo/*"
+    ]
+  }
+]
+}
+EOF
 }
 
 resource "kubernetes_secret" "track_a_query_s3" {


### PR DESCRIPTION
Access to existing S3 bucket in Template Deploy to allow sync operation with Cloud Platform deployed S3 Bucket