### PR TITLE
Add pingdom check to form builder

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
@@ -1,0 +1,30 @@
+provider "pingdom" {}
+
+locals {
+  forms = {
+    cica                   = "www.gov.uk/claim-compensation-criminal-injury/victim-lived-with-attacker-before-october-1979",
+    childrens-funeral-fund = "claim-for-costs-of-a-childs-funeral.form.service.justice.gov.uk",
+    hmcts-complaints       = "complain-about-a-court-or-tribunal.form.service.justice.gov.uk",
+    leavers-form           = "leavers.form.service.justice.gov.uk",
+    contact-us-form        = "contact.form.service.justice.gov.uk"
+  }
+  names = keys(local.forms)
+  hosts = values(local.forms)
+}
+
+resource "pingdom_check" "fb_services_pingdom" {
+  count                    = length(local.forms)
+  type                     = "http"
+  name                     = "Form Builder - ${local.names[count.index]}"
+  host                     = local.hosts[count.index]
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/ping.json"
+  encryption               = true
+  port                     = 443
+  tags                     = local.names[count.index]
+  probefilters             = "region:EU"
+  integrationids           = [100321]
+}


### PR DESCRIPTION
## What this PR does?

This PR adds the pingdom check to the main apps running on formbuilder-services-* namespace.

## Context

Within the formbuilder app called fb-publisher, every time a new user create a form and publish the form, we provision 2 more new pods into formbuilder-services-* namespace, with every pod being a single tenant app.

So we decided to go for the route of using Cloud Platform pingdom integration but then it means every time an user publish a new form we need to add here the form. The solution is good for now but will be revised the moment we have more forms than we currently have at the moment.

