### PR TITLE
Add a `git pull` before applying every namespace

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -17,6 +17,7 @@ for _f in namespaces/${cluster}/*; do
   if [ -d "${_f}" ]; then
     namespace="$(basename ${_f})"
     log blue "applying resources for namespace ${namespace} in ${cluster}"
+    git pull  # In case any PRs were merged since the pipeline started
     ( set -x; kubectl -n "${namespace}" apply -f "${_f}" )
     terraform_resources_path="namespaces/${cluster}/${namespace}/resources"
     if [ -d "${terraform_resources_path}" ]; then

--- a/bin/apply
+++ b/bin/apply
@@ -14,10 +14,10 @@ log green "applying for cluster ${cluster}"
 log blue "applying cluster-level resources for ${cluster}"
 ( set -x; kubectl apply -f "namespaces/${cluster}" ) || log blue "no global resources to apply"
 for _f in namespaces/${cluster}/*; do
+  git pull  # In case any PRs were merged since the pipeline started
   if [ -d "${_f}" ]; then
     namespace="$(basename ${_f})"
     log blue "applying resources for namespace ${namespace} in ${cluster}"
-    git pull  # In case any PRs were merged since the pipeline started
     ( set -x; kubectl -n "${namespace}" apply -f "${_f}" )
     terraform_resources_path="namespaces/${cluster}/${namespace}/resources"
     if [ -d "${terraform_resources_path}" ]; then


### PR DESCRIPTION
The build pipeline pulls a copy of the environments repo at the
start of each run, but it's possible that changes get merged
and applied by the `build-namespace-changes` pipeline after that.

This can cause the following issue:

* Namespace N is in state 1
* `build` pipeline starts, and gets environments repo code showing N in
state 1
* User merges a PR putting N into state 2
* `build-namespace-changes` pipeline puts N into state 2
* build pipeline applies its copy of N source code, and puts N into
state 1
* The next run of the `build` pipeline puts N into state 2

So, the namespace states go N1 -> N2 -> N1 -> N2

This is always confusing, and could cause major issues (e.g. if
the transition from N2 -> N1 causes an RDS instance to be destroyed
and recreated).

This change should fix this issue by ensuring that the `build`
pipeline is always applying the latest version of the code from the
environments repo.