### PR TITLE
Add laa-court-data-adaptor production namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-court-data-adaptor-prod
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/application: "LAA Court Data Adaptor"
+    cloud-platform.justice.gov.uk/owner: "LAA Crime Apps Team: laa-crime-apps@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-court-data-adaptor"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-court-data-adaptor-prod-admin
+  namespace: laa-court-data-adaptor-prod
+subjects:
+  - kind: Group
+    name: "github:laa-crime-apps-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-court-data-adaptor-prod
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-court-data-adaptor-prod
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-court-data-adaptor-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-court-data-adaptor-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Creates a user acceptance production environment/namespace for the laa-court-data-adaptor application:

https://github.com/ministryofjustice/laa-court-data-adaptor