### PR TITLE
Add a 'production' database to dstest namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
@@ -23,8 +23,8 @@ module "dstest_rds" {
 
 resource "kubernetes_secret" "dstest_rds_secret" {
   metadata {
-    name      = "dstest_rds_secret"
-    namespace = "dstest"
+    name      = "dstest-rds-instance-output"
+    namespace = var.namespace
   }
 
   data = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
@@ -1,0 +1,33 @@
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+module "dstest_rds" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=prevent_destroy"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+  force_ssl              = "true"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "dstest_rds_secret" {
+  metadata {
+    name      = "dstest_rds_secret"
+    namespace = "dstest"
+  }
+
+  data = {
+    url = "postgres://${module.dstest_rds.database_username}:${module.dstest_rds.database_password}@${module.dstest_rds.rds_instance_endpoint}/${module.dstest_rds.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
@@ -14,7 +14,6 @@ module "dstest_rds" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
-  force_ssl              = "true"
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/variables.tf
@@ -2,6 +2,10 @@ variable "team_name" {
   default = "webops"
 }
 
+variable "namespace" {
+  default = "dstest"
+}
+
 variable "is-production" {
   default = "true"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/variables.tf
@@ -1,0 +1,24 @@
+variable "team_name" {
+  default = "webops"
+}
+
+variable "is-production" {
+  default = "true"
+}
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "MoJ Digital"
+}
+
+variable "application" {
+  default = "RDS Module Test"
+}
+
+variable "environment-name" {
+  default = "development"
+}
+
+variable "infrastructure-support" {
+  default = "platforms@digital.justice.gov.uk"
+}


### PR DESCRIPTION
The purpose of this change is to test the delete protection
features for production databases, hence the value of
"is-production" is set to true for the terraform resources.

Later PRs will attempt to delete the RDS instance.

NB: This PR uses a branch of the RDS module repo.