### PR TITLE
Update the namespace reporter image version

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/deployment.yaml
@@ -14,6 +14,8 @@ spec:
         - name: usage-report
           image: ministryofjustice/cloud-platform-namespace-usage-report:1.6
           env:
+            - name: RACK_ENV
+              value: "production"
             - name: API_KEY
               valueFrom:
                 secretKeyRef:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: usage-report
-          image: ministryofjustice/cloud-platform-namespace-usage-report:1.5
+          image: ministryofjustice/cloud-platform-namespace-usage-report:1.6
           env:
             - name: API_KEY
               valueFrom:


### PR DESCRIPTION
This change uses the latest version of the namespace reporter,
which will display the "pods used vs. pods allowed" page.

depends on #1513