### PR TITLE
PQ Route53 Hosted Zone

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
@@ -1,6 +1,7 @@
 
 resource "aws_route53_zone" "parliamentary_questions" {
-  name = var.domain
+  name = "var.domain"
+
   tags = {
     business-unit          = var.team_name
     application            = var.application
@@ -13,7 +14,7 @@ resource "aws_route53_zone" "parliamentary_questions" {
 
 resource "kubernetes_secret" "parliamentary_questions_route53" {
   metadata {
-    name      = "parliamentary_questions_route53"
+    name      = "parliamentary-questions-route53"
     namespace = var.namespace
   }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
@@ -1,5 +1,5 @@
 
-resource "aws_route53_zone" "peoplefinder_route53_zone" {
+resource "aws_route53_zone" "parliamentary_questions" {
   name = var.domain
   tags = {
     business-unit          = var.team_name
@@ -8,5 +8,17 @@ resource "aws_route53_zone" "peoplefinder_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+  }
+}
+
+resource "kubernetes_secret" "parliamentary_questions_route53" {
+  metadata {
+    name      = "parliamentary_questions_route53"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id      = aws_route53_zone.parliamentary_questions.zone_id
+    name_servers = join("\n", aws_route53_zone.parliamentary_questions.name_servers)
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
@@ -1,0 +1,12 @@
+
+resource "aws_route53_zone" "peoplefinder_route53_zone" {
+  name = var.domain
+  tags = {
+    business-unit          = var.team_name
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/variables.tf
@@ -1,0 +1,46 @@
+variable "application" {
+  default = "Parliamentary Questions Tracker"
+}
+
+variable "aws_region" {
+  default = "eu-west-2"
+}
+
+variable "db_backup_retention_period" {
+  default = "7"
+}
+
+variable "environment-name" {
+  default = "production"
+}
+
+variable "infrastructure-support" {
+  default = "Tactical Products Team: pqsupport@digital.justice.gov.uk"
+}
+
+variable "is-production" {
+  default = true
+}
+
+variable "namespace" {
+  default = "parliamentary-questions-production"
+}
+
+variable "repo_name" {
+  default = "parliamentary-questions"
+}
+
+variable "team_name" {
+  default = "pq-team"
+}
+variable "domain" {
+  default = "trackparliamentaryquestions.service.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+


### PR DESCRIPTION
This PR creates a Route53 hosted zone in the Cloud Platform.

Once created, a secret will be populated  with `zone_id` and `name_servers`, in the relevant namespace.