### PR TITLE
Add formbuilder pingdom to public report

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
@@ -26,5 +26,6 @@ resource "pingdom_check" "fb_services_pingdom" {
   port                     = 443
   tags                     = local.names[count.index]
   probefilters             = "region:EU"
+  publicreport             = "true"
   integrationids           = [100321]
 }


### PR DESCRIPTION
## Context

#1984 and #1997 added the pingdom integration but didn't made public to appear on http://pingdom.service.dsd.io/

Add the flag so it can appear on the link above