### PR TITLE
put RDS snapshot on preprod to aid DB repair testing

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -24,3 +24,35 @@ resource "kubernetes_secret" "rds-instance" {
   }
 }
 
+module "rds-snapshot" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
+
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
+
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  force_ssl              = "false"
+  snapshot_identifier    = "rds:cloud-platform-fb1739914b873b00-2020-03-24-02-28"
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "rds-snapshot" {
+  metadata {
+    name      = "rds-snapshot-production"
+    namespace = var.preprod_namespace
+  }
+
+  data = {
+    access_key_id     = module.rds-instance.access_key_id
+    secret_access_key = module.rds-instance.secret_access_key
+    url               = "postgres://${module.rds-snapshot.database_username}:${module.rds-snapshot.database_password}@${module.rds-snapshot.rds_instance_endpoint}/${module.rds-snapshot.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
@@ -22,6 +22,10 @@ variable "namespace" {
   default = "hmpps-book-secure-move-api-production"
 }
 
+variable "preprod_namespace" {
+  default = "hmpps-book-secure-move-api-preprod"
+}
+
 variable "repo_name" {
   default = "hmpps-book-secure-move-api"
 }


### PR DESCRIPTION
This is the definitive version of the secure move database snapshot work - but for a production snapshot mounted on preprod