### PR TITLE
remove cccd-production A record pointing to TD load balancer

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -22,16 +22,3 @@ resource "kubernetes_secret" "cccd_route53_zone_sec" {
     name_servers = "${join("\n", aws_route53_zone.cccd_route53_zone.name_servers)}"
   }
 }
-
-resource "aws_route53_record" "cccd_route53_A_record_1" {
-  name    = "claim-crown-court-defence.service.gov.uk."
-  zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
-  type    = "A"
-
-  alias {
-    name    = "dualstack.advocated-elbgamma-17de5vdfln9zg-1726434105.eu-west-1.elb.amazonaws.com."
-    zone_id = "Z32O12XQLNTSW2"
-
-    evaluate_target_health = false
-  }
-}


### PR DESCRIPTION
POST MIGRATION only.

To ensure future traffic is directed to
live-1 cccd-production load balancer