### PR TITLE
add RDS to jason-lab, for testing purposes

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/jason-lab-rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/jason-lab-rds.tf
@@ -15,6 +15,26 @@ module "jason-lab-rds-instance" {
   }
 }
 
+
+module "jason-lab-rds-instance2" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.0"
+
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  force_ssl              = "false"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+
+
 resource "kubernetes_secret" "jason-lab-rds-instance" {
   metadata {
     name      = "jason-lab-${var.environment-name}"


### PR DESCRIPTION
Adding a new RDS to keep the change pipeline busy long enough to test the concurrency.
