### PR TITLE
Mount $APPDIR into the tools shell

### DIFF
--- a/makefile
+++ b/makefile
@@ -24,11 +24,13 @@ namespace:
 	@echo $${NAMESPACE_MESSAGE} | fmt
 	@echo
 
+# Set an env. var called APPDIR to the source code directory
+# you want to mount into your tools shell
 tools-shell:
 	@echo "Pulling Cloud Platform Tools docker image..."
 	@docker pull $(TOOLS_IMAGE) > /dev/null
 	@docker run --rm -it \
-		-v $$(pwd):/app \
+		-v $${APPDIR}:/app \
 		-v $${HOME}/.kube:/app/.kube \
 		-e KUBECONFIG=/app/.kube/config \
 		-v $${HOME}/.aws:/root/.aws \


### PR DESCRIPTION
This enables users to use the tools shell to deploy kubernetes
manifest files from any directory on their local machine.
It requires setting APPDIR before running `make tools-shell`

This is a bit clunky, but if people don't have kubectl installed,
it's the easiest way I could think of to use the tools image for
everything.