### PR TITLE
Gitops pipeline on manager cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Icon
 .Trashes
 .VolumeIcon.icns
 .com.apple.timemachine.donotpresent
+tags
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/gitops-namespace-resources/05-deployrole.yaml
+++ b/gitops-namespace-resources/05-deployrole.yaml
@@ -6,71 +6,16 @@ metadata:
   name: deploy
   namespace: ${namespace}
 ---
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: deploy
-  namespace: ${namespace}
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - "pods/portforward"
-      - "deployment"
-      - "secrets"
-      - "services"
-      - "pods"
-      - "cronjobs"
-    verbs:
-      - "patch"
-      - "get"
-      - "create"
-      - "delete"
-      - "list"
-  - apiGroups:
-      - "extensions"
-    resources:
-      - "deployments"
-      - "ingresses"
-      - "networkpolicies"
-    verbs:
-      - "get"
-      - "update"
-      - "delete"
-      - "create"
-      - "patch"
-      - "list"
-  - apiGroups:
-      - "monitoring.coreos.com"
-    resources:
-      - "service-monitor"
-      - "servicemonitors"
-      - "prometheusrules"
-    verbs:
-      - "*"
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - "networkpolicies"
-    verbs:
-      - "get"
-      - "update"
-      - "delete"
-      - "create"
-      - "patch"
-      - "list"
-
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: deploy
-  namespace: ${namespace}
+  name: namespace-usage-report-admin
+  namespace: namespace-usage-report
 subjects:
 - kind: ServiceAccount
   name: deploy
-  namespace: concourse-${github_team}
+  apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: Role
-  name: deploy
+  kind: ClusterRole
+  name: admin
   apiGroup: rbac.authorization.k8s.io

--- a/gitops-namespace-resources/05-deployrole.yaml
+++ b/gitops-namespace-resources/05-deployrole.yaml
@@ -3,17 +3,17 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: deploy
+  name: gitops-deploy
   namespace: ${namespace}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: namespace-usage-report-admin
-  namespace: namespace-usage-report
+  name: gitops-deploy
+  namespace: ${namespace}
 subjects:
 - kind: ServiceAccount
-  name: deploy
+  name: gitops-deploy
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/gitops-namespace-resources/05-deployrole.yaml
+++ b/gitops-namespace-resources/05-deployrole.yaml
@@ -1,3 +1,10 @@
+# This service account will be used to impersonate user privileges
+# and deploy user applications in a Gitops pipeline.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deploy
+  namespace: ${namespace}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,6 +20,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "cronjobs"
     verbs:
       - "patch"
       - "get"

--- a/gitops-namespace-resources/gitops-resources/deploy-serviceaccount.yaml
+++ b/gitops-namespace-resources/gitops-resources/deploy-serviceaccount.yaml
@@ -1,8 +1,0 @@
-# This service account will be used to impersonate user privileges
-# and deploy user applications in a Gitops pipeline.
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: deploy
-  namespace: concourse-${github_team}

--- a/lib/cp_env/gitops_gpg_keypair.rb
+++ b/lib/cp_env/gitops_gpg_keypair.rb
@@ -12,6 +12,7 @@ class CpEnv
 
     def generate_and_store
       unless gpg_key_exists?(seckey_secret_name)
+        log("blue", "Unable to find secret gpg key, removing leftover public keys.")
         delete_pubkey_secret
         pubkey, seckey = generate_keypair
         store_in_namespace_secrets(pubkey: pubkey, seckey: seckey)
@@ -27,7 +28,6 @@ class CpEnv
     end
 
     def delete_pubkey_secret
-      log("blue", "Unable to find secret gpg key, removing leftover public keys.")
       if gpg_key_exists?(pubkey_secret_name)
         executor.execute("kubectl -n #{namespace} delete secret #{pubkey_secret_name}")
       end

--- a/lib/cp_env/gitops_gpg_keypair.rb
+++ b/lib/cp_env/gitops_gpg_keypair.rb
@@ -33,7 +33,10 @@ class CpEnv
     end
 
     def delete_pubkey_secret
-      stdout, _, _ = executor.execute("kubectl -n #{namespace} delete secret #{pubkey_secret_name}", silent: true)
+      log("green", "Unable to find secret gpg key, removing leftover public keys.")
+      if secret_key_exists?
+        executor.execute("kubectl -n #{namespace} delete secret #{pubkey_secret_name}")
+      end
     end
 
     def pubkey_secret_name

--- a/lib/cp_env/gitops_gpg_keypair.rb
+++ b/lib/cp_env/gitops_gpg_keypair.rb
@@ -33,8 +33,8 @@ class CpEnv
     end
 
     def delete_pubkey_secret
-      log("green", "Unable to find secret gpg key, removing leftover public keys.")
-      if secret_key_exists?
+      log("blue", "Unable to find secret gpg key, removing leftover public keys.")
+      if public_key_exists?
         executor.execute("kubectl -n #{namespace} delete secret #{pubkey_secret_name}")
       end
     end

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -73,7 +73,7 @@ class CpEnv
       apply_terraform
     end
 
-    # Creates a concourse-<team-name> namespace and a kubeconfig secret inside. 
+    # Creates a concourse-<team-name> namespace and a kubeconfig secret inside.
     # The kubeconfig file is pulled down locally as part of the build-environments pipeline.
     def create_gitops_kubeconfig
       log("green", "creating kubeconfig secret inside concourse-#{team_name}")

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -3,7 +3,7 @@ class CpEnv
     attr_reader :cluster, :dir
     attr_reader :executor
 
-    GITOPS_RESOURCES_DIR = "gitops-resources"
+    GITOPS_RESOURCES_FILE = "resources/gitops.tf"
     # An ARN is required to switch context to the manager EKS cluster
     MANAGER_CLUSTER = "arn:aws:eks:eu-west-2:754256621582:cluster/manager"
 
@@ -33,7 +33,7 @@ class CpEnv
     end
 
     def gitops_namespace?
-      FileTest.exists?(File.join(dir, GITOPS_RESOURCES_DIR))
+      FileTest.exists?(File.join(dir, GITOPS_RESOURCES_FILE))
     end
 
     def team_name

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -4,6 +4,7 @@ class CpEnv
     attr_reader :executor
 
     GITOPS_RESOURCES_DIR = "gitops-resources"
+    # An ARN is required to switch context to the manager EKS cluster
     MANAGER_CLUSTER = "arn:aws:eks:eu-west-2:754256621582:cluster/manager"
 
     def initialize(args)

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -74,7 +74,7 @@ class CpEnv
     end
 
     # Creates a concourse-<team-name> namespace and a kubeconfig secret inside. 
-    # The kubeconfig file is pulled down locally as part of the build pipeline.
+    # The kubeconfig file is pulled down locally as part of the build-environments pipeline.
     def create_gitops_kubeconfig
       log("green", "creating kubeconfig secret inside concourse-#{team_name}")
       set_kube_context(MANAGER_CLUSTER)

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -69,7 +69,6 @@ class CpEnv
       return unless FileTest.directory?(dir)
 
       apply_kubernetes_files
-      apply_gitops_kubernetes_files
       create_gitops_kubeconfig
       apply_terraform
     end
@@ -95,11 +94,6 @@ class CpEnv
 
     def secret_exists?
       system("kubectl -n concourse-#{team_name} get secret kubectl-conf")
-    end
-
-    def apply_gitops_kubernetes_files
-      log("green", "applying concourse-#{team_name}")
-      executor.execute("kubectl -n concourse-#{team_name} apply -f #{dir}/gitops-resources")
     end
   end
 end

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/05-deployrole.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/05-deployrole.yaml
@@ -1,3 +1,10 @@
+# This service account will be used to impersonate user privileges
+# and deploy user applications in a Gitops pipeline.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deploy
+  namespace: namespace-usage-report
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,6 +20,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "cronjobs"
     verbs:
       - "patch"
       - "get"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/05-deployrole.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/05-deployrole.yaml
@@ -5,62 +5,9 @@ kind: ServiceAccount
 metadata:
   name: deploy
   namespace: namespace-usage-report
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: deploy
-  namespace: namespace-usage-report
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - "pods/portforward"
-      - "deployment"
-      - "secrets"
-      - "services"
-      - "pods"
-      - "cronjobs"
-    verbs:
-      - "patch"
-      - "get"
-      - "create"
-      - "delete"
-      - "list"
-  - apiGroups:
-      - "extensions"
-    resources:
-      - "deployments"
-      - "ingresses"
-      - "networkpolicies"
-    verbs:
-      - "get"
-      - "update"
-      - "delete"
-      - "create"
-      - "patch"
-      - "list"
-  - apiGroups:
-      - "monitoring.coreos.com"
-    resources:
-      - "service-monitor"
-      - "servicemonitors"
-      - "prometheusrules"
-    verbs:
-      - "*"
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - "networkpolicies"
-    verbs:
-      - "get"
-      - "update"
-      - "delete"
-      - "create"
-      - "patch"
-      - "list"
 
 ---
+
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -69,8 +16,9 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: deploy
-  namespace: concourse-webops
+  namespace: namespace-usage-report
 roleRef:
-  kind: Role
-  name: deploy
+  kind: ClusterRole
+  name: admin
   apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/gitops-resources/deploy-serviceaccount.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/gitops-resources/deploy-serviceaccount.yaml
@@ -1,8 +1,0 @@
-# This service account will be used to impersonate user privileges
-# and deploy user applications in a Gitops pipeline.
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: deploy
-  namespace: concourse-webops

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/resources/gitops.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/namespace-usage-report/resources/gitops.tf
@@ -1,0 +1,10 @@
+module "concourse-gitops" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-gitops"
+  source_code_url               = "https://github.com/ministryofjustice/cloud-platform-namespace-usage-report"
+  github_team                   = "webops"
+  namespace                     = "namespace-usage-report"
+  branch                        = "master"
+  concourse_basic_auth_username = var.concourse_basic_auth_username
+  concourse_url                 = var.concourse_url
+  concourse_basic_auth_password = var.concourse_basic_auth_password
+}


### PR DESCRIPTION
Overview
---
This PR allows the apply script to execute gitops actions on the EKS manager cluster. To enable this we had to re-work how the gitops pipeline would authenticate to both live and manager clusters and store secrets in live-1 in the application namespace not concourse. 

This PR also contains changes to the live-1 environment `namespace-usage-report` as this will be the first app using gitops. 

