### PR TITLE
Adjust 'apply for legal aid' UAT resource quotas

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: laa-apply-for-legalaid-uat
 spec:
   hard:
-    requests.cpu: 700m
-    requests.memory: 20Gi
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: laa-apply-for-legalaid-uat
 spec:
   hard:
-    requests.cpu: 500m
-    requests.memory: 15Gi
+    requests.cpu: 700m
+    requests.memory: 20Gi


### PR DESCRIPTION
Multiple testers are working in parallel releases under the namespace, and the team is being throttled by the Namespace Quota limits.
Adjusting the quotas to the usage needs.