### PR TITLE
Fix ecr secret name in laa-cla-public

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
@@ -11,7 +11,7 @@ module "ecr-repo" {
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
-    name      = "ecr-repo-laa-fala"
+    name      = "ecr-repo-laa-cla-public"
     namespace = var.namespace
   }
 


### PR DESCRIPTION
Bad copy-paste job.
We haven't started using it yet, so it's fine if this causes a deletion and recreation of the ecr repo.