### PR TITLE
Change c100-app prod ns. requests to match staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/03-resourcequota.yaml
@@ -5,6 +5,5 @@ metadata:
   namespace: c100-application-production
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 12Gi
-    
+    requests.cpu: 300m
+    requests.memory: 6Gi


### PR DESCRIPTION
Jesus has tested deployment into the staging namespace, with the
new quota values, and everything seems to be fine. So this change
brings the production namespace into line with staging.