### PR TITLE
Remove multi-version code from the pipeline

### DIFF
--- a/bin/pipeline.rb
+++ b/bin/pipeline.rb
@@ -52,17 +52,11 @@ class Terraform
 
   private
 
-  def terraform_executable
-    # The `terraform 0.12upgrade` creates a `versions.tf` file, so we can
-    # use the existence of that file to identify terraform 0.12 source code
-    FileTest.exists?("#{tf_dir}/versions.tf") ? "terraform12" : "terraform"
-  end
-
   def tf_init
     key = "#{key_prefix}#{cluster}/#{namespace}/terraform.tfstate"
 
     cmd = [
-      %(#{terraform_executable} init),
+      %(terraform init),
       %(-backend-config="bucket=#{bucket}"),
       %(-backend-config="key=#{key}"),
       %(-backend-config="dynamodb_table=#{lock_table}"),
@@ -98,7 +92,7 @@ class Terraform
     operation = opts.fetch(:operation)
     last = opts.fetch(:last)
 
-    "#{terraform_executable} #{operation} #{last}"
+    "terraform #{operation} #{last}"
   end
 end
 

--- a/bin/pipeline.rb
+++ b/bin/pipeline.rb
@@ -78,7 +78,7 @@ class Terraform
   def tf_plan
     cmd = tf_cmd(
       operation: "plan",
-      last: %( | grep -vE '^(\\x1b\\[0m)?\\s{3,}'),
+      last: " ",
     )
 
     execute("cd #{tf_dir}; #{cmd}")

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -29,97 +29,43 @@ describe Terraform do
 
   subject(:tf) { described_class.new(params) }
 
-  context "terraform 0.11" do
-    before do
-      allow(FileTest).to receive(:exists?).with("#{dir}/resources/versions.tf").and_return(false)
+  describe "plan" do
+    it "runs terraform plan" do
+      env_vars.each do |key, val|
+        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+      end
+      allow(FileTest).to receive(:directory?).and_return(true)
+
+      tf_dir = "#{dir}/resources"
+
+      tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+      tf_plan = "cd #{tf_dir}; terraform plan  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
+
+      expect_execute(tf_init, "", success)
+      expect_execute(tf_plan, "", success)
+      expect($stdout).to receive(:puts)
+
+      tf.plan
     end
+  end
 
-    describe "plan" do
-      it "runs terraform plan" do
-        env_vars.each do |key, val|
-          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-        end
-        allow(FileTest).to receive(:directory?).and_return(true)
-
-        tf_dir = "#{dir}/resources"
-
-        tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-        tf_plan = "cd #{tf_dir}; terraform plan  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
-
-        expect_execute(tf_init, "", success)
-        expect_execute(tf_plan, "", success)
-        expect($stdout).to receive(:puts)
-
-        tf.plan
+  describe "apply" do
+    it "applies terraform files" do
+      env_vars.each do |key, val|
+        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
       end
-    end
+      allow(FileTest).to receive(:directory?).and_return(true)
+      tf_dir = "#{dir}/resources"
+      tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-    describe "apply" do
-      it "applies terraform files" do
-        env_vars.each do |key, val|
-          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-        end
-        allow(FileTest).to receive(:directory?).and_return(true)
+      tf_apply = "cd #{tf_dir}; terraform apply -auto-approve"
 
-        tf_dir = "#{dir}/resources"
+      expect_execute(tf_init, "", success)
+      expect_execute(tf_apply, "", success)
+      expect($stdout).to receive(:puts)
 
-        tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-        tf_apply = "cd #{tf_dir}; terraform apply -auto-approve"
-
-        expect_execute(tf_init, "", success)
-        expect_execute(tf_apply, "", success)
-        expect($stdout).to receive(:puts)
-
-        tf.apply
-      end
-    end
-
-    context "terraform 0.12" do
-      before do
-        allow(FileTest).to receive(:exists?).with("#{dir}/resources/versions.tf").and_return(true)
-      end
-
-      describe "plan" do
-        it "runs terraform plan" do
-          env_vars.each do |key, val|
-            expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-          end
-          allow(FileTest).to receive(:directory?).and_return(true)
-
-          tf_dir = "#{dir}/resources"
-
-          tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-          tf_plan = "cd #{tf_dir}; terraform12 plan  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
-
-          expect_execute(tf_init, "", success)
-          expect_execute(tf_plan, "", success)
-          expect($stdout).to receive(:puts)
-
-          tf.plan
-        end
-      end
-
-      describe "apply" do
-        it "applies terraform files" do
-          env_vars.each do |key, val|
-            expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-          end
-          allow(FileTest).to receive(:directory?).and_return(true)
-          tf_dir = "#{dir}/resources"
-          tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-          tf_apply = "cd #{tf_dir}; terraform12 apply -auto-approve"
-
-          expect_execute(tf_init, "", success)
-          expect_execute(tf_apply, "", success)
-          expect($stdout).to receive(:puts)
-
-          tf.apply
-        end
-      end
+      tf.apply
     end
   end
 end

--- a/bin/spec/terraform_spec.rb
+++ b/bin/spec/terraform_spec.rb
@@ -40,7 +40,7 @@ describe Terraform do
 
       tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-      tf_plan = "cd #{tf_dir}; terraform plan  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
+      tf_plan = "cd #{tf_dir}; terraform plan  "
 
       expect_execute(tf_init, "", success)
       expect_execute(tf_plan, "", success)


### PR DESCRIPTION
Now that we have upgraded everything we care about
to terraform 0.12, we don't need branching logic
to run two different versions.

This depends on a change to the concourse pipeline to use
a version of the tools image where the `terraform` command
executes the terraform 0.12 binary.

depends on https://github.com/ministryofjustice/cloud-platform-tools-image/pull/46