### PR TITLE
Upgrade all modules to terraform 12

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/amq.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/amq.tf
@@ -6,7 +6,7 @@
  */
 
 module "example_team_broker" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-amq-broker?ref=2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-amq-broker?ref=TF12-DO-NOT-USE"
   team_name              = "example-team"
   business-unit          = "example-bu"
   application            = "cptf11app"
@@ -17,7 +17,7 @@ module "example_team_broker" {
   providers = {
     # Can be either 'aws.london' or 'aws.ireland'
     # It requires the two providers to be defined. see example/main.tf
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -27,10 +27,11 @@ resource "kubernetes_secret" "example_team_broker" {
     namespace = "cp-terraform-module-testing"
   }
 
-  data {
-    primary_amqp_ssl_endpoint  = "${module.example_team_broker.primary_amqp_ssl_endpoint}"
-    primary_stomp_ssl_endpoint = "${module.example_team_broker.primary_stomp_ssl_endpoint}"
-    username                   = "${module.example_team_broker.username}"
-    password                   = "${module.example_team_broker.password}"
+  data = {
+    primary_amqp_ssl_endpoint  = module.example_team_broker.primary_amqp_ssl_endpoint
+    primary_stomp_ssl_endpoint = module.example_team_broker.primary_stomp_ssl_endpoint
+    username                   = module.example_team_broker.username
+    password                   = module.example_team_broker.password
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/dynamo.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/dynamo.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=TF12-DO-NOT-USE"
 
   team_name              = "example-team"
   business-unit          = "example-bu"
@@ -25,10 +25,11 @@ resource "kubernetes_secret" "example_team_dynamodb" {
     namespace = "cp-terraform-module-testing"
   }
 
-  data {
-    table_name        = "${module.example_team_dynamodb.table_name}"
-    table_arn         = "${module.example_team_dynamodb.table_arn}"
-    access_key_id     = "${module.example_team_dynamodb.access_key_id}"
-    secret_access_key = "${module.example_team_dynamodb.secret_access_key}"
+  data = {
+    table_name        = module.example_team_dynamodb.table_name
+    table_arn         = module.example_team_dynamodb.table_arn
+    access_key_id     = module.example_team_dynamodb.access_key_id
+    secret_access_key = module.example_team_dynamodb.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/ecr.tf
@@ -5,14 +5,14 @@
  *
  */
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=TF12-DO-NOT-USE"
   repo_name = "cptf11-module"
   team_name = "cptf11-team"
 
   # aws_region = "eu-west-2"     # This input is deprecated from version 3.2 of this module
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -22,10 +22,11 @@ resource "kubernetes_secret" "example_team_ecr_credentials" {
     namespace = "cp-terraform-module-testing"
   }
 
-  data {
-    access_key_id     = "${module.example_team_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.example_team_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.example_team_ecr_credentials.repo_arn}"
-    repo_url          = "${module.example_team_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.example_team_ecr_credentials.access_key_id
+    secret_access_key = module.example_team_ecr_credentials.secret_access_key
+    repo_arn          = module.example_team_ecr_credentials.repo_arn
+    repo_url          = module.example_team_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/elasticache.tf
@@ -11,9 +11,9 @@
  *
  */
 module "example_team_ec_cluster" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=TF12-DO-NOT-USE"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "example-repo"
   business-unit          = "example-bu"
   application            = "cptf11app"
@@ -22,7 +22,7 @@ module "example_team_ec_cluster" {
   infrastructure-support = "example-team@digtal.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -32,9 +32,10 @@ resource "kubernetes_secret" "example_team_ec_cluster" {
     namespace = "cp-terraform-module-testing"
   }
 
-  data {
-    primary_endpoint_address = "${module.example_team_ec_cluster.primary_endpoint_address}"
-    member_clusters          = "${jsonencode(module.example_team_ec_cluster.member_clusters)}"
-    auth_token               = "${module.example_team_ec_cluster.auth_token}"
+  data = {
+    primary_endpoint_address = module.example_team_ec_cluster.primary_endpoint_address
+    member_clusters          = jsonencode(module.example_team_ec_cluster.member_clusters)
+    auth_token               = module.example_team_ec_cluster.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/elasticsearch.tf
@@ -11,9 +11,9 @@
  *
  */
 module "example_team_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=2.0"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=TF12-DO-NOT-USE"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   application            = "cptf11app"
   business-unit          = "example-bu"
   environment-name       = "dev"
@@ -26,3 +26,4 @@ module "example_team_es" {
   # change the elasticsearch version as you see fit.
   elasticsearch_version = "7.1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/main.tf
@@ -12,11 +12,6 @@ provider "aws" {
   region = "eu-west-2"
 }
 
-provider "aws" {
-  alias  = "ireland"
-  region = "eu-west-1"
-}
-
 variable "cluster_name" {
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -17,6 +17,9 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/rds.tf
@@ -11,9 +11,9 @@
  *
  */
 module "example_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=TF12-DO_NOT-USE"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
   team_name            = "example-repo"
   business-unit        = "example-bu"
   application          = "cptf11app"
@@ -37,7 +37,7 @@ module "example_team_rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -47,20 +47,20 @@ resource "kubernetes_secret" "example_team_rds" {
     namespace = "cp-terraform-module-testing"
   }
 
-  data {
-    rds_instance_endpoint = "${module.example_team_rds.rds_instance_endpoint}"
-    database_name         = "${module.example_team_rds.database_name}"
-    database_username     = "${module.example_team_rds.database_username}"
-    database_password     = "${module.example_team_rds.database_password}"
-    rds_instance_address  = "${module.example_team_rds.rds_instance_address}"
-    access_key_id         = "${module.example_team_rds.access_key_id}"
-    secret_access_key     = "${module.example_team_rds.secret_access_key}"
-
-    /* You can replace all of the above with the following, if you prefer to
+  data = {
+    rds_instance_endpoint = module.example_team_rds.rds_instance_endpoint
+    database_name         = module.example_team_rds.database_name
+    database_username     = module.example_team_rds.database_username
+    database_password     = module.example_team_rds.database_password
+    rds_instance_address  = module.example_team_rds.rds_instance_address
+    access_key_id         = module.example_team_rds.access_key_id
+    secret_access_key     = module.example_team_rds.secret_access_key
+  }
+  /* You can replace all of the above with the following, if you prefer to
      * use a single database URL value in your application code:
      *
      * url = "postgres://${module.example_team_rds.database_username}:${module.example_team_rds.database_password}@${module.example_team_rds.rds_instance_endpoint}/${module.example_team_rds.database_name}"
      *
      */
-  }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/s3.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=TF12-DO-NOT-USE"
 
   team_name              = "cloudplatform"
   business-unit          = "mojdigital"
@@ -16,10 +16,8 @@ module "example_team_s3_bucket" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
-  }
-
-  /*
+    aws = aws.london
+    /*
    * The following example can be used if you need to define CORS rules for your s3 bucket. 
    *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-cors"
    *  
@@ -80,13 +78,13 @@ module "example_team_s3_bucket" {
 
   */
 
-  /*
+    /*
    * The following are exampls of bucket and user policies. They are treated as
    * templates. Currently, the only available variable is `$${bucket_arn}`.
    *
    */
 
-  /*
+    /*
  * Allow a user (foobar) from another account (012345678901) to get objects from
  * this bucket.
  *
@@ -113,7 +111,7 @@ EOF
 
 */
 
-  /*
+    /*
  * Override the default policy for the generated machine user of this bucket.
  *
 
@@ -142,6 +140,7 @@ user_policy = <<EOF
 EOF
 
 */
+  }
 }
 
 resource "kubernetes_secret" "example_team_s3_bucket" {
@@ -150,10 +149,11 @@ resource "kubernetes_secret" "example_team_s3_bucket" {
     namespace = "cp-terraform-module-testing"
   }
 
-  data {
-    access_key_id     = "${module.example_team_s3_bucket.access_key_id}"
-    secret_access_key = "${module.example_team_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.example_team_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.example_team_s3_bucket.bucket_name}"
+  data = {
+    access_key_id     = module.example_team_s3_bucket.access_key_id
+    secret_access_key = module.example_team_s3_bucket.secret_access_key
+    bucket_arn        = module.example_team_s3_bucket.bucket_arn
+    bucket_name       = module.example_team_s3_bucket.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/sns.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/sns.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_sns_topic" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=TF12-DO_NOT-USE"
 
   team_name          = "cp-team"
   topic_display_name = "cp-topic-display-name"
@@ -18,9 +18,10 @@ resource "kubernetes_secret" "example_sns_topic" {
     namespace = "cp-terraform-module-testing"
   }
 
-  data {
-    access_key_id     = "${module.example_sns_topic.access_key_id}"
-    secret_access_key = "${module.example_sns_topic.secret_access_key}"
-    topic_arn         = "${module.example_sns_topic.topic_arn}"
+  data = {
+    access_key_id     = module.example_sns_topic.access_key_id
+    secret_access_key = module.example_sns_topic.secret_access_key
+    topic_arn         = module.example_sns_topic.topic_arn
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/sqs.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/sqs.tf
@@ -1,5 +1,5 @@
 module "example_sqs" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=TF12-DO_NOT-USE"
 
   environment-name       = "test"
   team_name              = "cp"
@@ -13,7 +13,7 @@ module "example_sqs" {
   # existing_user_name     = "${module.another_sqs_instance.user_name}"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -23,13 +23,13 @@ resource "kubernetes_secret" "example_sqs" {
     namespace = "cp-terraform-module-testing"
   }
 
-  data {
-    access_key_id     = "${module.example_sqs.access_key_id}"
-    secret_access_key = "${module.example_sqs.secret_access_key}"
-
+  data = {
+    access_key_id     = module.example_sqs.access_key_id
+    secret_access_key = module.example_sqs.secret_access_key
     # the above will not be set if existing_user_name is defined
-    sqs_id   = "${module.example_sqs.sqs_id}"
-    sqs_arn  = "${module.example_sqs.sqs_arn}"
-    sqs_name = "${module.example_sqs.sqs_name}"
+    sqs_id   = module.example_sqs.sqs_id
+    sqs_arn  = module.example_sqs.sqs_arn
+    sqs_name = module.example_sqs.sqs_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/1460.

Upgrading terraform module to 0.12.13 on testing namespace `cp-terraform-module-testing` to test how pipeline works with both tf 11 and tf12.