### PR TITLE
Tf 12 upgrade in environments repo batch 2

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,6 +18,9 @@ provider "aws" {
  *
  */
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/rds.tf
@@ -5,10 +5,10 @@
  *
  */
 module "check-financial-eligibility-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "apply-for-legal-aid"
   business-unit          = "laa"
   application            = "check-financial-eligibility"
@@ -22,7 +22,7 @@ module "check-financial-eligibility-rds" {
   rds_family             = "postgres11"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -32,11 +32,12 @@ resource "kubernetes_secret" "check-financial-eligibility-rds" {
     namespace = "check-financial-eligibility-staging"
   }
 
-  data {
-    rds_instance_endpoint = "${module.check-financial-eligibility-rds.rds_instance_endpoint}"
-    database_name         = "${module.check-financial-eligibility-rds.database_name}"
-    database_username     = "${module.check-financial-eligibility-rds.database_username}"
-    database_password     = "${module.check-financial-eligibility-rds.database_password}"
-    rds_instance_address  = "${module.check-financial-eligibility-rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.check-financial-eligibility-rds.rds_instance_endpoint
+    database_name         = module.check-financial-eligibility-rds.database_name
+    database_username     = module.check-financial-eligibility-rds.database_username
+    database_password     = module.check-financial-eligibility-rds.database_password
+    rds_instance_address  = module.check-financial-eligibility-rds.rds_instance_address
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
@@ -1,11 +1,11 @@
 module "ecr-repo-check-financial-eligibility-service" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "laa-apply-for-legal-aid"
   repo_name = "check-financial-eligibility-service"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -15,9 +15,10 @@ resource "kubernetes_secret" "ecr-repo-check-financial-eligibility-service" {
     namespace = "check-financial-eligibility-uat"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-check-financial-eligibility-service.repo_url}"
-    access_key_id     = "${module.ecr-repo-check-financial-eligibility-service.access_key_id}"
-    secret_access_key = "${module.ecr-repo-check-financial-eligibility-service.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-check-financial-eligibility-service.repo_url
+    access_key_id     = module.ecr-repo-check-financial-eligibility-service.access_key_id
+    secret_access_key = module.ecr-repo-check-financial-eligibility-service.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -23,6 +23,9 @@ provider "aws" {
  *
  */
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ecr.tf
@@ -1,10 +1,10 @@
 module "checkmydiary-service-dev" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "check-my-diary-dev"
   team_name = "check-my-diary"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -14,16 +14,16 @@ resource "kubernetes_secret" "checkmydiary_ecr_credentials" {
     namespace = "check-my-diary-dev"
   }
 
-  data {
-    access_key_id     = "${module.checkmydiary-service-dev.access_key_id}"
-    secret_access_key = "${module.checkmydiary-service-dev.secret_access_key}"
-    repo_arn          = "${module.checkmydiary-service-dev.repo_arn}"
-    repo_url          = "${module.checkmydiary-service-dev.repo_url}"
+  data = {
+    access_key_id     = module.checkmydiary-service-dev.access_key_id
+    secret_access_key = module.checkmydiary-service-dev.secret_access_key
+    repo_arn          = module.checkmydiary-service-dev.repo_arn
+    repo_url          = module.checkmydiary-service-dev.repo_url
   }
 }
 
 module "checkmydiary-notification-service-dev" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "check-my-diary-notification-service-dev"
   team_name = "check-my-diary"
 }
@@ -34,10 +34,11 @@ resource "kubernetes_secret" "checkmydiary-notification-service_ecr_credentials"
     namespace = "check-my-diary-dev"
   }
 
-  data {
-    access_key_id     = "${module.checkmydiary-notification-service-dev.access_key_id}"
-    secret_access_key = "${module.checkmydiary-notification-service-dev.secret_access_key}"
-    repo_arn          = "${module.checkmydiary-notification-service-dev.repo_arn}"
-    repo_url          = "${module.checkmydiary-notification-service-dev.repo_url}"
+  data = {
+    access_key_id     = module.checkmydiary-notification-service-dev.access_key_id
+    secret_access_key = module.checkmydiary-notification-service-dev.secret_access_key
+    repo_arn          = module.checkmydiary-notification-service-dev.repo_arn
+    repo_url          = module.checkmydiary-notification-service-dev.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/rds.tf
@@ -3,14 +3,17 @@
  * two variables are automatically supplied by the pipeline.
  */
 
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "checkmydiary_dev_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "check-my-diary"
   business-unit          = "HMPPS"
   application            = "check-my-diary"
@@ -21,7 +24,7 @@ module "checkmydiary_dev_rds" {
   force_ssl              = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -31,12 +34,13 @@ resource "kubernetes_secret" "checkmydiary_dev_rds" {
     namespace = "check-my-diary-dev"
   }
 
-  data {
-    rds_instance_endpoint = "${module.checkmydiary_dev_rds.rds_instance_endpoint}"
-    database_name         = "${module.checkmydiary_dev_rds.database_name}"
-    rds_instance_port     = "${module.checkmydiary_dev_rds.rds_instance_port}"
-    database_username     = "${module.checkmydiary_dev_rds.database_username}"
-    database_password     = "${module.checkmydiary_dev_rds.database_password}"
-    rds_instance_address  = "${module.checkmydiary_dev_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.checkmydiary_dev_rds.rds_instance_endpoint
+    database_name         = module.checkmydiary_dev_rds.database_name
+    rds_instance_port     = module.checkmydiary_dev_rds.rds_instance_port
+    database_username     = module.checkmydiary_dev_rds.database_username
+    database_password     = module.checkmydiary_dev_rds.database_password
+    rds_instance_address  = module.checkmydiary_dev_rds.rds_instance_address
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "checkmydiary-service-preprod" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "check-my-diary-preprod"
   team_name = "check-my-diary"
 }
@@ -10,16 +10,16 @@ resource "kubernetes_secret" "checkmydiary_ecr_credentials" {
     namespace = "check-my-diary-preprod"
   }
 
-  data {
-    access_key_id     = "${module.checkmydiary-service-preprod.access_key_id}"
-    secret_access_key = "${module.checkmydiary-service-preprod.secret_access_key}"
-    repo_arn          = "${module.checkmydiary-service-preprod.repo_arn}"
-    repo_url          = "${module.checkmydiary-service-preprod.repo_url}"
+  data = {
+    access_key_id     = module.checkmydiary-service-preprod.access_key_id
+    secret_access_key = module.checkmydiary-service-preprod.secret_access_key
+    repo_arn          = module.checkmydiary-service-preprod.repo_arn
+    repo_url          = module.checkmydiary-service-preprod.repo_url
   }
 }
 
 module "checkmydiary-notification-service-preprod" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "check-my-diary-notification-service-preprod"
   team_name = "check-my-diary"
 }
@@ -30,10 +30,11 @@ resource "kubernetes_secret" "checkmydiary-notification-service_ecr_credentials"
     namespace = "check-my-diary-preprod"
   }
 
-  data {
-    access_key_id     = "${module.checkmydiary-notification-service-preprod.access_key_id}"
-    secret_access_key = "${module.checkmydiary-notification-service-preprod.secret_access_key}"
-    repo_arn          = "${module.checkmydiary-notification-service-preprod.repo_arn}"
-    repo_url          = "${module.checkmydiary-notification-service-preprod.repo_url}"
+  data = {
+    access_key_id     = module.checkmydiary-notification-service-preprod.access_key_id
+    secret_access_key = module.checkmydiary-notification-service-preprod.secret_access_key
+    repo_arn          = module.checkmydiary-notification-service-preprod.repo_arn
+    repo_url          = module.checkmydiary-notification-service-preprod.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
@@ -3,14 +3,17 @@
  * two variables are automatically supplied by the pipeline.
  */
 
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "checkmydiary_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "check-my-diary"
   application            = "check-my-diary"
   is-production          = "false"
@@ -19,7 +22,7 @@ module "checkmydiary_rds" {
   force_ssl              = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -29,11 +32,12 @@ resource "kubernetes_secret" "checkmydiary_rds" {
     namespace = "check-my-diary-preprod"
   }
 
-  data {
-    rds_instance_endpoint = "${module.checkmydiary_rds.rds_instance_endpoint}"
-    database_name         = "${module.checkmydiary_rds.database_name}"
-    database_username     = "${module.checkmydiary_rds.database_username}"
-    database_password     = "${module.checkmydiary_rds.database_password}"
-    rds_instance_address  = "${module.checkmydiary_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.checkmydiary_rds.rds_instance_endpoint
+    database_name         = module.checkmydiary_rds.database_name
+    database_username     = module.checkmydiary_rds.database_username
+    database_password     = module.checkmydiary_rds.database_password
+    rds_instance_address  = module.checkmydiary_rds.rds_instance_address
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/ecr.tf
@@ -5,13 +5,13 @@
  *
  */
 module "cica-repo" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "cica"
   team_name = "cica"
 
   providers = {
-    aws = "aws.london"
-  } # this overwrite the region from the provider defined above.
+    aws = aws.london
+  }
 }
 
 resource "kubernetes_secret" "ecr-repo" {
@@ -20,9 +20,10 @@ resource "kubernetes_secret" "ecr-repo" {
     namespace = "cica-apply-for-compensation-uat"
   }
 
-  data {
-    access_key_id     = "${module.cica-repo.access_key_id}"
-    secret_access_key = "${module.cica-repo.secret_access_key}"
-    repo_url          = "${module.cica-repo.repo_url}"
+  data = {
+    access_key_id     = module.cica-repo.access_key_id
+    secret_access_key = module.cica-repo.secret_access_key
+    repo_url          = module.cica-repo.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/ecr.tf
@@ -5,25 +5,26 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
-  repo_name = "${var.repo_name}"
-  team_name = "${var.team_name}"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+  repo_name = var.repo_name
+  team_name = var.team_name
 
   providers = {
-    aws = "aws.london"
-  } # this overwrite the region from the provider defined above. 
+    aws = aws.london
+  }
 }
 
 resource "kubernetes_secret" "cica_ecr_credentials" {
   metadata {
     name      = "cica-ecr-credentials-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.cica_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.cica_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.cica_ecr_credentials.repo_arn}"
-    repo_url          = "${module.cica_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.cica_ecr_credentials.access_key_id
+    secret_access_key = module.cica_ecr_credentials.secret_access_key
+    repo_arn          = module.cica_ecr_credentials.repo_arn
+    repo_url          = module.cica_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -28,3 +28,4 @@ variable "repo_name" {
 variable "team_name" {
   default = "cica"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/ecr.tf
@@ -5,12 +5,12 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "cica-repo-dev"
   team_name = "cica"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -20,10 +20,11 @@ resource "kubernetes_secret" "ecr_repo" {
     namespace = "claim-criminal-injuries-compensation-dev"
   }
 
-  data {
-    access_key_id     = "${module.cica_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.cica_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.cica_ecr_credentials.repo_arn}"
-    repo_url          = "${module.cica_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.cica_ecr_credentials.access_key_id
+    secret_access_key = module.cica_ecr_credentials.secret_access_key
+    repo_arn          = module.cica_ecr_credentials.repo_arn
+    repo_url          = module.cica_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/pingdom.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
 
 provider "pingdom" {
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/pingdom.tf
@@ -1,9 +1,10 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 resource "pingdom_check" "claim-criminal-injuries-compensation-dev" {
   type                     = "http"
@@ -20,3 +21,4 @@ resource "pingdom_check" "claim-criminal-injuries-compensation-dev" {
   probefilters             = "region:EU"
   publicreport             = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
@@ -1,24 +1,27 @@
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  team_name                  = "${var.team_name}"
-  business-unit              = "${var.business-unit}"
-  application                = "${var.application}"
-  is-production              = "${var.is-production}"
-  environment-name           = "${var.environment-name}"
-  infrastructure-support     = "${var.email}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  team_name                  = var.team_name
+  business-unit              = var.business-unit
+  application                = var.application
+  is-production              = var.is-production
+  environment-name           = var.environment-name
+  infrastructure-support     = var.email
   force_ssl                  = "true"
   db_engine                  = "postgres"
   db_engine_version          = "10.6"
   db_instance_class          = "db.t2.small"
   db_allocated_storage       = "5"
   db_name                    = "datacaptureservice"
-  db_backup_retention_period = "${var.db_backup_retention_period}"
+  db_backup_retention_period = var.db_backup_retention_period
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11 
   # Pick the one that defines the postgres version the best 
@@ -29,22 +32,23 @@ module "rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland" 
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-dev"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.rds.rds_instance_endpoint}"
-    database_name         = "${module.rds.database_name}"
-    database_username     = "${module.rds.database_username}"
-    database_password     = "${module.rds.database_password}"
-    rds_instance_address  = "${module.rds.rds_instance_address}"
-    rds_instance_port     = "${module.rds.rds_instance_port}"
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    rds_instance_port     = module.rds.rds_instance_port
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/variable.tf
@@ -39,3 +39,4 @@ variable "db_backup_retention_period" {
   description = "The days to retain backup jobs. Must be 1 or greater to be a source for a Read Replica"
   default     = "35"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/ecr.tf
@@ -5,14 +5,14 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "cica-repo-stg"
   team_name = "cica"
 
   # aws_region = "eu-west-2"     # This input is deprecated from the version 3.2 of this module
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -22,10 +22,11 @@ resource "kubernetes_secret" "ecr_repo" {
     namespace = "claim-criminal-injuries-compensation-staging"
   }
 
-  data {
-    access_key_id     = "${module.cica_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.cica_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.cica_ecr_credentials.repo_arn}"
-    repo_url          = "${module.cica_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.cica_ecr_credentials.access_key_id
+    secret_access_key = module.cica_ecr_credentials.secret_access_key
+    repo_arn          = module.cica_ecr_credentials.repo_arn
+    repo_url          = module.cica_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/rds.tf
@@ -1,24 +1,27 @@
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  team_name                  = "${var.team_name}"
-  business-unit              = "${var.business-unit}"
-  application                = "${var.application}"
-  is-production              = "${var.is-production}"
-  environment-name           = "${var.environment-name}"
-  infrastructure-support     = "${var.email}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  team_name                  = var.team_name
+  business-unit              = var.business-unit
+  application                = var.application
+  is-production              = var.is-production
+  environment-name           = var.environment-name
+  infrastructure-support     = var.email
   force_ssl                  = "true"
   db_engine                  = "postgres"
   db_engine_version          = "10.6"
   db_instance_class          = "db.t2.small"
   db_allocated_storage       = "5"
   db_name                    = "datacaptureservice"
-  db_backup_retention_period = "${var.db_backup_retention_period}"
+  db_backup_retention_period = var.db_backup_retention_period
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11 
   # Pick the one that defines the postgres version the best 
@@ -29,22 +32,23 @@ module "rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland" 
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-staging"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.rds.rds_instance_endpoint}"
-    database_name         = "${module.rds.database_name}"
-    database_username     = "${module.rds.database_username}"
-    database_password     = "${module.rds.database_password}"
-    rds_instance_address  = "${module.rds.rds_instance_address}"
-    rds_instance_port     = "${module.rds.rds_instance_port}"
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    rds_instance_port     = module.rds.rds_instance_port
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/variables.tf
@@ -35,3 +35,4 @@ variable "db_backup_retention_period" {
   description = "The days to retain backups. Must be 1 or greater to be a source for a Read Replica"
   default     = "35"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/ecr.tf
@@ -5,14 +5,14 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "cica-repo-uat"
   team_name = "cica"
 
   # aws_region = "eu-west-2"     # This input is deprecated from the version 3.2 of this module 
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -22,10 +22,11 @@ resource "kubernetes_secret" "ecr_repo" {
     namespace = "claim-criminal-injuries-compensation-uat"
   }
 
-  data {
-    access_key_id     = "${module.cica_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.cica_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.cica_ecr_credentials.repo_arn}"
-    repo_url          = "${module.cica_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.cica_ecr_credentials.access_key_id
+    secret_access_key = module.cica_ecr_credentials.secret_access_key
+    repo_arn          = module.cica_ecr_credentials.repo_arn
+    repo_url          = module.cica_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/pingdom.tf
@@ -1,9 +1,10 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 resource "pingdom_check" "claim-criminal-injuries-compensation-uat" {
   type                     = "http"
@@ -20,3 +21,4 @@ resource "pingdom_check" "claim-criminal-injuries-compensation-uat" {
   probefilters             = "region:EU"
   publicreport             = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/pingdom.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
 
 provider "pingdom" {
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/rds.tf
@@ -1,24 +1,27 @@
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  team_name                  = "${var.team_name}"
-  business-unit              = "${var.business-unit}"
-  application                = "${var.application}"
-  is-production              = "${var.is-production}"
-  environment-name           = "${var.environment-name}"
-  infrastructure-support     = "${var.email}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  team_name                  = var.team_name
+  business-unit              = var.business-unit
+  application                = var.application
+  is-production              = var.is-production
+  environment-name           = var.environment-name
+  infrastructure-support     = var.email
   force_ssl                  = "true"
   db_engine                  = "postgres"
   db_engine_version          = "10.6"
   db_instance_class          = "db.t2.small"
   db_allocated_storage       = "5"
   db_name                    = "datacaptureservice"
-  db_backup_retention_period = "${var.db_backup_retention_period}"
+  db_backup_retention_period = var.db_backup_retention_period
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11 
   # Pick the one that defines the postgres version the best 
@@ -29,22 +32,23 @@ module "rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland" 
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.rds.rds_instance_endpoint}"
-    database_name         = "${module.rds.database_name}"
-    database_username     = "${module.rds.database_username}"
-    database_password     = "${module.rds.database_password}"
-    rds_instance_address  = "${module.rds.rds_instance_address}"
-    rds_instance_port     = "${module.rds.rds_instance_port}"
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    rds_instance_port     = module.rds.rds_instance_port
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/variable.tf
@@ -35,3 +35,4 @@ variable "db_backup_retention_period" {
   description = "The days to retain backups. Must be 1 or greater to be a source for a Read Replica"
   default     = "35"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/ecr.tf
@@ -5,14 +5,14 @@
  *
  */
 module "laa_crime_apps_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "laa-common-platform-connector"
   team_name = "laa-crime-apps-team"
 
   # aws_region = "eu-west-2"     # This input is deprecated from version 3.2 of this module
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -22,10 +22,11 @@ resource "kubernetes_secret" "laa_crime_apps_team_ecr_credentials" {
     namespace = "common-platform-connector-dev"
   }
 
-  data {
-    access_key_id     = "${module.laa_crime_apps_team_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.laa_crime_apps_team_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.laa_crime_apps_team_ecr_credentials.repo_arn}"
-    repo_url          = "${module.laa_crime_apps_team_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.laa_crime_apps_team_ecr_credentials.access_key_id
+    secret_access_key = module.laa_crime_apps_team_ecr_credentials.secret_access_key
+    repo_arn          = module.laa_crime_apps_team_ecr_credentials.repo_arn
+    repo_url          = module.laa_crime_apps_team_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/rds.tf
@@ -1,6 +1,8 @@
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 /*
  * Make sure that you use the latest version of the module by changing the
@@ -9,9 +11,9 @@ variable "cluster_state_bucket" {}
  *
  */
 module "rds-staging" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "Correspondence Staff"
   business-unit          = "Central Digital"
   application            = "correspondence-staff"
@@ -25,7 +27,7 @@ module "rds-staging" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -35,18 +37,18 @@ resource "kubernetes_secret" "rds-staging" {
     namespace = "correspondence-staff-staging"
   }
 
-  data {
-    rds_instance_endpoint = "${module.rds-staging.rds_instance_endpoint}"
-    database_name         = "${module.rds-staging.database_name}"
-    database_username     = "${module.rds-staging.database_username}"
-    database_password     = "${module.rds-staging.database_password}"
-    rds_instance_address  = "${module.rds-staging.rds_instance_address}"
-
-    /* You can replace all of the above with the following, if you prefer to
+  data = {
+    rds_instance_endpoint = module.rds-staging.rds_instance_endpoint
+    database_name         = module.rds-staging.database_name
+    database_username     = module.rds-staging.database_username
+    database_password     = module.rds-staging.database_password
+    rds_instance_address  = module.rds-staging.rds_instance_address
+  }
+  /* You can replace all of the above with the following, if you prefer to
      * use a single database URL value in your application code:
      *
      * url = "postgres://${module.rds-staging.database_username}:${module.rds-staging.database_password}@${module.rds-staging.rds_instance_endpoint}/${module.rds-staging.database_name}"
      *
      */
-  }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/dynamodb.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
 
 provider "aws" {
   region = "eu-west-2"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/dynamodb.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -14,13 +14,13 @@ provider "aws" {
  *
  */
 module "court_case_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.0"
 
   team_name              = "court-probation-team"
   application            = "Court Case Service"
-  business-unit          = "${var.business-unit}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  business-unit          = var.business-unit
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   is-production          = "false"
 
   hash_key  = "pk"
@@ -30,13 +30,14 @@ module "court_case_dynamodb" {
 resource "kubernetes_secret" "court_case_dynamodb" {
   metadata {
     name      = "court-case-dynamodb-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    table_name        = "${module.court_case_dynamodb.table_name}"
-    table_arn         = "${module.court_case_dynamodb.table_arn}"
-    access_key_id     = "${module.court_case_dynamodb.access_key_id}"
-    secret_access_key = "${module.court_case_dynamodb.secret_access_key}"
+  data = {
+    table_name        = module.court_case_dynamodb.table_name
+    table_arn         = module.court_case_dynamodb.table_arn
+    access_key_id     = module.court_case_dynamodb.access_key_id
+    secret_access_key = module.court_case_dynamodb.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -9,12 +9,12 @@ provider "aws" {
 }
 
 module "court_probation_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "court-probation-service"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,21 +24,21 @@ resource "kubernetes_secret" "court_probation_service_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.court_probation_service_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.court_probation_service_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.court_probation_service_ecr_credentials.repo_arn}"
-    repo_url          = "${module.court_probation_service_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.court_probation_service_ecr_credentials.access_key_id
+    secret_access_key = module.court_probation_service_ecr_credentials.secret_access_key
+    repo_arn          = module.court_probation_service_ecr_credentials.repo_arn
+    repo_url          = module.court_probation_service_ecr_credentials.repo_url
   }
 }
 
 module "ps_cps_pack_parser_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "cps-pack-parser"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -48,21 +48,21 @@ resource "kubernetes_secret" "ps_cps_pack_parser_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.ps_cps_pack_parser_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.ps_cps_pack_parser_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.ps_cps_pack_parser_ecr_credentials.repo_arn}"
-    repo_url          = "${module.ps_cps_pack_parser_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.ps_cps_pack_parser_ecr_credentials.access_key_id
+    secret_access_key = module.ps_cps_pack_parser_ecr_credentials.secret_access_key
+    repo_arn          = module.ps_cps_pack_parser_ecr_credentials.repo_arn
+    repo_url          = module.ps_cps_pack_parser_ecr_credentials.repo_url
   }
 }
 
 module "mock_cp_court_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "mock-cp-court-service"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -72,21 +72,21 @@ resource "kubernetes_secret" "mock_cp_court_service_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.mock_cp_court_service_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.mock_cp_court_service_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.mock_cp_court_service_ecr_credentials.repo_arn}"
-    repo_url          = "${module.mock_cp_court_service_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.mock_cp_court_service_ecr_credentials.access_key_id
+    secret_access_key = module.mock_cp_court_service_ecr_credentials.secret_access_key
+    repo_arn          = module.mock_cp_court_service_ecr_credentials.repo_arn
+    repo_url          = module.mock_cp_court_service_ecr_credentials.repo_url
   }
 }
 
 module "court_list_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "court-list-service"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -96,21 +96,21 @@ resource "kubernetes_secret" "court_list_service_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.court_list_service_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.court_list_service_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.court_list_service_ecr_credentials.repo_arn}"
-    repo_url          = "${module.court_list_service_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.court_list_service_ecr_credentials.access_key_id
+    secret_access_key = module.court_list_service_ecr_credentials.secret_access_key
+    repo_arn          = module.court_list_service_ecr_credentials.repo_arn
+    repo_url          = module.court_list_service_ecr_credentials.repo_url
   }
 }
 
 module "prepare_probation_courtcases_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "prepare-probation-courtcases"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -120,21 +120,21 @@ resource "kubernetes_secret" "prepare_probation_courtcases_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.prepare_probation_courtcases_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.prepare_probation_courtcases_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.prepare_probation_courtcases_ecr_credentials.repo_arn}"
-    repo_url          = "${module.prepare_probation_courtcases_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.prepare_probation_courtcases_ecr_credentials.access_key_id
+    secret_access_key = module.prepare_probation_courtcases_ecr_credentials.secret_access_key
+    repo_arn          = module.prepare_probation_courtcases_ecr_credentials.repo_arn
+    repo_url          = module.prepare_probation_courtcases_ecr_credentials.repo_url
   }
 }
 
 module "ndelius_new_tech_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "ndelius-new-tech"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -144,21 +144,21 @@ resource "kubernetes_secret" "ndelius_new_tech_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.ndelius_new_tech_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.ndelius_new_tech_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.ndelius_new_tech_ecr_credentials.repo_arn}"
-    repo_url          = "${module.ndelius_new_tech_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.ndelius_new_tech_ecr_credentials.access_key_id
+    secret_access_key = module.ndelius_new_tech_ecr_credentials.secret_access_key
+    repo_arn          = module.ndelius_new_tech_ecr_credentials.repo_arn
+    repo_url          = module.ndelius_new_tech_ecr_credentials.repo_url
   }
 }
 
 module "community_api_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "community-api"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -168,21 +168,21 @@ resource "kubernetes_secret" "community_api_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.community_api_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.community_api_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.community_api_ecr_credentials.repo_arn}"
-    repo_url          = "${module.community_api_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.community_api_ecr_credentials.access_key_id
+    secret_access_key = module.community_api_ecr_credentials.secret_access_key
+    repo_arn          = module.community_api_ecr_credentials.repo_arn
+    repo_url          = module.community_api_ecr_credentials.repo_url
   }
 }
 
 module "ukcloud_proxy_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "ukcloud-proxy"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -192,69 +192,69 @@ resource "kubernetes_secret" "ukcloud_proxy_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.ukcloud_proxy_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.ukcloud_proxy_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.ukcloud_proxy_ecr_credentials.repo_arn}"
-    repo_url          = "${module.ukcloud_proxy_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.ukcloud_proxy_ecr_credentials.access_key_id
+    secret_access_key = module.ukcloud_proxy_ecr_credentials.secret_access_key
+    repo_arn          = module.ukcloud_proxy_ecr_credentials.repo_arn
+    repo_url          = module.ukcloud_proxy_ecr_credentials.repo_url
   }
 }
 
 module "delius_oauth2_server_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "delius-oauth2-server"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "delius_oauth2_server_ecr_credentials" {
   metadata {
     name      = "delius-oauth2-server-ecr-credentials"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.delius_oauth2_server_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.delius_oauth2_server_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.delius_oauth2_server_ecr_credentials.repo_arn}"
-    repo_url          = "${module.delius_oauth2_server_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.delius_oauth2_server_ecr_credentials.access_key_id
+    secret_access_key = module.delius_oauth2_server_ecr_credentials.secret_access_key
+    repo_arn          = module.delius_oauth2_server_ecr_credentials.repo_arn
+    repo_url          = module.delius_oauth2_server_ecr_credentials.repo_url
   }
 }
 
 module "probation_court_prototype_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "probation-court-prototype"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "probation_court_prototype_ecr_credentials" {
   metadata {
     name      = "probation-court-prototype-ecr-credentials"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.probation_court_prototype_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.probation_court_prototype_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.probation_court_prototype_ecr_credentials.repo_arn}"
-    repo_url          = "${module.probation_court_prototype_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.probation_court_prototype_ecr_credentials.access_key_id
+    secret_access_key = module.probation_court_prototype_ecr_credentials.secret_access_key
+    repo_arn          = module.probation_court_prototype_ecr_credentials.repo_arn
+    repo_url          = module.probation_court_prototype_ecr_credentials.repo_url
   }
 }
 
 module "court_list_mock_data_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "court-list-mock-data"
   team_name = "probation-services"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -264,10 +264,11 @@ resource "kubernetes_secret" "court_list_mock_data_ecr_credentials" {
     namespace = "court-probation-dev"
   }
 
-  data {
-    access_key_id     = "${module.court_list_mock_data_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.court_list_mock_data_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.court_list_mock_data_ecr_credentials.repo_arn}"
-    repo_url          = "${module.court_list_mock_data_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.court_list_mock_data_ecr_credentials.access_key_id
+    secret_access_key = module.court_list_mock_data_ecr_credentials.secret_access_key
+    repo_arn          = module.court_list_mock_data_ecr_credentials.repo_arn
+    repo_url          = module.court_list_mock_data_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds.tf
@@ -1,37 +1,40 @@
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 module "auth_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
   application            = "delius oauth2 server"
   is-production          = "false"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   rds_family             = "postgres10"
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "auth_rds" {
   metadata {
     name      = "auth-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.auth_rds.rds_instance_endpoint}"
-    database_name         = "${module.auth_rds.database_name}"
-    database_username     = "${module.auth_rds.database_username}"
-    database_password     = "${module.auth_rds.database_password}"
-    rds_instance_address  = "${module.auth_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.auth_rds.rds_instance_endpoint
+    database_name         = module.auth_rds.database_name
+    database_username     = module.auth_rds.database_username
+    database_password     = module.auth_rds.database_password
+    rds_instance_address  = module.auth_rds.rds_instance_address
     url                   = "postgres://${module.auth_rds.database_username}:${module.auth_rds.database_password}@${module.auth_rds.rds_instance_endpoint}/${module.auth_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/variables.tf
@@ -21,3 +21,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/dynamodb.tf
@@ -5,13 +5,13 @@
  *
  */
 module "court_case_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.0"
 
   team_name              = "court-probation-team"
   application            = "Court Case Service"
-  business-unit          = "${var.business-unit}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  business-unit          = var.business-unit
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   is-production          = "false"
 
   hash_key  = "pk"
@@ -21,13 +21,14 @@ module "court_case_dynamodb" {
 resource "kubernetes_secret" "court_case_dynamodb" {
   metadata {
     name      = "court-case-dynamodb-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    table_name        = "${module.court_case_dynamodb.table_name}"
-    table_arn         = "${module.court_case_dynamodb.table_arn}"
-    access_key_id     = "${module.court_case_dynamodb.access_key_id}"
-    secret_access_key = "${module.court_case_dynamodb.secret_access_key}"
+  data = {
+    table_name        = module.court_case_dynamodb.table_name
+    table_arn         = module.court_case_dynamodb.table_arn
+    access_key_id     = module.court_case_dynamodb.access_key_id
+    secret_access_key = module.court_case_dynamodb.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
@@ -1,37 +1,40 @@
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 module "auth_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  rds_family             = "${var.rds-family}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+  rds_family             = var.rds-family
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "auth_rds" {
   metadata {
     name      = "auth-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.auth_rds.rds_instance_endpoint}"
-    database_name         = "${module.auth_rds.database_name}"
-    database_username     = "${module.auth_rds.database_username}"
-    database_password     = "${module.auth_rds.database_password}"
-    rds_instance_address  = "${module.auth_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.auth_rds.rds_instance_endpoint
+    database_name         = module.auth_rds.database_name
+    database_username     = module.auth_rds.database_username
+    database_password     = module.auth_rds.database_password
+    rds_instance_address  = module.auth_rds.rds_instance_address
     url                   = "postgres://${module.auth_rds.database_username}:${module.auth_rds.database_password}@${module.auth_rds.rds_instance_endpoint}/${module.auth_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/variables.tf
@@ -33,3 +33,4 @@ variable "is-production" {
 variable "rds-family" {
   default = "postgres10"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/dynamodb.tf
@@ -5,13 +5,13 @@
  *
  */
 module "court_case_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.0"
 
   team_name              = "court-probation-team"
   application            = "Court Case Service"
-  business-unit          = "${var.business-unit}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  business-unit          = var.business-unit
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   is-production          = "false"
 
   hash_key  = "pk"
@@ -21,13 +21,14 @@ module "court_case_dynamodb" {
 resource "kubernetes_secret" "court_case_dynamodb" {
   metadata {
     name      = "court-case-dynamodb-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    table_name        = "${module.court_case_dynamodb.table_name}"
-    table_arn         = "${module.court_case_dynamodb.table_arn}"
-    access_key_id     = "${module.court_case_dynamodb.access_key_id}"
-    secret_access_key = "${module.court_case_dynamodb.secret_access_key}"
+  data = {
+    table_name        = module.court_case_dynamodb.table_name
+    table_arn         = module.court_case_dynamodb.table_arn
+    access_key_id     = module.court_case_dynamodb.access_key_id
+    secret_access_key = module.court_case_dynamodb.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds.tf
@@ -1,37 +1,40 @@
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 module "auth_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  rds_family             = "${var.rds-family}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+  rds_family             = var.rds-family
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "auth_rds" {
   metadata {
     name      = "auth-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.auth_rds.rds_instance_endpoint}"
-    database_name         = "${module.auth_rds.database_name}"
-    database_username     = "${module.auth_rds.database_username}"
-    database_password     = "${module.auth_rds.database_password}"
-    rds_instance_address  = "${module.auth_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.auth_rds.rds_instance_endpoint
+    database_name         = module.auth_rds.database_name
+    database_username     = module.auth_rds.database_username
+    database_password     = module.auth_rds.database_password
+    rds_instance_address  = module.auth_rds.rds_instance_address
     url                   = "postgres://${module.auth_rds.database_username}:${module.auth_rds.database_password}@${module.auth_rds.rds_instance_endpoint}/${module.auth_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/variables.tf
@@ -33,3 +33,4 @@ variable "is-production" {
 variable "rds-family" {
   default = "postgres10"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/elasticache.tf
@@ -4,9 +4,9 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "correspondence"
   business-unit          = "Central Digital"
   application            = "track-a-query"
@@ -15,7 +15,7 @@ module "track_a_query_elasticache_redis" {
   infrastructure-support = "mohammed.seedat@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -25,9 +25,10 @@ resource "kubernetes_secret" "track_a_query_elasticache_redis" {
     namespace = "cts-prototype-dev-poc"
   }
 
-  data {
-    primary_endpoint_address = "${module.track_a_query_elasticache_redis.primary_endpoint_address}"
-    auth_token               = "${module.track_a_query_elasticache_redis.auth_token}"
+  data = {
+    primary_endpoint_address = module.track_a_query_elasticache_redis.primary_endpoint_address
+    auth_token               = module.track_a_query_elasticache_redis.auth_token
     url                      = "rediss://appuser:${module.track_a_query_elasticache_redis.auth_token}@${module.track_a_query_elasticache_redis.primary_endpoint_address}:6379"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/rds.tf
@@ -4,9 +4,9 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "correspondence"
   business-unit              = "Central Digital"
   application                = "track-a-query"
@@ -30,7 +30,7 @@ module "track_a_query_rds" {
   allow_major_version_upgrade = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -40,12 +40,13 @@ resource "kubernetes_secret" "track_a_query_rds" {
     namespace = "cts-prototype-dev-poc"
   }
 
-  data {
-    rds_instance_endpoint = "${module.track_a_query_rds.rds_instance_endpoint}"
-    database_name         = "${module.track_a_query_rds.database_name}"
-    database_username     = "${module.track_a_query_rds.database_username}"
-    database_password     = "${module.track_a_query_rds.database_password}"
-    rds_instance_address  = "${module.track_a_query_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.track_a_query_rds.rds_instance_endpoint
+    database_name         = module.track_a_query_rds.database_name
+    database_username     = module.track_a_query_rds.database_username
+    database_password     = module.track_a_query_rds.database_password
+    rds_instance_address  = module.track_a_query_rds.rds_instance_address
     url                   = "postgres://${module.track_a_query_rds.database_username}:${module.track_a_query_rds.database_password}@${module.track_a_query_rds.rds_instance_endpoint}/${module.track_a_query_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"
@@ -14,7 +14,7 @@ module "track_a_query_s3" {
   infrastructure-support = "mohammed.seedat@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,10 +24,11 @@ resource "kubernetes_secret" "track_a_query_s3" {
     namespace = "cts-prototype-dev-poc"
   }
 
-  data {
-    access_key_id     = "${module.track_a_query_s3.access_key_id}"
-    secret_access_key = "${module.track_a_query_s3.secret_access_key}"
-    bucket_arn        = "${module.track_a_query_s3.bucket_arn}"
-    bucket_name       = "${module.track_a_query_s3.bucket_name}"
+  data = {
+    access_key_id     = module.track_a_query_s3.access_key_id
+    secret_access_key = module.track_a_query_s3.secret_access_key
+    bucket_arn        = module.track_a_query_s3.bucket_arn
+    bucket_name       = module.track_a_query_s3.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/variables.tf
@@ -3,5 +3,9 @@
  * two variables are automatically supplied by the pipeline.
  */
 
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/elasticache.tf
@@ -1,33 +1,36 @@
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
-  number_cache_clusters  = "${var.number_cache_clusters}"
-  node_type              = "${var.node-type}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = var.node-type
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "dps_redis" {
   metadata {
     name      = "dps-redis"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    REDIS_HOST      = "${module.dps_redis.primary_endpoint_address}"
-    REDIS_PASSWORD  = "${module.dps_redis.auth_token}"
-    member_clusters = "${jsonencode(module.dps_redis.member_clusters)}"
+  data = {
+    REDIS_HOST      = module.dps_redis.primary_endpoint_address
+    REDIS_PASSWORD  = module.dps_redis.auth_token
+    member_clusters = jsonencode(module.dps_redis.member_clusters)
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/variables.tf
@@ -37,3 +37,4 @@ variable "node-type" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/elasticache.tf
@@ -1,33 +1,36 @@
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
-  number_cache_clusters  = "${var.number_cache_clusters}"
-  node_type              = "${var.node-type}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = var.node-type
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "dps_redis" {
   metadata {
     name      = "dps-redis"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    REDIS_HOST      = "${module.dps_redis.primary_endpoint_address}"
-    REDIS_PASSWORD  = "${module.dps_redis.auth_token}"
-    member_clusters = "${jsonencode(module.dps_redis.member_clusters)}"
+  data = {
+    REDIS_HOST      = module.dps_redis.primary_endpoint_address
+    REDIS_PASSWORD  = module.dps_redis.auth_token
+    member_clusters = jsonencode(module.dps_redis.member_clusters)
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/variables.tf
@@ -37,3 +37,4 @@ variable "node-type" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
@@ -3,25 +3,26 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.repo_name}"
+  team_name = var.team_name
+  repo_name = var.repo_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
     name      = "ecr-repo-disclosure-checker"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    repo_url          = "${module.ecr-repo.repo_url}"
-    access_key_id     = "${module.ecr-repo.access_key_id}"
-    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
@@ -3,31 +3,32 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = true
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-disclosure-checker-staging"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ecr.tf
@@ -1,10 +1,10 @@
 module "dstest_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "dstest"
   team_name = "webops"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -14,10 +14,11 @@ resource "kubernetes_secret" "dstest_ecr_credentials" {
     namespace = "dstest"
   }
 
-  data {
-    access_key_id     = "${module.dstest_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.dstest_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.dstest_ecr_credentials.repo_arn}"
-    repo_url          = "${module.dstest_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.dstest_ecr_credentials.access_key_id
+    secret_access_key = module.dstest_ecr_credentials.secret_access_key
+    repo_arn          = module.dstest_ecr_credentials.repo_arn
+    repo_url          = module.dstest_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
@@ -3,25 +3,26 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.repo_name}"
+  team_name = var.team_name
+  repo_name = var.repo_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
     name      = "ecr-repo-family-mediators-api"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    repo_url          = "${module.ecr-repo.repo_url}"
-    access_key_id     = "${module.ecr-repo.access_key_id}"
-    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
@@ -3,31 +3,32 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = true
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-family-mediators-api-staging"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ecr.tf
@@ -3,25 +3,26 @@
 ####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.repo_name}"
+  team_name = var.team_name
+  repo_name = var.repo_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
     name      = "ecr-repo-fj-cait"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    repo_url          = "${module.ecr-repo.repo_url}"
-    access_key_id     = "${module.ecr-repo.access_key_id}"
-    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/variables.tf
@@ -31,6 +31,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
@@ -1,17 +1,17 @@
 module "json-output-attachments-s3-bucket" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   acl                    = "private"
   versioning             = false
   business-unit          = "transformed-department"
   application            = "formbuilderuserfilestore"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -31,19 +31,18 @@ module "json-output-attachments-s3-bucket" {
 }
 EOF
 
+
   lifecycle_rule = [
     {
       enabled                                = true
       id                                     = "expire-7d"
       prefix                                 = "7d/"
       abort_incomplete_multipart_upload_days = 7
-
       expiration = [
         {
           days = 7
         },
       ]
-
       noncurrent_version_expiration = [
         {
           days = 7
@@ -59,10 +58,11 @@ resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
-    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
-    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
-    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  data = {
+    access_key_id     = module.json-output-attachments-s3-bucket.access_key_id
+    bucket_arn        = module.json-output-attachments-s3-bucket.bucket_arn
+    bucket_name       = module.json-output-attachments-s3-bucket.bucket_name
+    secret_access_key = module.json-output-attachments-s3-bucket.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/main.tf
@@ -1,7 +1,7 @@
 # auto-generated from fb-cloud-platforms-environments
 terraform {
-
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -12,3 +12,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/main.tf
@@ -1,6 +1,6 @@
 # auto-generated from fb-cloud-platforms-environments
 terraform {
-  required_version = "0.11.14"
+
   backend          "s3"             {}
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
@@ -1,5 +1,5 @@
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
@@ -1,17 +1,17 @@
 module "service-token-cache-elasticache" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
   application            = "formbuilderservice-token-cache"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -21,8 +21,9 @@ resource "kubernetes_secret" "service-token-cache-elasticache" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    primary_endpoint_address = "${module.service-token-cache-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.service-token-cache-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.service-token-cache-elasticache.primary_endpoint_address
+    auth_token               = module.service-token-cache-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
@@ -1,5 +1,5 @@
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
@@ -1,20 +1,20 @@
 module "submitter-rds-instance" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_submitter}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_submitter
   application                = "formbuildersubmitter"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "submitter-rds-instance" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
   cluster_name               = "${var.cluster_name}"
   cluster_state_bucket       = "${var.cluster_state_bucket}"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -1,20 +1,20 @@
 module "user-datastore-rds-instance" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_user_datastore}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_user_datastore
   application                = "formbuilderuserdatastore"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "user-datastore-rds-instance" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "${var.team_name}"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
@@ -4,17 +4,17 @@
 module "user-filestore-s3-bucket" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   acl                    = "private"
   versioning             = false
   business-unit          = "transformed-department"
   application            = "formbuilderuserfilestore"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -63,19 +63,18 @@ module "user-filestore-s3-bucket" {
 }
 EOF
 
+
   lifecycle_rule = [
     {
       enabled                                = true
       id                                     = "expire-28d"
       prefix                                 = "28d/"
       abort_incomplete_multipart_upload_days = 28
-
       expiration = [
         {
           days = 28
         },
       ]
-
       noncurrent_version_expiration = [
         {
           days = 28
@@ -91,10 +90,11 @@ resource "kubernetes_secret" "user-filestore-s3-bucket" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    access_key_id     = "${module.user-filestore-s3-bucket.access_key_id}"
-    bucket_arn        = "${module.user-filestore-s3-bucket.bucket_arn}"
-    bucket_name       = "${module.user-filestore-s3-bucket.bucket_name}"
-    secret_access_key = "${module.user-filestore-s3-bucket.secret_access_key}"
+  data = {
+    access_key_id     = module.user-filestore-s3-bucket.access_key_id
+    bucket_arn        = module.user-filestore-s3-bucket.bucket_arn
+    bucket_name       = module.user-filestore-s3-bucket.bucket_name
+    secret_access_key = module.user-filestore-s3-bucket.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/variables.tf
@@ -24,6 +24,9 @@ variable "infrastructure-support" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
@@ -1,17 +1,17 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   acl                    = "private"
   versioning             = false
   business-unit          = "transformed-department"
   application            = "formbuilderuserfilestore"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -31,19 +31,18 @@ module "json-output-attachments-s3-bucket" {
 }
 EOF
 
+
   lifecycle_rule = [
     {
       enabled                                = true
       id                                     = "expire-7d"
       prefix                                 = "7d/"
       abort_incomplete_multipart_upload_days = 7
-
       expiration = [
         {
           days = 7
         },
       ]
-
       noncurrent_version_expiration = [
         {
           days = 7
@@ -59,10 +58,11 @@ resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
-    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
-    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
-    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  data = {
+    access_key_id     = module.json-output-attachments-s3-bucket.access_key_id
+    bucket_arn        = module.json-output-attachments-s3-bucket.bucket_arn
+    bucket_name       = module.json-output-attachments-s3-bucket.bucket_name
+    secret_access_key = module.json-output-attachments-s3-bucket.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/main.tf
@@ -1,7 +1,7 @@
 # auto-generated from fb-cloud-platforms-environments
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -12,3 +12,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
@@ -1,5 +1,5 @@
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
@@ -1,17 +1,17 @@
 module "service-token-cache-elasticache" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
   application            = "formbuilderservice-token-cache"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -21,8 +21,9 @@ resource "kubernetes_secret" "service-token-cache-elasticache" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    primary_endpoint_address = "${module.service-token-cache-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.service-token-cache-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.service-token-cache-elasticache.primary_endpoint_address
+    auth_token               = module.service-token-cache-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
@@ -1,20 +1,20 @@
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_submitter}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_submitter
   application                = "formbuildersubmitter"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "submitter-rds-instance" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -1,20 +1,20 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_user_datastore}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_user_datastore
   application                = "formbuilderuserdatastore"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "user-datastore-rds-instance" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
@@ -2,19 +2,19 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   acl                    = "private"
   versioning             = false
   business-unit          = "transformed-department"
   application            = "formbuilderuserfilestore"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -63,19 +63,18 @@ module "user-filestore-s3-bucket" {
 }
 EOF
 
+
   lifecycle_rule = [
     {
       enabled                                = true
       id                                     = "expire-28d"
       prefix                                 = "28d/"
       abort_incomplete_multipart_upload_days = 28
-
       expiration = [
         {
           days = 28
         },
       ]
-
       noncurrent_version_expiration = [
         {
           days = 28
@@ -91,10 +90,11 @@ resource "kubernetes_secret" "user-filestore-s3-bucket" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    access_key_id     = "${module.user-filestore-s3-bucket.access_key_id}"
-    bucket_arn        = "${module.user-filestore-s3-bucket.bucket_arn}"
-    bucket_name       = "${module.user-filestore-s3-bucket.bucket_name}"
-    secret_access_key = "${module.user-filestore-s3-bucket.secret_access_key}"
+  data = {
+    access_key_id     = module.user-filestore-s3-bucket.access_key_id
+    bucket_arn        = module.user-filestore-s3-bucket.bucket_arn
+    bucket_name       = module.user-filestore-s3-bucket.bucket_name
+    secret_access_key = module.user-filestore-s3-bucket.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/variables.tf
@@ -24,6 +24,9 @@ variable "infrastructure-support" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/json-output-attachments-s3.tf
@@ -1,17 +1,17 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   acl                    = "private"
   versioning             = false
   business-unit          = "transformed-department"
   application            = "formbuilderuserfilestore"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -31,19 +31,18 @@ module "json-output-attachments-s3-bucket" {
 }
 EOF
 
+
   lifecycle_rule = [
     {
       enabled                                = true
       id                                     = "expire-7d"
       prefix                                 = "7d/"
       abort_incomplete_multipart_upload_days = 7
-
       expiration = [
         {
           days = 7
         },
       ]
-
       noncurrent_version_expiration = [
         {
           days = 7
@@ -59,10 +58,11 @@ resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
-    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
-    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
-    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  data = {
+    access_key_id     = module.json-output-attachments-s3-bucket.access_key_id
+    bucket_arn        = module.json-output-attachments-s3-bucket.bucket_arn
+    bucket_name       = module.json-output-attachments-s3-bucket.bucket_name
+    secret_access_key = module.json-output-attachments-s3-bucket.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/main.tf
@@ -1,7 +1,7 @@
 # auto-generated from fb-cloud-platforms-environments
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -12,3 +12,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
@@ -1,5 +1,5 @@
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
@@ -1,17 +1,17 @@
 module "service-token-cache-elasticache" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
   application            = "formbuilderservice-token-cache"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -21,8 +21,9 @@ resource "kubernetes_secret" "service-token-cache-elasticache" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    primary_endpoint_address = "${module.service-token-cache-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.service-token-cache-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.service-token-cache-elasticache.primary_endpoint_address
+    auth_token               = module.service-token-cache-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/submitter.tf
@@ -1,20 +1,20 @@
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_submitter}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_submitter
   application                = "formbuildersubmitter"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "submitter-rds-instance" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-datastore.tf
@@ -1,20 +1,20 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_user_datastore}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_user_datastore
   application                = "formbuilderuserdatastore"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "user-datastore-rds-instance" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-filestore.tf
@@ -2,19 +2,19 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   acl                    = "private"
   versioning             = false
   business-unit          = "transformed-department"
   application            = "formbuilderuserfilestore"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -63,19 +63,18 @@ module "user-filestore-s3-bucket" {
 }
 EOF
 
+
   lifecycle_rule = [
     {
       enabled                                = true
       id                                     = "expire-28d"
       prefix                                 = "28d/"
       abort_incomplete_multipart_upload_days = 28
-
       expiration = [
         {
           days = 28
         },
       ]
-
       noncurrent_version_expiration = [
         {
           days = 28
@@ -91,10 +90,11 @@ resource "kubernetes_secret" "user-filestore-s3-bucket" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    access_key_id     = "${module.user-filestore-s3-bucket.access_key_id}"
-    bucket_arn        = "${module.user-filestore-s3-bucket.bucket_arn}"
-    bucket_name       = "${module.user-filestore-s3-bucket.bucket_name}"
-    secret_access_key = "${module.user-filestore-s3-bucket.secret_access_key}"
+  data = {
+    access_key_id     = module.user-filestore-s3-bucket.access_key_id
+    bucket_arn        = module.user-filestore-s3-bucket.bucket_arn
+    bucket_name       = module.user-filestore-s3-bucket.bucket_name
+    secret_access_key = module.user-filestore-s3-bucket.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/variables.tf
@@ -24,6 +24,9 @@ variable "infrastructure-support" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/main.tf
@@ -1,7 +1,7 @@
 # auto-generated from fb-cloud-platforms-environments
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -12,3 +12,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
@@ -34,7 +34,7 @@ resource "kubernetes_secret" "publisher-rds-instance" {
 ########################################################
 # Publisher Elasticache Redis (for resque + job logging)
 module "publisher-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
@@ -1,19 +1,19 @@
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period
   application                = "formbuilderpublisher"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -23,7 +23,7 @@ resource "kubernetes_secret" "publisher-rds-instance" {
     namespace = "formbuilder-publisher-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.publisher-rds-instance.database_username}:${module.publisher-rds-instance.database_password}@${module.publisher-rds-instance.rds_instance_endpoint}/${module.publisher-rds-instance.database_name}"
   }
@@ -36,17 +36,17 @@ resource "kubernetes_secret" "publisher-rds-instance" {
 module "publisher-elasticache" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
   application            = "formbuilderpublisher"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -56,8 +56,9 @@ resource "kubernetes_secret" "publisher-elasticache" {
     namespace = "formbuilder-publisher-${var.environment-name}"
   }
 
-  data {
-    primary_endpoint_address = "${module.publisher-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.publisher-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.publisher-elasticache.primary_endpoint_address
+    auth_token               = module.publisher-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/variables.tf
@@ -20,6 +20,9 @@ variable "infrastructure-support" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Updated below namespaces


check-financial-eligibility-staging
check-financial-eligibility-uat
check-my-diary-dev
check-my-diary-preprod
cica-apply-for-compensation-uat
cica-oas-basic-testing
claim-criminal-injuries-compensation-dev
claim-criminal-injuries-compensation-staging
claim-criminal-injuries-compensation-uat
common-platform-connector-dev
correspondence-staff-staging
court-probation-dev
court-probation-preprod
court-probation-prod
cp-terraform-module-testing
cts-prototype-dev-poc
digital-prison-services-dev
digital-prison-services-preprod
disclosure-checker-staging
dps-welcome-dev
dstest
family-mediators-api-staging
fj-cait-staging
formbuilder-monitoring
formbuilder-platform-test-dev
formbuilder-platform-test-production
formbuilder-publisher-test
formbuilder-services-test-dev
formbuilder-services-test-production



Terraform 0.12 upgrade and update modules version to use the tf0.12
