### PR TITLE
Reduce resourcequota for c100 app. staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/03-resourcequota.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: c100-application-staging
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 12Gi
-    
+    requests.cpu: 300m
+    requests.memory: 6Gi
+


### PR DESCRIPTION
This reduces CPU from 3000m to 300m (5 x current requests total),
and memory from 12Gi to 6Gi (4 x current requests total).

Jesus will try a deployment with maxSurge: 100% after this PR is
merged, and if there are no problems a subsequent PR will make the
same changes to the production namespace.