### PR TITLE
Add a github action to run bin/spec tests

### DIFF
--- a/.github/workflows/bin-rspec.yml
+++ b/.github/workflows/bin-rspec.yml
@@ -1,0 +1,32 @@
+name: Rspec Tests for bin directory
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+
+    - name: Install gems
+      run: |
+        cd bin
+        gem install bundler
+        bundle install
+
+    - name: Run specs
+      run: |
+        cd bin
+        bundle exec rspec


### PR DESCRIPTION
This action will run all the rspec tests in the bin/spec
directory whenever a PR is raised, or code is pushed to the
master branch.

Developed and tested in this repo:
https://github.com/digitalronin/github-actions-rspec

The only visible output of this action is to put a green tick or
a red cross against the PR, so it may be desirable in future to
add alerting via Slack, or some other, more 'pro-active' result.

closes https://github.com/ministryofjustice/cloud-platform/issues/1436