### PR TITLE
Fix dashboard-postgresql-exporter-metrics

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/dashboard-postgresql-exporter.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/dashboard-postgresql-exporter.yaml
@@ -2112,7 +2112,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "PostgreSQL Statistics",
+      "title": "PostgreSQL exporter metrics",
       "uid": "yok15cwWk",
       "version": 1
     }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/dashboard-postgresql-exporter.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/dashboard-postgresql-exporter.yaml
@@ -5,7 +5,7 @@ metadata:
   name: dashboard-postgresql-exporter-metrics
   namespace: monitoring
   labels:
-    grafana_dashboard: "PostgreSQL exporter metrics"
+    grafana_dashboard: "PostgreSQL-exporter-metrics"
 data:
   postgresql-exporter-metrics-dashboard.json: |
     {


### PR DESCRIPTION
Fixed Invalid value: "PostgreSQL exporter metrics" by removed spaces