### PR TITLE
Add prometheus rules to namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/prometheus.yml
@@ -1,0 +1,97 @@
+# Prometheus Alerts
+#
+# https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#creating-your-own-custom-alerts
+#
+# Note: we are using the `cloud-platform.justice.gov.uk/business-unit` namespace annotation
+# to filter and trigger alerts in all our (Family Justice) services.
+# This file needs to be applied in just one namespace.
+#
+# To see the current alerts in this namespace:
+#   kubectl describe prometheusrule -n c100-application-production
+#
+# Alerts will be sent to the slack channel: #cross_justice_team
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: c100-application-prometheus-production
+  namespace: c100-application-production
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: FJ-DeploymentReplicasMismatch
+      expr: >-
+        kube_deployment_spec_replicas{job="kube-state-metrics"}
+        * on(namespace) group_left() kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="Family Justice"}
+        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+      for: 30m
+      labels:
+        severity: family-justice
+      annotations:
+        message: Deployment `{{ $labels.deployment }}` has not matched the expected number of replicas for more than 30 mins.
+
+    - alert: FJ-JobFailed
+      expr: >-
+        kube_job_status_failed{job="kube-state-metrics"}
+        * on(namespace) group_left() kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="Family Justice"}
+        > 0
+      for: 1h
+      labels:
+        severity: family-justice
+      annotations:
+        message: Job `{{ $labels.job_name }}` failed to complete.
+
+    - alert: FJ-NamespaceMissing
+      expr: >-
+        absent(kube_namespace_created)
+        * on(namespace) group_left() kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="Family Justice"}
+      for: 1m
+      labels:
+        severity: family-justice
+      annotations:
+        message: Namespace `{{ $labels.namespace }}` is missing.
+
+    - alert: FJ-ContainerNotSeen
+      expr: >-
+        (time() - container_last_seen{container_name="webapp"})
+        * on(namespace) group_left() kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="Family Justice"}
+        > 45
+      for: 1m
+      labels:
+        severity: family-justice
+      annotations:
+        summary: This usually is the consequence of a deploy, where old pods are replaced with new ones.
+        message: Pod `{{ $labels.pod_name }}` not seen for a while in `{{ $labels.namespace }}` namespace.
+
+    - alert: FJ-ContainerRestarting
+      expr: >-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[5m])
+        * on(namespace) group_left() kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="Family Justice"}
+        > 0
+      for: 1m
+      labels:
+        severity: family-justice
+      annotations:
+        message: Pod `{{ $labels.pod }}` has been restarting in `{{ $labels.namespace }}` for the last 5 minutes.
+
+    # This alert is only for production namespaces, as staging envs will easily trigger it and cause noise
+    # Filter out errors 499 caused by client dropping the connection as these are normal, and 401 due to many
+    # namespaces having http auth credentials.
+    #
+    - alert: FJ-IncreasedHTTPErrors
+      expr: >-
+        100
+        * sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace=~".*-production$", status=~"400|40[2-9]|4[1-8][0-9]|49[0-8]|5.."}[5m]))
+        / sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace=~".*-production$"}[5m]))
+        * on(exported_namespace) group_left() label_replace(
+          kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="Family Justice"},
+          "exported_namespace", "$1", "namespace", "(.+)"
+        ) > 3
+      for: 10m
+      labels:
+        severity: family-justice
+      annotations:
+        message: '{{ printf "%0.0f" $value }}% HTTP error rate in `{{ $labels.exported_namespace }}` for the last 10 minutes.'


### PR DESCRIPTION
We had this in the deploy repo.

Adding the file to the environments repo so that rules can be deployed and re-created via the pipeline in case of cluster failure (essentially like we do with certificates).