### PR TITLE
Revert "Amend RDS database name"

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
@@ -9,7 +9,7 @@ module "rds_instance" {
   db_backup_retention_period = var.db_backup_retention_period
   db_engine                  = "postgres"
   db_engine_version          = "11"
-  db_name                    = "parliamentary-questions_dev"
+  db_name                    = "parliamentary_questions_dev"
   environment-name           = var.environment-name
   infrastructure-support     = var.infrastructure-support
   is-production              = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/rds.tf
@@ -11,7 +11,7 @@ module "rds_instance" {
   db_backup_retention_period  = var.db_backup_retention_period
   db_engine                   = "postgres"
   db_engine_version           = "11"
-  db_name                     = "parliamentary-questions_dev"
+  db_name                     = "parliamentary_questions_dev"
   environment-name            = var.environment-name
   infrastructure-support      = var.infrastructure-support
   is-production               = var.is-production
@@ -39,3 +39,4 @@ resource "kubernetes_secret" "rds_instance" {
     url                   = "postgres://${module.rds_instance.database_username}:${module.rds_instance.database_password}@${module.rds_instance.rds_instance_endpoint}/${module.rds_instance.database_name}"
   }
 }
+


### PR DESCRIPTION
This reverts commit 3bea1fd318cf298bc3566dc1b2896b269822f2d6.

AWS does not allow hyphens in RDS database names (they are allowed
in *instance* names, but not in database names).