### PR TITLE
Tf 12 upgrade environment repo for non-prod namespaces-batch1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/ecr.tf
@@ -1,10 +1,10 @@
 module "becca_test_app_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "becca-test-app"
   team_name = "tactical-products"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -14,10 +14,11 @@ resource "kubernetes_secret" "becca_test_app_ecr_credentials" {
     namespace = "becca-test-app-dev"
   }
 
-  data {
-    access_key_id     = "${module.becca_test_app_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.becca_test_app_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.becca_test_app_ecr_credentials.repo_arn}"
-    repo_url          = "${module.becca_test_app_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.becca_test_app_ecr_credentials.access_key_id
+    secret_access_key = module.becca_test_app_ecr_credentials.secret_access_key
+    repo_arn          = module.becca_test_app_ecr_credentials.repo_arn
+    repo_url          = module.becca_test_app_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/rds.tf
@@ -1,11 +1,13 @@
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 module "becca_test_app_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "tactical-products"
   business-unit          = "central-digital"
   application            = "becca-test-app"
@@ -15,7 +17,7 @@ module "becca_test_app_rds" {
   force_ssl              = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -25,7 +27,8 @@ resource "kubernetes_secret" "becca_test_app_rds" {
     namespace = "becca-test-app-dev"
   }
 
-  data {
+  data = {
     url = "postgres://${module.becca_test_app_rds.database_username}:${module.becca_test_app_rds.database_password}@${module.becca_test_app_rds.rds_instance_endpoint}/${module.becca_test_app_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/becca-test-app-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ecr.tf
@@ -3,25 +3,26 @@
 #################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.repo_name}"
+  team_name = var.team_name
+  repo_name = var.repo_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
     name      = "ecr-repo-c100"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    repo_url          = "${module.ecr-repo.repo_url}"
-    access_key_id     = "${module.ecr-repo.access_key_id}"
-    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
@@ -3,31 +3,32 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = true
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-c100-staging"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/redis.tf
@@ -3,30 +3,31 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {
   metadata {
     name      = "elasticache-c100-staging"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.redis-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.redis-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.redis-elasticache.primary_endpoint_address
+    auth_token               = module.redis-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/variables.tf
@@ -10,9 +10,11 @@ variable "namespace" {
   default = "case-notes-to-probation-dev"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -37,3 +39,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/variables.tf
@@ -10,9 +10,11 @@ variable "namespace" {
   default = "case-notes-to-probation-preprod"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -37,3 +39,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/elasticache.tf
@@ -4,15 +4,15 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   engine_version        = "4.0.10"
   parameter_group_name  = "default.redis4.0"
@@ -23,13 +23,14 @@ module "cccd_elasticache_redis" {
 resource "kubernetes_secret" "cccd_elasticache_redis" {
   metadata {
     name      = "cccd-elasticache-redis"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
-    auth_token               = "${module.cccd_elasticache_redis.auth_token}"
-    member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
+  data = {
+    primary_endpoint_address = module.cccd_elasticache_redis.primary_endpoint_address
+    auth_token               = module.cccd_elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.cccd_elasticache_redis.member_clusters)
     url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
@@ -6,15 +6,15 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name                = "${var.cluster_name}"
-  cluster_state_bucket        = "${var.cluster_state_bucket}"
-  team_name                   = "${var.team_name}"
-  business-unit               = "${var.business-unit}"
-  application                 = "${var.application}"
-  is-production               = "${var.is-production}"
-  environment-name            = "${var.environment-name}"
-  infrastructure-support      = "${var.infrastructure-support}"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name                = var.cluster_name
+  cluster_state_bucket        = var.cluster_state_bucket
+  team_name                   = var.team_name
+  business-unit               = var.business-unit
+  application                 = var.application
+  is-production               = var.is-production
+  environment-name            = var.environment-name
+  infrastructure-support      = var.infrastructure-support
   db_allocated_storage        = "50"
   db_instance_class           = "db.t3.medium"
   db_engine_version           = "9.6"
@@ -23,22 +23,23 @@ module "cccd_rds" {
   force_ssl                   = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "cccd_rds" {
   metadata {
     name      = "cccd-rds"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.cccd_rds.rds_instance_endpoint}"
-    database_name         = "${module.cccd_rds.database_name}"
-    database_username     = "${module.cccd_rds.database_username}"
-    database_password     = "${module.cccd_rds.database_password}"
-    rds_instance_address  = "${module.cccd_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.cccd_rds.rds_instance_endpoint
+    database_name         = module.cccd_rds.database_name
+    database_username     = module.cccd_rds.database_username
+    database_password     = module.cccd_rds.database_password
+    rds_instance_address  = module.cccd_rds.rds_instance_address
     url                   = "postgres://${module.cccd_rds.database_username}:${module.cccd_rds.database_password}@${module.cccd_rds.rds_instance_endpoint}/${module.cccd_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"
@@ -9,7 +9,7 @@ module "cccd_s3_bucket" {
   infrastructure-support = "crowncourtdefence@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -42,6 +42,7 @@ module "cccd_s3_bucket" {
 ]
 }
 EOF
+
 }
 
 resource "kubernetes_secret" "cccd_s3_bucket" {
@@ -50,10 +51,11 @@ resource "kubernetes_secret" "cccd_s3_bucket" {
     namespace = "cccd-api-sandbox"
   }
 
-  data {
-    access_key_id     = "${module.cccd_s3_bucket.access_key_id}"
-    secret_access_key = "${module.cccd_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.cccd_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.cccd_s3_bucket.bucket_name}"
+  data = {
+    access_key_id     = module.cccd_s3_bucket.access_key_id
+    secret_access_key = module.cccd_s3_bucket.secret_access_key
+    bucket_arn        = module.cccd_s3_bucket.bucket_arn
+    bucket_name       = module.cccd_s3_bucket.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/variables.tf
@@ -35,6 +35,9 @@ variable "is-production" {
  * two variables are automatically supplied by the pipeline.
  *
  */
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
@@ -1,15 +1,15 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 module "cccd_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "cccd"
   team_name = "laa-get-paid"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -19,10 +19,11 @@ resource "kubernetes_secret" "cccd_ecr_credentials" {
     namespace = "cccd-dev"
   }
 
-  data {
-    access_key_id     = "${module.cccd_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.cccd_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.cccd_ecr_credentials.repo_arn}"
-    repo_url          = "${module.cccd_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.cccd_ecr_credentials.access_key_id
+    secret_access_key = module.cccd_ecr_credentials.secret_access_key
+    repo_arn          = module.cccd_ecr_credentials.repo_arn
+    repo_url          = module.cccd_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
 
 module "cccd_ecr_credentials" {
   source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
@@ -4,15 +4,15 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   engine_version        = "4.0.10"
   parameter_group_name  = "default.redis4.0"
@@ -23,13 +23,14 @@ module "cccd_elasticache_redis" {
 resource "kubernetes_secret" "cccd_elasticache_redis" {
   metadata {
     name      = "cccd-elasticache-redis"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
-    auth_token               = "${module.cccd_elasticache_redis.auth_token}"
-    member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
+  data = {
+    primary_endpoint_address = module.cccd_elasticache_redis.primary_endpoint_address
+    auth_token               = module.cccd_elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.cccd_elasticache_redis.member_clusters)
     url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
@@ -1,38 +1,40 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
 
-  team_name          = "${var.team_name}"
+  team_name          = var.team_name
   topic_display_name = "cccd-claims-submitted"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "claims_for_ccr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-for-ccr"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.ccr_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
-  queue_url = "${module.claims_for_ccr.sqs_id}"
+  queue_url = module.claims_for_ccr.sqs_id
 
   policy = <<EOF
   {
@@ -55,33 +57,37 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
         }
       ]
   }
-  EOF
+  
+EOF
+
 }
 
 module "claims_for_cclf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-for-cclf"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.cclf_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
-  queue_url = "${module.claims_for_cclf.sqs_id}"
+  queue_url = module.claims_for_cclf.sqs_id
 
   policy = <<EOF
   {
@@ -104,76 +110,80 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
         }
       ]
   }
-  EOF
+  
+EOF
+
 }
 
 module "responses_for_cccd" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "responses-for-cccd"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.cccd_response_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "ccr_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-submitted-ccr-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "cclf_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-submitted-cclf-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "cccd_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "reponses-for-cccd-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -183,43 +193,44 @@ resource "kubernetes_secret" "cccd_claims_submitted" {
     namespace = "cccd-dev"
   }
 
-  data {
-    access_key_id     = "${module.cccd_claims_submitted.access_key_id}"
-    secret_access_key = "${module.cccd_claims_submitted.secret_access_key}"
-    topic_arn         = "${module.cccd_claims_submitted.topic_arn}"
-    sqs_ccr_name      = "${module.claims_for_ccr.sqs_name}"
-    sqs_ccr_url       = "${module.claims_for_ccr.sqs_id}"
-    sqs_ccr_arn       = "${module.claims_for_ccr.sqs_arn}"
-    sqs_ccr_dlq_name  = "${module.ccr_dead_letter_queue.sqs_name}"
-    sqs_ccr_dlq_url   = "${module.ccr_dead_letter_queue.sqs_id}"
-    sqs_ccr_dlq_arn   = "${module.ccr_dead_letter_queue.sqs_arn}"
-    sqs_cclf_name     = "${module.claims_for_cclf.sqs_name}"
-    sqs_cclf_url      = "${module.claims_for_cclf.sqs_id}"
-    sqs_cclf_arn      = "${module.claims_for_cclf.sqs_arn}"
-    sqs_cclf_dlq_name = "${module.cclf_dead_letter_queue.sqs_name}"
-    sqs_cclf_dlq_url  = "${module.cclf_dead_letter_queue.sqs_id}"
-    sqs_cclf_dlq_arn  = "${module.cclf_dead_letter_queue.sqs_arn}"
-    sqs_cccd_name     = "${module.responses_for_cccd.sqs_name}"
-    sqs_cccd_url      = "${module.responses_for_cccd.sqs_id}"
-    sqs_cccd_arn      = "${module.responses_for_cccd.sqs_arn}"
-    sqs_cccd_dlq_name = "${module.cccd_response_dead_letter_queue.sqs_name}"
-    sqs_cccd_dlq_url  = "${module.cccd_response_dead_letter_queue.sqs_id}"
-    sqs_cccd_dlq_arn  = "${module.cccd_response_dead_letter_queue.sqs_arn}"
+  data = {
+    access_key_id     = module.cccd_claims_submitted.access_key_id
+    secret_access_key = module.cccd_claims_submitted.secret_access_key
+    topic_arn         = module.cccd_claims_submitted.topic_arn
+    sqs_ccr_name      = module.claims_for_ccr.sqs_name
+    sqs_ccr_url       = module.claims_for_ccr.sqs_id
+    sqs_ccr_arn       = module.claims_for_ccr.sqs_arn
+    sqs_ccr_dlq_name  = module.ccr_dead_letter_queue.sqs_name
+    sqs_ccr_dlq_url   = module.ccr_dead_letter_queue.sqs_id
+    sqs_ccr_dlq_arn   = module.ccr_dead_letter_queue.sqs_arn
+    sqs_cclf_name     = module.claims_for_cclf.sqs_name
+    sqs_cclf_url      = module.claims_for_cclf.sqs_id
+    sqs_cclf_arn      = module.claims_for_cclf.sqs_arn
+    sqs_cclf_dlq_name = module.cclf_dead_letter_queue.sqs_name
+    sqs_cclf_dlq_url  = module.cclf_dead_letter_queue.sqs_id
+    sqs_cclf_dlq_arn  = module.cclf_dead_letter_queue.sqs_arn
+    sqs_cccd_name     = module.responses_for_cccd.sqs_name
+    sqs_cccd_url      = module.responses_for_cccd.sqs_id
+    sqs_cccd_arn      = module.responses_for_cccd.sqs_arn
+    sqs_cccd_dlq_name = module.cccd_response_dead_letter_queue.sqs_name
+    sqs_cccd_dlq_url  = module.cccd_response_dead_letter_queue.sqs_id
+    sqs_cccd_dlq_arn  = module.cccd_response_dead_letter_queue.sqs_arn
   }
 }
 
 resource "aws_sns_topic_subscription" "ccr-queue-subscription" {
-  provider      = "aws.london"
-  topic_arn     = "${module.cccd_claims_submitted.topic_arn}"
+  provider      = aws.london
+  topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
-  endpoint      = "${module.claims_for_ccr.sqs_arn}"
+  endpoint      = module.claims_for_ccr.sqs_arn
   filter_policy = "{\"claim_type\": [\"Claim::AdvocateClaim\", \"Claim::AdvocateInterimClaim\", \"Claim::AdvocateSupplementaryClaim\"]}"
 }
 
 resource "aws_sns_topic_subscription" "cclf-queue-subscription" {
-  provider      = "aws.london"
-  topic_arn     = "${module.cccd_claims_submitted.topic_arn}"
+  provider      = aws.london
+  topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
-  endpoint      = "${module.claims_for_cclf.sqs_arn}"
+  endpoint      = module.claims_for_cclf.sqs_arn
   filter_policy = "{\"claim_type\": [\"Claim::LitigatorClaim\", \"Claim::InterimClaim\", \"Claim::TransferClaim\"]}"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds.tf
@@ -6,15 +6,15 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name                = "${var.cluster_name}"
-  cluster_state_bucket        = "${var.cluster_state_bucket}"
-  team_name                   = "${var.team_name}"
-  business-unit               = "${var.business-unit}"
-  application                 = "${var.application}"
-  is-production               = "${var.is-production}"
-  environment-name            = "${var.environment-name}"
-  infrastructure-support      = "${var.infrastructure-support}"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name                = var.cluster_name
+  cluster_state_bucket        = var.cluster_state_bucket
+  team_name                   = var.team_name
+  business-unit               = var.business-unit
+  application                 = var.application
+  is-production               = var.is-production
+  environment-name            = var.environment-name
+  infrastructure-support      = var.infrastructure-support
   db_allocated_storage        = "50"
   db_instance_class           = "db.t3.small"
   db_engine_version           = "9.6"
@@ -24,22 +24,23 @@ module "cccd_rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "cccd_rds" {
   metadata {
     name      = "cccd-rds"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.cccd_rds.rds_instance_endpoint}"
-    database_name         = "${module.cccd_rds.database_name}"
-    database_username     = "${module.cccd_rds.database_username}"
-    database_password     = "${module.cccd_rds.database_password}"
-    rds_instance_address  = "${module.cccd_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.cccd_rds.rds_instance_endpoint
+    database_name         = module.cccd_rds.database_name
+    database_username     = module.cccd_rds.database_username
+    database_password     = module.cccd_rds.database_password
+    rds_instance_address  = module.cccd_rds.rds_instance_address
     url                   = "postgres://${module.cccd_rds.database_username}:${module.cccd_rds.database_password}@${module.cccd_rds.rds_instance_endpoint}/${module.cccd_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/route53.tf
@@ -1,23 +1,24 @@
 resource "aws_route53_zone" "cccd_route53_zone" {
-  name = "${var.domain}"
+  name = var.domain
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "cccd_route53_zone_sec" {
   metadata {
     name      = "cccd-route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.cccd_route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.cccd_route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"
@@ -9,7 +9,7 @@ module "cccd_s3_bucket" {
   infrastructure-support = "crowncourtdefence@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -42,6 +42,7 @@ module "cccd_s3_bucket" {
 ]
 }
 EOF
+
 }
 
 resource "kubernetes_secret" "cccd_s3_bucket" {
@@ -50,10 +51,11 @@ resource "kubernetes_secret" "cccd_s3_bucket" {
     namespace = "cccd-dev"
   }
 
-  data {
-    access_key_id     = "${module.cccd_s3_bucket.access_key_id}"
-    secret_access_key = "${module.cccd_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.cccd_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.cccd_s3_bucket.bucket_name}"
+  data = {
+    access_key_id     = module.cccd_s3_bucket.access_key_id
+    secret_access_key = module.cccd_s3_bucket.secret_access_key
+    bucket_arn        = module.cccd_s3_bucket.bucket_arn
+    bucket_name       = module.cccd_s3_bucket.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/variables.tf
@@ -39,6 +39,9 @@ variable "is-production" {
  * two variables are automatically supplied by the pipeline.
  *
  */
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/elasticache.tf
@@ -4,15 +4,15 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   engine_version        = "4.0.10"
   parameter_group_name  = "default.redis4.0"
@@ -23,13 +23,14 @@ module "cccd_elasticache_redis" {
 resource "kubernetes_secret" "cccd_elasticache_redis" {
   metadata {
     name      = "cccd-elasticache-redis"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
-    auth_token               = "${module.cccd_elasticache_redis.auth_token}"
-    member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
+  data = {
+    primary_endpoint_address = module.cccd_elasticache_redis.primary_endpoint_address
+    auth_token               = module.cccd_elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.cccd_elasticache_redis.member_clusters)
     url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
@@ -1,38 +1,40 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
 
   team_name          = "laa-get-paid"
   topic_display_name = "cccd-claims-submitted"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "claims_for_ccr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-for-ccr"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.ccr_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
-  queue_url = "${module.claims_for_ccr.sqs_id}"
+  queue_url = module.claims_for_ccr.sqs_id
 
   policy = <<EOF
   {
@@ -55,33 +57,37 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
         }
       ]
   }
-  EOF
+  
+EOF
+
 }
 
 module "claims_for_cclf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-for-cclf"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.cclf_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
-  queue_url = "${module.claims_for_cclf.sqs_id}"
+  queue_url = module.claims_for_cclf.sqs_id
 
   policy = <<EOF
   {
@@ -104,76 +110,80 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
         }
       ]
   }
-  EOF
+  
+EOF
+
 }
 
 module "responses_for_cccd" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "responses-for-cccd"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.cccd_response_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "ccr_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-submitted-ccr-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "cclf_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-submitted-cclf-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "cccd_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "reponses-for-cccd-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -183,43 +193,44 @@ resource "kubernetes_secret" "cccd_claims_submitted" {
     namespace = "cccd-staging"
   }
 
-  data {
-    access_key_id     = "${module.cccd_claims_submitted.access_key_id}"
-    secret_access_key = "${module.cccd_claims_submitted.secret_access_key}"
-    topic_arn         = "${module.cccd_claims_submitted.topic_arn}"
-    sqs_ccr_name      = "${module.claims_for_ccr.sqs_name}"
-    sqs_ccr_url       = "${module.claims_for_ccr.sqs_id}"
-    sqs_ccr_arn       = "${module.claims_for_ccr.sqs_arn}"
-    sqs_ccr_dlq_name  = "${module.ccr_dead_letter_queue.sqs_name}"
-    sqs_ccr_dlq_url   = "${module.ccr_dead_letter_queue.sqs_id}"
-    sqs_ccr_dlq_arn   = "${module.ccr_dead_letter_queue.sqs_arn}"
-    sqs_cclf_name     = "${module.claims_for_cclf.sqs_name}"
-    sqs_cclf_url      = "${module.claims_for_cclf.sqs_id}"
-    sqs_cclf_arn      = "${module.claims_for_cclf.sqs_arn}"
-    sqs_cclf_dlq_name = "${module.cclf_dead_letter_queue.sqs_name}"
-    sqs_cclf_dlq_url  = "${module.cclf_dead_letter_queue.sqs_id}"
-    sqs_cclf_dlq_arn  = "${module.cclf_dead_letter_queue.sqs_arn}"
-    sqs_cccd_name     = "${module.responses_for_cccd.sqs_name}"
-    sqs_cccd_url      = "${module.responses_for_cccd.sqs_id}"
-    sqs_cccd_arn      = "${module.responses_for_cccd.sqs_arn}"
-    sqs_cccd_dlq_name = "${module.cccd_response_dead_letter_queue.sqs_name}"
-    sqs_cccd_dlq_url  = "${module.cccd_response_dead_letter_queue.sqs_id}"
-    sqs_cccd_dlq_arn  = "${module.cccd_response_dead_letter_queue.sqs_arn}"
+  data = {
+    access_key_id     = module.cccd_claims_submitted.access_key_id
+    secret_access_key = module.cccd_claims_submitted.secret_access_key
+    topic_arn         = module.cccd_claims_submitted.topic_arn
+    sqs_ccr_name      = module.claims_for_ccr.sqs_name
+    sqs_ccr_url       = module.claims_for_ccr.sqs_id
+    sqs_ccr_arn       = module.claims_for_ccr.sqs_arn
+    sqs_ccr_dlq_name  = module.ccr_dead_letter_queue.sqs_name
+    sqs_ccr_dlq_url   = module.ccr_dead_letter_queue.sqs_id
+    sqs_ccr_dlq_arn   = module.ccr_dead_letter_queue.sqs_arn
+    sqs_cclf_name     = module.claims_for_cclf.sqs_name
+    sqs_cclf_url      = module.claims_for_cclf.sqs_id
+    sqs_cclf_arn      = module.claims_for_cclf.sqs_arn
+    sqs_cclf_dlq_name = module.cclf_dead_letter_queue.sqs_name
+    sqs_cclf_dlq_url  = module.cclf_dead_letter_queue.sqs_id
+    sqs_cclf_dlq_arn  = module.cclf_dead_letter_queue.sqs_arn
+    sqs_cccd_name     = module.responses_for_cccd.sqs_name
+    sqs_cccd_url      = module.responses_for_cccd.sqs_id
+    sqs_cccd_arn      = module.responses_for_cccd.sqs_arn
+    sqs_cccd_dlq_name = module.cccd_response_dead_letter_queue.sqs_name
+    sqs_cccd_dlq_url  = module.cccd_response_dead_letter_queue.sqs_id
+    sqs_cccd_dlq_arn  = module.cccd_response_dead_letter_queue.sqs_arn
   }
 }
 
 resource "aws_sns_topic_subscription" "ccr-queue-subscription" {
-  provider      = "aws.london"
-  topic_arn     = "${module.cccd_claims_submitted.topic_arn}"
+  provider      = aws.london
+  topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
-  endpoint      = "${module.claims_for_ccr.sqs_arn}"
+  endpoint      = module.claims_for_ccr.sqs_arn
   filter_policy = "{\"claim_type\": [\"Claim::AdvocateClaim\", \"Claim::AdvocateInterimClaim\", \"Claim::AdvocateSupplementaryClaim\"]}"
 }
 
 resource "aws_sns_topic_subscription" "cclf-queue-subscription" {
-  provider      = "aws.london"
-  topic_arn     = "${module.cccd_claims_submitted.topic_arn}"
+  provider      = aws.london
+  topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
-  endpoint      = "${module.claims_for_cclf.sqs_arn}"
+  endpoint      = module.claims_for_cclf.sqs_arn
   filter_policy = "{\"claim_type\": [\"Claim::LitigatorClaim\", \"Claim::InterimClaim\", \"Claim::TransferClaim\"]}"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
@@ -1,9 +1,10 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 resource "pingdom_check" "claim-crown-court-defence-staging" {
   type                     = "http"
@@ -21,3 +22,4 @@ resource "pingdom_check" "claim-crown-court-defence-staging" {
   publicreport             = "true"
   integrationids           = [94703]
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
 
 provider "pingdom" {
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
@@ -6,15 +6,15 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name                = "${var.cluster_name}"
-  cluster_state_bucket        = "${var.cluster_state_bucket}"
-  team_name                   = "${var.team_name}"
-  business-unit               = "${var.business-unit}"
-  application                 = "${var.application}"
-  is-production               = "${var.is-production}"
-  environment-name            = "${var.environment-name}"
-  infrastructure-support      = "${var.infrastructure-support}"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name                = var.cluster_name
+  cluster_state_bucket        = var.cluster_state_bucket
+  team_name                   = var.team_name
+  business-unit               = var.business-unit
+  application                 = var.application
+  is-production               = var.is-production
+  environment-name            = var.environment-name
+  infrastructure-support      = var.infrastructure-support
   db_allocated_storage        = "50"
   db_instance_class           = "db.t3.medium"
   db_engine_version           = "9.6"
@@ -24,22 +24,23 @@ module "cccd_rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "cccd_rds" {
   metadata {
     name      = "cccd-rds"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.cccd_rds.rds_instance_endpoint}"
-    database_name         = "${module.cccd_rds.database_name}"
-    database_username     = "${module.cccd_rds.database_username}"
-    database_password     = "${module.cccd_rds.database_password}"
-    rds_instance_address  = "${module.cccd_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.cccd_rds.rds_instance_endpoint
+    database_name         = module.cccd_rds.database_name
+    database_username     = module.cccd_rds.database_username
+    database_password     = module.cccd_rds.database_password
+    rds_instance_address  = module.cccd_rds.rds_instance_address
     url                   = "postgres://${module.cccd_rds.database_username}:${module.cccd_rds.database_password}@${module.cccd_rds.rds_instance_endpoint}/${module.cccd_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"
@@ -9,7 +9,7 @@ module "cccd_s3_bucket" {
   infrastructure-support = "crowncourtdefence@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -42,6 +42,7 @@ module "cccd_s3_bucket" {
 ]
 }
 EOF
+
 }
 
 resource "kubernetes_secret" "cccd_s3_bucket" {
@@ -50,10 +51,11 @@ resource "kubernetes_secret" "cccd_s3_bucket" {
     namespace = "cccd-staging"
   }
 
-  data {
-    access_key_id     = "${module.cccd_s3_bucket.access_key_id}"
-    secret_access_key = "${module.cccd_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.cccd_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.cccd_s3_bucket.bucket_name}"
+  data = {
+    access_key_id     = module.cccd_s3_bucket.access_key_id
+    secret_access_key = module.cccd_s3_bucket.secret_access_key
+    bucket_arn        = module.cccd_s3_bucket.bucket_arn
+    bucket_name       = module.cccd_s3_bucket.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/variables.tf
@@ -35,6 +35,9 @@ variable "is-production" {
  * two variables are automatically supplied by the pipeline.
  *
  */
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/sqs.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/resources/sqs.tf
@@ -1,5 +1,5 @@
 module "example_sqs" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=TF12-DO_NOT-USE"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
   environment-name       = "test"
   team_name              = "cp"


### PR DESCRIPTION
Updated below namespaces

becca-test-app-dev
c100-application-staging
case-notes-to-probation-dev
case-notes-to-probation-preprod
cccd-api-sandbox
cccd-dev
cccd-staging

Terraform 0.12 upgrade and update modules version to use the tf0.12
