### PR TITLE
Tf12 upgrade for prod namespaces in environments repo

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "cloudplatform"
   business-unit          = "mojdigital"
@@ -9,7 +9,7 @@ module "authorized-keys" {
   infrastructure-support = "platforms@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -19,10 +19,11 @@ resource "kubernetes_secret" "s3_bucket_credentials" {
     namespace = "authorized-keys-provider"
   }
 
-  data {
-    bucket_name       = "${module.authorized-keys.bucket_name}"
-    access_key_id     = "${module.authorized-keys.access_key_id}"
-    bucket_arn        = "${module.authorized-keys.bucket_arn}"
-    secret_access_key = "${module.authorized-keys.secret_access_key}"
+  data = {
+    bucket_name       = module.authorized-keys.bucket_name
+    access_key_id     = module.authorized-keys.access_key_id
+    bucket_arn        = module.authorized-keys.bucket_arn
+    secret_access_key = module.authorized-keys.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/rds.tf
@@ -3,31 +3,32 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = true
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-c100-production"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/redis.tf
@@ -3,30 +3,31 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {
   metadata {
     name      = "elasticache-c100-production"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.redis-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.redis-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.redis-elasticache.primary_endpoint_address
+    auth_token               = module.redis-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
@@ -1,35 +1,36 @@
 resource "aws_route53_zone" "route53_zone_short" {
   name = "c100.service.justice.gov.uk"
 
-  tags {
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "aws_route53_zone" "route53_zone_long" {
   name = "apply-to-court-about-child-arrangements.service.justice.gov.uk"
 
-  tags {
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    short_zone_id = "${aws_route53_zone.route53_zone_short.zone_id}"
-    long_zone_id  = "${aws_route53_zone.route53_zone_long.zone_id}"
+  data = {
+    short_zone_id = aws_route53_zone.route53_zone_short.zone_id
+    long_zone_id  = aws_route53_zone.route53_zone_long.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-prod/resources/variables.tf
@@ -10,9 +10,11 @@ variable "namespace" {
   default = "case-notes-to-probation-prod"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -37,3 +39,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
@@ -6,15 +6,15 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   engine_version        = "4.0.10"
   parameter_group_name  = "default.redis4.0"
@@ -25,13 +25,14 @@ module "cccd_elasticache_redis" {
 resource "kubernetes_secret" "cccd_elasticache_redis" {
   metadata {
     name      = "cccd-elasticache-redis"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.cccd_elasticache_redis.primary_endpoint_address}"
-    auth_token               = "${module.cccd_elasticache_redis.auth_token}"
-    member_clusters          = "${jsonencode(module.cccd_elasticache_redis.member_clusters)}"
+  data = {
+    primary_endpoint_address = module.cccd_elasticache_redis.primary_endpoint_address
+    auth_token               = module.cccd_elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.cccd_elasticache_redis.member_clusters)
     url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
@@ -1,38 +1,40 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
 
-  team_name          = "${var.team_name}"
+  team_name          = var.team_name
   topic_display_name = "cccd-claims-submitted"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "claims_for_ccr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-for-ccr"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.ccr_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
-  queue_url = "${module.claims_for_ccr.sqs_id}"
+  queue_url = module.claims_for_ccr.sqs_id
 
   policy = <<EOF
   {
@@ -55,33 +57,37 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
         }
       ]
   }
-  EOF
+  
+EOF
+
 }
 
 module "claims_for_cclf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-for-cclf"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.cclf_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
-  queue_url = "${module.claims_for_cclf.sqs_id}"
+  queue_url = module.claims_for_cclf.sqs_id
 
   policy = <<EOF
   {
@@ -104,122 +110,127 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
         }
       ]
   }
-  EOF
+  
+EOF
+
 }
 
 module "responses_for_cccd" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "responses-for-cccd"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   redrive_policy = <<EOF
   {
     "deadLetterTargetArn": "${module.cccd_response_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  EOF
+  
+EOF
+
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "ccr_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-submitted-ccr-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "cclf_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "cccd-claims-submitted-cclf-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 module "cccd_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
 
-  environment-name       = "${var.environment-name}"
-  team_name              = "${var.team_name}"
-  infrastructure-support = "${var.infrastructure-support}"
-  application            = "${var.application}"
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
   sqs_name               = "reponses-for-cccd-dlq"
-  existing_user_name     = "${module.cccd_claims_submitted.user_name}"
+  existing_user_name     = module.cccd_claims_submitted.user_name
   encrypt_sqs_kms        = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "cccd_claims_submitted" {
   metadata {
     name      = "cccd-messaging"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.cccd_claims_submitted.access_key_id}"
-    secret_access_key = "${module.cccd_claims_submitted.secret_access_key}"
-    topic_arn         = "${module.cccd_claims_submitted.topic_arn}"
-    sqs_ccr_name      = "${module.claims_for_ccr.sqs_name}"
-    sqs_ccr_url       = "${module.claims_for_ccr.sqs_id}"
-    sqs_ccr_arn       = "${module.claims_for_ccr.sqs_arn}"
-    sqs_ccr_dlq_name  = "${module.ccr_dead_letter_queue.sqs_name}"
-    sqs_ccr_dlq_url   = "${module.ccr_dead_letter_queue.sqs_id}"
-    sqs_ccr_dlq_arn   = "${module.ccr_dead_letter_queue.sqs_arn}"
-    sqs_cclf_name     = "${module.claims_for_cclf.sqs_name}"
-    sqs_cclf_url      = "${module.claims_for_cclf.sqs_id}"
-    sqs_cclf_arn      = "${module.claims_for_cclf.sqs_arn}"
-    sqs_cclf_dlq_name = "${module.cclf_dead_letter_queue.sqs_name}"
-    sqs_cclf_dlq_url  = "${module.cclf_dead_letter_queue.sqs_id}"
-    sqs_cclf_dlq_arn  = "${module.cclf_dead_letter_queue.sqs_arn}"
-    sqs_cccd_name     = "${module.responses_for_cccd.sqs_name}"
-    sqs_cccd_url      = "${module.responses_for_cccd.sqs_id}"
-    sqs_cccd_arn      = "${module.responses_for_cccd.sqs_arn}"
-    sqs_cccd_dlq_name = "${module.cccd_response_dead_letter_queue.sqs_name}"
-    sqs_cccd_dlq_url  = "${module.cccd_response_dead_letter_queue.sqs_id}"
-    sqs_cccd_dlq_arn  = "${module.cccd_response_dead_letter_queue.sqs_arn}"
+  data = {
+    access_key_id     = module.cccd_claims_submitted.access_key_id
+    secret_access_key = module.cccd_claims_submitted.secret_access_key
+    topic_arn         = module.cccd_claims_submitted.topic_arn
+    sqs_ccr_name      = module.claims_for_ccr.sqs_name
+    sqs_ccr_url       = module.claims_for_ccr.sqs_id
+    sqs_ccr_arn       = module.claims_for_ccr.sqs_arn
+    sqs_ccr_dlq_name  = module.ccr_dead_letter_queue.sqs_name
+    sqs_ccr_dlq_url   = module.ccr_dead_letter_queue.sqs_id
+    sqs_ccr_dlq_arn   = module.ccr_dead_letter_queue.sqs_arn
+    sqs_cclf_name     = module.claims_for_cclf.sqs_name
+    sqs_cclf_url      = module.claims_for_cclf.sqs_id
+    sqs_cclf_arn      = module.claims_for_cclf.sqs_arn
+    sqs_cclf_dlq_name = module.cclf_dead_letter_queue.sqs_name
+    sqs_cclf_dlq_url  = module.cclf_dead_letter_queue.sqs_id
+    sqs_cclf_dlq_arn  = module.cclf_dead_letter_queue.sqs_arn
+    sqs_cccd_name     = module.responses_for_cccd.sqs_name
+    sqs_cccd_url      = module.responses_for_cccd.sqs_id
+    sqs_cccd_arn      = module.responses_for_cccd.sqs_arn
+    sqs_cccd_dlq_name = module.cccd_response_dead_letter_queue.sqs_name
+    sqs_cccd_dlq_url  = module.cccd_response_dead_letter_queue.sqs_id
+    sqs_cccd_dlq_arn  = module.cccd_response_dead_letter_queue.sqs_arn
   }
 }
 
 resource "aws_sns_topic_subscription" "ccr-queue-subscription" {
-  provider      = "aws.london"
-  topic_arn     = "${module.cccd_claims_submitted.topic_arn}"
+  provider      = aws.london
+  topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
-  endpoint      = "${module.claims_for_ccr.sqs_arn}"
+  endpoint      = module.claims_for_ccr.sqs_arn
   filter_policy = "{\"claim_type\": [\"Claim::AdvocateClaim\", \"Claim::AdvocateInterimClaim\", \"Claim::AdvocateSupplementaryClaim\"]}"
 }
 
 resource "aws_sns_topic_subscription" "cclf-queue-subscription" {
-  provider      = "aws.london"
-  topic_arn     = "${module.cccd_claims_submitted.topic_arn}"
+  provider      = aws.london
+  topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
-  endpoint      = "${module.claims_for_cclf.sqs_arn}"
+  endpoint      = module.claims_for_cclf.sqs_arn
   filter_policy = "{\"claim_type\": [\"Claim::LitigatorClaim\", \"Claim::InterimClaim\", \"Claim::TransferClaim\"]}"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/pingdom.tf
@@ -1,9 +1,10 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 resource "pingdom_check" "claim-crown-court-defence-production" {
   type                     = "http"
@@ -21,3 +22,4 @@ resource "pingdom_check" "claim-crown-court-defence-production" {
   publicreport             = "true"
   integrationids           = [94703]
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/pingdom.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
 
 provider "pingdom" {
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/rds.tf
@@ -6,15 +6,15 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name                = "${var.cluster_name}"
-  cluster_state_bucket        = "${var.cluster_state_bucket}"
-  team_name                   = "${var.team_name}"
-  business-unit               = "${var.business-unit}"
-  application                 = "${var.application}"
-  is-production               = "${var.is-production}"
-  environment-name            = "${var.environment-name}"
-  infrastructure-support      = "${var.infrastructure-support}"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name                = var.cluster_name
+  cluster_state_bucket        = var.cluster_state_bucket
+  team_name                   = var.team_name
+  business-unit               = var.business-unit
+  application                 = var.application
+  is-production               = var.is-production
+  environment-name            = var.environment-name
+  infrastructure-support      = var.infrastructure-support
   db_allocated_storage        = "50"
   db_instance_class           = "db.t3.medium"
   db_engine_version           = "9.6"
@@ -24,22 +24,23 @@ module "cccd_rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "cccd_rds" {
   metadata {
     name      = "cccd-rds"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.cccd_rds.rds_instance_endpoint}"
-    database_name         = "${module.cccd_rds.database_name}"
-    database_username     = "${module.cccd_rds.database_username}"
-    database_password     = "${module.cccd_rds.database_password}"
-    rds_instance_address  = "${module.cccd_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.cccd_rds.rds_instance_endpoint
+    database_name         = module.cccd_rds.database_name
+    database_username     = module.cccd_rds.database_username
+    database_password     = module.cccd_rds.database_password
+    rds_instance_address  = module.cccd_rds.rds_instance_address
     url                   = "postgres://${module.cccd_rds.database_username}:${module.cccd_rds.database_password}@${module.cccd_rds.rds_instance_endpoint}/${module.cccd_rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -1,24 +1,25 @@
 resource "aws_route53_zone" "cccd_route53_zone" {
-  name = "${var.domain}"
+  name = var.domain
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "cccd_route53_zone_sec" {
   metadata {
     name      = "cccd-route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id      = "${aws_route53_zone.cccd_route53_zone.zone_id}"
-    name_servers = "${join("\n", aws_route53_zone.cccd_route53_zone.name_servers)}"
+  data = {
+    zone_id      = aws_route53_zone.cccd_route53_zone.zone_id
+    name_servers = join("\n", aws_route53_zone.cccd_route53_zone.name_servers)
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
@@ -6,17 +6,17 @@
  */
 
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -49,18 +49,20 @@ module "cccd_s3_bucket" {
 ]
 }
 EOF
+
 }
 
 resource "kubernetes_secret" "cccd_s3_bucket" {
   metadata {
     name      = "cccd-s3-bucket"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.cccd_s3_bucket.access_key_id}"
-    secret_access_key = "${module.cccd_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.cccd_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.cccd_s3_bucket.bucket_name}"
+  data = {
+    access_key_id     = module.cccd_s3_bucket.access_key_id
+    secret_access_key = module.cccd_s3_bucket.secret_access_key
+    bucket_arn        = module.cccd_s3_bucket.bucket_arn
+    bucket_name       = module.cccd_s3_bucket.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/variables.tf
@@ -39,6 +39,9 @@ variable "is-production" {
  * two variables are automatically supplied by the pipeline.
  *
  */
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,6 +18,9 @@ provider "aws" {
  *
  */
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/resources/rds.tf
@@ -5,10 +5,10 @@
  *
  */
 module "check-financial-eligibility-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "apply-for-legal-aid"
   business-unit          = "laa"
   application            = "check-financial-eligibility"
@@ -22,7 +22,7 @@ module "check-financial-eligibility-rds" {
   rds_family             = "postgres11"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -32,11 +32,12 @@ resource "kubernetes_secret" "check-financial-eligibility-rds" {
     namespace = "check-financial-eligibility-production"
   }
 
-  data {
-    rds_instance_endpoint = "${module.check-financial-eligibility-rds.rds_instance_endpoint}"
-    database_name         = "${module.check-financial-eligibility-rds.database_name}"
-    database_username     = "${module.check-financial-eligibility-rds.database_username}"
-    database_password     = "${module.check-financial-eligibility-rds.database_password}"
-    rds_instance_address  = "${module.check-financial-eligibility-rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.check-financial-eligibility-rds.rds_instance_endpoint
+    database_name         = module.check-financial-eligibility-rds.database_name
+    database_username     = module.check-financial-eligibility-rds.database_username
+    database_password     = module.check-financial-eligibility-rds.database_password
+    rds_instance_address  = module.check-financial-eligibility-rds.rds_instance_address
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "checkmydiary-service-prod" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "check-my-diary-prod"
   team_name = "check-my-diary"
 }
@@ -10,16 +10,16 @@ resource "kubernetes_secret" "checkmydiary_ecr_credentials" {
     namespace = "check-my-diary-prod"
   }
 
-  data {
-    access_key_id     = "${module.checkmydiary-service-prod.access_key_id}"
-    secret_access_key = "${module.checkmydiary-service-prod.secret_access_key}"
-    repo_arn          = "${module.checkmydiary-service-prod.repo_arn}"
-    repo_url          = "${module.checkmydiary-service-prod.repo_url}"
+  data = {
+    access_key_id     = module.checkmydiary-service-prod.access_key_id
+    secret_access_key = module.checkmydiary-service-prod.secret_access_key
+    repo_arn          = module.checkmydiary-service-prod.repo_arn
+    repo_url          = module.checkmydiary-service-prod.repo_url
   }
 }
 
 module "checkmydiary-notification-service-prod" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "check-my-diary-notification-service-prod"
   team_name = "check-my-diary"
 }
@@ -30,10 +30,11 @@ resource "kubernetes_secret" "checkmydiary-notification-service_ecr_credentials"
     namespace = "check-my-diary-prod"
   }
 
-  data {
-    access_key_id     = "${module.checkmydiary-notification-service-prod.access_key_id}"
-    secret_access_key = "${module.checkmydiary-notification-service-prod.secret_access_key}"
-    repo_arn          = "${module.checkmydiary-notification-service-prod.repo_arn}"
-    repo_url          = "${module.checkmydiary-notification-service-prod.repo_url}"
+  data = {
+    access_key_id     = module.checkmydiary-notification-service-prod.access_key_id
+    secret_access_key = module.checkmydiary-notification-service-prod.secret_access_key
+    repo_arn          = module.checkmydiary-notification-service-prod.repo_arn
+    repo_url          = module.checkmydiary-notification-service-prod.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/rds.tf
@@ -3,14 +3,17 @@
  * two variables are automatically supplied by the pipeline.
  */
 
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "checkmydiary_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "check-my-diary"
   application            = "check-my-diary"
   is-production          = "true"
@@ -19,7 +22,7 @@ module "checkmydiary_rds" {
   force_ssl              = "false"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -29,11 +32,12 @@ resource "kubernetes_secret" "checkmydiary_rds" {
     namespace = "check-my-diary-prod"
   }
 
-  data {
-    rds_instance_endpoint = "${module.checkmydiary_rds.rds_instance_endpoint}"
-    database_name         = "${module.checkmydiary_rds.database_name}"
-    database_username     = "${module.checkmydiary_rds.database_username}"
-    database_password     = "${module.checkmydiary_rds.database_password}"
-    rds_instance_address  = "${module.checkmydiary_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.checkmydiary_rds.rds_instance_endpoint
+    database_name         = module.checkmydiary_rds.database_name
+    database_username     = module.checkmydiary_rds.database_username
+    database_password     = module.checkmydiary_rds.database_password
+    rds_instance_address  = module.checkmydiary_rds.rds_instance_address
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/route53.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_zone" "check-my-diary-prod" {
   name = "checkmydiary.service.justice.gov.uk"
 
-  tags {
+  tags = {
     business-unit          = "Check My Diary"
     application            = "Check My Diary"
     is-production          = "true"
@@ -17,7 +17,8 @@ resource "kubernetes_secret" "check-my-diary-prod_sec" {
     namespace = "check-my-diary-prod"
   }
 
-  data {
-    zone_id = "${aws_route53_zone.check-my-diary-prod.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.check-my-diary-prod.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/ecr.tf
@@ -5,12 +5,12 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "cica-repo-prod"
   team_name = "cica"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -20,10 +20,11 @@ resource "kubernetes_secret" "ecr_repo" {
     namespace = "claim-criminal-injuries-compensation-prod"
   }
 
-  data {
-    access_key_id     = "${module.cica_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.cica_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.cica_ecr_credentials.repo_arn}"
-    repo_url          = "${module.cica_ecr_credentials.repo_url}"
+  data = {
+    access_key_id     = module.cica_ecr_credentials.access_key_id
+    secret_access_key = module.cica_ecr_credentials.secret_access_key
+    repo_arn          = module.cica_ecr_credentials.repo_arn
+    repo_url          = module.cica_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/pingdom.tf
@@ -1,9 +1,10 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 resource "pingdom_check" "claim-criminal-injuries-compensation-prod" {
   type                     = "http"
@@ -20,3 +21,4 @@ resource "pingdom_check" "claim-criminal-injuries-compensation-prod" {
   probefilters             = "region:EU"
   publicreport             = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/pingdom.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
 
 provider "pingdom" {
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/rds.tf
@@ -1,24 +1,27 @@
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  team_name                  = "${var.team_name}"
-  business-unit              = "${var.business-unit}"
-  application                = "${var.application}"
-  is-production              = "${var.is-production}"
-  environment-name           = "${var.environment-name}"
-  infrastructure-support     = "${var.email}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  team_name                  = var.team_name
+  business-unit              = var.business-unit
+  application                = var.application
+  is-production              = var.is-production
+  environment-name           = var.environment-name
+  infrastructure-support     = var.email
   force_ssl                  = "true"
   db_engine                  = "postgres"
   db_engine_version          = "10.6"
   db_instance_class          = "db.t2.small"
   db_allocated_storage       = "10"
   db_name                    = "datacaptureservice"
-  db_backup_retention_period = "${var.db_backup_retention_period}"
+  db_backup_retention_period = var.db_backup_retention_period
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11 
   # Pick the one that defines the postgres version the best 
@@ -29,22 +32,23 @@ module "rds" {
 
   providers = {
     # Can be either "aws.london" or "aws.ireland" 
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-production"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.rds.rds_instance_endpoint}"
-    database_name         = "${module.rds.database_name}"
-    database_username     = "${module.rds.database_username}"
-    database_password     = "${module.rds.database_password}"
-    rds_instance_address  = "${module.rds.rds_instance_address}"
-    rds_instance_port     = "${module.rds.rds_instance_port}"
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    rds_instance_port     = module.rds.rds_instance_port
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/route53.tf
@@ -1,23 +1,24 @@
 resource "aws_route53_zone" "route53_zone" {
-  name = "${var.domain}"
+  name = var.domain
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/variable.tf
@@ -39,3 +39,4 @@ variable "db_backup_retention_period" {
   description = "The days to retain backup jobs. Must be 1 or greater to be a source for a Read Replica"
   default     = "35"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/elasticache.tf
@@ -1,29 +1,30 @@
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
-  number_cache_clusters  = "${var.number_cache_clusters}"
-  node_type              = "${var.node-type}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = var.node-type
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "dps_redis" {
   metadata {
     name      = "dps-redis"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    REDIS_HOST      = "${module.dps_redis.primary_endpoint_address}"
-    REDIS_PASSWORD  = "${module.dps_redis.auth_token}"
-    member_clusters = "${jsonencode(module.dps_redis.member_clusters)}"
+  data = {
+    REDIS_HOST      = module.dps_redis.primary_endpoint_address
+    REDIS_PASSWORD  = module.dps_redis.auth_token
+    member_clusters = jsonencode(module.dps_redis.member_clusters)
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/pingdom.tf
@@ -1,4 +1,5 @@
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 # Integration IDs
 # 96624 = #dps_alerts
@@ -35,3 +36,4 @@ resource "pingdom_check" "dps-production-check-whereabouts" {
   probefilters             = "region:EU"
   integrationids           = [96624, 96628]
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/route53.tf
@@ -1,23 +1,24 @@
 resource "aws_route53_zone" "route53_zone" {
-  name = "${var.domain}"
+  name = var.domain
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/variables.tf
@@ -10,9 +10,11 @@ variable "namespace" {
   default = "digital-prison-services-prod"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -45,3 +47,4 @@ variable "node-type" {
 variable "is-production" {
   default = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/rds.tf
@@ -3,31 +3,32 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = true
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-disclosure-checker-production"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/resources/route53.tf
@@ -1,23 +1,24 @@
 resource "aws_route53_zone" "route53_zone" {
-  name = "${var.domain}"
+  name = var.domain
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/resources/variables.tf
@@ -33,3 +33,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-welcome-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Updated below namespaces with terraform 12 changes.

authorized-keys-provider
c100-application-metabase
c100-application-production
case-notes-to-probation-prod
cccd-production
cert-manager
check-financial-eligibility-production
check-my-diary-prod
claim-criminal-injuries-compensation-prod
concourse
concourse-main
digital-prison-services-prod
disclosure-checker-production
dps-welcome-prod

Terraform 0.12 upgrade and update modules version to use the tf0.12