### PR TITLE
Change application variable to be more explicit

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/variables.tf
@@ -15,7 +15,7 @@ variable "infrastructure-support" {
 }
 
 variable "application" {
-  default = "Disclosure Checker"
+  default = "Check when to disclose cautions or convictions"
 }
 
 variable "namespace" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/variables.tf
@@ -15,7 +15,7 @@ variable "infrastructure-support" {
 }
 
 variable "application" {
-  default = "Disclosure Checker"
+  default = "Check when to disclose cautions or convictions"
 }
 
 variable "namespace" {


### PR DESCRIPTION
Now the name of the service has been decided, this makes it more explicit in the `application` variable.

Staging and production environments.