### PR TITLE
Update elasticache-cluster modules to use latest ver

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/redis.tf
@@ -3,7 +3,7 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -13,6 +13,10 @@ module "redis-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/redis.tf
@@ -3,7 +3,7 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -13,6 +13,10 @@ module "redis-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
@@ -2,7 +2,7 @@
 ########################################################
 # Service Token Cache Elasticache Redis (for resque + job logging)
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -12,6 +12,10 @@ module "service-token-cache-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "service-token-cache-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
@@ -35,7 +35,7 @@ resource "kubernetes_secret" "submitter-rds-instance" {
 ########################################################
 # Submitter Elasticache Redis (for resque + job logging)
 module "submitter-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -45,6 +45,10 @@ module "submitter-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "submitter-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/service_token_cache.tf
@@ -2,7 +2,7 @@
 ########################################################
 # Service Token Cache Elasticache Redis (for resque + job logging)
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -12,6 +12,10 @@ module "service-token-cache-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "service-token-cache-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
@@ -35,7 +35,7 @@ resource "kubernetes_secret" "submitter-rds-instance" {
 ########################################################
 # Submitter Elasticache Redis (for resque + job logging)
 module "submitter-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -45,6 +45,10 @@ module "submitter-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "submitter-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/service_token_cache.tf
@@ -2,7 +2,7 @@
 ########################################################
 # Service Token Cache Elasticache Redis (for resque + job logging)
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -12,6 +12,10 @@ module "service-token-cache-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "service-token-cache-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/submitter.tf
@@ -37,7 +37,7 @@ resource "kubernetes_secret" "submitter-rds-instance" {
 ########################################################
 # Submitter Elasticache Redis (for resque + job logging)
 module "submitter-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -47,6 +47,10 @@ module "submitter-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "submitter-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
@@ -2,7 +2,7 @@
 ########################################################
 # Service Token Cache Elasticache Redis (for resque + job logging)
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -12,6 +12,10 @@ module "service-token-cache-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "service-token-cache-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
@@ -35,7 +35,7 @@ resource "kubernetes_secret" "submitter-rds-instance" {
 ########################################################
 # Submitter Elasticache Redis (for resque + job logging)
 module "submitter-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -45,6 +45,10 @@ module "submitter-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "submitter-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
@@ -2,7 +2,7 @@
 ########################################################
 # Service Token Cache Elasticache Redis (for resque + job logging)
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -12,6 +12,10 @@ module "service-token-cache-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "service-token-cache-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/submitter.tf
@@ -35,7 +35,7 @@ resource "kubernetes_secret" "submitter-rds-instance" {
 ########################################################
 # Submitter Elasticache Redis (for resque + job logging)
 module "submitter-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -45,6 +45,10 @@ module "submitter-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "submitter-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/service_token_cache.tf
@@ -2,7 +2,7 @@
 ########################################################
 # Service Token Cache Elasticache Redis (for resque + job logging)
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -12,6 +12,10 @@ module "service-token-cache-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "service-token-cache-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/submitter.tf
@@ -38,7 +38,7 @@ resource "kubernetes_secret" "submitter-rds-instance" {
 ########################################################
 # Submitter Elasticache Redis (for resque + job logging)
 module "submitter-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -48,6 +48,10 @@ module "submitter-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "submitter-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/publisher.tf
@@ -34,7 +34,7 @@ resource "kubernetes_secret" "publisher-rds-instance" {
 ########################################################
 # Publisher Elasticache Redis (for resque + job logging)
 module "publisher-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -44,6 +44,10 @@ module "publisher-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "publisher-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
@@ -34,7 +34,7 @@ resource "kubernetes_secret" "publisher-rds-instance" {
 ########################################################
 # Publisher Elasticache Redis (for resque + job logging)
 module "publisher-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -44,6 +44,10 @@ module "publisher-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "publisher-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -9,6 +9,10 @@ module "redis-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -9,6 +9,10 @@ module "redis-elasticache" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-offender-management-allocation-manager" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
   node_type              = "cache.m4.xlarge"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
@@ -8,7 +8,10 @@ module "ec-cluster-offender-management-allocation-manager" {
   is-production          = "${var.is-production}"
   environment-name       = "${var.environment-name}"
   infrastructure-support = "${var.infrastructure-support}"
-  aws_region             = "eu-west-2"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "ec-cluster-offender-management-allocation-manager-staging" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-prison-visits-booking-staff" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "${var.team_name}"
@@ -7,7 +7,10 @@ module "ec-cluster-prison-visits-booking-staff" {
   is-production          = "${var.is-production}"
   environment-name       = "${var.environment-name}"
   infrastructure-support = "${var.infrastructure-support}"
-  aws_region             = "eu-west-2"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "ec-cluster-prison-visits-booking-staff" {


### PR DESCRIPTION
This is the pre-requisite before we work on upgrading tfv0.12

This is related to https://github.com/ministryofjustice/cloud-platform/issues/1363.

The latest elasticache-cluster version have provider and "apply_immediately = true" changes.