### PR TITLE
Update dryrun_kubernetes_files in pipeline.rb

### DIFF
--- a/lib/cp_env/pipeline.rb
+++ b/lib/cp_env/pipeline.rb
@@ -62,7 +62,7 @@ end
 def dryrun_kubernetes_files(_cluster, namespace, dir)
   if contains_kubernetes_files?(dir)
     log("green", "Dry-run #{namespace}")
-    execute("kubectl -n #{namespace} apply --server-dry-run -f #{dir}")
+    execute("kubectl -n #{namespace} apply --dry-run -f #{dir}")
   end
 end
 


### PR DESCRIPTION
This is because --server-dry-run is failing on new namespace creation.
error: namespaces not found