### PR TITLE
Amend pingdom host inline with ingress changes

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/pingdom.tf
@@ -5,7 +5,7 @@ provider "pingdom" {
 resource "pingdom_check" "claim-crown-court-defence-production" {
   type                     = "http"
   name                     = "Claim for crown court defence production - ping"
-  host                     = "cccd-production.apps.live-1.cloud-platform.service.justice.gov.uk"
+  host                     = "claim-crown-court-defence.service.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6


### PR DESCRIPTION
Have changed ingress to remove default live-1
cluster ingress. Pingdom therefore indicating
it is down as a result.

http://pingdom.service.dsd.io/5404882