### PR TITLE
Add a script to notify us about deleted namespaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "aws-sdk-s3", "~> 1"
 gem "kubeclient"
+gem "slack-notify"
 
 group :development do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    faraday (0.17.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -40,6 +42,7 @@ GEM
     http-parser (1.2.1)
       ffi-compiler (>= 1.0, < 2.0)
     jmespath (1.4.0)
+    json (2.2.0)
     kubeclient (4.5.0)
       http (>= 3.0, < 5.0)
       recursive-open-struct (~> 1.0, >= 1.0.4)
@@ -48,6 +51,7 @@ GEM
     mime-types (3.3)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
+    multipart-post (2.1.1)
     netrc (0.11.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -76,6 +80,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    slack-notify (0.5.0)
+      faraday (~> 0.9)
+      json (>= 1.8, <= 3.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
@@ -88,6 +95,7 @@ DEPENDENCIES
   kubeclient
   pry-byebug
   rspec
+  slack-notify
 
 BUNDLED WITH
    2.0.2

--- a/bin/deleted-namespaces.rb
+++ b/bin/deleted-namespaces.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+require File.join(".", File.dirname(__FILE__), "..", "lib", "cp_env")
+
+require "slack-notify"
+
+def send_notification(msg)
+  webhook_url = "https://hooks.slack.com/services/#{ENV.fetch("SLACK_WEBHOOK")}"
+
+  SlackNotify::Client.new(
+    channel: "#cloud-platform",
+    webhook_url: webhook_url,
+    username: "Namespace deleter",
+    icon_emoji: ":killitwithfire:"
+  ).notify(msg)
+end
+
+namespaces = deleted_namespaces("live-1.cloud-platform.service.justice.gov.uk")
+
+if namespaces.any?
+  msg = <<~EOF
+    The following namespaces have been removed from the environments repository:
+
+      - #{namespaces.join("\n  - ")}
+
+    Please delete them:
+
+    https://runbooks.cloud-platform.service.justice.gov.uk/manually-delete-namespace-resources.html#manually-delete-namespace-resources
+
+  EOF
+
+  puts msg
+  send_notification(msg)
+else
+  puts "No namespaces to delete"
+end

--- a/lib/cp_env/pipeline.rb
+++ b/lib/cp_env/pipeline.rb
@@ -18,6 +18,12 @@ def changed_namespace_dirs(cluster)
   namespace_dirs_from_changed_files(cluster, changed_files)
 end
 
+def deleted_namespaces(cluster)
+  changed_namespace_dirs(cluster)
+    .find_all { |dir| !FileTest.directory?(dir) }
+    .map { |dir| dir.split("/").last }
+end
+
 def namespace_dirs_from_changed_files(cluster, files)
   namespace_regex = %r{namespaces.#{cluster}}
 

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -160,6 +160,24 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
     end
   end
 
+  context "deleted namespaces" do
+    let(:cmd) { "git diff --no-commit-id --name-only -r HEAD~1..HEAD" }
+
+    let(:deleted) { "poornima-dev" }
+
+    before do
+      allow(FileTest).to receive(:directory?).and_return(true)
+      allow(FileTest).to receive(:directory?)
+        .with("namespaces/live-1.cloud-platform.service.justice.gov.uk/#{deleted}").and_return(false)
+    end
+
+    it "gets deleted namespaces" do
+      expect_execute(cmd, files, success)
+      expect($stdout).to receive(:puts).with(files)
+      expect(deleted_namespaces(cluster)).to eq([deleted])
+    end
+  end
+
   context "execute" do
     let(:cmd) { "ls" }
 


### PR DESCRIPTION
This script is designed to be executed by a concourse pipeline, whenever a
commit to the environments repo is merged to master. It will send a notification
to #cloud-platform if there are any namespaces which should be deleted. The
notification includes a link to the runbook for 'manually' deleting a namespace
and its AWS resources, using the deleter script.

This is a temporary manual step until we are confident that the only
namespaces which are being flagged for deletion are the right ones.
Subsequent commits will alter this script to delete the namespaces by
itself, and merely notify us that this has happened.