### PR TITLE
PAT-708 - Add snapshot arn to resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -59,8 +59,8 @@ data "aws_iam_policy_document" "policy" {
     resources = [
       "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rds:*",
       "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:*",
-      "${module.pathfinder_reporting_s3_bucket.bucket_arn}:${module.pathfinder_reporting_s3_bucket.bucket_name}",
-      "${module.pathfinder_reporting_s3_bucket.bucket_arn}:${module.pathfinder_reporting_s3_bucket.bucket_name}/*"
+      "${module.pathfinder_reporting_s3_bucket.bucket_arn}",
+      "${module.pathfinder_reporting_s3_bucket.bucket_arn}/*"
     ]
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -57,7 +57,8 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:*",
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rds:*",
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:*",
       "${module.pathfinder_reporting_s3_bucket.bucket_arn}:${module.pathfinder_reporting_s3_bucket.bucket_name}",
       "${module.pathfinder_reporting_s3_bucket.bucket_arn}:${module.pathfinder_reporting_s3_bucket.bucket_name}/*"
     ]


### PR DESCRIPTION
During testing it turns out we need snapshot access as its the snapshots that are extracted to s3.

Could the reviewer check the policy is correctly setup? I'm not sure if the account id and region are being pulled through correctly. I used the rds template as an example.
