### PR TITLE
Increase resource quotas for Book A Secure Move

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: hmpps-book-secure-move-api-production
 spec:
   hard:
-    requests.cpu: 50m
+    requests.cpu: 500m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: hmpps-book-secure-move-api-staging
 spec:
   hard:
-    requests.cpu: 50m
+    requests.cpu: 500m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-production
 spec:
   hard:
-    requests.cpu: 50m
+    requests.cpu: 500m
     requests.memory: 6Gi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-staging
 spec:
   hard:
-    requests.cpu: 50m
+    requests.cpu: 500m
     requests.memory: 6Gi


### PR DESCRIPTION
In #1414 we reduced the resource quota from 3000 to 50, under the assumption that these were not hard limits. We then experienced failed rollouts with the following error:

````
26m        26m         1         hmpps-book-secure-move-api-deployment-staging-544d45c8d5   ReplicaSet               Warning   FailedCreate        replicaset-controller   Error creating: pods hmpps-book-secure-move-api-deployment-staging-544d45c8d5-q5mll is forbidden: exceeded quota: namespace-quota, requested: requests.cpu=20m, used: requests.cpu=40m, limited: requests.cpu=50m
```

This commit increases our resource quotas significantly to work around the immediate issue, and a follow-on from this will reduce it more appropriately, as the current state blocks deploys of our application at a critical time for the project