### PR TITLE
Add Amazon ElastiCache for Redis for laa-legal-adviser-api-production namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/elasticache.tf
@@ -1,0 +1,28 @@
+module "celery-broker" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "${var.team_name}"
+  application            = "${var.application}"
+  is-production          = "${var.is-production}"
+  node_type              = "cache.t2.medium"
+  environment-name       = "${var.environment-name}"
+  infrastructure-support = "${var.email}"
+
+  providers = {
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "celery-broker" {
+  metadata {
+    name      = "celery-broker"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    url                      = "redis://:${module.celery-broker.auth_token}@${module.celery-broker.primary_endpoint_address}:6379"
+    primary_endpoint_address = "${module.celery-broker.primary_endpoint_address}"
+    auth_token               = "${module.celery-broker.auth_token}"
+  }
+}


### PR DESCRIPTION
Production version of https://github.com/ministryofjustice/cloud-platform-environments/pull/1182