### PR TITLE
Add make target for tools shell in the cluster

### DIFF
--- a/makefile
+++ b/makefile
@@ -53,4 +53,30 @@ tools-shell:
 		-v $${HOME}/.gnupg:/root/.gnupg \
 		-w /app $(TOOLS_IMAGE) bash
 
-.PHONY: pull-tools namespace namespace-message gitops-namespace tools-shell
+# Launch a tools shell on a pod in the cluster. This can be useful if e.g. you
+# need to run terraform code that manipulates an RDS database instance, since
+# you won't be able to access any AWS resources from outside the cloud platform
+# VPC.
+#
+# Note: This command is optimised to be able to run terraform on a namespace, so
+# it expects a lot of environment variables which you won't necessarily need.
+#
+# NB: You *must* have a NAMESPACE environment variable set.
+#
+tools-shell-in-cluster:
+	kubectl run tools-image --rm -it \
+		-n $${NAMESPACE} \
+		--attach=true \
+		--generator=run-pod/v1 \
+		--image=$(TOOLS_IMAGE) \
+		--env="KOPS_STATE_STORE=s3://cloud-platform-kops-state" \
+		--env="PIPELINE_CLUSTER=live-1.cloud-platform.service.justice.gov.uk" \
+		--env="TF_VAR_cluster_name=live-1" \
+		--env="TF_VAR_cluster_state_bucket=cloud-platform-terraform-state" \
+		--env="TF_VAR_cluster_state_key=cloud-platform/live-1/terraform.tfstate" \
+		--env="AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID}" \
+		--env="AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY}" \
+		--env="AWS_DEFAULT_REGION=eu-west-2" \
+		bash
+
+.PHONY: pull-tools namespace namespace-message gitops-namespace tools-shell tools-shell-in-cluster

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := ministryofjustice/cloud-platform-tools
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.13
 
 namespace-report.json: bin/namespace-reporter.rb namespaces/live-1.cloud-platform.service.justice.gov.uk/*/*.yaml
 	./bin/namespace-reporter.rb -o json -n '.*' > namespace-report.json


### PR DESCRIPTION
Sometimes we need to be able to run terraform code from inside the same VPC
as the cluster (e.g. code which manipulates an RDS database).

To make this easier, this makefile target launches a temporary tools-image
inside the cluster,  mapping useful environment variables into it.