### PR TITLE
Track a Query - remove demo DNS A record

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
@@ -53,16 +53,3 @@ resource "aws_route53_record" "track_a_query_route53_A_record_development" {
     evaluate_target_health = true
   }
 }
-
-resource "aws_route53_record" "track_a_query_route53_A_record_demo" {
-  name    = "demo"
-  zone_id = "${aws_route53_zone.track_a_query_route53_zone.zone_id}"
-  type    = "A"
-
-  alias {
-    name    = "haproxy-track-a-query-1357848984.eu-west-1.elb.amazonaws.com."
-    zone_id = "Z32O12XQLNTSW2"
-
-    evaluate_target_health = true
-  }
-}


### PR DESCRIPTION
Removes DNS A Record in route53 settings for Cloud Platform track a query

This will ensure demo.track-a-query.service.justice.gov.uk is served from cloud platform
