### PR TITLE
Revert pathfinder-dev rds version

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -3,7 +3,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "${var.team_name}"


### PR DESCRIPTION
As v4.7 got issue using path from team-name.

Need to fix the module to upgrade to the latest version.

For now reverting to old version4.5