### PR TITLE
Tf 12 upgrade on environment repo for non-prod namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -1,20 +1,20 @@
 module "hmcts-complaints-adapter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_hmcts_complaints_adapter}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_hmcts_complaints_adapter
   application                = "hmcts-complaints-formbuilder-adapter"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "11.4"
   rds_family                 = "postgres11"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "hmcts-complaints-adapter-rds-instance" {
     namespace = "hmcts-complaints-formbuilder-adapter-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.hmcts-complaints-adapter-rds-instance.database_username}:${module.hmcts-complaints-adapter-rds-instance.database_password}@${module.hmcts-complaints-adapter-rds-instance.rds_instance_endpoint}/${module.hmcts-complaints-adapter-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/variables.tf
@@ -9,9 +9,11 @@ variable "environment-name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "db_backup_retention_period_hmcts_complaints_adapter" {
   default = "2"
@@ -25,3 +27,4 @@ variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "Form Builder form-builder-team@digital.justice.gov.uk"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/ecr.tf
@@ -5,14 +5,14 @@
  *
  */
 module "laa_crime_apps_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "hmcts-common-platform-mock-api"
   team_name = "laa-crime-apps-team"
 
   # aws_region = "eu-west-2"     # This input is deprecated from version 3.2 of this module
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -22,10 +22,11 @@ resource "kubernetes_secret" "laa_crime_apps_team_ecr_credentials" {
     namespace = "hmcts-mock-api-dev"
   }
 
-  data {
-    access_key_id     = "${module.laa_crime_apps_team_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.laa_crime_apps_team_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.laa_crime_apps_team_ecr_credentials.repo_arn}"
-    repo_url          = "${module.laa_crime_apps_team_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.laa_crime_apps_team_ecr_credentials.access_key_id
+    secret_access_key = module.laa_crime_apps_team_ecr_credentials.secret_access_key
+    repo_arn          = module.laa_crime_apps_team_ecr_credentials.repo_arn
+    repo_url          = module.laa_crime_apps_team_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
@@ -1,11 +1,14 @@
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "hmcts_mock_api_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name                = "${var.cluster_name}"
-  cluster_state_bucket        = "${var.cluster_state_bucket}"
+  cluster_name                = var.cluster_name
+  cluster_state_bucket        = var.cluster_state_bucket
   team_name                   = "laa-crime-apps-team"
   business-unit               = "Crime Apps"
   application                 = "hmcts-common-platform-mock-api"
@@ -18,7 +21,7 @@ module "hmcts_mock_api_rds" {
   allow_major_version_upgrade = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -28,7 +31,8 @@ resource "kubernetes_secret" "hmcts_mock_api_rds" {
     namespace = "hmcts-mock-api-dev"
   }
 
-  data {
+  data = {
     url = "postgres://${module.hmcts_mock_api_rds.database_username}:${module.hmcts_mock_api_rds.database_password}@${module.hmcts_mock_api_rds.rds_instance_endpoint}/${module.hmcts_mock_api_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -1,31 +1,32 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = "false"
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-hmpps-book-secure-move-api-preprod"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.rds-instance.access_key_id}"
-    secret_access_key = "${module.rds-instance.secret_access_key}"
+  data = {
+    access_key_id     = module.rds-instance.access_key_id
+    secret_access_key = module.rds-instance.secret_access_key
     url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/route53.tf
@@ -1,23 +1,24 @@
 resource "aws_route53_zone" "route53_zone" {
-  name = "${var.domain}"
+  name = var.domain
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3.tf
@@ -2,32 +2,33 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   business-unit          = "Digital and Technology"
-  application            = "${var.application}"
-  infrastructure-support = "${var.infrastructure-support}"
+  application            = var.application
+  infrastructure-support = var.infrastructure-support
 
-  is-production    = "${var.is-production}"
-  environment-name = "${var.environment-name}"
+  is-production    = var.is-production
+  environment-name = var.environment-name
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
   metadata {
     name      = "book-a-secure-move-documents-s3-bucket"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.book_a_secure_move_documents_s3_bucket.access_key_id}"
-    secret_access_key = "${module.book_a_secure_move_documents_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.book_a_secure_move_documents_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.book_a_secure_move_documents_s3_bucket.bucket_name}"
+  data = {
+    access_key_id     = module.book_a_secure_move_documents_s3_bucket.access_key_id
+    secret_access_key = module.book_a_secure_move_documents_s3_bucket.secret_access_key
+    bucket_arn        = module.book_a_secure_move_documents_s3_bucket.bucket_arn
+    bucket_name       = module.book_a_secure_move_documents_s3_bucket.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/variables.tf
@@ -35,6 +35,9 @@ variable "domain" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr.tf
@@ -1,23 +1,24 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.repo_name}"
+  team_name = var.team_name
+  repo_name = var.repo_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
     name      = "ecr-repo-hmpps-book-secure-move-api"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    repo_url          = "${module.ecr-repo.repo_url}"
-    access_key_id     = "${module.ecr-repo.access_key_id}"
-    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -1,30 +1,31 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-hmpps-book-secure-move-api-staging"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.rds-instance.access_key_id}"
-    secret_access_key = "${module.rds-instance.secret_access_key}"
+  data = {
+    access_key_id     = module.rds-instance.access_key_id
+    secret_access_key = module.rds-instance.secret_access_key
     url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3.tf
@@ -2,32 +2,33 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   business-unit          = "Digital and Technology"
-  application            = "${var.application}"
-  infrastructure-support = "${var.infrastructure-support}"
+  application            = var.application
+  infrastructure-support = var.infrastructure-support
 
-  is-production    = "${var.is-production}"
-  environment-name = "${var.environment-name}"
+  is-production    = var.is-production
+  environment-name = var.environment-name
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
   metadata {
     name      = "book-a-secure-move-documents-s3-bucket"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.book_a_secure_move_documents_s3_bucket.access_key_id}"
-    secret_access_key = "${module.book_a_secure_move_documents_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.book_a_secure_move_documents_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.book_a_secure_move_documents_s3_bucket.bucket_name}"
+  data = {
+    access_key_id     = module.book_a_secure_move_documents_s3_bucket.access_key_id
+    secret_access_key = module.book_a_secure_move_documents_s3_bucket.secret_access_key
+    bucket_arn        = module.book_a_secure_move_documents_s3_bucket.bucket_arn
+    bucket_name       = module.book_a_secure_move_documents_s3_bucket.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
@@ -1,28 +1,29 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {
   metadata {
     name      = "elasticache-hmpps-book-secure-move-frontend-preprod"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.redis-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.redis-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.redis-elasticache.primary_endpoint_address
+    auth_token               = module.redis-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ecr.tf
@@ -1,19 +1,20 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.repo_name}"
+  team_name = var.team_name
+  repo_name = var.repo_name
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
     name      = "ecr-repo-hmpps-book-secure-move-frontend"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    repo_url          = "${module.ecr-repo.repo_url}"
-    access_key_id     = "${module.ecr-repo.access_key_id}"
-    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -1,28 +1,29 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {
   metadata {
     name      = "elasticache-hmpps-book-secure-move-frontend-staging"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.redis-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.redis-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.redis-elasticache.primary_endpoint_address
+    auth_token               = module.redis-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/jason-lab-rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/jason-lab-rds.tf
@@ -1,17 +1,17 @@
 module "jason-lab-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -21,8 +21,9 @@ resource "kubernetes_secret" "jason-lab-rds-instance" {
     namespace = "jason-lab"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.jason-lab-rds-instance.database_username}:${module.jason-lab-rds-instance.database_password}@${module.jason-lab-rds-instance.rds_instance_endpoint}/${module.jason-lab-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/variables.tf
@@ -74,6 +74,9 @@ variable "rds_family" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/rds.tf
@@ -1,33 +1,34 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {
     name      = "dps-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.dps_rds.rds_instance_endpoint}"
-    database_name         = "${module.dps_rds.database_name}"
-    database_username     = "${module.dps_rds.database_username}"
-    database_password     = "${module.dps_rds.database_password}"
-    rds_instance_address  = "${module.dps_rds.rds_instance_address}"
-    access_key_id         = "${module.dps_rds.access_key_id}"
-    secret_access_key     = "${module.dps_rds.secret_access_key}"
+  data = {
+    rds_instance_endpoint = module.dps_rds.rds_instance_endpoint
+    database_name         = module.dps_rds.database_name
+    database_username     = module.dps_rds.database_username
+    database_password     = module.dps_rds.database_password
+    rds_instance_address  = module.dps_rds.rds_instance_address
+    access_key_id         = module.dps_rds.access_key_id
+    secret_access_key     = module.dps_rds.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/variables.tf
@@ -6,9 +6,11 @@ variable "namespace" {
   default = "keyworker-api-dev"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -33,3 +35,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
@@ -1,33 +1,34 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {
     name      = "dps-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.dps_rds.rds_instance_endpoint}"
-    database_name         = "${module.dps_rds.database_name}"
-    database_username     = "${module.dps_rds.database_username}"
-    database_password     = "${module.dps_rds.database_password}"
-    rds_instance_address  = "${module.dps_rds.rds_instance_address}"
-    access_key_id         = "${module.dps_rds.access_key_id}"
-    secret_access_key     = "${module.dps_rds.secret_access_key}"
+  data = {
+    rds_instance_endpoint = module.dps_rds.rds_instance_endpoint
+    database_name         = module.dps_rds.database_name
+    database_username     = module.dps_rds.database_username
+    database_password     = module.dps_rds.database_password
+    rds_instance_address  = module.dps_rds.rds_instance_address
+    access_key_id         = module.dps_rds.access_key_id
+    secret_access_key     = module.dps_rds.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/variables.tf
@@ -6,9 +6,11 @@ variable "namespace" {
   default = "keyworker-api-preprod"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -33,3 +35,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
@@ -5,10 +5,10 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "apply-for-legal-aid"
   business-unit          = "laa"
   application            = "laa-apply-for-legal-aid"
@@ -17,7 +17,7 @@ module "apply-for-legal-aid-elasticache" {
   infrastructure-support = "apply@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -27,9 +27,10 @@ resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
     namespace = "laa-apply-for-legalaid-staging"
   }
 
-  data {
-    primary_endpoint_address = "${module.apply-for-legal-aid-elasticache.primary_endpoint_address}"
-    member_clusters          = "${jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)}"
-    auth_token               = "${module.apply-for-legal-aid-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.apply-for-legal-aid-elasticache.primary_endpoint_address
+    member_clusters          = jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)
+    auth_token               = module.apply-for-legal-aid-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -25,6 +25,9 @@ provider "aws" {
  *
  */
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -5,10 +5,10 @@
  *
  */
 module "apply-for-legal-aid-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "apply-for-legal-aid"
   business-unit          = "laa"
   application            = "laa-apply-for-legal-aid"
@@ -21,7 +21,7 @@ module "apply-for-legal-aid-rds" {
   rds_family             = "postgres11"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -31,15 +31,15 @@ resource "kubernetes_secret" "apply-for-legal-aid-rds" {
     namespace = "laa-apply-for-legalaid-staging"
   }
 
-  data {
-    rds_instance_endpoint = "${module.apply-for-legal-aid-rds.rds_instance_endpoint}"
-    database_name         = "${module.apply-for-legal-aid-rds.database_name}"
-    database_username     = "${module.apply-for-legal-aid-rds.database_username}"
-    database_password     = "${module.apply-for-legal-aid-rds.database_password}"
-    rds_instance_address  = "${module.apply-for-legal-aid-rds.rds_instance_address}"
-    access_key_id         = "${module.apply-for-legal-aid-rds.access_key_id}"
-    secret_access_key     = "${module.apply-for-legal-aid-rds.secret_access_key}"
-
-    url = "postgres://${module.apply-for-legal-aid-rds.database_username}:${module.apply-for-legal-aid-rds.database_password}@${module.apply-for-legal-aid-rds.rds_instance_endpoint}/${module.apply-for-legal-aid-rds.database_name}"
+  data = {
+    rds_instance_endpoint = module.apply-for-legal-aid-rds.rds_instance_endpoint
+    database_name         = module.apply-for-legal-aid-rds.database_name
+    database_username     = module.apply-for-legal-aid-rds.database_username
+    database_password     = module.apply-for-legal-aid-rds.database_password
+    rds_instance_address  = module.apply-for-legal-aid-rds.rds_instance_address
+    access_key_id         = module.apply-for-legal-aid-rds.access_key_id
+    secret_access_key     = module.apply-for-legal-aid-rds.secret_access_key
+    url                   = "postgres://${module.apply-for-legal-aid-rds.database_username}:${module.apply-for-legal-aid-rds.database_password}@${module.apply-for-legal-aid-rds.rds_instance_endpoint}/${module.apply-for-legal-aid-rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"
@@ -10,7 +10,7 @@ module "authorized-keys" {
   infrastructure-support = "apply@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -20,9 +20,10 @@ resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
     namespace = "laa-apply-for-legalaid-staging"
   }
 
-  data {
-    bucket_name       = "${module.authorized-keys.bucket_name}"
-    access_key_id     = "${module.authorized-keys.access_key_id}"
-    secret_access_key = "${module.authorized-keys.secret_access_key}"
+  data = {
+    bucket_name       = module.authorized-keys.bucket_name
+    access_key_id     = module.authorized-keys.access_key_id
+    secret_access_key = module.authorized-keys.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
@@ -5,10 +5,10 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "apply-for-legal-aid"
   business-unit          = "laa"
   application            = "laa-apply-for-legal-aid"
@@ -17,7 +17,7 @@ module "apply-for-legal-aid-elasticache" {
   infrastructure-support = "apply@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -27,9 +27,10 @@ resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
     namespace = "laa-apply-for-legalaid-uat"
   }
 
-  data {
-    primary_endpoint_address = "${module.apply-for-legal-aid-elasticache.primary_endpoint_address}"
-    member_clusters          = "${jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)}"
-    auth_token               = "${module.apply-for-legal-aid-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.apply-for-legal-aid-elasticache.primary_endpoint_address
+    member_clusters          = jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)
+    auth_token               = module.apply-for-legal-aid-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -25,6 +25,9 @@ provider "aws" {
  *
  */
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"
@@ -10,7 +10,7 @@ module "authorized-keys" {
   infrastructure-support = "apply@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -20,9 +20,10 @@ resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
     namespace = "laa-apply-for-legalaid-uat"
   }
 
-  data {
-    bucket_name       = "${module.authorized-keys.bucket_name}"
-    access_key_id     = "${module.authorized-keys.access_key_id}"
-    secret_access_key = "${module.authorized-keys.secret_access_key}"
+  data = {
+    bucket_name       = module.authorized-keys.bucket_name
+    access_key_id     = module.authorized-keys.access_key_id
+    secret_access_key = module.authorized-keys.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-aws-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-aws-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-aws-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-aws-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/main.tf
@@ -1,5 +1,6 @@
 terraform {
-  backend "s3" {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -15,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/ecr.tf
@@ -5,12 +5,12 @@
  *
  */
 module "laa_crime_apps_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "laa-court-data-adaptor"
   team_name = "laa-crime-apps-team"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -20,10 +20,11 @@ resource "kubernetes_secret" "laa_crime_apps_team_ecr_credentials" {
     namespace = "laa-court-data-adaptor-dev"
   }
 
-  data {
-    access_key_id     = "${module.laa_crime_apps_team_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.laa_crime_apps_team_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.laa_crime_apps_team_ecr_credentials.repo_arn}"
-    repo_url          = "${module.laa_crime_apps_team_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.laa_crime_apps_team_ecr_credentials.access_key_id
+    secret_access_key = module.laa_crime_apps_team_ecr_credentials.secret_access_key
+    repo_arn          = module.laa_crime_apps_team_ecr_credentials.repo_arn
+    repo_url          = module.laa_crime_apps_team_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds.tf
@@ -4,9 +4,11 @@
  *
  */
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 /*
  * Make sure that you use the latest version of the module by changing the
@@ -15,9 +17,9 @@ variable "cluster_state_bucket" {}
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
   team_name            = "laa-crime-apps-team"
   business-unit        = "Crime Apps"
   application          = "laa-court-data-adaptor"
@@ -41,7 +43,7 @@ module "laa_crime_apps_team_rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -51,7 +53,8 @@ resource "kubernetes_secret" "laa_crime_apps_team_rds" {
     namespace = "laa-court-data-adaptor-dev"
   }
 
-  data {
+  data = {
     url = "postgres://${module.laa_crime_apps_team_rds.database_username}:${module.laa_crime_apps_team_rds.database_password}@${module.laa_crime_apps_team_rds.rds_instance_endpoint}/${module.laa_crime_apps_team_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/ecr.tf
@@ -1,23 +1,24 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.repo_name}"
+  team_name = var.team_name
+  repo_name = var.repo_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
     name      = "ecr-repo-laa-fala"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    repo_url          = "${module.ecr-repo.repo_url}"
-    access_key_id     = "${module.ecr-repo.access_key_id}"
-    secret_access_key = "${module.ecr-repo.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
@@ -1,29 +1,30 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.email}"
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.email
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "s3" {
   metadata {
     name      = "s3"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.s3.access_key_id}"
-    secret_access_key = "${module.s3.secret_access_key}"
-    bucket_arn        = "${module.s3.bucket_arn}"
-    bucket_name       = "${module.s3.bucket_name}"
+  data = {
+    access_key_id     = module.s3.access_key_id
+    secret_access_key = module.s3.secret_access_key
+    bucket_arn        = module.s3.bucket_arn
+    bucket_name       = module.s3.bucket_name
     region            = "eu-west-2"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/variable.tf
@@ -29,3 +29,4 @@ variable "environment-name" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ecr.tf
@@ -5,25 +5,26 @@
  *
  */
 module "laa_fee_caclulator_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
-  repo_name = "${var.repo_name}"
-  team_name = "${var.team_name}"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+  repo_name = var.repo_name
+  team_name = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "laa_fee_caclulator_team_ecr_credentials" {
   metadata {
     name      = "laa-fee-caclulator-team-ecr-credentials-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.laa_fee_caclulator_team_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.laa_fee_caclulator_team_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.laa_fee_caclulator_team_ecr_credentials.repo_arn}"
-    repo_url          = "${module.laa_fee_caclulator_team_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.laa_fee_caclulator_team_ecr_credentials.access_key_id
+    secret_access_key = module.laa_fee_caclulator_team_ecr_credentials.secret_access_key
+    repo_arn          = module.laa_fee_caclulator_team_ecr_credentials.repo_arn
+    repo_url          = module.laa_fee_caclulator_team_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/route53.tf
@@ -1,23 +1,24 @@
 resource "aws_route53_zone" "laa_fee_calculator_route53_zone" {
-  name = "${var.domain}"
+  name = var.domain
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "laa_fee_calculator_route53_zone_sec" {
   metadata {
     name      = "laa-fee-calculator-route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.laa_fee_calculator_route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.laa_fee_calculator_route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/variables.tf
@@ -39,6 +39,9 @@ variable "is-production" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
@@ -1,11 +1,11 @@
 module "ecr-repo-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
-  repo_name = "${var.repo_name}"
+  team_name = var.team_name
+  repo_name = var.repo_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -15,9 +15,10 @@ resource "kubernetes_secret" "ecr-repo-api" {
     namespace = "laa-legal-adviser-api-staging"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-api.repo_url}"
-    access_key_id     = "${module.ecr-repo-api.access_key_id}"
-    secret_access_key = "${module.ecr-repo-api.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-api.repo_url
+    access_key_id     = module.ecr-repo-api.access_key_id
+    secret_access_key = module.ecr-repo-api.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/elasticache.tf
@@ -1,28 +1,29 @@
 module "celery-broker" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  application            = var.application
+  is-production          = var.is-production
   node_type              = "cache.t2.micro"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.email}"
+  environment-name       = var.environment-name
+  infrastructure-support = var.email
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "celery-broker" {
   metadata {
     name      = "celery-broker"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
+  data = {
     url                      = "redis://:${module.celery-broker.auth_token}@${module.celery-broker.primary_endpoint_address}:6379"
-    primary_endpoint_address = "${module.celery-broker.primary_endpoint_address}"
-    auth_token               = "${module.celery-broker.auth_token}"
+    primary_endpoint_address = module.celery-broker.primary_endpoint_address
+    auth_token               = module.celery-broker.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/pingdom.tf
@@ -1,4 +1,5 @@
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 resource "pingdom_check" "laa-legal-adviser-api-search" {
   type                     = "http"
@@ -15,3 +16,4 @@ resource "pingdom_check" "laa-legal-adviser-api-search" {
   probefilters             = "region:EU"
   integrationids           = [87631]
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
@@ -1,17 +1,20 @@
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.email}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.email
   db_engine              = "postgres"
   db_engine_version      = "9.4"
   db_instance_class      = "db.t2.small"
@@ -21,23 +24,24 @@ module "rds" {
   rds_family             = "postgres9.4"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "db" {
   metadata {
     name      = "db"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    endpoint = "${module.rds.rds_instance_endpoint}"
-    name     = "${module.rds.database_name}"
-    user     = "${module.rds.database_username}"
-    password = "${module.rds.database_password}"
-    host     = "${module.rds.rds_instance_address}"
-    port     = "${module.rds.rds_instance_port}"
+  data = {
+    endpoint = module.rds.rds_instance_endpoint
+    name     = module.rds.database_name
+    user     = module.rds.database_username
+    password = module.rds.database_password
+    host     = module.rds.rds_instance_address
+    port     = module.rds.rds_instance_port
     url      = "postgis://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
@@ -1,29 +1,30 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.email}"
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.email
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "s3" {
   metadata {
     name      = "s3"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.s3.access_key_id}"
-    secret_access_key = "${module.s3.secret_access_key}"
-    bucket_arn        = "${module.s3.bucket_arn}"
-    bucket_name       = "${module.s3.bucket_name}"
+  data = {
+    access_key_id     = module.s3.access_key_id
+    secret_access_key = module.s3.secret_access_key
+    bucket_arn        = module.s3.bucket_arn
+    bucket_name       = module.s3.bucket_name
     region            = "eu-west-2"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/variable.tf
@@ -29,3 +29,4 @@ variable "environment-name" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
@@ -1,17 +1,17 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -22,15 +22,16 @@ resource "random_id" "probation_teams_password" {
 resource "kubernetes_secret" "dps_rds" {
   metadata {
     name      = "dps-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint    = "${module.dps_rds.rds_instance_endpoint}"
-    database_name            = "${module.dps_rds.database_name}"
-    database_username        = "${module.dps_rds.database_username}"
-    database_password        = "${module.dps_rds.database_password}"
-    rds_instance_address     = "${module.dps_rds.rds_instance_address}"
-    probation_teams_password = "${random_id.probation_teams_password.b64}"
+  data = {
+    rds_instance_endpoint    = module.dps_rds.rds_instance_endpoint
+    database_name            = module.dps_rds.database_name
+    database_username        = module.dps_rds.database_username
+    database_password        = module.dps_rds.database_password
+    rds_instance_address     = module.dps_rds.rds_instance_address
+    probation_teams_password = random_id.probation_teams_password.b64
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/variables.tf
@@ -6,9 +6,11 @@ variable "namespace" {
   default = "licences-dev"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -33,3 +35,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/rds.tf
@@ -1,31 +1,32 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {
     name      = "dps-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.dps_rds.rds_instance_endpoint}"
-    database_name         = "${module.dps_rds.database_name}"
-    database_username     = "${module.dps_rds.database_username}"
-    database_password     = "${module.dps_rds.database_password}"
-    rds_instance_address  = "${module.dps_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.dps_rds.rds_instance_endpoint
+    database_name         = module.dps_rds.database_name
+    database_username     = module.dps_rds.database_username
+    database_password     = module.dps_rds.database_password
+    rds_instance_address  = module.dps_rds.rds_instance_address
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/variables.tf
@@ -6,9 +6,11 @@ variable "namespace" {
   default = "licences-preprod"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -33,3 +35,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Updated below namespaces with terraform 12 changes.

hmcts-complaints-formbuilder-adapter-staging
hmcts-mock-api-dev
hmpps-book-secure-move-api-preprod
hmpps-book-secure-move-api-staging
hmpps-book-secure-move-frontend-preprod
hmpps-book-secure-move-frontend-staging
jason-lab
keyworker-api-dev
keyworker-api-preprod
kube-public
kube-system
laa-apply-for-legalaid-staging
laa-apply-for-legalaid-uat
laa-aws-dev
laa-cla-public-staging
laa-court-data-adaptor-dev
laa-fala-staging
laa-fee-calculator-staging
laa-get-access-service-improvement
laa-legal-adviser-api-staging
licences-dev
licences-preprod



Terraform 0.12 upgrade and update modules version to use the tf0.12