### PR TITLE
Remove request limits from dev. namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/learning-cloud-deployments-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/learning-cloud-deployments-dev/03-resourcequota.yaml
@@ -6,5 +6,3 @@ metadata:
 spec:
   hard:
     pods: "50"
-    requests.cpu: 100m
-    requests.memory: 5000Mi


### PR DESCRIPTION
This change frees up some CPU and memory in the
cluster which is being unnecessarily 'ring-fenced'
by a sandbox namespace.
In general, we don't want to set request limits
in namespaces - this one must have slipped through
the PR review process.