### PR TITLE
Add cccd production DNS records

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -19,6 +19,7 @@ resource "kubernetes_secret" "cccd_route53_zone_sec" {
 
   data {
     zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
+    name_servers = "${join("\n", aws_route53_zone.cccd_route53_zone.name_servers)}"
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -18,7 +18,7 @@ resource "kubernetes_secret" "cccd_route53_zone_sec" {
   }
 
   data {
-    zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
+    zone_id      = "${aws_route53_zone.cccd_route53_zone.zone_id}"
     name_servers = "${join("\n", aws_route53_zone.cccd_route53_zone.name_servers)}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -21,3 +21,29 @@ resource "kubernetes_secret" "cccd_route53_zone_sec" {
     zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
   }
 }
+
+resource "aws_route53_record" "cccd_route53_A_record_1" {
+  name    = "gamma.advocatedefencepayments.dsd.io."
+  zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
+  type    = "A"
+
+  alias {
+    name    = "advocated-elbgamma-17de5vdfln9zg-1726434105.eu-west-1.elb.amazonaws.com."
+    zone_id = "Z32O12XQLNTSW2"
+
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cccd_route53_A_record_2" {
+  name    = "gamma-a17d94fe.advocatedefencepayments.dsd.io."
+  zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
+  type    = "A"
+
+  alias {
+    name    = "advocated-elbgamma-17de5vdfln9zg-1726434105.eu-west-1.elb.amazonaws.com."
+    zone_id = "Z32O12XQLNTSW2"
+
+    evaluate_target_health = false
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -24,25 +24,12 @@ resource "kubernetes_secret" "cccd_route53_zone_sec" {
 }
 
 resource "aws_route53_record" "cccd_route53_A_record_1" {
-  name    = "gamma.advocatedefencepayments.dsd.io."
+  name    = "claim-crown-court-defence.service.gov.uk."
   zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
   type    = "A"
 
   alias {
-    name    = "advocated-elbgamma-17de5vdfln9zg-1726434105.eu-west-1.elb.amazonaws.com."
-    zone_id = "Z32O12XQLNTSW2"
-
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cccd_route53_A_record_2" {
-  name    = "gamma-a17d94fe.advocatedefencepayments.dsd.io."
-  zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
-  type    = "A"
-
-  alias {
-    name    = "advocated-elbgamma-17de5vdfln9zg-1726434105.eu-west-1.elb.amazonaws.com."
+    name    = "dualstack.advocated-elbgamma-17de5vdfln9zg-1726434105.eu-west-1.elb.amazonaws.com."
     zone_id = "Z32O12XQLNTSW2"
 
     evaluate_target_health = false


### PR DESCRIPTION
### What
copies of existing template-deploy DNS records

### Why

In preparation for having GDS delegate control
for production service.gov.uk domain.