### PR TITLE
Allow pods in "Prisoner money" namespaces to assume IAM roles

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/00-namespace.yaml
@@ -11,3 +11,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "money-to-prisoners"
     cloud-platform.justice.gov.uk/owner: "Prisoner Money Team: money-to-prisoners@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/money-to-prisoners"
+    iam.amazonaws.com/permitted: "money-to-prisoners-prod-iam-role-.*"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/00-namespace.yaml
@@ -11,3 +11,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "money-to-prisoners"
     cloud-platform.justice.gov.uk/owner: "Prisoner Money Team: money-to-prisoners@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/money-to-prisoners"
+    iam.amazonaws.com/permitted: "money-to-prisoners-test-iam-role-.*"


### PR DESCRIPTION
…with namespace-specific name prefixes in the form `[namespace]-iam-role-[application-specific]`.

This is to trial cross-account S3 bucket access.