### PR TITLE
Support deployments now being in apps group

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/05-serviceaccount-circleci.yaml
@@ -28,9 +28,19 @@ rules:
       - "delete"
       - "list"
   - apiGroups:
-      - "extensions"
+      - "apps"
     resources:
       - "deployments"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+  - apiGroups:
+      - "extensions"
+    resources:
       - "ingresses"
     verbs:
       - "get"


### PR DESCRIPTION
`deployment` seems to have moved to `apps` now, and I think Helm set my new Deployment template up to use that api version. I could change it back to the extensions beta version, but seems more sensible (give none of this is live yet) to go ahead with it in apps and change the service account permissions accordingly