### PR TITLE
Use how-out-of-date-are-we docker image v. 1.2

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: how-out-of-date-are-we
-          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:0.2
+          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:1.2
           env:
             - name: RACK_ENV
               value: "production"


### PR DESCRIPTION
depends on #2203

This version adds a page showing the status of namespaces' terraform
module versions, and has some changes to the API endpoints.