### PR TITLE
Replace authorized-keys-provider request limits

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/03-resourcequota.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: authorized-keys-provider
 spec:
   hard:
-    requests.cpu: 1000m
-    requests.memory: 1000Mi
-
+    pods: "5"


### PR DESCRIPTION
The authorized-keys-provider is running a single container.

This change removes the cpu and memory request limits on the
namespace, and replaces them with a limit of 5 on the number of
pods the namespace may run concurrently.