### PR TITLE
Tf 12 upgrade for prod namespaces in env repo-batch2

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
@@ -3,31 +3,32 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
   force_ssl              = true
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-family-mediators-api-production"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/route53.tf
@@ -1,22 +1,23 @@
 resource "aws_route53_zone" "route53_zone" {
   name = "familymediators.service.justice.gov.uk"
 
-  tags {
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/route53.tf
@@ -1,23 +1,24 @@
 resource "aws_route53_zone" "route53_zone" {
   name = "helpwithchildarrangements.service.justice.gov.uk"
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/variables.tf
@@ -31,6 +31,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/json-output-attachments-s3.tf
@@ -1,17 +1,17 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   acl                    = "private"
   versioning             = false
   business-unit          = "transformed-department"
   application            = "formbuilderuserfilestore"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -31,19 +31,18 @@ module "json-output-attachments-s3-bucket" {
 }
 EOF
 
+
   lifecycle_rule = [
     {
       enabled                                = true
       id                                     = "expire-7d"
       prefix                                 = "7d/"
       abort_incomplete_multipart_upload_days = 7
-
       expiration = [
         {
           days = 7
         },
       ]
-
       noncurrent_version_expiration = [
         {
           days = 7
@@ -59,10 +58,11 @@ resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    access_key_id     = "${module.json-output-attachments-s3-bucket.access_key_id}"
-    bucket_arn        = "${module.json-output-attachments-s3-bucket.bucket_arn}"
-    bucket_name       = "${module.json-output-attachments-s3-bucket.bucket_name}"
-    secret_access_key = "${module.json-output-attachments-s3-bucket.secret_access_key}"
+  data = {
+    access_key_id     = module.json-output-attachments-s3-bucket.access_key_id
+    bucket_arn        = module.json-output-attachments-s3-bucket.bucket_arn
+    bucket_name       = module.json-output-attachments-s3-bucket.bucket_name
+    secret_access_key = module.json-output-attachments-s3-bucket.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/main.tf
@@ -1,7 +1,7 @@
 # auto-generated from fb-cloud-platforms-environments
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -12,3 +12,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/service_token_cache.tf
@@ -1,17 +1,17 @@
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
   application            = "formbuilderservice-token-cache"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -21,8 +21,9 @@ resource "kubernetes_secret" "service-token-cache-elasticache" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    primary_endpoint_address = "${module.service-token-cache-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.service-token-cache-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.service-token-cache-elasticache.primary_endpoint_address
+    auth_token               = module.service-token-cache-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
@@ -1,20 +1,20 @@
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_submitter}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_submitter
   application                = "formbuildersubmitter"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "submitter-rds-instance" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -1,20 +1,20 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_user_datastore}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_user_datastore
   application                = "formbuilderuserdatastore"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "user-datastore-rds-instance" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-filestore.tf
@@ -2,19 +2,19 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   acl                    = "private"
   versioning             = false
   business-unit          = "transformed-department"
   application            = "formbuilderuserfilestore"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 
   user_policy = <<EOF
@@ -63,19 +63,18 @@ module "user-filestore-s3-bucket" {
 }
 EOF
 
+
   lifecycle_rule = [
     {
       enabled                                = true
       id                                     = "expire-28d"
       prefix                                 = "28d/"
       abort_incomplete_multipart_upload_days = 28
-
       expiration = [
         {
           days = 28
         },
       ]
-
       noncurrent_version_expiration = [
         {
           days = 28
@@ -91,10 +90,11 @@ resource "kubernetes_secret" "user-filestore-s3-bucket" {
     namespace = "formbuilder-platform-${var.environment-name}"
   }
 
-  data {
-    access_key_id     = "${module.user-filestore-s3-bucket.access_key_id}"
-    bucket_arn        = "${module.user-filestore-s3-bucket.bucket_arn}"
-    bucket_name       = "${module.user-filestore-s3-bucket.bucket_name}"
-    secret_access_key = "${module.user-filestore-s3-bucket.secret_access_key}"
+  data = {
+    access_key_id     = module.user-filestore-s3-bucket.access_key_id
+    bucket_arn        = module.user-filestore-s3-bucket.bucket_arn
+    bucket_name       = module.user-filestore-s3-bucket.bucket_name
+    secret_access_key = module.user-filestore-s3-bucket.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/variables.tf
@@ -24,6 +24,9 @@ variable "infrastructure-support" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/ecr.tf
@@ -1,10 +1,10 @@
 module "formbuilder_product_page_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
   repo_name = "formbuilder-product-page"
   team_name = "formbuilder"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -14,10 +14,11 @@ resource "kubernetes_secret" "formbuilder_product_page_ecr_credentials" {
     namespace = "formbuilder-product-page-prod"
   }
 
-  data {
-    access_key        = "${module.formbuilder_product_page_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.formbuilder_product_page_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.formbuilder_product_page_ecr_credentials.repo_arn}"
-    repo_url          = "${module.formbuilder_product_page_ecr_credentials.repo_url}"
+  data = {
+    access_key        = module.formbuilder_product_page_ecr_credentials.access_key_id
+    secret_access_key = module.formbuilder_product_page_ecr_credentials.secret_access_key
+    repo_arn          = module.formbuilder_product_page_ecr_credentials.repo_arn
+    repo_url          = module.formbuilder_product_page_ecr_credentials.repo_url
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/main.tf
@@ -1,7 +1,7 @@
 # auto-generated from fb-cloud-platforms-environments
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -12,3 +12,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/publisher.tf
@@ -34,7 +34,7 @@ resource "kubernetes_secret" "publisher-rds-instance" {
 ########################################################
 # Publisher Elasticache Redis (for resque + job logging)
 module "publisher-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/publisher.tf
@@ -1,19 +1,19 @@
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period
   application                = "formbuilderpublisher"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   db_engine_version          = "10.9"
   apply_method               = "immediate"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -23,7 +23,7 @@ resource "kubernetes_secret" "publisher-rds-instance" {
     namespace = "formbuilder-publisher-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.publisher-rds-instance.database_username}:${module.publisher-rds-instance.database_password}@${module.publisher-rds-instance.rds_instance_endpoint}/${module.publisher-rds-instance.database_name}"
   }
@@ -36,17 +36,17 @@ resource "kubernetes_secret" "publisher-rds-instance" {
 module "publisher-elasticache" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.2"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
   application            = "formbuilderpublisher"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -56,8 +56,9 @@ resource "kubernetes_secret" "publisher-elasticache" {
     namespace = "formbuilder-publisher-${var.environment-name}"
   }
 
-  data {
-    primary_endpoint_address = "${module.publisher-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.publisher-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.publisher-elasticache.primary_endpoint_address
+    auth_token               = module.publisher-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/variables.tf
@@ -20,6 +20,9 @@ variable "infrastructure-support" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -1,13 +1,13 @@
 # Publisher ECR Repos
 
 module "ecr-repo-fb-publisher-base" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-publisher-base"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -17,21 +17,21 @@ resource "kubernetes_secret" "ecr-repo-fb-publisher-base" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-publisher-base.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-publisher-base.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-publisher-base.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-publisher-base.repo_url
+    access_key_id     = module.ecr-repo-fb-publisher-base.access_key_id
+    secret_access_key = module.ecr-repo-fb-publisher-base.secret_access_key
   }
 }
 
 module "ecr-repo-fb-publisher-web" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-publisher-web"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -41,21 +41,21 @@ resource "kubernetes_secret" "ecr-repo-fb-publisher-web" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-publisher-web.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-publisher-web.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-publisher-web.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-publisher-web.repo_url
+    access_key_id     = module.ecr-repo-fb-publisher-web.access_key_id
+    secret_access_key = module.ecr-repo-fb-publisher-web.secret_access_key
   }
 }
 
 module "ecr-repo-fb-publisher-worker" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-publisher-worker"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -65,10 +65,10 @@ resource "kubernetes_secret" "ecr-repo-fb-publisher-worker" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-publisher-worker.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-publisher-worker.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-publisher-worker.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-publisher-worker.repo_url
+    access_key_id     = module.ecr-repo-fb-publisher-worker.access_key_id
+    secret_access_key = module.ecr-repo-fb-publisher-worker.secret_access_key
   }
 }
 
@@ -76,13 +76,13 @@ resource "kubernetes_secret" "ecr-repo-fb-publisher-worker" {
 
 # Runner ECR Repos
 module "ecr-repo-fb-runner-node" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-runner-node"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -92,10 +92,10 @@ resource "kubernetes_secret" "ecr-repo-fb-runner-node" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-runner-node.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-runner-node.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-runner-node.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-runner-node.repo_url
+    access_key_id     = module.ecr-repo-fb-runner-node.access_key_id
+    secret_access_key = module.ecr-repo-fb-runner-node.secret_access_key
   }
 }
 
@@ -103,13 +103,13 @@ resource "kubernetes_secret" "ecr-repo-fb-runner-node" {
 
 # Service Token Cache ECR Repos
 module "ecr-repo-fb-service-token-cache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-service-token-cache"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -119,10 +119,10 @@ resource "kubernetes_secret" "ecr-repo-fb-service-token-cache" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-service-token-cache.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-service-token-cache.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-service-token-cache.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-service-token-cache.repo_url
+    access_key_id     = module.ecr-repo-fb-service-token-cache.access_key_id
+    secret_access_key = module.ecr-repo-fb-service-token-cache.secret_access_key
   }
 }
 
@@ -130,13 +130,13 @@ resource "kubernetes_secret" "ecr-repo-fb-service-token-cache" {
 
 # Submitter ECR Repos
 module "ecr-repo-fb-submitter-base" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-submitter-base"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -146,21 +146,21 @@ resource "kubernetes_secret" "ecr-repo-fb-submitter-base" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-submitter-base.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-submitter-base.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-submitter-base.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-submitter-base.repo_url
+    access_key_id     = module.ecr-repo-fb-submitter-base.access_key_id
+    secret_access_key = module.ecr-repo-fb-submitter-base.secret_access_key
   }
 }
 
 module "ecr-repo-fb-submitter-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-submitter-api"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -170,21 +170,21 @@ resource "kubernetes_secret" "ecr-repo-fb-submitter-api" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-submitter-api.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-submitter-api.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-submitter-api.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-submitter-api.repo_url
+    access_key_id     = module.ecr-repo-fb-submitter-api.access_key_id
+    secret_access_key = module.ecr-repo-fb-submitter-api.secret_access_key
   }
 }
 
 module "ecr-repo-fb-submitter-worker" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-submitter-worker"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -194,10 +194,10 @@ resource "kubernetes_secret" "ecr-repo-fb-submitter-worke" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-submitter-worker.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-submitter-worker.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-submitter-worker.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-submitter-worker.repo_url
+    access_key_id     = module.ecr-repo-fb-submitter-worker.access_key_id
+    secret_access_key = module.ecr-repo-fb-submitter-worker.secret_access_key
   }
 }
 
@@ -205,13 +205,13 @@ resource "kubernetes_secret" "ecr-repo-fb-submitter-worke" {
 
 # User Datastore ECR Repos
 module "ecr-repo-fb-user-datastore-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-user-datastore-api"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -221,10 +221,10 @@ resource "kubernetes_secret" "ecr-repo-fb-user-datastore-api" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-user-datastore-api.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-user-datastore-api.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-user-datastore-api.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-user-datastore-api.repo_url
+    access_key_id     = module.ecr-repo-fb-user-datastore-api.access_key_id
+    secret_access_key = module.ecr-repo-fb-user-datastore-api.secret_access_key
   }
 }
 
@@ -232,13 +232,13 @@ resource "kubernetes_secret" "ecr-repo-fb-user-datastore-api" {
 
 # User Filestore ECR Repos
 module "ecr-repo-fb-user-filestore-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-user-filestore-api"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -248,10 +248,10 @@ resource "kubernetes_secret" "ecr-repo-fb-user-filestore-api" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-user-filestore-api.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-user-filestore-api.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-user-filestore-api.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-user-filestore-api.repo_url
+    access_key_id     = module.ecr-repo-fb-user-filestore-api.access_key_id
+    secret_access_key = module.ecr-repo-fb-user-filestore-api.secret_access_key
   }
 }
 
@@ -259,13 +259,13 @@ resource "kubernetes_secret" "ecr-repo-fb-user-filestore-api" {
 
 # AV (Anti Virus) ECR Repos
 module "ecr-repo-fb-av" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-av"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -275,10 +275,10 @@ resource "kubernetes_secret" "ecr-repo-fb-av" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-av.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-av.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-av.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-av.repo_url
+    access_key_id     = module.ecr-repo-fb-av.access_key_id
+    secret_access_key = module.ecr-repo-fb-av.secret_access_key
   }
 }
 
@@ -286,13 +286,13 @@ resource "kubernetes_secret" "ecr-repo-fb-av" {
 
 # fb-builder - docker image used to build form builder components
 module "ecr-repo-fb-builder" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-builder"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -302,10 +302,10 @@ resource "kubernetes_secret" "ecr-repo-fb-builder" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-builder.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-builder.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-builder.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-builder.repo_url
+    access_key_id     = module.ecr-repo-fb-builder.access_key_id
+    secret_access_key = module.ecr-repo-fb-builder.secret_access_key
   }
 }
 
@@ -313,7 +313,7 @@ resource "kubernetes_secret" "ecr-repo-fb-builder" {
 
 # fb-runner-init-containers - docker image used to initialise runner containers
 module "ecr-repo-fb-runner-init-containers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-runner-init-containers"
@@ -325,17 +325,17 @@ resource "kubernetes_secret" "ecr-repo-fb-runner-init-containers" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-runner-init-containers.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-runner-init-containers.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-runner-init-containers.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-runner-init-containers.repo_url
+    access_key_id     = module.ecr-repo-fb-runner-init-containers.access_key_id
+    secret_access_key = module.ecr-repo-fb-runner-init-containers.secret_access_key
   }
 }
 
 ##################################################
 
 module "ecr-repo-fb-pdf-generator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "formbuilder"
   repo_name = "fb-pdf-generator"
@@ -347,9 +347,10 @@ resource "kubernetes_secret" "ecr-repo-fb-pdf-generator" {
     namespace = "formbuilder-repos"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-fb-pdf-generator.repo_url}"
-    access_key_id     = "${module.ecr-repo-fb-pdf-generator.access_key_id}"
-    secret_access_key = "${module.ecr-repo-fb-pdf-generator.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-fb-pdf-generator.repo_url
+    access_key_id     = module.ecr-repo-fb-pdf-generator.access_key_id
+    secret_access_key = module.ecr-repo-fb-pdf-generator.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/route53.tf
@@ -1,12 +1,13 @@
 resource "aws_route53_zone" "main" {
   name = "form.service.justice.gov.uk"
 
-  tags {
+  tags = {
     business-unit          = "transformed-department"
     application            = "formbuilder"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/variables.tf
@@ -13,3 +13,4 @@ variable "team_name" {
 variable "infrastructure-support" {
   default = "Form Builder form-builder-team@digital.justice.gov.uk"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/ecr.tf
@@ -1,8 +1,8 @@
 # HMCTS Complaints Adapter ECR Repos
 module "ecr-repo-hmcts-complaints-adapter" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
-  team_name = "${var.team_name}"
+  team_name = var.team_name
   repo_name = "hmcts-complaints-formbuilder-adapter"
 }
 
@@ -12,9 +12,10 @@ resource "kubernetes_secret" "ecr-repo-hmcts-complaints-adapter" {
     namespace = "hmcts-complaints-formbuilder-adapter-${var.environment-name}"
   }
 
-  data {
-    repo_url          = "${module.ecr-repo-hmcts-complaints-adapter.repo_url}"
-    access_key_id     = "${module.ecr-repo-hmcts-complaints-adapter.access_key_id}"
-    secret_access_key = "${module.ecr-repo-hmcts-complaints-adapter.secret_access_key}"
+  data = {
+    repo_url          = module.ecr-repo-hmcts-complaints-adapter.repo_url
+    access_key_id     = module.ecr-repo-hmcts-complaints-adapter.access_key_id
+    secret_access_key = module.ecr-repo-hmcts-complaints-adapter.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
@@ -1,20 +1,20 @@
 module "hmcts-complaints-adapter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name               = "${var.cluster_name}"
-  cluster_state_bucket       = "${var.cluster_state_bucket}"
-  db_backup_retention_period = "${var.db_backup_retention_period_hmcts_complaints_adapter}"
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_hmcts_complaints_adapter
   application                = "hmcts-complaints-formbuilder-adapter"
-  environment-name           = "${var.environment-name}"
-  is-production              = "${var.is-production}"
-  infrastructure-support     = "${var.infrastructure-support}"
-  team_name                  = "${var.team_name}"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
   force_ssl                  = true
   db_engine_version          = "11.4"
   rds_family                 = "postgres11"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -24,8 +24,9 @@ resource "kubernetes_secret" "hmcts-complaints-adapter-rds-instance" {
     namespace = "hmcts-complaints-formbuilder-adapter-${var.environment-name}"
   }
 
-  data {
+  data = {
     # postgres://USER:PASSWORD@HOST:PORT/NAME
     url = "postgres://${module.hmcts-complaints-adapter-rds-instance.database_username}:${module.hmcts-complaints-adapter-rds-instance.database_password}@${module.hmcts-complaints-adapter-rds-instance.rds_instance_endpoint}/${module.hmcts-complaints-adapter-rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/variables.tf
@@ -9,9 +9,11 @@ variable "environment-name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "db_backup_retention_period_hmcts_complaints_adapter" {
   default = "2"
@@ -25,3 +27,4 @@ variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "Form Builder form-builder-team@digital.justice.gov.uk"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -1,25 +1,26 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 }
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-hmpps-book-secure-move-api-production"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.rds-instance.access_key_id}"
-    secret_access_key = "${module.rds-instance.secret_access_key}"
+  data = {
+    access_key_id     = module.rds-instance.access_key_id
+    secret_access_key = module.rds-instance.secret_access_key
     url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/route53.tf
@@ -1,23 +1,24 @@
 resource "aws_route53_zone" "route53_zone" {
-  name = "${var.domain}"
+  name = var.domain
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3.tf
@@ -2,32 +2,33 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
+  team_name              = var.team_name
   business-unit          = "Digital and Technology"
-  application            = "${var.application}"
-  infrastructure-support = "${var.infrastructure-support}"
+  application            = var.application
+  infrastructure-support = var.infrastructure-support
 
-  is-production    = "${var.is-production}"
-  environment-name = "${var.environment-name}"
+  is-production    = var.is-production
+  environment-name = var.environment-name
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "book_a_secure_move_documents_s3_bucket" {
   metadata {
     name      = "book-a-secure-move-documents-s3-bucket"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.book_a_secure_move_documents_s3_bucket.access_key_id}"
-    secret_access_key = "${module.book_a_secure_move_documents_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.book_a_secure_move_documents_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.book_a_secure_move_documents_s3_bucket.bucket_name}"
+  data = {
+    access_key_id     = module.book_a_secure_move_documents_s3_bucket.access_key_id
+    secret_access_key = module.book_a_secure_move_documents_s3_bucket.secret_access_key
+    bucket_arn        = module.book_a_secure_move_documents_s3_bucket.bucket_arn
+    bucket_name       = module.book_a_secure_move_documents_s3_bucket.bucket_name
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
@@ -35,6 +35,9 @@ variable "domain" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
@@ -1,28 +1,29 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name         = "${var.cluster_name}"
-  cluster_state_bucket = "${var.cluster_state_bucket}"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
-  application            = "${var.application}"
-  environment-name       = "${var.environment-name}"
-  is-production          = "${var.is-production}"
-  infrastructure-support = "${var.infrastructure-support}"
-  team_name              = "${var.team_name}"
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "redis-elasticache" {
   metadata {
     name      = "elasticache-hmpps-book-secure-move-frontend-production"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    primary_endpoint_address = "${module.redis-elasticache.primary_endpoint_address}"
-    auth_token               = "${module.redis-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.redis-elasticache.primary_endpoint_address
+    auth_token               = module.redis-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/variables.tf
@@ -27,6 +27,9 @@ variable "repo_name" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/pingdom.tf
@@ -1,4 +1,5 @@
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 # Integration IDs
 # 96624 = #dps_alerts
@@ -19,3 +20,4 @@ resource "pingdom_check" "dps-production-check" {
   probefilters             = "region:EU"
   integrationids           = [96624, 96628]
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/rds.tf
@@ -1,33 +1,34 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {
     name      = "dps-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.dps_rds.rds_instance_endpoint}"
-    database_name         = "${module.dps_rds.database_name}"
-    database_username     = "${module.dps_rds.database_username}"
-    database_password     = "${module.dps_rds.database_password}"
-    rds_instance_address  = "${module.dps_rds.rds_instance_address}"
-    access_key_id         = "${module.dps_rds.access_key_id}"
-    secret_access_key     = "${module.dps_rds.secret_access_key}"
+  data = {
+    rds_instance_endpoint = module.dps_rds.rds_instance_endpoint
+    database_name         = module.dps_rds.database_name
+    database_username     = module.dps_rds.database_username
+    database_password     = module.dps_rds.database_password
+    rds_instance_address  = module.dps_rds.rds_instance_address
+    access_key_id         = module.dps_rds.access_key_id
+    secret_access_key     = module.dps_rds.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/variables.tf
@@ -6,9 +6,11 @@ variable "namespace" {
   default = "keyworker-api-prod"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -33,3 +35,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
@@ -1,11 +1,11 @@
 module "ecr-repo-applyforlegalaid-service" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "laa-apply-for-legal-aid"
   repo_name = "applyforlegalaid-service"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -15,22 +15,22 @@ resource "kubernetes_secret" "ecr-repo-applyforlegalaid-service" {
     namespace = "laa-apply-for-legalaid-production"
   }
 
-  data {
-    repo_arn          = "${module.ecr-repo-applyforlegalaid-service.repo_arn}"
-    repo_url          = "${module.ecr-repo-applyforlegalaid-service.repo_url}"
-    access_key_id     = "${module.ecr-repo-applyforlegalaid-service.access_key_id}"
-    secret_access_key = "${module.ecr-repo-applyforlegalaid-service.secret_access_key}"
+  data = {
+    repo_arn          = module.ecr-repo-applyforlegalaid-service.repo_arn
+    repo_url          = module.ecr-repo-applyforlegalaid-service.repo_url
+    access_key_id     = module.ecr-repo-applyforlegalaid-service.access_key_id
+    secret_access_key = module.ecr-repo-applyforlegalaid-service.secret_access_key
   }
 }
 
 module "ecr-repo-clamav" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
 
   team_name = "laa-apply-for-legal-aid"
   repo_name = "clamav"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -40,10 +40,11 @@ resource "kubernetes_secret" "ecr-repo-clamav" {
     namespace = "laa-apply-for-legalaid-production"
   }
 
-  data {
-    repo_arn          = "${module.ecr-repo-clamav.repo_arn}"
-    repo_url          = "${module.ecr-repo-clamav.repo_url}"
-    access_key_id     = "${module.ecr-repo-clamav.access_key_id}"
-    secret_access_key = "${module.ecr-repo-clamav.secret_access_key}"
+  data = {
+    repo_arn          = module.ecr-repo-clamav.repo_arn
+    repo_url          = module.ecr-repo-clamav.repo_url
+    access_key_id     = module.ecr-repo-clamav.access_key_id
+    secret_access_key = module.ecr-repo-clamav.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
@@ -5,10 +5,10 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "apply-for-legal-aid"
   business-unit          = "laa"
   application            = "laa-apply-for-legal-aid"
@@ -17,7 +17,7 @@ module "apply-for-legal-aid-elasticache" {
   infrastructure-support = "apply@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -27,9 +27,10 @@ resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
     namespace = "laa-apply-for-legalaid-production"
   }
 
-  data {
-    primary_endpoint_address = "${module.apply-for-legal-aid-elasticache.primary_endpoint_address}"
-    member_clusters          = "${jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)}"
-    auth_token               = "${module.apply-for-legal-aid-elasticache.auth_token}"
+  data = {
+    primary_endpoint_address = module.apply-for-legal-aid-elasticache.primary_endpoint_address
+    member_clusters          = jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)
+    auth_token               = module.apply-for-legal-aid-elasticache.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -25,6 +25,9 @@ provider "aws" {
  *
  */
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
@@ -5,10 +5,10 @@
  *
  */
 module "apply-for-legal-aid-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "apply-for-legal-aid"
   business-unit          = "laa"
   application            = "laa-apply-for-legal-aid"
@@ -21,7 +21,7 @@ module "apply-for-legal-aid-rds" {
   rds_family             = "postgres11"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -31,15 +31,15 @@ resource "kubernetes_secret" "apply-for-legal-aid-rds" {
     namespace = "laa-apply-for-legalaid-production"
   }
 
-  data {
-    rds_instance_endpoint = "${module.apply-for-legal-aid-rds.rds_instance_endpoint}"
-    database_name         = "${module.apply-for-legal-aid-rds.database_name}"
-    database_username     = "${module.apply-for-legal-aid-rds.database_username}"
-    database_password     = "${module.apply-for-legal-aid-rds.database_password}"
-    rds_instance_address  = "${module.apply-for-legal-aid-rds.rds_instance_address}"
-    access_key_id         = "${module.apply-for-legal-aid-rds.access_key_id}"
-    secret_access_key     = "${module.apply-for-legal-aid-rds.secret_access_key}"
-
-    url = "postgres://${module.apply-for-legal-aid-rds.database_username}:${module.apply-for-legal-aid-rds.database_password}@${module.apply-for-legal-aid-rds.rds_instance_endpoint}/${module.apply-for-legal-aid-rds.database_name}"
+  data = {
+    rds_instance_endpoint = module.apply-for-legal-aid-rds.rds_instance_endpoint
+    database_name         = module.apply-for-legal-aid-rds.database_name
+    database_username     = module.apply-for-legal-aid-rds.database_username
+    database_password     = module.apply-for-legal-aid-rds.database_password
+    rds_instance_address  = module.apply-for-legal-aid-rds.rds_instance_address
+    access_key_id         = module.apply-for-legal-aid-rds.access_key_id
+    secret_access_key     = module.apply-for-legal-aid-rds.secret_access_key
+    url                   = "postgres://${module.apply-for-legal-aid-rds.database_username}:${module.apply-for-legal-aid-rds.database_password}@${module.apply-for-legal-aid-rds.rds_instance_endpoint}/${module.apply-for-legal-aid-rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_zone" "apply_for_legal_aid_route53_zone" {
   name = "apply-for-legal-aid.service.justice.gov.uk"
 
-  tags {
+  tags = {
     business-unit          = "laa"
     application            = "laa-apply-for-legal-aid"
     is-production          = "true"
@@ -17,7 +17,8 @@ resource "kubernetes_secret" "apply_for_legal_aid_route_53_zone_sec" {
     namespace = "laa-apply-for-legalaid-production"
   }
 
-  data {
-    zone_id = "${aws_route53_zone.apply_for_legal_aid_route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.apply_for_legal_aid_route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"
@@ -10,7 +10,7 @@ module "authorized-keys" {
   infrastructure-support = "apply@digital.justice.gov.uk"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
@@ -20,9 +20,10 @@ resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
     namespace = "laa-apply-for-legalaid-production"
   }
 
-  data {
-    bucket_name       = "${module.authorized-keys.bucket_name}"
-    access_key_id     = "${module.authorized-keys.access_key_id}"
-    secret_access_key = "${module.authorized-keys.secret_access_key}"
+  data = {
+    bucket_name       = module.authorized-keys.bucket_name
+    access_key_id     = module.authorized-keys.access_key_id
+    secret_access_key = module.authorized-keys.secret_access_key
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/route53.tf
@@ -1,22 +1,23 @@
 resource "aws_route53_zone" "route53_zone" {
   name = "find-legal-advice.justice.gov.uk"
 
-  tags {
-    business-unit    = "${var.business-unit}"
-    application      = "${var.application}"
-    is-production    = "${var.is-production}"
-    environment-name = "${var.environment-name}"
-    owner            = "${var.team_name}"
+  tags = {
+    business-unit    = var.business-unit
+    application      = var.application
+    is-production    = var.is-production
+    environment-name = var.environment-name
+    owner            = var.team_name
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id = "${aws_route53_zone.route53_zone.zone_id}"
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/s3.tf
@@ -1,29 +1,30 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.email}"
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.email
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "s3" {
   metadata {
     name      = "s3"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.s3.access_key_id}"
-    secret_access_key = "${module.s3.secret_access_key}"
-    bucket_arn        = "${module.s3.bucket_arn}"
-    bucket_name       = "${module.s3.bucket_name}"
+  data = {
+    access_key_id     = module.s3.access_key_id
+    secret_access_key = module.s3.secret_access_key
+    bucket_arn        = module.s3.bucket_arn
+    bucket_name       = module.s3.bucket_name
     region            = "eu-west-2"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/variable.tf
@@ -29,3 +29,4 @@ variable "environment-name" {
 variable "is-production" {
   default = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -16,3 +16,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/variables.tf
@@ -39,6 +39,9 @@ variable "is-production" {
 }
 
 // The following two variables are provided at runtime by the pipeline.
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/elasticache.tf
@@ -1,28 +1,29 @@
 module "celery-broker" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=3.1"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  application            = var.application
+  is-production          = var.is-production
   node_type              = "cache.t2.medium"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.email}"
+  environment-name       = var.environment-name
+  infrastructure-support = var.email
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "celery-broker" {
   metadata {
     name      = "celery-broker"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
+  data = {
     url                      = "redis://:${module.celery-broker.auth_token}@${module.celery-broker.primary_endpoint_address}:6379"
-    primary_endpoint_address = "${module.celery-broker.primary_endpoint_address}"
-    auth_token               = "${module.celery-broker.auth_token}"
+    primary_endpoint_address = module.celery-broker.primary_endpoint_address
+    auth_token               = module.celery-broker.auth_token
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -11,3 +11,4 @@ provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/pingdom.tf
@@ -1,4 +1,5 @@
-provider "pingdom" {}
+provider "pingdom" {
+}
 
 resource "pingdom_check" "laa-legal-adviser-api-search" {
   type                     = "http"
@@ -33,3 +34,4 @@ resource "pingdom_check" "laa-legal-adviser-api-admin" {
   publicreport             = "true"
   integrationids           = [87631, 83320]
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/rds.tf
@@ -1,17 +1,20 @@
-variable "cluster_name" {}
-variable "cluster_state_bucket" {}
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
 
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.email}"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.email
   db_engine              = "postgres"
   db_engine_version      = "9.4"
   db_instance_class      = "db.t2.small"
@@ -21,23 +24,24 @@ module "rds" {
   rds_family             = "postgres9.4"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "db" {
   metadata {
     name      = "db"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    endpoint = "${module.rds.rds_instance_endpoint}"
-    name     = "${module.rds.database_name}"
-    user     = "${module.rds.database_username}"
-    password = "${module.rds.database_password}"
-    host     = "${module.rds.rds_instance_address}"
-    port     = "${module.rds.rds_instance_port}"
+  data = {
+    endpoint = module.rds.rds_instance_endpoint
+    name     = module.rds.database_name
+    user     = module.rds.database_username
+    password = module.rds.database_password
+    host     = module.rds.rds_instance_address
+    port     = module.rds.rds_instance_port
     url      = "postgis://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/s3.tf
@@ -1,29 +1,30 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
 
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.email}"
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.email
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "s3" {
   metadata {
     name      = "s3"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    access_key_id     = "${module.s3.access_key_id}"
-    secret_access_key = "${module.s3.secret_access_key}"
-    bucket_arn        = "${module.s3.bucket_arn}"
-    bucket_name       = "${module.s3.bucket_name}"
+  data = {
+    access_key_id     = module.s3.access_key_id
+    secret_access_key = module.s3.secret_access_key
+    bucket_arn        = module.s3.bucket_arn
+    bucket_name       = module.s3.bucket_name
     region            = "eu-west-2"
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/variable.tf
@@ -29,3 +29,4 @@ variable "environment-name" {
 variable "is-production" {
   default = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/main.tf
@@ -1,6 +1,6 @@
 terraform {
-  required_version = "0.11.14"
-  backend          "s3"             {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -18,3 +18,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
@@ -1,31 +1,32 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.8"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "${var.team_name}"
-  business-unit          = "${var.business-unit}"
-  application            = "${var.application}"
-  is-production          = "${var.is-production}"
-  environment-name       = "${var.environment-name}"
-  infrastructure-support = "${var.infrastructure-support}"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
   force_ssl              = "true"
 
   providers = {
-    aws = "aws.london"
+    aws = aws.london
   }
 }
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {
     name      = "dps-rds-instance-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    rds_instance_endpoint = "${module.dps_rds.rds_instance_endpoint}"
-    database_name         = "${module.dps_rds.database_name}"
-    database_username     = "${module.dps_rds.database_username}"
-    database_password     = "${module.dps_rds.database_password}"
-    rds_instance_address  = "${module.dps_rds.rds_instance_address}"
+  data = {
+    rds_instance_endpoint = module.dps_rds.rds_instance_endpoint
+    database_name         = module.dps_rds.database_name
+    database_username     = module.dps_rds.database_username
+    database_password     = module.dps_rds.database_password
+    rds_instance_address  = module.dps_rds.rds_instance_address
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/route53.tf
@@ -1,24 +1,25 @@
 resource "aws_route53_zone" "route53_zone" {
   name = "licences.service.hmpps.dsd.io"
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
     name      = "route53-zone-output"
-    namespace = "${var.namespace}"
+    namespace = var.namespace
   }
 
-  data {
-    zone_id      = "${aws_route53_zone.route53_zone.zone_id}"
-    name_servers = "${join(", ", aws_route53_zone.route53_zone.name_servers)}"
+  data = {
+    zone_id      = aws_route53_zone.route53_zone.zone_id
+    name_servers = join(", ", aws_route53_zone.route53_zone.name_servers)
   }
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/variables.tf
@@ -6,9 +6,11 @@ variable "namespace" {
   default = "licences-prod"
 }
 
-variable "cluster_name" {}
+variable "cluster_name" {
+}
 
-variable "cluster_state_bucket" {}
+variable "cluster_state_bucket" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
@@ -33,3 +35,4 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Updated below namespaces with terraform 12 changes.


family-mediators-api-production
fj-cait-production
formbuilder-platform-live-dev
formbuilder-platform-live-production
formbuilder-product-page-prod
formbuilder-publisher-live
formbuilder-repos
formbuilder-services-live-dev
formbuilder-services-live-production
hmcts-complaints-formbuilder-adapter-production
hmpps-book-secure-move-api-production
hmpps-book-secure-move-frontend-production
ingress-controllers
keyworker-api-prod
kiam
kuberos
laa-apply-for-legalaid-production
laa-fala-production
laa-fee-calculator-production
laa-legal-adviser-api-production
licences-prod


Terraform 0.12 upgrade and update modules version to use the tf0.12