### PR TITLE
PAT-708 - add Pathfinder IAM user with rds to s3 export permissions.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -1,7 +1,15 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
 variable "cluster_name" {
 }
 
 variable "cluster_state_bucket" {
+}
+
+resource "random_id" "id" {
+  byte_length = 8
 }
 
 module "dps_rds" {
@@ -23,6 +31,46 @@ module "dps_rds" {
   }
 }
 
+resource "aws_iam_user" "user" {
+  name = "pathfinder-rds-to-s3-snapshots-user-${random_id.id.hex}"
+  path = "/system/pathfinder-rds-to-s3-snapshots-user/"
+}
+
+resource "aws_iam_access_key" "user" {
+  user = aws_iam_user.user.name
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    actions = [
+      "rds:DescribeDBClusterSnapshots",
+      "rds:DescribeDBClusters",
+      "rds:DescribeDBInstances",
+      "rds:DescribeDBSnapshots",
+      "rds:DescribeExportTasks",
+      "rds:StartExportTask",
+      "s3:PutObject*",
+      "s3:GetObject*",
+      "s3:ListBucket",
+      "s3:DeleteObject*",
+      "s3:GetBucketLocation"
+    ]
+
+    resources = [
+      module.dps_rds.arn,
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:*",
+      "${module.pathfinder_reporting_s3_bucket.bucket_arn}:${module.pathfinder_reporting_s3_bucket.bucket_name}",
+      "${module.pathfinder_reporting_s3_bucket.bucket_arn}:${module.pathfinder_reporting_s3_bucket.bucket_name}/*"
+    ]
+  }
+}
+
+resource "aws_iam_user_policy" "policy" {
+  name   = "pathfinder-rds-to-s3-snapshots-read-write"
+  policy = data.aws_iam_policy_document.policy.json
+  user   = aws_iam_user.user.name
+}
+
 resource "kubernetes_secret" "dps_rds" {
   metadata {
     name      = "dps-rds-instance-output"
@@ -38,6 +86,9 @@ resource "kubernetes_secret" "dps_rds" {
     access_key_id         = module.dps_rds.access_key_id
     secret_access_key     = module.dps_rds.secret_access_key
     url                   = "postgres://${module.dps_rds.database_username}:${module.dps_rds.database_password}@${module.dps_rds.rds_instance_endpoint}/${module.dps_rds.database_name}"
+    rds_to_s3_user_arn    = aws_iam_user.user.arn
+    rds_to_s3_access_key_id = aws_iam_access_key.user.id
+    rds_to_s3_secret_access_key = aws_iam_access_key.user.secret
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -57,8 +57,7 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      module.dps_rds.arn,
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:*",
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:*",
       "${module.pathfinder_reporting_s3_bucket.bucket_arn}:${module.pathfinder_reporting_s3_bucket.bucket_name}",
       "${module.pathfinder_reporting_s3_bucket.bucket_arn}:${module.pathfinder_reporting_s3_bucket.bucket_name}/*"
     ]


### PR DESCRIPTION
The purpose of this IAM user is to allow a future pod running in the pathfinder namespace to create an RDS to S3 snapshot export. In dev the export will be to an s3 pathfinder reporting bucket configured in the dev namespace. In production the bucket will exist in the MOJ Analytical environment. The MOJ AP will grant permission to this IAM user to put snapshots into their S3 staging bucket.

We decided not to use an assumed role like the prisoner money team do because in theory any other namespace could assume that role and export data from the DB. A specific pathfinder IAM user will contain who can perform the export task and where to.

If the reviewer could check the syntax of creating the iam user and exposing the creds to kubernetes that would be appreciated.

See: https://dsdmoj.atlassian.net/browse/PAT-708 for further details.