### PR TITLE
PAT-730 - Add permission to write to snapshot and also wire up s3 acc…

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -113,7 +113,8 @@ data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
     ]
 
     resources = [
-      "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:db:${element(split(".", module.dps_rds.rds_instance_endpoint), 0)}"
+      "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:db:${element(split(".", module.dps_rds.rds_instance_endpoint), 0)}",
+      "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:snapshot:*",
     ]
   }
 
@@ -154,7 +155,9 @@ data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
       "${module.pathfinder_analytics_s3_bucket.bucket_arn}",
       "${module.pathfinder_analytics_s3_bucket.bucket_arn}/*",
       "${module.pathfinder_reporting_s3_bucket.bucket_arn}",
-      "${module.pathfinder_reporting_s3_bucket.bucket_arn}/*"
+      "${module.pathfinder_reporting_s3_bucket.bucket_arn}/*",
+      "arn:aws:s3:::mojap-land/hmpps/pathfinder/",
+      "arn:aws:s3:::mojap-land/hmpps/pathfinder/*"
     ]
   }
 


### PR DESCRIPTION
As part of the script to extract pathfinder rds snapshot data to S3 and transfer to the MOJ analytical platform the user needs access to write snapshots and write to the MOJ AP staging bucket. MOJ AP will add the necessary permissions on their side to allow the CP IAM user to write to the bucket.