### PR TITLE
Re-use AWS creds for terraform & getting kube conf

### DIFF
--- a/bin/delete-namespace.rb
+++ b/bin/delete-namespace.rb
@@ -18,9 +18,6 @@
 #
 #   # Env vars to enable kubectl to operate on the cluster by grabbing the kubeconfig
 #   # file from S3
-#   export KUBECONFIG_AWS_ACCESS_KEY_ID=[redacted]
-#   export KUBECONFIG_AWS_SECRET_ACCESS_KEY=[redacted]
-#   export KUBECONFIG_AWS_REGION=eu-west-2
 #   export KUBECONFIG_S3_BUCKET=cloud-platform-concourse-kubeconfig
 #   export KUBECONFIG_S3_KEY=kubeconfig
 #   export KUBE_CONFIG=/tmp/kubeconfig

--- a/lib/cp_env/namespace_deleter.rb
+++ b/lib/cp_env/namespace_deleter.rb
@@ -15,7 +15,7 @@ class CpEnv
     attr_reader :namespace, :k8s_client
 
     CLUSTER = "live-1.cloud-platform.service.justice.gov.uk"
-    KUBECONFIG_AWS_REGION = "eu-west-2"
+    AWS_REGION = "eu-west-2"
     NAMEPACES_DIR = "namespaces/#{CLUSTER}"
     PRODUCTION_LABEL = "cloud-platform.justice.gov.uk/is-production"
     LABEL_TRUE = "true"
@@ -41,8 +41,8 @@ class CpEnv
       raise "No namespace supplied" if namespace.to_s.empty?
 
       %w[
-        KUBECONFIG_AWS_ACCESS_KEY_ID
-        KUBECONFIG_AWS_SECRET_ACCESS_KEY
+        AWS_ACCESS_KEY_ID
+        AWS_SECRET_ACCESS_KEY
         KUBECONFIG_S3_BUCKET
         KUBECONFIG_S3_KEY
         KUBE_CONFIG
@@ -94,10 +94,10 @@ class CpEnv
     def initialise_k8s_client
       kubeconfig = {
         s3client: Aws::S3::Client.new(
-          region: KUBECONFIG_AWS_REGION,
+          region: AWS_REGION,
           credentials: Aws::Credentials.new(
-            env("KUBECONFIG_AWS_ACCESS_KEY_ID"),
-            env("KUBECONFIG_AWS_SECRET_ACCESS_KEY")
+            env("AWS_ACCESS_KEY_ID"),
+            env("AWS_SECRET_ACCESS_KEY")
           )
         ),
         bucket: env("KUBECONFIG_S3_BUCKET"),


### PR DESCRIPTION
Previously, the code this was based upon had to 
work on both live-0 and live-1, which are in 
different AWS accounts, so in one cluster we
needed two different sets of AWS credentials.

Now that we only have to worry about live-1, we
can be sure that the same AWS credentials that
give us access to the terraform state files will
also give us access to the kubeconfig file's S3
bucket. So, we can reduce complexity by only
using a single set of AWS credentials.