### PR TITLE
Book A Secure Move – adds RDS client ID/secret to k8s secrets

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -18,8 +18,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    access_key_id         = "${module.example_team_rds.access_key_id}"
-    secret_access_key     = "${module.example_team_rds.secret_access_key}"
+    access_key_id         = "${module.rds-instance.access_key_id}"
+    secret_access_key     = "${module.rds-instance.secret_access_key}"
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -9,6 +9,12 @@ module "rds-instance" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+  force_ssl              = "false"
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "rds-instance" {
@@ -18,8 +24,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    access_key_id         = "${module.rds-instance.access_key_id}"
-    secret_access_key     = "${module.rds-instance.secret_access_key}"
-    url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
+    access_key_id     = "${module.rds-instance.access_key_id}"
+    secret_access_key = "${module.rds-instance.secret_access_key}"
+    url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -18,7 +18,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    access_key_id         = "${module.example_team_rds.access_key_id}"
+    secret_access_key     = "${module.example_team_rds.secret_access_key}"
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -18,8 +18,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    access_key_id         = "${module.example_team_rds.access_key_id}"
-    secret_access_key     = "${module.example_team_rds.secret_access_key}"
+    access_key_id         = "${module.rds-instance.access_key_id}"
+    secret_access_key     = "${module.rds-instance.secret_access_key}"
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -18,7 +18,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    access_key_id         = "${module.example_team_rds.access_key_id}"
+    secret_access_key     = "${module.example_team_rds.secret_access_key}"
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -18,8 +18,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    access_key_id         = "${module.rds-instance.access_key_id}"
-    secret_access_key     = "${module.rds-instance.secret_access_key}"
-    url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
+    access_key_id     = "${module.rds-instance.access_key_id}"
+    secret_access_key = "${module.rds-instance.secret_access_key}"
+    url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -18,8 +18,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    access_key_id         = "${module.example_team_rds.access_key_id}"
-    secret_access_key     = "${module.example_team_rds.secret_access_key}"
+    access_key_id         = "${module.rds-instance.access_key_id}"
+    secret_access_key     = "${module.rds-instance.secret_access_key}"
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -9,6 +9,11 @@ module "rds-instance" {
   is-production          = "${var.is-production}"
   infrastructure-support = "${var.infrastructure-support}"
   team_name              = "${var.team_name}"
+  force_ssl              = "false"
+
+  providers = {
+    aws = "aws.london"
+  }
 }
 
 resource "kubernetes_secret" "rds-instance" {
@@ -18,8 +23,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    access_key_id         = "${module.rds-instance.access_key_id}"
-    secret_access_key     = "${module.rds-instance.secret_access_key}"
-    url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
+    access_key_id     = "${module.rds-instance.access_key_id}"
+    secret_access_key = "${module.rds-instance.secret_access_key}"
+    url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
 
   cluster_name         = "${var.cluster_name}"
   cluster_state_bucket = "${var.cluster_state_bucket}"
@@ -18,7 +18,8 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data {
-    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    access_key_id         = "${module.example_team_rds.access_key_id}"
+    secret_access_key     = "${module.example_team_rds.secret_access_key}"
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }


### PR DESCRIPTION
This PR adds the AWS client ID/secret for RDS so we can inspect snapshots for Book A Secure Move.

It also updates to the latest version of the RDS module.