### PR TITLE
Replace logging request limits with pods: 100

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/03-resourcequota.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: logging
 spec:
   hard:
-    requests.cpu: 3000m
-    requests.memory: 12Gi
+    pods: "100"


### PR DESCRIPTION
This change removes the cpu and memory request limits from the
logging namespace, and replaces them with a limit of 100 on the
number of pods the namespace may launch.

There are currently 29 pods in the logging namespace, so this
change allows for temporary spikes, e.g. if we were to launch
a full set of new pods before deleting the old ones.