### PR TITLE
Increase LimitRange to 24Gi for Prometheus

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1600m
-      memory: 16Gi
+      memory: 24Gi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
Increasing LimitRange from 16Gi to 24Gi for Prometheus.
This is due to seeing Prometheus gradually using more memory over the past month.
We are adding more metrics into Prometheus including a number of new metrics from CloudWatch.
Will continue to closely monitor usage over the next few weeks