### PR TITLE
Add the ability for circleci to update cronjobs to other cccd namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/serviceaccount-circleci.yaml
@@ -36,6 +36,19 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
 
 ---
 kind: RoleBinding

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/serviceaccount-circleci.yaml
@@ -36,6 +36,19 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
 
 ---
 kind: RoleBinding

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/serviceaccount-circleci.yaml
@@ -36,6 +36,19 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
Add the ability for circleci to update cccd cronjobs in live1 to other cccd namespaces. See also https://github.com/ministryofjustice/cloud-platform-environments/pull/1548.