### PR TITLE
Put development gems into :development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem "rspec"
-gem "pry-byebug"
+group :development do
+  gem "rspec"
+  gem "pry-byebug"
+end


### PR DESCRIPTION
The tools image doesn't install development gems, so we need to
put any gems which are not already installed on the tools image
into a group, so that ruby doesn't try to load them, and complain
when they're missing.