### PR TITLE
Add policy to allow aws legacy to recieve message

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/cp_test_queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/cp_test_queue.tf
@@ -25,7 +25,7 @@ resource "aws_sqs_queue_policy" "cp_test_queue" {
     "Statement":
       [
         {
-          "Sid": "first"
+          "Sid": "first",
           "Effect": "Allow",
           "Principal": {"AWS": "*"},
           "Resource": "${module.cp_test_queue.sqs_arn}",
@@ -38,14 +38,9 @@ resource "aws_sqs_queue_policy" "cp_test_queue" {
           "AWS": [
             "902837325998"
               ]
-          }
+          },
           "Action": "sqs:ReceiveMessage",
-          "Resource": "arn:aws:sqs:eu-west-2:754256621582:crimeapps-development-cp-test-queue",
-          "Condition": {
-              "ArnEquals": {
-                   "aws:SourceArn": "arn:aws:sqs:us-east-1:111045819866:test-queue"
-                     }
-              }
+          "Resource": "arn:aws:sqs:eu-west-2:754256621582:crimeapps-development-cp-test-queue"
         }
       ]
   }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/cp_test_queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/cp_test_queue.tf
@@ -25,10 +25,27 @@ resource "aws_sqs_queue_policy" "cp_test_queue" {
     "Statement":
       [
         {
+          "Sid": "first"
           "Effect": "Allow",
           "Principal": {"AWS": "*"},
           "Resource": "${module.cp_test_queue.sqs_arn}",
           "Action": "SQS:*"
+        },
+        {
+          "Sid": "Second",
+          "Effect": "Allow",
+          "Principal": {
+          "AWS": [
+            "902837325998"
+              ]
+          }
+          "Action": "sqs:ReceiveMessage",
+          "Resource": "arn:aws:sqs:eu-west-2:754256621582:crimeapps-development-cp-test-queue",
+          "Condition": {
+              "ArnEquals": {
+                   "aws:SourceArn": "arn:aws:sqs:us-east-1:111045819866:test-queue"
+                     }
+              }
         }
       ]
   }


### PR DESCRIPTION
Updated policy to queue to allow receive message on aws legacy.