### PR TITLE
Update sqs module to use the latest version3.5

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
@@ -10,7 +10,7 @@ module "cccd_claims_submitted" {
 }
 
 module "claims_for_ccr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -18,6 +18,7 @@ module "claims_for_ccr" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-for-ccr"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -58,7 +59,7 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
 }
 
 module "claims_for_cclf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -66,6 +67,7 @@ module "claims_for_cclf" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-for-cclf"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -106,7 +108,7 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
 }
 
 module "responses_for_cccd" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -114,6 +116,7 @@ module "responses_for_cccd" {
   application            = "${var.application}"
   sqs_name               = "responses-for-cccd"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -127,7 +130,7 @@ module "responses_for_cccd" {
 }
 
 module "ccr_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -135,6 +138,7 @@ module "ccr_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-submitted-ccr-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"
@@ -142,7 +146,7 @@ module "ccr_dead_letter_queue" {
 }
 
 module "cclf_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -150,6 +154,7 @@ module "cclf_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-submitted-cclf-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"
@@ -157,7 +162,7 @@ module "cclf_dead_letter_queue" {
 }
 
 module "cccd_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -165,6 +170,7 @@ module "cccd_response_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "reponses-for-cccd-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
@@ -10,7 +10,7 @@ module "cccd_claims_submitted" {
 }
 
 module "claims_for_ccr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -18,6 +18,7 @@ module "claims_for_ccr" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-for-ccr"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -58,7 +59,7 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
 }
 
 module "claims_for_cclf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -66,6 +67,7 @@ module "claims_for_cclf" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-for-cclf"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -106,7 +108,7 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
 }
 
 module "responses_for_cccd" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -114,6 +116,7 @@ module "responses_for_cccd" {
   application            = "${var.application}"
   sqs_name               = "responses-for-cccd"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -127,7 +130,7 @@ module "responses_for_cccd" {
 }
 
 module "ccr_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -135,6 +138,7 @@ module "ccr_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-submitted-ccr-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"
@@ -142,7 +146,7 @@ module "ccr_dead_letter_queue" {
 }
 
 module "cclf_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -150,6 +154,7 @@ module "cclf_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-submitted-cclf-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"
@@ -157,7 +162,7 @@ module "cclf_dead_letter_queue" {
 }
 
 module "cccd_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -165,6 +170,7 @@ module "cccd_response_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "reponses-for-cccd-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
@@ -10,7 +10,7 @@ module "cccd_claims_submitted" {
 }
 
 module "claims_for_ccr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -18,6 +18,7 @@ module "claims_for_ccr" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-for-ccr"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -58,7 +59,7 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
 }
 
 module "claims_for_cclf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -66,6 +67,7 @@ module "claims_for_cclf" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-for-cclf"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -106,7 +108,7 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
 }
 
 module "responses_for_cccd" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -114,6 +116,7 @@ module "responses_for_cccd" {
   application            = "${var.application}"
   sqs_name               = "responses-for-cccd"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -127,7 +130,7 @@ module "responses_for_cccd" {
 }
 
 module "ccr_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -135,6 +138,7 @@ module "ccr_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-submitted-ccr-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"
@@ -142,7 +146,7 @@ module "ccr_dead_letter_queue" {
 }
 
 module "cclf_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -150,6 +154,7 @@ module "cclf_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "cccd-claims-submitted-cclf-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"
@@ -157,7 +162,7 @@ module "cclf_dead_letter_queue" {
 }
 
 module "cccd_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
@@ -165,6 +170,7 @@ module "cccd_response_dead_letter_queue" {
   application            = "${var.application}"
   sqs_name               = "reponses-for-cccd-dlq"
   existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/messaging.tf
@@ -1,11 +1,12 @@
 module "risk_profiler_change" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "risk_profiler_change"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -39,13 +40,14 @@ resource "aws_sqs_queue_policy" "risk_profiler_change_policy" {
 }
 
 module "risk_profiler_change_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "risk_profiler_change_dl"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/messaging.tf
@@ -1,11 +1,12 @@
 module "risk_profiler_change" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "risk_profiler_change"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -39,13 +40,14 @@ resource "aws_sqs_queue_policy" "risk_profiler_change_policy" {
 }
 
 module "risk_profiler_change_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "risk_profiler_change_dl"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/messaging.tf
@@ -1,11 +1,12 @@
 module "risk_profiler_change" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "risk_profiler_change"
+  encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
@@ -39,13 +40,14 @@ resource "aws_sqs_queue_policy" "risk_profiler_change_policy" {
 }
 
 module "risk_profiler_change_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "risk_profiler_change_dl"
+  encrypt_sqs_kms        = "false"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/messaging.tf
@@ -36,13 +36,14 @@ resource "kubernetes_secret" "offender_case_notes" {
 }
 
 module "keyworker_api_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "keyworker_api_queue"
+  encrypt_sqs_kms        = "true"
 
   redrive_policy = <<EOF
   {
@@ -83,13 +84,14 @@ resource "aws_sqs_queue_policy" "keyworker_api_queue_policy" {
 }
 
 module "keyworker_api_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "keyworker_api_queue_dl"
+  encrypt_sqs_kms        = "true"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/poll-pusher-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/poll-pusher-sub-queue.tf
@@ -1,11 +1,12 @@
 module "case_note_poll_pusher_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "case_note_poll_pusher_queue"
+  encrypt_sqs_kms        = "true"
 
   redrive_policy = <<EOF
   {
@@ -46,13 +47,14 @@ resource "aws_sqs_queue_policy" "case_note_poll_pusher_queue_policy" {
 }
 
 module "case_note_poll_pusher_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "case_note_poll_pusher_queue_dl"
+  encrypt_sqs_kms        = "true"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/messaging.tf
@@ -36,13 +36,14 @@ resource "kubernetes_secret" "offender_case_notes" {
 }
 
 module "keyworker_api_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "keyworker_api_queue"
+  encrypt_sqs_kms        = "true"
 
   redrive_policy = <<EOF
   {
@@ -83,13 +84,14 @@ resource "aws_sqs_queue_policy" "keyworker_api_queue_policy" {
 }
 
 module "keyworker_api_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "keyworker_api_queue_dl"
+  encrypt_sqs_kms        = "true"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/poll-pusher-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/poll-pusher-sub-queue.tf
@@ -1,11 +1,12 @@
 module "case_note_poll_pusher_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "case_note_poll_pusher_queue"
+  encrypt_sqs_kms        = "true"
 
   redrive_policy = <<EOF
   {
@@ -46,13 +47,14 @@ resource "aws_sqs_queue_policy" "case_note_poll_pusher_queue_policy" {
 }
 
 module "case_note_poll_pusher_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "case_note_poll_pusher_queue_dl"
+  encrypt_sqs_kms        = "true"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/messaging.tf
@@ -36,13 +36,14 @@ resource "kubernetes_secret" "offender_case_notes" {
 }
 
 module "keyworker_api_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "keyworker_api_queue"
+  encrypt_sqs_kms        = "true"
 
   redrive_policy = <<EOF
   {
@@ -83,13 +84,14 @@ resource "aws_sqs_queue_policy" "keyworker_api_queue_policy" {
 }
 
 module "keyworker_api_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "keyworker_api_queue_dl"
+  encrypt_sqs_kms        = "true"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/poll-pusher-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/poll-pusher-sub-queue.tf
@@ -1,11 +1,12 @@
 module "case_note_poll_pusher_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "case_note_poll_pusher_queue"
+  encrypt_sqs_kms        = "true"
 
   redrive_policy = <<EOF
   {
@@ -46,13 +47,14 @@ resource "aws_sqs_queue_policy" "case_note_poll_pusher_queue_policy" {
 }
 
 module "case_note_poll_pusher_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
 
   environment-name       = "${var.environment-name}"
   team_name              = "${var.team_name}"
   infrastructure-support = "${var.infrastructure-support}"
   application            = "${var.application}"
   sqs_name               = "case_note_poll_pusher_queue_dl"
+  encrypt_sqs_kms        = "true"
 
   providers = {
     aws = "aws.london"


### PR DESCRIPTION
Latest module v3.5 contains encryption option.

Modules moved from v3.2(who don't have encryption enabled) will have encrypt_sqs_kms  = "false".

Modules moved from v3.4 (which are already using encryption) will have encrypt_sqs_kms  = "true"