### PR TITLE
Add cccd-production certificate for cutover

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: cccd-production-cert
+  namespace: cccd-production
+spec:
+  secretName: cccd-production-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 'claim-crown-court-defence.service.gov.uk'
+  acme:
+    config:
+    - domains:
+      - 'claim-crown-court-defence.service.gov.uk'
+      dns01:
+        provider: route53-cloud-platform


### PR DESCRIPTION
This is the domain for current (live/template-deploy)
production environment that will need to be the
ingress after cutover.