### PR TITLE
Remove new namespace CPU & memory request limits

### DIFF
--- a/namespace-resources/03-resourcequota.yaml
+++ b/namespace-resources/03-resourcequota.yaml
@@ -6,5 +6,3 @@ metadata:
 spec:
   hard:
     pods: "50"
-    requests.cpu: 100m
-    requests.memory: 5000Mi


### PR DESCRIPTION
related to
https://github.com/ministryofjustice/cloud-platform/issues/1357

If we are going to remove CPU & memory request limits for all
namespaces in the near future, it makes sense to remove those
limits for any new namespaces. The change ensures that new
namespaces only have pod count limits applied, by default.