### PR TITLE
Lock terraform state during `terraform plan`

### DIFF
--- a/bin/plan
+++ b/bin/plan
@@ -27,6 +27,7 @@ if [ -n "$changed_dirs" ]; then
         terraform init \
           -backend-config="bucket=${PIPELINE_STATE_BUCKET}" \
           -backend-config="key=${PIPELINE_STATE_KEY_PREFIX}${cluster}/${namespace}/terraform.tfstate" \
+          -backend-config="dynamodb_table=${PIPELINE_TERRAFORM_STATE_LOCK_TABLE}" \
           -backend-config="region=${PIPELINE_STATE_REGION}"
         terraform plan \
           -var="cluster_name=${cluster%%.*}" \


### PR DESCRIPTION
depends on
https://github.com/ministryofjustice/cloud-platform-concourse/pull/114

This commit makes the `plan` pipeline use terraform state locking in
the same way as the build pipeline does.

This isn't strictly necessary, but it prevents the plan stage from
happening if the build pipeline is in the middle of applying, to the
same terraform state file.