### PR TITLE
Create prometheus-custom-rules-hmpps-book-a-secure-move-api.yml

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/prometheus-custom-rules-hmpps-book-a-secure-move-api.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/prometheus-custom-rules-hmpps-book-a-secure-move-api.yml
@@ -1,0 +1,28 @@
+# Prometheus Alerts
+#
+# https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#creating-your-own-custom-alerts
+#
+# To see the current alerts in this namespace:
+#   kubectl describe prometheusrule -n hmpps-book-secure-move-api-staging
+#
+# Alerts will be sent to the slack channel: #pecs-alerts
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hmpps-book-secure-move-api-alerting-staging
+  namespace: hmpps-book-secure-move-api-staging
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: KubePodCrashLooping
+        annotations:
+          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+        expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
+        for: 1h
+        labels:
+          severity: warning

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/prometheus-custom-rules-hmpps-book-a-secure-move-api.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/prometheus-custom-rules-hmpps-book-a-secure-move-api.yml
@@ -19,10 +19,10 @@ spec:
   - name: application-rules
     rules:
     - alert: KubePodCrashLooping
-        annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
-        expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
-        for: 1h
-        labels:
-          severity: warning
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
+      for: 1h
+      labels:
+        severity: warning

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/prometheus-custom-rules-hmpps-book-a-secure-move-api.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/prometheus-custom-rules-hmpps-book-a-secure-move-api.yml
@@ -1,6 +1,6 @@
 # Prometheus Alerts
 #
-# https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#creating-your-own-custom-alerts
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#overview
 #
 # To see the current alerts in this namespace:
 #   kubectl describe prometheusrule -n hmpps-book-secure-move-api-staging
@@ -25,4 +25,4 @@ spec:
       expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
       for: 1h
       labels:
-        severity: warning
+        severity: hmpps-book-secure-move


### PR DESCRIPTION
I am trying to setup a new prometheus rule to alert slack channel `#pecs-alerts` when a staging Kubernetes pod crashes. I'll roll this out to other environments once it is working on staging.

I have created a secret named `pecs_alerts_webhook_url` which will hold the base-64 encoded webhook URL to the slack channel `#pecs-alerts` (NB: this secret is not yet deployed). (https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy/pull/53)

Some questions:

* How or where do I indicate in this rule that it should use the `pecs_alerts_webhook_url` secret?
* It it sufficient to simply add the new secret to `secrets.yml` in Kubernetes, or is it also necessary to create ENV VARs for the secret for all containers ?
* In addition to creating `prometheus-custom-rules-hmpps-book-a-secure-move-api.yml` and the new secret `pecs_alerts_webhook_url`, what else is required to get the alerts to run ?

I'm not sure if this is correct and would appreciate some feedback :-) 