### PR TITLE
Add DNS hosted zone for cccd-production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "cccd_route53_zone" {
+  name = "${var.domain}"
+
+  tags {
+    business-unit          = "${var.business-unit}"
+    application            = "${var.application}"
+    is-production          = "${var.is-production}"
+    environment-name       = "${var.environment-name}"
+    owner                  = "${var.team_name}"
+    infrastructure-support = "${var.infrastructure-support}"
+  }
+}
+
+resource "kubernetes_secret" "cccd_route53_zone_sec" {
+  metadata {
+    name      = "cccd-route53-zone-output"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/variables.tf
@@ -1,3 +1,7 @@
+variable "domain" {
+  default = "claim-crown-court-defence.service.gov.uk"
+}
+
 variable "application" {
   default = "cccd"
 }


### PR DESCRIPTION
This is to be used to have GDS nameserver
authorities point to - and enable control over
cutover from template-deploy to live-1 servers.