### PR TITLE
Add script to delete manually-created pods

### DIFF
--- a/bin/delete_manually_created_pods.rb
+++ b/bin/delete_manually_created_pods.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+require File.join(".", File.dirname(__FILE__), "..", "lib", "cp_env")
+
+# This script will delete any pods which are:
+#
+#   * not part of a ReplicaSet
+#   * and not in kube-system
+#   * and have been running for more than 2 days
+#
+# Such pods prevent the node-recycler from draining a node to
+# replace it.
+#
+# NB: The script has a 'dry-run' mode, in which pods will be listed
+# but not deleted. To use this, pass the string `--dry-run` as the
+# first and only argument.
+#
+# Developers need to run manual pods for tasks such as port-forwarding
+# to a database, but there's no good reason for such a pod to still be
+# running after 48 hours. If pods should always be running, they should
+# be part of a deployment (and hence a ReplicaSet).
+#
+# The script requires the following environment variables:
+#
+#   export PIPELINE_CLUSTER=live-1.cloud-platform.service.justice.gov.uk
+#
+# It also needs to be able to run:
+#
+#   kubectl config use-context #{cluster}
+#
+
+cluster = ENV.fetch("PIPELINE_CLUSTER")
+
+dry_run = ARGV.shift == "--dry-run"
+
+if dry_run
+  log("green", "Dry run: detecting manually created pods in #{cluster}")
+else
+  log("green", "Deleting manually created pods in #{cluster}")
+end
+
+set_kube_context(cluster)
+
+CpEnv::ManuallyCreatedPodDeleter.new(dry_run: dry_run).run
+
+log("green", "Done.")

--- a/lib/cp_env.rb
+++ b/lib/cp_env.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require "date"
 require "kubeclient"
 require "open3"
 require "open-uri"
@@ -12,3 +13,4 @@ require File.join(File.dirname(__FILE__), "cp_env", "pipeline")
 require File.join(File.dirname(__FILE__), "cp_env", "terraform")
 require File.join(File.dirname(__FILE__), "cp_env", "namespace_deleter")
 require File.join(File.dirname(__FILE__), "cp_env", "kubeconfig")
+require File.join(File.dirname(__FILE__), "cp_env", "manually_created_pod_deleter")

--- a/lib/cp_env.rb
+++ b/lib/cp_env.rb
@@ -7,6 +7,7 @@ require "aws-sdk-s3"
 class CpEnv
 end
 
+require File.join(File.dirname(__FILE__), "cp_env", "executor")
 require File.join(File.dirname(__FILE__), "cp_env", "pipeline")
 require File.join(File.dirname(__FILE__), "cp_env", "terraform")
 require File.join(File.dirname(__FILE__), "cp_env", "namespace_deleter")

--- a/lib/cp_env/executor.rb
+++ b/lib/cp_env/executor.rb
@@ -1,0 +1,19 @@
+class CpEnv
+  class Executor
+    def execute(cmd, can_fail: false, silent: false)
+      log("blue", "executing: #{cmd}") unless silent
+
+      stdout, stderr, status = Open3.capture3(cmd)
+
+      unless can_fail || status.success?
+        log("red", "Command: #{cmd} failed.")
+        puts stderr
+        raise
+      end
+
+      puts stdout unless silent
+
+      [stdout, stderr, status]
+    end
+  end
+end

--- a/lib/cp_env/manually_created_pod_deleter.rb
+++ b/lib/cp_env/manually_created_pod_deleter.rb
@@ -1,0 +1,59 @@
+class CpEnv
+  # Detect and kill any pods which are:
+  #
+  #   * not part of a ReplicaSet
+  #   * and not in kube-system
+  #   * and have been running for more than 2 days
+  #
+  # Such pods prevent the node-recycler from draining a node to
+  # replace it.
+  #
+  # Developers need to run manual pods for tasks such as port-forwarding
+  # to a database, but there's no good reason for such a pod to still be
+  # running after 48 hours. If pods should always be running, they should
+  # be part of a deployment (and hence a ReplicaSet).
+  #
+  # To see a list of pods that *would be* deleted, without actually
+  # deleting any, pass `dry_run: true` to the `initialize` method.
+  class ManuallyCreatedPodDeleter
+    attr_reader :executor, :dry_run
+
+    SYSTEM_NAMESPACE = "kube-system"
+    MAX_AGE_IN_SECONDS = 2 * 24 * 60 * 60 # 2 days
+
+    def initialize(args = {})
+      @executor = args.fetch(:executor) { Executor.new }
+      @dry_run = args.fetch(:dry_run, false)
+    end
+
+    def run
+      pods_to_delete = get_all_pods
+        .reject { |pod| pod.fetch("metadata").key?("ownerReferences") }
+        .reject { |pod| pod.dig("metadata", "namespace") == SYSTEM_NAMESPACE }
+        .reject { |pod| seconds_running(pod) < MAX_AGE_IN_SECONDS }
+
+      pods_to_delete.map { |pod| delete_pod(pod) }
+    end
+
+    private
+
+    def get_all_pods
+      stdout, _stderr, _status = executor.execute("kubectl get pods --all-namespaces -o json", silent: true)
+      JSON.parse(stdout).fetch("items")
+    end
+
+    def seconds_running(pod)
+      Time.now.to_i - DateTime.parse(pod.dig("status", "startTime")).to_time.to_i
+    end
+
+    def delete_pod(pod)
+      namespace = pod.dig("metadata", "namespace")
+      name = pod.dig("metadata", "name")
+      if dry_run
+        log("blue", "dry run: would delete pod #{name} from namespace #{namespace}")
+      else
+        executor.execute("kubectl -n #{namespace} delete pod #{name}")
+      end
+    end
+  end
+end

--- a/lib/cp_env/pipeline.rb
+++ b/lib/cp_env/pipeline.rb
@@ -81,19 +81,8 @@ def apply_terraform(cluster, namespace, dir)
   Terraform.new(cluster: cluster, namespace: namespace, dir: dir).apply
 end
 
-def execute(cmd, can_fail: false)
-  log("blue", "executing: #{cmd}")
-  stdout, stderr, status = Open3.capture3(cmd)
-
-  unless can_fail || status.success?
-    log("red", "Command: #{cmd} failed.")
-    puts stderr
-    raise
-  end
-
-  puts stdout
-
-  [stdout, stderr, status]
+def execute(cmd, can_fail: false, silent: false)
+  CpEnv::Executor.new.execute(cmd, can_fail: can_fail, silent: silent)
 end
 
 def log(colour, message)

--- a/spec/manually_created_pod_deleter_spec.rb
+++ b/spec/manually_created_pod_deleter_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+
+describe CpEnv::ManuallyCreatedPodDeleter do
+  let(:executor) { double(CpEnv::Executor) }
+  let(:params) {
+    {
+      executor: executor,
+    }
+  }
+  subject(:deleter) { described_class.new(params) }
+
+  let(:json) { %({"items": []}) }
+
+  before do
+    allow(executor).to receive(:execute).with("kubectl get pods --all-namespaces -o json", silent: true).and_return(json)
+  end
+
+  it "gets all pods" do
+    expect(executor).to receive(:execute).with("kubectl get pods --all-namespaces -o json", silent: true).and_return(json)
+    deleter.run
+  end
+
+  context "when there are pods" do
+    let(:namespace) { "mynamespace" }
+    let(:startTime) { (Date.today - 3).to_s }
+
+    let(:pod) {
+      %(
+         {
+           "metadata": {
+             "name": "mypod",
+             "namespace": "#{namespace}"
+           },
+           "status": {
+             "startTime": "#{startTime}"
+           }
+         }
+       )
+    }
+
+    let(:json) { %({"items": [ #{pod} ]}) }
+
+    context "but the pod is 1 day old" do
+      let(:startTime) { (Date.today - 1).to_s }
+
+      it "does not delete the pod" do
+        expect(executor).to_not receive(:execute).with("kubectl -n mynamespace delete pod mypod")
+        deleter.run
+      end
+    end
+
+    context "and the pod is 3 days old" do
+      let(:startTime) { (Date.today - 3).to_s }
+
+      it "deletes pod" do
+        expect(executor).to receive(:execute).with("kubectl -n mynamespace delete pod mypod")
+        deleter.run
+      end
+
+      context "in dry-run mode" do
+        let(:params) { super().merge(dry_run: true) }
+
+        # suppress log output
+        before do
+          allow($stdout).to receive(:puts).with("\e[34mdry run: would delete pod mypod from namespace mynamespace\e[0m")
+        end
+
+        it "does not delete the pod" do
+          expect(executor).to_not receive(:execute).with("kubectl -n mynamespace delete pod mypod")
+          deleter.run
+        end
+      end
+
+      context "but the pod is in kube-system" do
+        let(:namespace) { "kube-system" }
+
+        it "does not delete the pod" do
+          expect(executor).to_not receive(:execute).with("kubectl -n mynamespace delete pod mypod")
+          deleter.run
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This script will delete any pods which are:
* not part of a ReplicaSet
* and not in kube-system
* and have been running for more than 2 days
Such pods prevent the node-recycler from draining a node to
replace it.

Developers need to run manual pods for tasks such as port-forwarding
to a database, but there's no good reason for such a pod to still be
running after 48 hours. If pods should always be running, they should
be part of a deployment (and hence a ReplicaSet).

NB: This PR adds the script. A subsequent PR will
create a concourse pipeline to execute it daily.