### PR TITLE
Track a query r53 records

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
@@ -29,7 +29,7 @@ resource "kubernetes_secret" "track_a_query_route53_zone_sec" {
 }
 
 resource "aws_route53_record" "track_a_query_route53_A_record_production" {
-  name    = "track-a-query.service.gov.uk."
+  name    = "."
   zone_id = "${aws_route53_zone.track_a_query_route53_zone.zone_id}"
   type    = "A"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
@@ -42,7 +42,7 @@ resource "aws_route53_record" "track_a_query_route53_A_record_production" {
 }
 
 resource "aws_route53_record" "track_a_query_route53_A_record_development" {
-  name    = "development.track-a-query.service.gov.uk."
+  name    = "development"
   zone_id = "${aws_route53_zone.track_a_query_route53_zone.zone_id}"
   type    = "A"
 
@@ -55,7 +55,7 @@ resource "aws_route53_record" "track_a_query_route53_A_record_development" {
 }
 
 resource "aws_route53_record" "track_a_query_route53_A_record_staging" {
-  name    = "staging.track-a-query.service.gov.uk."
+  name    = "staging"
   zone_id = "${aws_route53_zone.track_a_query_route53_zone.zone_id}"
   type    = "A"
 
@@ -68,7 +68,7 @@ resource "aws_route53_record" "track_a_query_route53_A_record_staging" {
 }
 
 resource "aws_route53_record" "track_a_query_route53_A_record_demo" {
-  name    = "demo.track-a-query.service.gov.uk."
+  name    = "demo"
   zone_id = "${aws_route53_zone.track_a_query_route53_zone.zone_id}"
   type    = "A"
 


### PR DESCRIPTION
When creating route53 records with terraform should not be the full name. 
Instead an A record's name should only be the prefix to be addedd to zone name (if any) 

`track-a-query.service.gov.uk.` ->  `.`
`staging.track-a-query.service.gov.uk.` -> `staging` 

