### PR TITLE
Rename formbuilder submit product ecr credentials

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -347,8 +347,8 @@ resource "kubernetes_secret" "ecr-repo-fb-submit-product" {
   }
 
   data = {
-    repo_url          = module.ecr-repo-fb-pdf-generator.repo_url
-    access_key_id     = module.ecr-repo-fb-pdf-generator.access_key_id
-    secret_access_key = module.ecr-repo-fb-pdf-generator.secret_access_key
+    repo_url          = module.ecr-repo-fb-submit-product.repo_url
+    access_key_id     = module.ecr-repo-fb-submit-product.access_key_id
+    secret_access_key = module.ecr-repo-fb-submit-product.secret_access_key
   }
 }


### PR DESCRIPTION
## Description

The "fb-submit-product" were using the "fb-pdf-generator" credentials.

The purpose of this PR is to populate kubernetes secrets with correct ecr credentials.