### PR TITLE
Use dynamodb table to lock environments tf states

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -26,6 +26,7 @@ for _f in namespaces/${cluster}/*; do
         terraform init \
           -backend-config="bucket=${PIPELINE_STATE_BUCKET}" \
           -backend-config="key=${PIPELINE_STATE_KEY_PREFIX}${cluster}/${namespace}/terraform.tfstate" \
+          -backend-config="dynamodb_table=${PIPELINE_TERRAFORM_STATE_LOCK_TABLE}" \
           -backend-config="region=${PIPELINE_STATE_REGION}"
         terraform apply \
           -var="cluster_name=${cluster%%.*}" \


### PR DESCRIPTION
This commit depends on https://github.com/ministryofjustice/cloud-platform-concourse/pull/112, which makes the table name available as
an environment variable.

It also depends on https://github.com/ministryofjustice/cloud-platform-concourse/pull/111, which created the dynamodb table.

AFAICT, if the table is missing, or the env var.
is not available, the pipeline would still run
successfully, but would simply not lock the 
terraform states. I might be wrong about this, but
that's what seemed to be happening while I was
figuring this out.