### PR TITLE
Attempt to enable circleci to apply updates to cccd cronjobs

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/serviceaccount-circleci.yaml
@@ -36,6 +36,19 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
Attempt to enable circleci to apply updates to cccd cronjobs,. Currently kubectl apply -f kubernetes_deploy/cron_jobs/archive_stale.yaml but this is failing with in config.yml but this is failing with 'cronjobs.batch "cccd-archive-stale" is forbidden: User "system:serviceaccount:********:circleci" cannot get resource "cronjobs" in API group "batch" in the namespace "********".