### PR TITLE
move read-only secret into k8s 'dev' namespace where it can be picked up

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -45,7 +45,17 @@ resource "kubernetes_secret" "rds-instance" {
     access_key_id     = module.rds-instance.access_key_id
     secret_access_key = module.rds-instance.secret_access_key
     url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
-    readonly_url      = "postgres://${postgresql_role.readonly_role.name}:${postgresql_role.readonly_role.password}}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
+  }
+}
+
+resource "kubernetes_secret" "ro-rds-access" {
+  metadata {
+    name      = "rds-instance-hmpps-book-secure-move-api-staging-ro"
+    namespace = var.dev_namespace
+  }
+
+  data = {
+    url = "postgres://${postgresql_role.readonly_role.name}:${postgresql_role.readonly_role.password}}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/variables.tf
@@ -22,6 +22,10 @@ variable "namespace" {
   default = "hmpps-book-secure-move-api-staging"
 }
 
+variable "dev_namespace" {
+  default = "hmpps-book-secure-move-api-dev"
+}
+
 variable "repo_name" {
   default = "hmpps-book-secure-move-api"
 }


### PR DESCRIPTION
I think this is now the right plan for reading my staging database from dev - create a new secret in the 'dev' namespace that refers to the read-only database resource in the 'staging' universe. 
