### PR TITLE
Set pvb staging resourcequota to production values

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: prison-visits-booking-staging
 spec:
   hard:
-    requests.cpu: 600m
-    requests.memory: 8500Mi
+    requests.cpu: 2000m
+    requests.memory: 16000Mi


### PR DESCRIPTION
The PVB team had a problem deploying an update in their staging
namespace. We traced this to container memory requests hitting the
namespace memory request limit, which was set lower than the
production namespace.

This change makes the resourcequota values consistent between
staging and production, which should avoid this issue in future.

On a related note, their deployments specify quite high memory
request values for some of their containers. These should probably
be reduced to avoid these kinds of issues.