### PR TITLE
Correct gitops module spec fixtures

### DIFF
--- a/spec/fixtures/make-gitops-namespace-test-dev/resources/gitops.tf
+++ b/spec/fixtures/make-gitops-namespace-test-dev/resources/gitops.tf
@@ -1,5 +1,5 @@
 module "concourse-gitops" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-gitops?ref=tf12"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-gitops"
   source_code_url               = "https://foo.bar.baz"
   github_team                   = "webops"
   namespace                     = "make-gitops-namespace-test-dev"


### PR DESCRIPTION
Current integration tests fail with the message:
```
       Diff:
       @@ -1,5 +1,5 @@
        module "concourse-gitops" {
       -  source                        = "github.com/ministryofjustice/cloud-platform-terraform-gitops"
       +  source                        = "github.com/ministryofjustice/cloud-platform-terraform-gitops?ref=tf12"
          source_code_url               = "https://foo.bar.baz"
          github_team                   = "webops"
          namespace                     = "make-gitops-namespace-test-dev"
```
The template module now only references the source from master. 