### PR TITLE
Enable our concourse pipelines to work with terraform 0.12 code

### DIFF
--- a/bin/pipeline.rb
+++ b/bin/pipeline.rb
@@ -39,11 +39,15 @@ class Terraform
 
   private
 
+  def terraform_executable
+    "terraform"
+  end
+
   def tf_init
     key = "#{key_prefix}#{cluster}/#{namespace}/terraform.tfstate"
 
     cmd = [
-      %(terraform init),
+      %(#{terraform_executable} init),
       %(-backend-config="bucket=#{bucket}"),
       %(-backend-config="key=#{key}"),
       %(-backend-config="dynamodb_table=#{lock_table}"),
@@ -86,7 +90,7 @@ class Terraform
     key = "#{cluster_key_prefix}#{name}/terraform.tfstate"
 
     [
-      %(terraform #{operation}),
+      %(#{terraform_executable} #{operation}),
       %(-var="cluster_name=#{name}"),
       %(-var="cluster_state_bucket=#{cluster_bucket}"),
       %(-var="cluster_state_key=#{key}"),

--- a/bin/pipeline.rb
+++ b/bin/pipeline.rb
@@ -27,11 +27,11 @@ class Terraform
     # However, it's not so strict about environment variables, so we can
     # ensure that our pipelines always set these env. vars. This check is
     # here so that we get a sensible error if we ever fail to do that.
-    %w(
+    %w[
       TF_VAR_cluster_name
       TF_VAR_cluster_state_bucket
       TF_VAR_cluster_state_key
-    ).each { |var| ENV.fetch(var) }
+    ].each { |var| ENV.fetch(var) }
   end
 
   def plan

--- a/bin/pipeline.rb
+++ b/bin/pipeline.rb
@@ -40,7 +40,9 @@ class Terraform
   private
 
   def terraform_executable
-    "terraform"
+    # The `terraform 0.12upgrade` creates a `versions.tf` file, so we can
+    # use the existence of that file to identify terraform 0.12 source code
+    FileTest.exists?("#{tf_dir}/versions.tf") ? "terraform12" : "terraform"
   end
 
   def tf_init

--- a/bin/spec/pipeline_spec.rb
+++ b/bin/spec/pipeline_spec.rb
@@ -11,8 +11,9 @@ describe "pipeline" do
       "PIPELINE_STATE_KEY_PREFIX" => "key-prefix/",
       "PIPELINE_TERRAFORM_STATE_LOCK_TABLE" => "lock-table",
       "PIPELINE_STATE_REGION" => "region",
-      "PIPELINE_CLUSTER_STATE_BUCKET" => "cluster-bucket",
-      "PIPELINE_CLUSTER_STATE_KEY_PREFIX" => "state-key-prefix/",
+      "TF_VAR_cluster_name" => cluster,
+      "TF_VAR_cluster_state_bucket" => "cloud-platform-terraform-state",
+      "TF_VAR_cluster_state_key" => "cloud-platform/live-1/terraform.tfstate"
     }
   }
 

--- a/bin/spec/pipeline_spec.rb
+++ b/bin/spec/pipeline_spec.rb
@@ -13,7 +13,7 @@ describe "pipeline" do
       "PIPELINE_STATE_REGION" => "region",
       "TF_VAR_cluster_name" => cluster,
       "TF_VAR_cluster_state_bucket" => "cloud-platform-terraform-state",
-      "TF_VAR_cluster_state_key" => "cloud-platform/live-1/terraform.tfstate"
+      "TF_VAR_cluster_state_key" => "cloud-platform/live-1/terraform.tfstate",
     }
   }
 

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -15,7 +15,7 @@ describe Terraform do
       "PIPELINE_STATE_REGION" => "region",
       "TF_VAR_cluster_name" => cluster,
       "TF_VAR_cluster_state_bucket" => "cloud-platform-terraform-state",
-      "TF_VAR_cluster_state_key" => "cloud-platform/live-1/terraform.tfstate"
+      "TF_VAR_cluster_state_key" => "cloud-platform/live-1/terraform.tfstate",
     }
   }
 

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -74,5 +74,53 @@ describe Terraform do
         tf.apply
       end
     end
+
+    context "terraform 0.12" do
+      before do
+        allow(FileTest).to receive(:exists?).with("#{dir}/resources/versions.tf").and_return(true)
+      end
+
+      describe "plan" do
+        it "runs terraform plan" do
+          env_vars.each do |key, val|
+            expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+          end
+          allow(FileTest).to receive(:directory?).and_return(true)
+
+          tf_dir = "#{dir}/resources"
+
+          tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+          tf_plan = "cd #{tf_dir}; terraform12 plan -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\"  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
+
+          expect_execute(tf_init, "", success)
+          expect_execute(tf_plan, "", success)
+          expect($stdout).to receive(:puts)
+
+          tf.plan
+        end
+      end
+
+      describe "apply" do
+        it "applies terraform files" do
+          env_vars.each do |key, val|
+            expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+          end
+          allow(FileTest).to receive(:directory?).and_return(true)
+
+          tf_dir = "#{dir}/resources"
+
+          tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+          tf_apply = "cd #{tf_dir}; terraform12 apply -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\" -auto-approve"
+
+          expect_execute(tf_init, "", success)
+          expect_execute(tf_apply, "", success)
+          expect($stdout).to receive(:puts)
+
+          tf.apply
+        end
+      end
+    end
   end
 end

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -13,8 +13,9 @@ describe Terraform do
       "PIPELINE_STATE_KEY_PREFIX" => "key-prefix/",
       "PIPELINE_TERRAFORM_STATE_LOCK_TABLE" => "lock-table",
       "PIPELINE_STATE_REGION" => "region",
-      "PIPELINE_CLUSTER_STATE_BUCKET" => "cluster-bucket",
-      "PIPELINE_CLUSTER_STATE_KEY_PREFIX" => "state-key-prefix/",
+      "TF_VAR_cluster_name" => cluster,
+      "TF_VAR_cluster_state_bucket" => "cloud-platform-terraform-state",
+      "TF_VAR_cluster_state_key" => "cloud-platform/live-1/terraform.tfstate"
     }
   }
 
@@ -44,7 +45,7 @@ describe Terraform do
 
         tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-        tf_plan = "cd #{tf_dir}; terraform plan -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\"  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
+        tf_plan = "cd #{tf_dir}; terraform plan  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
 
         expect_execute(tf_init, "", success)
         expect_execute(tf_plan, "", success)
@@ -65,7 +66,7 @@ describe Terraform do
 
         tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-        tf_apply = "cd #{tf_dir}; terraform apply -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\" -auto-approve"
+        tf_apply = "cd #{tf_dir}; terraform apply -auto-approve"
 
         expect_execute(tf_init, "", success)
         expect_execute(tf_apply, "", success)
@@ -91,7 +92,7 @@ describe Terraform do
 
           tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-          tf_plan = "cd #{tf_dir}; terraform12 plan -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\"  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
+          tf_plan = "cd #{tf_dir}; terraform12 plan  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
 
           expect_execute(tf_init, "", success)
           expect_execute(tf_plan, "", success)
@@ -112,7 +113,7 @@ describe Terraform do
 
           tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-          tf_apply = "cd #{tf_dir}; terraform12 apply -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\" -auto-approve"
+          tf_apply = "cd #{tf_dir}; terraform12 apply -auto-approve"
 
           expect_execute(tf_init, "", success)
           expect_execute(tf_apply, "", success)

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -28,45 +28,51 @@ describe Terraform do
 
   subject(:tf) { described_class.new(params) }
 
-  describe "plan" do
-    it "runs terraform plan" do
-      env_vars.each do |key, val|
-        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-      end
-      allow(FileTest).to receive(:directory?).and_return(true)
-
-      tf_dir = "#{dir}/resources"
-
-      tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-      tf_plan = "cd #{tf_dir}; terraform plan -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\"  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
-
-      expect_execute(tf_init, "", success)
-      expect_execute(tf_plan, "", success)
-      expect($stdout).to receive(:puts)
-
-      tf.plan
+  context "terraform 0.11" do
+    before do
+      allow(FileTest).to receive(:exists?).with("#{dir}/resources/versions.tf").and_return(false)
     end
-  end
 
-  describe "apply" do
-    it "applies terraform files" do
-      env_vars.each do |key, val|
-        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+    describe "plan" do
+      it "runs terraform plan" do
+        env_vars.each do |key, val|
+          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+        end
+        allow(FileTest).to receive(:directory?).and_return(true)
+
+        tf_dir = "#{dir}/resources"
+
+        tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+        tf_plan = "cd #{tf_dir}; terraform plan -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\"  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
+
+        expect_execute(tf_init, "", success)
+        expect_execute(tf_plan, "", success)
+        expect($stdout).to receive(:puts)
+
+        tf.plan
       end
-      allow(FileTest).to receive(:directory?).and_return(true)
+    end
 
-      tf_dir = "#{dir}/resources"
+    describe "apply" do
+      it "applies terraform files" do
+        env_vars.each do |key, val|
+          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+        end
+        allow(FileTest).to receive(:directory?).and_return(true)
 
-      tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+        tf_dir = "#{dir}/resources"
 
-      tf_apply = "cd #{tf_dir}; terraform apply -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\" -auto-approve"
+        tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-      expect_execute(tf_init, "", success)
-      expect_execute(tf_apply, "", success)
-      expect($stdout).to receive(:puts)
+        tf_apply = "cd #{tf_dir}; terraform apply -var=\"cluster_name=live-1\" -var=\"cluster_state_bucket=cluster-bucket\" -var=\"cluster_state_key=state-key-prefix/live-1/terraform.tfstate\" -auto-approve"
 
-      tf.apply
+        expect_execute(tf_init, "", success)
+        expect_execute(tf_apply, "", success)
+        expect($stdout).to receive(:puts)
+
+        tf.apply
+      end
     end
   end
 end


### PR DESCRIPTION
This change will make the plan, build and apply-namespace changes pipelines
work with source code written for both versions of terraform that we care about
(0.11.14 and 0.12.13).

The existence of a `versions.tf` file is used as a test for terraform 0.12 code
and, if found, will cause the pipeline to run `terraform12` instead of
`terraform` (see the `terraform_executable` method in the `Terraform` class).

terraform12 was added to the tools image by this PR
https://github.com/ministryofjustice/cloud-platform-tools-image/pull/44

Terraform 0.12 requires that any variable passed on the command-line to `plan`
and `apply` is actually used in the relevant source code. We have no way to
know this in advance, so this change depends on
https://github.com/ministryofjustice/cloud-platform-concourse/pull/128

Variables which might be required by `plan` and `apply` are now avaiable via
TF_VAR_xxx environment variables, and so do not need to be passed on the
command-line anymore.

NB: This change may break the live-0 pipelines. We have decided we don't care.