### PR TITLE
Update RDS to latest v4.8 from v4.2

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
 /*
  * When using this module through the cloud-platform-environments, the following
  * two variables are automatically supplied by the pipeline.

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "check-financial-eligibility-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
@@ -18,6 +18,12 @@ module "check-financial-eligibility-rds" {
   db_engine              = "postgres"
   db_engine_version      = "11.2"
   db_name                = "check_financial_eligibility_staging"
+  force_ssl              = "false"
+  rds_family             = "postgres11"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "check-financial-eligibility-rds" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/rds.tf
@@ -9,7 +9,7 @@ variable "cluster_state_bucket" {}
  *
  */
 module "rds-staging" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "Correspondence Staff"
@@ -18,6 +18,7 @@ module "rds-staging" {
   is-production          = "false"
   environment-name       = "staging"
   infrastructure-support = "mohammed.seedat@digital.justice.gov.uk"
+  force_ssl              = "false"
 
   # Deprecated from the version 4.2 of this module
   #aws_region             = "eu-west-2"  

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds" {
   db_instance_class      = "db.t2.small"
   db_allocated_storage   = "5"
   db_name                = "laalaa"
-  force_ssl              = "false"	
+  force_ssl              = "false"
   rds_family             = "postgres9.4"
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
@@ -2,7 +2,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
@@ -17,6 +17,12 @@ module "rds" {
   db_instance_class      = "db.t2.small"
   db_allocated_storage   = "5"
   db_name                = "laalaa"
+  force_ssl              = "false"	
+  rds_family             = "postgres9.4"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "db" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/nomis-api-access-staging/resources/rds.tf
@@ -3,7 +3,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "nomis-api-access_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "Digital Prison Services/New Nomis"
@@ -12,6 +12,7 @@ module "nomis-api-access_rds" {
   is-production          = "false"
   environment-name       = "staging"
   infrastructure-support = "dps-hmpps@digital.justice.gov.uk"
+  force_ssl              = "false"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/rds-prison-visits.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/rds-prison-visits.tf
@@ -16,7 +16,7 @@ variable "cluster_state_bucket" {}
  */
 
 module "prison-visits-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
@@ -29,6 +29,8 @@ module "prison-visits-rds" {
   db_engine              = "postgres"
   db_engine_version      = "9.6"
   db_name                = "visits"
+  force_ssl              = "false"
+  rds_family             = "postgres9.6"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/rds.tf
@@ -3,7 +3,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "sentence-planning_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "Sentence Planning"
@@ -12,6 +12,7 @@ module "sentence-planning_rds" {
   is-production          = "false"
   environment-name       = "preprod"
   infrastructure-support = "michael.willis@digital.justice.gov.uk"
+  force_ssl              = "false"
 
   providers = {
     aws = "aws.london"


### PR DESCRIPTION
Updated RDS to latest v4.8 from v4.2

This is for all the non-production namespaces

This is pre-requisite to get env repo upgraded to tf0.12