### PR TITLE
Include pods count (limit & used) in the report

### DIFF
--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -233,11 +233,10 @@ end
 options = parse_options
 pattern = options.fetch(:namespace)
 
-names = Namespace.names(pattern)
+reports = Namespace.names(pattern).map { |name| Namespace.new(name).report }
 
 if options.fetch(:format) == JSON_OUTPUT
-  namespaces = names.map { |name| Namespace.new(name).report }
-  puts({ items: namespaces, last_updated: Time.now }.to_json)
+  puts({ items: reports, last_updated: Time.now }.to_json)
 else
-  names.each { |name| text_output(Namespace.new(name).report) }
+  reports.each { |report| text_output(report) }
 end

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -112,9 +112,9 @@ class Namespace
     if quota.nil?
       {
         hard_request_limit: {cpu: nil, memory: nil},
-        hard_limit: {cpu: nil, memory: nil},
+        hard_limit: {cpu: nil, memory: nil, pods: nil},
         requested: {cpu: nil, memory: nil},
-        hard_limit_used: {cpu: nil, memory: nil}
+        hard_limit_used: {cpu: nil, memory: nil, pods: nil},
       }
     else
       data = quota.dig("status")
@@ -126,12 +126,14 @@ class Namespace
 
       hard_limit = {
         cpu: cpu_value(data.dig("hard", "limits.cpu")),
-        memory: memory_value(data.dig("hard", "limits.memory"))
+        memory: memory_value(data.dig("hard", "limits.memory")),
+        pods: integer_value(data.dig("hard", "pods")),
       }
 
       hard_limit_used = {
         cpu: cpu_value(data.dig("used", "limits.cpu")),
-        memory: memory_value(data.dig("used", "limits.memory"))
+        memory: memory_value(data.dig("used", "limits.memory")),
+        pods: integer_value(data.dig("used", "pods")),
       }
 
       requested = {
@@ -169,6 +171,10 @@ class Namespace
     else
       raise %[CPU value: "#{str}" was not in expected format]
     end
+  end
+
+  def integer_value(str)
+    str.nil? ? nil : str.to_i
   end
 
   def memory_value(str)

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -21,8 +21,8 @@
 #     cat namespaces.json | jq '.items[].container_count' | paste -sd+ - | bc
 # https://stackoverflow.com/a/18141152/794111
 
-require 'json'
-require 'optparse'
+require "json"
+require "optparse"
 
 # Output formats
 TEXT_OUTPUT = "text"
@@ -48,13 +48,13 @@ class Namespace
       hard_limit: ns_quota.fetch(:hard_limit),
       hard_limit_used: ns_quota.fetch(:hard_limit_used),
       resources_requested: ns_quota.fetch(:requested),
-      container_count: container_count(name)
+      container_count: container_count(name),
     }
   end
 
   def self.names(pattern)
     `kubectl get ns -o jsonpath='{.items[*].metadata.name}'`.chomp
-      .split(' ')
+      .split(" ")
       .grep(/#{pattern}/)
   end
 
@@ -66,17 +66,16 @@ class Namespace
     lines = usage.split("\n")
     lines.shift
 
-    hash = lines.inject({ cpu: [], memory: [] }) do |h, l|
+    hash = lines.each_with_object({cpu: [], memory: []}) { |l, h|
       fields = l.split(" ")
       h[:cpu] << fields[1]
       h[:memory] << fields[2]
-      h
-    end
+    }
 
-    cpu = hash[:cpu].inject(0) {|sum, c| sum += cpu_value(c)}
-    memory = hash[:memory].inject(0) {|sum, c| sum += memory_value(c)}
+    cpu = hash[:cpu].inject(0) { |sum, c| sum += cpu_value(c) }
+    memory = hash[:memory].inject(0) { |sum, c| sum += memory_value(c) }
 
-    { cpu: cpu, memory: memory }
+    {cpu: cpu, memory: memory}
   end
 
   def default_request(limits)
@@ -93,12 +92,12 @@ class Namespace
 
     {
       cpu: cpu_value(data.fetch("cpu", nil)),
-      memory: memory_value(data.fetch("memory", nil))
+      memory: memory_value(data.fetch("memory", nil)),
     }
   rescue
     {
       cpu: nil,
-      memory: nil
+      memory: nil,
     }
   end
 
@@ -121,7 +120,7 @@ class Namespace
 
       hard_request_limit = {
         cpu: cpu_value(data.dig("hard", "requests.cpu")),
-        memory: memory_value(data.dig("hard", "requests.memory"))
+        memory: memory_value(data.dig("hard", "requests.memory")),
       }
 
       hard_limit = {
@@ -138,21 +137,21 @@ class Namespace
 
       requested = {
         cpu: cpu_value(data.dig("used", "requests.cpu")),
-        memory: memory_value(data.dig("used", "requests.memory"))
+        memory: memory_value(data.dig("used", "requests.memory")),
       }
 
       {
         hard_request_limit: hard_request_limit,
         hard_limit: hard_limit,
         hard_limit_used: hard_limit_used,
-        requested: requested
+        requested: requested,
       }
     end
   end
 
   def container_count(name)
     data = kubectl_get("pods")
-    data.collect {|i| i.dig("spec", "containers")}.flatten.compact.count
+    data.collect { |i| i.dig("spec", "containers") }.flatten.compact.count
   end
 
   def kubectl_get(obj)
@@ -169,7 +168,7 @@ class Namespace
     when /^(\d+)m$/
       $1.to_i
     else
-      raise %[CPU value: "#{str}" was not in expected format]
+      raise %(CPU value: "#{str}" was not in expected format)
     end
   end
 
@@ -192,7 +191,7 @@ class Namespace
     when /^(\d+)Mi/
       $1.to_i
     else
-      raise %[Memory value: "#{str}" was not in expected format]
+      raise %(Memory value: "#{str}" was not in expected format)
     end
   end
 end
@@ -214,9 +213,9 @@ def text_output(ns)
 end
 
 def parse_options
-  options = { format: TEXT_OUTPUT }
+  options = {format: TEXT_OUTPUT}
 
-  OptionParser.new do |opts|
+  OptionParser.new { |opts|
     opts.on("-n", "--namespace NAMESPACE", "Namespace name pattern (required)") do |ns|
       options[:namespace] = ns
     end
@@ -229,7 +228,7 @@ def parse_options
       puts opts
       exit
     end
-  end.parse!
+  }.parse!
 
   options
 end
@@ -242,7 +241,7 @@ pattern = options.fetch(:namespace)
 reports = Namespace.names(pattern).map { |name| Namespace.new(name).report }
 
 if options.fetch(:format) == JSON_OUTPUT
-  puts({ items: reports, last_updated: Time.now }.to_json)
+  puts({items: reports, last_updated: Time.now}.to_json)
 else
   reports.each { |report| text_output(report) }
 end

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -75,7 +75,7 @@ class Namespace
     cpu = hash[:cpu].inject(0) { |sum, c| sum += cpu_value(c) }
     memory = hash[:memory].inject(0) { |sum, c| sum += memory_value(c) }
 
-    {cpu: cpu, memory: memory}
+    { cpu: cpu, memory: memory, pods: lines.count }
   end
 
   def default_request(limits)
@@ -113,7 +113,7 @@ class Namespace
         hard_request_limit: {cpu: nil, memory: nil},
         hard_limit: {cpu: nil, memory: nil, pods: nil},
         requested: {cpu: nil, memory: nil},
-        hard_limit_used: {cpu: nil, memory: nil, pods: nil},
+        hard_limit_used: {cpu: nil, memory: nil},
       }
     else
       data = quota.dig("status")
@@ -132,7 +132,6 @@ class Namespace
       hard_limit_used = {
         cpu: cpu_value(data.dig("used", "limits.cpu")),
         memory: memory_value(data.dig("used", "limits.memory")),
-        pods: integer_value(data.dig("used", "pods")),
       }
 
       requested = {
@@ -206,7 +205,7 @@ def text_output(ns)
   puts "  Num. containers:\t#{ns[:container_count]}"
   puts "  Req. per-container:\tCPU: #{ns[:default_request][:cpu]},\tMemory: #{ns[:default_request][:memory]}"
   puts
-  puts "  Resources in-use:\tCPU: #{ns[:resources_used][:cpu]},\tMemory: #{ns[:resources_used][:memory]}"
+  puts "  Resources in-use:\tCPU: #{ns[:resources_used][:cpu]},\tMemory: #{ns[:resources_used][:memory]},\tPods: #{ns[:resources_used][:pods]}"
   puts
   puts "CPU values are in millicores (m). Memory values are in mebibytes (Mi)."
   puts

--- a/bin/namespace-reporter.rb
+++ b/bin/namespace-reporter.rb
@@ -75,7 +75,7 @@ class Namespace
     cpu = hash[:cpu].inject(0) { |sum, c| sum += cpu_value(c) }
     memory = hash[:memory].inject(0) { |sum, c| sum += memory_value(c) }
 
-    { cpu: cpu, memory: memory, pods: lines.count }
+    {cpu: cpu, memory: memory, pods: lines.count}
   end
 
   def default_request(limits)


### PR DESCRIPTION
We are planning to use pod count limits as the only way namespaces are
restricted. To support this, we will have a page showing a chart of the
number of pods allowed vs. used in each namespace. This change enables that
feature to be built.