### PR TITLE
Create dstest-dev? namespaces with ECRs

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dstest-deva
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "Gitops Namespace Deletion"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform/issues/1437"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dstest-deva-admin
+  namespace: dstest-deva
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: dstest-deva
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: dstest-deva
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: dstest-deva
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: dstest-deva
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/resources/ecr.tf
@@ -1,0 +1,23 @@
+module "dstest_deva_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+  repo_name = "dstest-deva"
+  team_name = "webops"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "dstest_deva_ecr_credentials" {
+  metadata {
+    name      = "ecr-credentials-output"
+    namespace = "dstest-deva"
+  }
+
+  data = {
+    access_key_id     = module.dstest_deva_ecr_credentials.access_key_id
+    secret_access_key = module.dstest_deva_ecr_credentials.secret_access_key
+    repo_arn          = module.dstest_deva_ecr_credentials.repo_arn
+    repo_url          = module.dstest_deva_ecr_credentials.repo_url
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deva/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dstest-devb
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "Gitops Namespace Deletion"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform/issues/1437"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dstest-devb-admin
+  namespace: dstest-devb
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: dstest-devb
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: dstest-devb
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: dstest-devb
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: dstest-devb
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/resources/ecr.tf
@@ -1,0 +1,23 @@
+module "dstest_devb_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+  repo_name = "dstest-devb"
+  team_name = "webops"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "dstest_devb_ecr_credentials" {
+  metadata {
+    name      = "ecr-credentials-output"
+    namespace = "dstest-devb"
+  }
+
+  data = {
+    access_key_id     = module.dstest_devb_ecr_credentials.access_key_id
+    secret_access_key = module.dstest_devb_ecr_credentials.secret_access_key
+    repo_arn          = module.dstest_devb_ecr_credentials.repo_arn
+    repo_url          = module.dstest_devb_ecr_credentials.repo_url
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devb/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dstest-devc
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "Gitops Namespace Deletion"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform/issues/1437"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dstest-devc-admin
+  namespace: dstest-devc
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: dstest-devc
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: dstest-devc
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: dstest-devc
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: dstest-devc
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/resources/ecr.tf
@@ -1,0 +1,23 @@
+module "dstest_devc_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+  repo_name = "dstest-devc"
+  team_name = "webops"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "dstest_devc_ecr_credentials" {
+  metadata {
+    name      = "ecr-credentials-output"
+    namespace = "dstest-devc"
+  }
+
+  data = {
+    access_key_id     = module.dstest_devc_ecr_credentials.access_key_id
+    secret_access_key = module.dstest_devc_ecr_credentials.secret_access_key
+    repo_arn          = module.dstest_devc_ecr_credentials.repo_arn
+    repo_url          = module.dstest_devc_ecr_credentials.repo_url
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devc/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dstest-devd
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "Gitops Namespace Deletion"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform/issues/1437"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dstest-devd-admin
+  namespace: dstest-devd
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: dstest-devd
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: dstest-devd
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: dstest-devd
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: dstest-devd
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/resources/ecr.tf
@@ -1,0 +1,23 @@
+module "dstest_devd_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+  repo_name = "dstest-devd"
+  team_name = "webops"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "dstest_devd_ecr_credentials" {
+  metadata {
+    name      = "ecr-credentials-output"
+    namespace = "dstest-devd"
+  }
+
+  data = {
+    access_key_id     = module.dstest_devd_ecr_credentials.access_key_id
+    secret_access_key = module.dstest_devd_ecr_credentials.secret_access_key
+    repo_arn          = module.dstest_devd_ecr_credentials.repo_arn
+    repo_url          = module.dstest_devd_ecr_credentials.repo_url
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-devd/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dstest-deve
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "Gitops Namespace Deletion"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform/issues/1437"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dstest-deve-admin
+  namespace: dstest-deve
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: dstest-deve
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: dstest-deve
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: dstest-deve
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: dstest-deve
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/resources/ecr.tf
@@ -1,0 +1,23 @@
+module "dstest_deve_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+  repo_name = "dstest-deve"
+  team_name = "webops"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "dstest_deve_ecr_credentials" {
+  metadata {
+    name      = "ecr-credentials-output"
+    namespace = "dstest-deve"
+  }
+
+  data = {
+    access_key_id     = module.dstest_deve_ecr_credentials.access_key_id
+    secret_access_key = module.dstest_deve_ecr_credentials.secret_access_key
+    repo_arn          = module.dstest_deve_ecr_credentials.repo_arn
+    repo_url          = module.dstest_deve_ecr_credentials.repo_url
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest-deve/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
blocks
https://github.com/ministryofjustice/cloud-platform/issues/1437

This PR creates 5 dev namespaces, each containing an ECR. These will be
used during the development and testing of a process to remove AWS
resources and namespaces from the cluster whenever a change is detected
which removes a namespace directory.

Each namespace is a clone of dstest-deva with 'deva' replaced with
'dev{b,c,d,e}' using commands like

```
cp -r dstest-devb dstest-devc
find dstest-devc -type f | xargs sed -i '' 's/devb/devc/g'
```