### PR TITLE
Updated s3 module to v4.1 for pathfinder-preprod

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "pathfinder_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.1"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -15,7 +15,7 @@ module "pathfinder_document_s3_bucket" {
 }
 
 module "pathfinder_reporting_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.1"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false


### PR DESCRIPTION
This module got a fix for the error 

Error: Error creating IAM User s3-bucket-user-840fd3f2f8b97cc72167c4818098f121: ValidationError: The specified value for path is invalid. It must begin and end with / and contain only alphanumeric characters and/or / characters.