### PR TITLE
Change namespace resourcequota

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/03-resourcequota.yaml
@@ -5,5 +5,6 @@ metadata:
   namespace: laa-get-access-service-improvement
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 6Gi
+    pods: "50"
+    requests.cpu: 10m
+    requests.memory: 500Mi


### PR DESCRIPTION
* reduce CPU request from 3000m to 10m
* reduce memory request from 6000Mi to 500Mi
* set limit on number of pods to 50

This namespace has been completely empty since May 2019.