### PR TITLE
Delete manually created pods after 24 hours

### DIFF
--- a/lib/cp_env/manually_created_pod_deleter.rb
+++ b/lib/cp_env/manually_created_pod_deleter.rb
@@ -19,7 +19,7 @@ class CpEnv
     attr_reader :executor, :dry_run
 
     SYSTEM_NAMESPACE = "kube-system"
-    MAX_AGE_IN_SECONDS = 2 * 24 * 60 * 60 # 2 days
+    MAX_AGE_IN_SECONDS = 24 * 60 * 60 # 1 day
 
     def initialize(args = {})
       @executor = args.fetch(:executor) { Executor.new }

--- a/spec/manually_created_pod_deleter_spec.rb
+++ b/spec/manually_created_pod_deleter_spec.rb
@@ -40,8 +40,8 @@ describe CpEnv::ManuallyCreatedPodDeleter do
 
     let(:json) { %({"items": [ #{pod} ]}) }
 
-    context "but the pod is 1 day old" do
-      let(:startTime) { (Date.today - 1).to_s }
+    context "but the pod is 23 hours old" do
+      let(:startTime) { (Time.now - (23 * 3600)).to_s }
 
       it "does not delete the pod" do
         expect(executor).to_not receive(:execute).with("kubectl -n mynamespace delete pod mypod")
@@ -49,8 +49,8 @@ describe CpEnv::ManuallyCreatedPodDeleter do
       end
     end
 
-    context "and the pod is 3 days old" do
-      let(:startTime) { (Date.today - 3).to_s }
+    context "and the pod is 2 days old" do
+      let(:startTime) { (Date.today - 2).to_s }
 
       it "deletes pod" do
         expect(executor).to receive(:execute).with("kubectl -n mynamespace delete pod mypod")

--- a/spec/manually_created_pod_deleter_spec.rb
+++ b/spec/manually_created_pod_deleter_spec.rb
@@ -4,7 +4,7 @@ describe CpEnv::ManuallyCreatedPodDeleter do
   let(:executor) { double(CpEnv::Executor) }
   let(:params) {
     {
-      executor: executor,
+      executor: executor
     }
   }
   subject(:deleter) { described_class.new(params) }


### PR DESCRIPTION
Currently, the pipeline to delete manually-created pods runs every 24h,
but the script only deletes such pods when they are more than 48h old.

This change reduces to 24h the age at which a manually-created pod
becomes eligible for deletion.

We recently changed the node recycler to run every 8 hours, 7 days/week,
instead of once/day, Monday to Friday.

This change means the node recycler will spend less time "stuck" waiting
for manually-created pods to be cleared away.

Another option, in future, might be to enable the node recycler to
delete such pods by itself.