### PR TITLE
Update rds to latest version 4.8 from 4.6 and 4.7

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/rds.tf
@@ -3,7 +3,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "becca_test_app_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "tactical-products"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name                = "${var.cluster_name}"
   cluster_state_bucket        = "${var.cluster_state_bucket}"
   team_name                   = "${var.team_name}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name                = "${var.cluster_name}"
   cluster_state_bucket        = "${var.cluster_state_bucket}"
   team_name                   = "${var.team_name}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.6"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
@@ -1,5 +1,5 @@
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
@@ -1,5 +1,5 @@
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmcts-complaints-adapter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
@@ -2,7 +2,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "hmcts_mock_api_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name                = "${var.cluster_name}"
   cluster_state_bucket        = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "${var.team_name}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "${var.team_name}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds.tf
@@ -15,7 +15,7 @@ variable "cluster_state_bucket" {}
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
   team_name            = "laa-crime-apps-team"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -4,7 +4,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   providers = {
     aws = "aws.london"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds_instance" {
   infrastructure-support     = "${var.infrastructure-support}"
   is-production              = "${var.is-production}"
   rds_family                 = "postgres11"
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   team_name                  = "${var.team_name}"
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/rds.tf
@@ -16,7 +16,7 @@ module "rds_instance" {
   infrastructure-support      = "${var.infrastructure-support}"
   is-production               = "${var.is-production}"
   rds_family                  = "postgres11"
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   team_name                   = "${var.team_name}"
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-core-services-tooling/resources/sonarqube-db.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-core-services-tooling/resources/sonarqube-db.tf
@@ -6,7 +6,7 @@
  */
 
 module "pcs_sonarqube_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name                = "${var.cluster_name}"
   cluster_state_bucket        = "${var.cluster_state_bucket}"
   team_name                   = "${var.team_name}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.7"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.6"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.6"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.6"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"
   team_name                  = "correspondence"


### PR DESCRIPTION
Update RDS to latest v4.8 from v4.6 and 4.7

This is for all the non-production namespaces

This is pre-requisite to get env repo upgraded to tf0.12