### PR TITLE
DT-326: Add offender events topic secret to case notes namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/messaging.tf
@@ -22,7 +22,7 @@ resource "kubernetes_secret" "offender_events" {
   }
 }
 
-resource "kubernetes_secret" "offender_events" {
+resource "kubernetes_secret" "offender_case_notes" {
   metadata {
     name      = "offender-events-topic"
     namespace = "offender-case-notes-dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/messaging.tf
@@ -22,6 +22,19 @@ resource "kubernetes_secret" "offender_events" {
   }
 }
 
+resource "kubernetes_secret" "offender_events" {
+  metadata {
+    name      = "offender-events-topic"
+    namespace = "offender-case-notes-dev"
+  }
+
+  data {
+    access_key_id     = "${module.offender_events.access_key_id}"
+    secret_access_key = "${module.offender_events.secret_access_key}"
+    topic_arn         = "${module.offender_events.topic_arn}"
+  }
+}
+
 module "keyworker_api_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/messaging.tf
@@ -22,7 +22,7 @@ resource "kubernetes_secret" "offender_events" {
   }
 }
 
-resource "kubernetes_secret" "offender_events" {
+resource "kubernetes_secret" "offender_case_notes" {
   metadata {
     name      = "offender-events-topic"
     namespace = "offender-case-notes-preprod"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/messaging.tf
@@ -22,6 +22,19 @@ resource "kubernetes_secret" "offender_events" {
   }
 }
 
+resource "kubernetes_secret" "offender_events" {
+  metadata {
+    name      = "offender-events-topic"
+    namespace = "offender-case-notes-preprod"
+  }
+
+  data {
+    access_key_id     = "${module.offender_events.access_key_id}"
+    secret_access_key = "${module.offender_events.secret_access_key}"
+    topic_arn         = "${module.offender_events.topic_arn}"
+  }
+}
+
 module "keyworker_api_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/messaging.tf
@@ -22,6 +22,19 @@ resource "kubernetes_secret" "offender_events" {
   }
 }
 
+resource "kubernetes_secret" "offender_events" {
+  metadata {
+    name      = "offender-events-topic"
+    namespace = "offender-case-notes-prod"
+  }
+
+  data {
+    access_key_id     = "${module.offender_events.access_key_id}"
+    secret_access_key = "${module.offender_events.secret_access_key}"
+    topic_arn         = "${module.offender_events.topic_arn}"
+  }
+}
+
 module "keyworker_api_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/messaging.tf
@@ -22,7 +22,7 @@ resource "kubernetes_secret" "offender_events" {
   }
 }
 
-resource "kubernetes_secret" "offender_events" {
+resource "kubernetes_secret" "offender_case_notes" {
   metadata {
     name      = "offender-events-topic"
     namespace = "offender-case-notes-prod"


### PR DESCRIPTION
How's best to the get the secret into another namespace?  I've raised this PR to hopefully cope the secret from the offender-events-x namespace into the offender-case-notes-x namespace - not sure if it will work or if there is a better way?