### PR TITLE
Track a Query - add production S3 settings to access Template Deploy

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/s3.tf
@@ -16,6 +16,37 @@ module "track_a_query_s3" {
   providers = {
     aws = "aws.london"
   }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ],
+    "Resource": [
+      "$${bucket_arn}",
+      "arn:aws:s3:::correspondence-staff-case-uploads-prod"
+    ]
+  },
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:*"
+    ],
+    "Resource": [
+      "$${bucket_arn}/*",
+      "arn:aws:s3:::correspondence-staff-case-uploads-prod/*"
+    ]
+  }
+]
+}
+EOF
 }
 
 resource "kubernetes_secret" "track_a_query_s3" {


### PR DESCRIPTION
Allow access to Template Deploy based S3 bucket for sync operations