### PR TITLE
Add Kube-sysem label and monitoring network policy

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
@@ -4,3 +4,4 @@ metadata:
   name: kube-system
   labels: 
     openpolicyagent.org/webhook: "ignore"
+    component: kube-system

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-kube-api
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: kube-system


### PR DESCRIPTION
This PR will add a new label to the kube-system namespace and a network policy in the monitoring namespace for it to allow kube-system pods access. 

This is required to get the prometheus rules webhook working within the prometheus-operator. 