### PR TITLE
Updated s3 modules to use the latest version

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
 
   team_name              = "${var.team_name}"
   business-unit          = "${var.business-unit}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
 
   team_name              = "${var.team_name}"
   business-unit          = "${var.business-unit}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
   team_name              = "${var.team_name}"
   acl                    = "private"
   versioning             = false
@@ -8,7 +8,10 @@ module "risk_profiler_s3_bucket" {
   is-production          = "${var.is-production}"
   environment-name       = "${var.environment-name}"
   infrastructure-support = "${var.infrastructure-support}"
-  aws-s3-region          = "eu-west-2"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "risk_profiler_s3_bucket" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
   team_name              = "${var.team_name}"
   acl                    = "private"
   versioning             = false
@@ -8,7 +8,10 @@ module "risk_profiler_s3_bucket" {
   is-production          = "${var.is-production}"
   environment-name       = "${var.environment-name}"
   infrastructure-support = "${var.infrastructure-support}"
-  aws-s3-region          = "eu-west-2"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "risk_profiler_s3_bucket" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
   team_name              = "${var.team_name}"
   acl                    = "private"
   versioning             = false
@@ -8,7 +8,10 @@ module "risk_profiler_s3_bucket" {
   is-production          = "${var.is-production}"
   environment-name       = "${var.environment-name}"
   infrastructure-support = "${var.infrastructure-support}"
-  aws-s3-region          = "eu-west-2"
+
+  providers = {
+    aws = "aws.london"
+  }
 
   bucket_policy = <<EOF
 {


### PR DESCRIPTION
This is Pre-requisites  for terraform upgrade v0.12

This is related to https://github.com/ministryofjustice/cloud-platform/issues/1363

s3 module v3.0 to v3.3 contains, below changes, which are not effected as the modules i updated are not using these changes.
provider changes 
s3 lifecycle object
user_policy

aws-s3-region tag is removed in v3.2, so we can see a change in this for modules updated from v3.0.