### PR TITLE
Update pipeline.rb to add dryrun_kubernetes_files

### DIFF
--- a/lib/cp_env/pipeline.rb
+++ b/lib/cp_env/pipeline.rb
@@ -55,6 +55,18 @@ def plan_namespace_dir(cluster, dir)
   return unless FileTest.directory?(dir)
 
   namespace = File.basename(dir)
+  dryrun_kubernetes_files(cluster, namespace, dir)
+  plan_terraform(cluster, namespace, dir)
+end
+
+def dryrun_kubernetes_files(_cluster, namespace, dir)
+  if contains_kubernetes_files?(dir)
+    log("green", "Dry-run #{namespace}")
+    execute("kubectl -n #{namespace} apply --server-dry-run -f #{dir}")
+  end
+end
+
+def plan_terraform(cluster, namespace, dir)
   CpEnv::Terraform.new(cluster: cluster, namespace: namespace, dir: dir).plan
 end
 


### PR DESCRIPTION
This will run kubectl apply --server-dry-run, in plan pipeline.

This is related to `https://github.com/ministryofjustice/cloud-platform/issues/1402`

Tests:
Positive: `https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/plan-environments/jobs/plan-live-1/builds/206#L5e58d7e8:73:85`
Negative: `https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/plan-environments/jobs/plan-live-1/builds/207#L5e58d7f7:74:86`