### PR TITLE
removed spaces from variable.tf in laa api staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/variable.tf
@@ -11,7 +11,7 @@ variable "team_name" {
 }
 
 variable "application" {
-  default = "LAA Legal Adviser API"
+  default = "LAA-Legal-Adviser-API"
 }
 
 variable "repo_name" {


### PR DESCRIPTION
- replaced spaces with hyphens in a variable.tf file. 

It seems both variables and uppercases letter are forbidden in the Pingdom resource.