### PR TITLE
Add a `make tools-shell` command in env. repo

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,3 +23,14 @@ namespace:
 	@echo
 	@echo $${NAMESPACE_MESSAGE} | fmt
 	@echo
+
+tools-shell:
+	@echo "Pulling Cloud Platform Tools docker image..."
+	@docker pull $(TOOLS_IMAGE) > /dev/null
+	@docker run --rm -it \
+		-v $$(pwd):/app \
+		-v $${HOME}/.kube:/app/.kube \
+		-e KUBECONFIG=/app/.kube/config \
+		-v $${HOME}/.aws:/root/.aws \
+		-v $${HOME}/.gnupg:/root/.gnupg \
+		-w /app $(TOOLS_IMAGE) bash


### PR DESCRIPTION
This will enable users to interact with the 
cluster, without having to install kubectl
locally