### PR TITLE
Adds S3 buckets to Book A Secure Move API environments

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3.tf
@@ -1,0 +1,33 @@
+/*
+ Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
+ */
+module "book_a_secure_move_documents_s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+
+  team_name              = "${var.team_name}"
+  business-unit          = "Digital and Technology"
+  application            = "${var.application}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
+  metadata {
+    name      = "book_a_secure_move_documents_s3_bucket"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    access_key_id     = "${module.book_a_secure_move_documents_s3_bucket.access_key_id}"
+    secret_access_key = "${module.book_a_secure_move_documents_s3_bucket.secret_access_key}"
+    bucket_arn        = "${module.book_a_secure_move_documents_s3_bucket.bucket_arn}"
+    bucket_name       = "${module.book_a_secure_move_documents_s3_bucket.bucket_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3.tf
@@ -20,7 +20,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
 resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
   metadata {
-    name      = "book_a_secure_move_documents_s3_bucket"
+    name      = "book-a-secure-move-documents-s3-bucket"
     namespace = "${var.namespace}"
   }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3.tf
@@ -9,8 +9,8 @@ module "book_a_secure_move_documents_s3_bucket" {
   application            = "${var.application}"
   infrastructure-support = "${var.infrastructure-support}"
 
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
+  is-production    = "${var.is-production}"
+  environment-name = "${var.environment-name}"
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3.tf
@@ -1,0 +1,33 @@
+/*
+ Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
+ */
+module "book_a_secure_move_documents_s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+
+  team_name              = "${var.team_name}"
+  business-unit          = "Digital and Technology"
+  application            = "${var.application}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
+  metadata {
+    name      = "book_a_secure_move_documents_s3_bucket"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    access_key_id     = "${module.book_a_secure_move_documents_s3_bucket.access_key_id}"
+    secret_access_key = "${module.book_a_secure_move_documents_s3_bucket.secret_access_key}"
+    bucket_arn        = "${module.book_a_secure_move_documents_s3_bucket.bucket_arn}"
+    bucket_name       = "${module.book_a_secure_move_documents_s3_bucket.bucket_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3.tf
@@ -20,7 +20,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
 resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
   metadata {
-    name      = "book_a_secure_move_documents_s3_bucket"
+    name      = "book-a-secure-move-documents-s3-bucket"
     namespace = "${var.namespace}"
   }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3.tf
@@ -9,8 +9,8 @@ module "book_a_secure_move_documents_s3_bucket" {
   application            = "${var.application}"
   infrastructure-support = "${var.infrastructure-support}"
 
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
+  is-production    = "${var.is-production}"
+  environment-name = "${var.environment-name}"
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3.tf
@@ -1,0 +1,33 @@
+/*
+ Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
+ */
+module "book_a_secure_move_documents_s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+
+  team_name              = "${var.team_name}"
+  business-unit          = "Digital and Technology"
+  application            = "${var.application}"
+  infrastructure-support = "${var.infrastructure-support}"
+
+  is-production          = "${var.is-production}"
+  environment-name       = "${var.environment-name}"
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
+  metadata {
+    name      = "book_a_secure_move_documents_s3_bucket"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    access_key_id     = "${module.book_a_secure_move_documents_s3_bucket.access_key_id}"
+    secret_access_key = "${module.book_a_secure_move_documents_s3_bucket.secret_access_key}"
+    bucket_arn        = "${module.book_a_secure_move_documents_s3_bucket.bucket_arn}"
+    bucket_name       = "${module.book_a_secure_move_documents_s3_bucket.bucket_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3.tf
@@ -20,7 +20,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
 resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
   metadata {
-    name      = "book_a_secure_move_documents_s3_bucket"
+    name      = "book-a-secure-move-documents-s3-bucket"
     namespace = "${var.namespace}"
   }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3.tf
@@ -9,8 +9,8 @@ module "book_a_secure_move_documents_s3_bucket" {
   application            = "${var.application}"
   infrastructure-support = "${var.infrastructure-support}"
 
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
+  is-production    = "${var.is-production}"
+  environment-name = "${var.environment-name}"
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
This PR adds S3 buckets to our Book A Secure Move API application and stores the secrets so our app can extract them later.

Looking at existing implementations, it doesn't _appear_ to be necessary to add IAM policies as we're just using the generated credentials in our API container.