### PR TITLE
DCS-266 Deploy probation-teams service to preprod. 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/07-certificates.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/07-certificates.yaml
@@ -16,3 +16,21 @@ spec:
       - 'licences-preprod.prison.service.justice.gov.uk'
       dns01:
         provider: route53-cloud-platform
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: probation-teams-preprod.prison.service.justice.gov.uk
+  namespace: licences-preprod
+spec:
+  secretName: probation-teams-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 'probation-teams-preprod.prison.service.justice.gov.uk'
+  acme:
+    config:
+      - domains:
+          - 'probation-teams-preprod.prison.service.justice.gov.uk'
+        dns01:
+          provider: route53-cloud-platform

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/rds.tf
@@ -15,6 +15,10 @@ module "dps_rds" {
   }
 }
 
+resource "random_id" "probation_teams_password" {
+  byte_length = 32
+}
+
 resource "kubernetes_secret" "dps_rds" {
   metadata {
     name      = "dps-rds-instance-output"
@@ -22,11 +26,11 @@ resource "kubernetes_secret" "dps_rds" {
   }
 
   data = {
-    rds_instance_endpoint = module.dps_rds.rds_instance_endpoint
-    database_name         = module.dps_rds.database_name
-    database_username     = module.dps_rds.database_username
-    database_password     = module.dps_rds.database_password
-    rds_instance_address  = module.dps_rds.rds_instance_address
+    rds_instance_endpoint    = module.dps_rds.rds_instance_endpoint
+    database_name            = module.dps_rds.database_name
+    database_username        = module.dps_rds.database_username
+    database_password        = module.dps_rds.database_password
+    rds_instance_address     = module.dps_rds.rds_instance_address
+    probation_teams_password = random_id.probation_teams_password.b64
   }
 }
-


### PR DESCRIPTION
Create a certificate and a password for new 'probation_teams' schema/role in db shared with licences-preprod