### PR TITLE
Update s3 modules to use the latest version 3.4

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "cloudplatform"
   business-unit          = "mojdigital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
@@ -6,7 +6,7 @@
  */
 
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   business-unit          = "${var.business-unit}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-staging/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-staging/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   business-unit          = "${var.business-unit}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   business-unit          = "${var.business-unit}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   business-unit          = "${var.business-unit}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
 
   team_name              = "${var.team_name}"
   business-unit          = "${var.business-unit}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
   team_name              = "${var.team_name}"
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
   team_name              = "${var.team_name}"
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
   team_name              = "${var.team_name}"
   acl                    = "private"
   versioning             = false


### PR DESCRIPTION
This is prerequisite to upgrade to terraform v0.12

Updated s3 modules to v3.4, this change shouldn't have any effect as v3.3 to v3.4 contains CORS changes, which will only effect when cors_rule is used.