### PR TITLE
Add a docker registry pull-through cache to the cluster

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: docker-registry-cache
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "docker-registry-cache"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform <platforms@digital.justice.gov.uk>: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-docker-registry-cache"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: docker-registry-cache-admin
+  namespace: docker-registry-cache
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: docker-registry-cache
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: docker-registry-cache
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: docker-registry-cache
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: docker-registry-cache
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: docker-registry-cache
+  namespace: docker-cache
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: docker-registry-cache
+    spec:
+      containers:
+      - name: registry
+        image: ministryofjustice/docker-registry-cache:1.4
+        ports:
+        - containerPort: 5000
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - /usr/local/bin/disk-usage-high
+          initialDelaySeconds: 60
+          periodSeconds: 1800

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: docker-registry-cache-ingress
+  namespace: docker-cache
+spec:
+  tls:
+  - hosts:
+    - docker-registry-cache.apps.live-1.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: docker-registry-cache.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docker-registry-cache-service
+          servicePort: 5000

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/service.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/docker-registry-cache/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-registry-cache-service
+  namespace: docker-cache
+  labels:
+    app: docker-registry-cache
+spec:
+  ports:
+  - port: 5000
+    name: http
+    targetPort: 5000
+  selector:
+    app: docker-registry-cache


### PR DESCRIPTION
A subsequent PR will alter the kops config so that worker nodes
will use this cache, when pulling images from docker hub.

Of course the cache will not be present in a new cluster, even
though the workers will be configured to use it, but this does
not cause problems - the docker daemon on the worker nodes will
try the cache first, but will fail over to contacting docker
hub directly if the cache is not responding.

see: https://github.com/ministryofjustice/cloud-platform-docker-registry-cache

related to: https://github.com/ministryofjustice/cloud-platform/issues/1443