### PR TITLE
Track a Query - alter development host name for certificate

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/05-certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/05-certificate.yaml
@@ -8,10 +8,10 @@ spec:
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: 'development.track-a-query.service.justice.gov.uk'
+  commonName: 'dev.track-a-query.service.justice.gov.uk'
   acme:
     config:
     - domains:
-      - 'development.track-a-query.service.justice.gov.uk'
+      - 'dev.track-a-query.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform


### PR DESCRIPTION
Use the correct development environment host name - change from `development` to `dev` to match existing dev environment url.