### PR TITLE
Further work on RDS to S3 Export IAM policy 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -107,6 +107,7 @@ data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
 
   statement {
     actions = [
+      "rds:CreateDBSnapshot",
       "rds:DescribeDBSnapshots",
       "rds:DescribeDBInstances"
     ]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -203,6 +203,7 @@ resource "kubernetes_secret" "dps_rds" {
     rds_to_s3_user_arn          = aws_iam_user.user.arn
     rds_to_s3_access_key_id     = aws_iam_access_key.user.id
     rds_to_s3_secret_access_key = aws_iam_access_key.user.secret
+    rds_to_s3_role_arn          = aws_iam_role.pathfinder_dev_rds_to_s3_role.arn
     rds_to_s3_cmk_key_id        = aws_kms_key.pathfinder_rds_to_s3_export_key.key_id
   }
 }


### PR DESCRIPTION
Now that the role has a random string in its name the arn needs to be exported so that it can be injected into the pod that will run the export script. Also create db snapshot permission required in order to create a temporary snapshot used by the rds to s3 export script.