### PR TITLE
Add internal (`.justice.`) hosted domain for service

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/route53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_zone" "lcdui_route53_zone" {
+  name = var.domain
+
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
+  }
+}
+
+resource "kubernetes_secret" "lcdui_route53_zone_sec" {
+  metadata {
+    name      = "lcdui-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.lcdui_route53_zone.zone_id
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/variables.tf
@@ -6,6 +6,10 @@ variable "namespace" {
   default = "laa-court-data-ui-dev"
 }
 
+variable "domain" {
+  default = "view-court-data.service.justice.gov.uk"
+}
+
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
   default     = "legal-aid-agency"


### PR DESCRIPTION
add hosted zone for laa-court-data-ui environments

to allow custom DNS records.

