### PR TITLE
poeplefinder remove slash from url

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/s3.tf
@@ -19,7 +19,7 @@ module "peoplefinder_s3" {
       allowed_methods = ["GET", "POST", "PUT"]
       allowed_origins = [
         "https://demo.peoplefinder.service.gov.uk",
-        "https://peoplefinder-demo.apps.live-1.cloud-platform.service.justice.gov.uk/"
+        "https://peoplefinder-demo.apps.live-1.cloud-platform.service.justice.gov.uk"
       ]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/s3.tf
@@ -19,7 +19,7 @@ module "peoplefinder_s3" {
       allowed_methods = ["GET", "POST", "PUT"]
       allowed_origins = [
         "https://staging.peoplefinder.service.gov.uk",
-        "https://peoplefinder-staging.apps.live-1.cloud-platform.service.justice.gov.uk/"
+        "https://peoplefinder-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
       ]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000


### PR DESCRIPTION
I couldn't see the pictures that I synced, I'm hoping it's because of the slash. Sorry to keep doing this!