### PR TITLE
Revert "RDS snapshot, from production -> preprod for db repair testing"

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -17,26 +17,6 @@ module "rds-instance" {
   }
 }
 
-module "rds-snapshot" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
-
-  cluster_name         = var.cluster_name
-  cluster_state_bucket = var.cluster_state_bucket
-
-  application            = var.application
-  environment-name       = var.environment-name
-  is-production          = var.is-production
-  infrastructure-support = var.infrastructure-support
-  team_name              = var.team_name
-  force_ssl              = "false"
-  snapshot_identifier    = "rds:cloud-platform-fb1739914b873b00-2020-03-24-02-28"
-
-  providers = {
-    # Can be either "aws.london" or "aws.ireland"
-    aws = aws.london
-  }
-}
-
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-hmpps-book-secure-move-api-preprod"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -24,15 +24,3 @@ resource "kubernetes_secret" "rds-instance" {
   }
 }
 
-resource "kubernetes_secret" "rds-snapshot" {
-  metadata {
-    name      = "rds-snapshot-production"
-    namespace = var.preprod_namespace
-  }
-
-  data = {
-    access_key_id     = module.rds-instance.access_key_id
-    secret_access_key = module.rds-instance.secret_access_key
-    url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
-  }
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
@@ -22,10 +22,6 @@ variable "namespace" {
   default = "hmpps-book-secure-move-api-production"
 }
 
-variable "preprod_namespace" {
-  default = "hmpps-book-secure-move-api-preprod"
-}
-
 variable "repo_name" {
   default = "hmpps-book-secure-move-api"
 }


### PR DESCRIPTION
This reverts commit e4f9e4fbc24e143197a6b5966fb348e58be0efd8.

Revert this change, as it was horribly broken - it didn't correctly use the DB snapshot.