### PR TITLE
Add dns zone and cert for new fala staging custom domain

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/06-certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/06-certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: fala-staging-cert
+  namespace: laa-fala-staging
+spec:
+  secretName: fala-tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 'staging.find-legal-advice.justice.gov.uk'
+  acme:
+    config:
+    - domains:
+      - 'staging.find-legal-advice.justice.gov.uk'
+      dns01:
+        provider: route53-cloud-platform

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/route53.tf
@@ -1,22 +1,22 @@
 resource "aws_route53_zone" "route53_zone" {
   name = "staging.find-legal-advice.justice.gov.uk"
 
-  tags {
-    business-unit    = "${var.business-unit}"
-    application      = "${var.application}"
-    is-production    = "${var.is-production}"
-    environment-name = "${var.environment-name}"
-    owner            = "${var.team_name}"
+  tags = {
+    business-unit    = var.business-unit
+    application      = var.application
+    is-production    = var.is-production
+    environment-name = var.environment-name
+    owner            = var.team_name
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/route53.tf
@@ -1,0 +1,22 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = "staging.find-legal-advice.justice.gov.uk"
+
+  tags {
+    business-unit    = "${var.business-unit}"
+    application      = "${var.application}"
+    is-production    = "${var.is-production}"
+    environment-name = "${var.environment-name}"
+    owner            = "${var.team_name}"
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = "${var.namespace}"
+  }
+
+  data {
+    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  }
+}


### PR DESCRIPTION
If this is approved, would somebody be able to test it pre-merge please?

`find-legal-advice.justice.gov.uk` is in production use on `live-0` so if these DNS changes to a subdomain of it would disrupt that, that either needs to not happen or to be rolled back asap