### PR TITLE
Add temporary testing domain to cla-public prod cert

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/06-certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/06-certificate.yaml
@@ -13,5 +13,6 @@ spec:
     config:
     - domains:
       - 'checklegalaid.service.gov.uk'
+      - 'live1.checklegalaid.service.gov.uk'
       dns01:
         provider: route53-cloud-platform


### PR DESCRIPTION
To allow us to set up the production ingress exactly like it will be but using `live1.checklegalaid.service.gov.uk` instead of `checklegalaid.service.gov.uk` so we have as few moving parts as possible when we're getting ready to switch.