### PR TITLE
Track a Query - Replace dev.track-a-query.service.gov.uk URL

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/05-certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/05-certificate.yaml
@@ -8,10 +8,10 @@ spec:
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: 'dev.track-a-query.service.justice.gov.uk'
+  commonName: 'development.track-a-query.service.justice.gov.uk'
   acme:
     config:
     - domains:
-      - 'dev.track-a-query.service.justice.gov.uk'
+      - 'development.track-a-query.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -19,7 +19,6 @@ module "track_a_query_s3" {
       allowed_methods = ["GET", "POST", "PUT"]
 
       allowed_origins = [
-        "https://dev.track-a-query.service.justice.gov.uk",
         "https://development.track-a-query.service.justice.gov.uk",
         "https://track-a-query-development.apps.live-1.cloud-platform.service.justice.gov.uk",
       ]


### PR DESCRIPTION
Prefer `development.track-a-query.service.gov.uk` rather than the current `dev.`