### PR TITLE
Refactor bin/pipeline.rb; extract Terraform class

### DIFF
--- a/bin/pipeline.rb
+++ b/bin/pipeline.rb
@@ -150,7 +150,7 @@ def plan_namespace_dir(cluster, dir)
   return unless FileTest.directory?(dir)
 
   namespace = File.basename(dir)
-  plan_terraform(cluster, namespace, dir)
+  Terraform.new(cluster: cluster, namespace: namespace, dir: dir).plan
 end
 
 def apply_kubernetes_files(_cluster, namespace, dir)
@@ -160,10 +160,6 @@ end
 
 def apply_terraform(cluster, namespace, dir)
   Terraform.new(cluster: cluster, namespace: namespace, dir: dir).apply
-end
-
-def plan_terraform(cluster, namespace, dir)
-  Terraform.new(cluster: cluster, namespace: namespace, dir: dir).plan
 end
 
 def execute(cmd, can_fail: false)

--- a/bin/spec/pipeline_spec.rb
+++ b/bin/spec/pipeline_spec.rb
@@ -111,19 +111,9 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
       it "applies terraform files" do
         allow_any_instance_of(Object).to receive(:apply_kubernetes_files).and_return(nil)
 
-        env_vars.each do |key, val|
-          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-        end
-
-        tf_dir = "namespaces/live-1.cloud-platform.service.justice.gov.uk/mynamespace/resources"
-
-        tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-        tf_apply = "cd #{tf_dir}; terraform apply -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\" -auto-approve"
-
-        expect_execute(tf_init, "", success)
-        expect_execute(tf_apply, "", success)
-        expect($stdout).to receive(:puts)
+        allow(FileTest).to receive(:directory?).and_return(true)
+        expect(Terraform).to receive(:new).with(cluster: cluster, namespace: namespace, dir: dir).and_return(tf)
+        expect(tf).to receive(:apply)
 
         apply_namespace_dir(cluster, dir)
       end

--- a/bin/spec/pipeline_spec.rb
+++ b/bin/spec/pipeline_spec.rb
@@ -1,11 +1,5 @@
 require "spec_helper"
 
-def expect_execute(cmd, stdout, status)
-  expect(Open3).to receive(:capture3).with(cmd).and_return([stdout, "", status])
-  allow($stdout).to receive(:puts).with("\e[34mexecuting: #{cmd}\e[0m")
-  allow($stdout).to receive(:puts).with("")
-end
-
 describe "pipeline" do
   let(:cluster) { "live-1.cloud-platform.service.justice.gov.uk" }
   let(:success) { double(success?: true) }

--- a/bin/spec/pipeline_spec.rb
+++ b/bin/spec/pipeline_spec.rb
@@ -38,23 +38,15 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
   }
 
   let(:namespace_dirs) { namespaces.map { |namespace| "namespaces/#{cluster}/#{namespace}" } }
+  let(:namespace) { "mynamespace" }
+  let(:dir) { "namespaces/#{cluster}/#{namespace}" }
+
+  let(:tf) { double(Terraform) }
 
   it "runs terraform plan" do
-    env_vars.each do |key, val|
-      expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-    end
     allow(FileTest).to receive(:directory?).and_return(true)
-
-    dir = "namespaces/#{cluster}/mynamespace"
-    tf_dir = "#{dir}/resources"
-
-    tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-    tf_plan = "cd #{tf_dir}; terraform plan -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\"  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
-
-    expect_execute(tf_init, "", success)
-    expect_execute(tf_plan, "", success)
-    expect($stdout).to receive(:puts)
+    expect(Terraform).to receive(:new).with(cluster: cluster, namespace: namespace, dir: dir).and_return(tf)
+    expect(tf).to receive(:plan)
 
     plan_namespace_dir(cluster, dir)
   end

--- a/bin/spec/pipeline_spec.rb
+++ b/bin/spec/pipeline_spec.rb
@@ -47,7 +47,7 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
 
   it "runs terraform plan" do
     env_vars.each do |key, val|
-      expect(ENV).to receive(:fetch).with(key).and_return(val)
+      expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
     end
     allow(FileTest).to receive(:directory?).and_return(true)
 
@@ -126,7 +126,7 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
         allow_any_instance_of(Object).to receive(:apply_kubernetes_files).and_return(nil)
 
         env_vars.each do |key, val|
-          expect(ENV).to receive(:fetch).with(key).and_return(val)
+          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
         end
 
         tf_dir = "namespaces/live-1.cloud-platform.service.justice.gov.uk/mynamespace/resources"

--- a/bin/spec/spec_helper.rb
+++ b/bin/spec/spec_helper.rb
@@ -100,3 +100,10 @@ end
 require "pry-byebug"
 
 require "./pipeline"
+
+def expect_execute(cmd, stdout, status)
+  expect(Open3).to receive(:capture3).with(cmd).and_return([stdout, "", status])
+  allow($stdout).to receive(:puts).with("\e[34mexecuting: #{cmd}\e[0m")
+  allow($stdout).to receive(:puts).with("")
+end
+

--- a/bin/spec/spec_helper.rb
+++ b/bin/spec/spec_helper.rb
@@ -106,4 +106,3 @@ def expect_execute(cmd, stdout, status)
   allow($stdout).to receive(:puts).with("\e[34mexecuting: #{cmd}\e[0m")
   allow($stdout).to receive(:puts).with("")
 end
-

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -46,4 +46,26 @@ describe Terraform do
       tf.plan
     end
   end
+
+  describe "apply" do
+    it "applies terraform files" do
+      env_vars.each do |key, val|
+        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+      end
+      allow(FileTest).to receive(:directory?).and_return(true)
+
+      tf_dir = "#{dir}/resources"
+
+      tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+      tf_apply = "cd #{tf_dir}; terraform apply -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\" -auto-approve"
+
+      expect_execute(tf_init, "", success)
+      expect_execute(tf_apply, "", success)
+      expect($stdout).to receive(:puts)
+
+      tf.apply
+    end
+
+  end
 end

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+describe Terraform do
+  let(:cluster) { "live-1.cloud-platform.service.justice.gov.uk" }
+  let(:namespace) { "mynamespace" }
+  let(:dir) { "namespaces/#{cluster}/#{namespace}" }
+  let(:success) { double(success?: true) }
+  let(:failure) { double(success?: false) }
+
+  let(:env_vars) {
+    {
+      "PIPELINE_STATE_BUCKET" => "bucket",
+      "PIPELINE_STATE_KEY_PREFIX" => "key-prefix/",
+      "PIPELINE_TERRAFORM_STATE_LOCK_TABLE" => "lock-table",
+      "PIPELINE_STATE_REGION" => "region",
+      "PIPELINE_CLUSTER_STATE_BUCKET" => "cluster-bucket",
+      "PIPELINE_CLUSTER_STATE_KEY_PREFIX" => "state-key-prefix/",
+    }
+  }
+
+  let(:params) { {
+    cluster: cluster,
+    namespace: namespace,
+    dir: dir
+  } }
+
+  subject(:tf) { described_class.new(params) }
+
+  describe "plan" do
+    it "runs terraform plan" do
+      env_vars.each do |key, val|
+        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+      end
+      allow(FileTest).to receive(:directory?).and_return(true)
+
+      tf_dir = "#{dir}/resources"
+
+      tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+      tf_plan = "cd #{tf_dir}; terraform plan -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\"  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
+
+      expect_execute(tf_init, "", success)
+      expect_execute(tf_plan, "", success)
+      expect($stdout).to receive(:puts)
+
+      tf.plan
+    end
+  end
+end

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -18,11 +18,13 @@ describe Terraform do
     }
   }
 
-  let(:params) { {
-    cluster: cluster,
-    namespace: namespace,
-    dir: dir
-  } }
+  let(:params) {
+    {
+      cluster: cluster,
+      namespace: namespace,
+      dir: dir,
+    }
+  }
 
   subject(:tf) { described_class.new(params) }
 
@@ -66,6 +68,5 @@ describe Terraform do
 
       tf.apply
     end
-
   end
 end


### PR DESCRIPTION
This change is designed to make it easier to alter the
pipeline scripts to accomodate both terraform 12 and
terraform 11 source code.