### PR TITLE
Track a Query switch production url to Cloud Platform!

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
@@ -27,16 +27,3 @@ resource "kubernetes_secret" "track_a_query_route53_zone_sec" {
     name_servers = "${join("\n", aws_route53_zone.track_a_query_route53_zone.name_servers)}"
   }
 }
-
-resource "aws_route53_record" "track_a_query_route53_A_record_production" {
-  name    = "."
-  zone_id = "${aws_route53_zone.track_a_query_route53_zone.zone_id}"
-  type    = "A"
-
-  alias {
-    name    = "haproxy-track-a-query-1357848984.eu-west-1.elb.amazonaws.com."
-    zone_id = "Z32O12XQLNTSW2"
-
-    evaluate_target_health = true
-  }
-}


### PR DESCRIPTION
Remove the Cloud Platform production DNS entry that points the live domain to old site on template deploy