### PR TITLE
Track a Query - Add S3 CORS rules for staging bucket

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -13,6 +13,22 @@ module "track_a_query_s3" {
   environment-name       = "staging"
   infrastructure-support = "correspondence-support@digital.justice.gov.uk"
 
+  cors_rule = [
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET", "POST", "PUT"]
+      allowed_origins = ["https://staging.track-a-query.service.justice.gov.uk", "https://track-a-query-staging.apps.live-1.cloud-platform.service.justice.gov.uk"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    },
+    {
+      allowed_headers = ["Authorization"]
+      allowed_methods = ["GET"]
+      allowed_origins = ["*"]
+      max_age_seconds = 3000
+    },
+  ]
+
   providers = {
     aws = "aws.london"
   }
@@ -61,20 +77,4 @@ resource "kubernetes_secret" "track_a_query_s3" {
     bucket_arn        = "${module.track_a_query_s3.bucket_arn}"
     bucket_name       = "${module.track_a_query_s3.bucket_name}"
   }
-
-  cors_rule = [
-    {
-      allowed_headers = ["*"]
-      allowed_methods = ["GET", "POST", "PUT"]
-      allowed_origins = ["https://staging.track-a-query.service.justice.gov.uk", "https://track-a-query-staging.apps.live-1.cloud-platform.service.justice.gov.uk"]
-      expose_headers  = ["ETag"]
-      max_age_seconds = 3000
-    },
-    {
-      allowed_headers = ["Authorization"]
-      allowed_methods = ["GET"]
-      allowed_origins = ["*"]
-      max_age_seconds = 3000
-    },
-  ]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -65,7 +65,7 @@ resource "kubernetes_secret" "track_a_query_s3" {
 
 resource "track_a_query_dropzone_cors" "track_a_query_s3" {
   bucket = "${module.track_a_query_s3.bucket_name}"
-  acl    = "public-read"
+  acl    = "bucket-owner-full-control"
 
   cors_rule {
     allowed_headers = ["*"]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -62,3 +62,28 @@ resource "kubernetes_secret" "track_a_query_s3" {
     bucket_name       = "${module.track_a_query_s3.bucket_name}"
   }
 }
+
+resource "track_a_query_dropzone_cors" "track_a_query_s3" {
+  bucket = "${module.track_a_query_s3.bucket_name}"
+  acl    = "public-read"
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "POST", "PUT"]
+    allowed_origins = ["https://staging.track-a-query.service.justice.gov.uk", "https://track-a-query-staging.apps.live-1.cloud-platform.service.justice.gov.uk"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
+resource "track_a_query_other_cors" "track_a_query_s3" {
+  bucket = "${module.track_a_query_s3.bucket_name}"
+  acl    = "public-read"
+
+  cors_rule {
+    allowed_headers = ["Authorization"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3000
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -61,29 +61,20 @@ resource "kubernetes_secret" "track_a_query_s3" {
     bucket_arn        = "${module.track_a_query_s3.bucket_arn}"
     bucket_name       = "${module.track_a_query_s3.bucket_name}"
   }
-}
 
-resource "track_a_query_dropzone_cors" "track_a_query_s3" {
-  bucket = "${module.track_a_query_s3.bucket_name}"
-  acl    = "bucket-owner-full-control"
-
-  cors_rule {
-    allowed_headers = ["*"]
-    allowed_methods = ["GET", "POST", "PUT"]
-    allowed_origins = ["https://staging.track-a-query.service.justice.gov.uk", "https://track-a-query-staging.apps.live-1.cloud-platform.service.justice.gov.uk"]
-    expose_headers  = ["ETag"]
-    max_age_seconds = 3000
-  }
-}
-
-resource "track_a_query_other_cors" "track_a_query_s3" {
-  bucket = "${module.track_a_query_s3.bucket_name}"
-  acl    = "public-read"
-
-  cors_rule {
-    allowed_headers = ["Authorization"]
-    allowed_methods = ["GET"]
-    allowed_origins = ["*"]
-    max_age_seconds = 3000
-  }
+  cors_rule = [
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET", "POST", "PUT"]
+      allowed_origins = ["https://staging.track-a-query.service.justice.gov.uk", "https://track-a-query-staging.apps.live-1.cloud-platform.service.justice.gov.uk"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    },
+    {
+      allowed_headers = ["Authorization"]
+      allowed_methods = ["GET"]
+      allowed_origins = ["*"]
+      max_age_seconds = 3000
+    }
+  ]
 }


### PR DESCRIPTION
Track a Query uses Dropzone in the browser to allow users to upload documents directly into S3. This module amendment will set the appropriate CORS rules for both the cloud platform generated URL and the actual staging.track-a-query domain