### PR TITLE
Restoring RDS from older snapshot. 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/resources/rds-mysql.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/resources/rds-mysql.tf
@@ -25,6 +25,7 @@ module "wplearndev_rds" {
   db_name                    = "wordpress"
   environment-name           = "development"
   infrastructure-support     = "cloud-platform@digital.justice.gov.uk"
+  snapshot_identifier        = "rds:cloud-platform-f38f3202975b4afe-2020-02-08-04-23"
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best


### PR DESCRIPTION
Before merging, the db instance id has to be renamed in order for the db instance to be created in the same db instance id. And hence, the security group, kms key and other parameters matches.