### PR TITLE
PAT 730 tidy up bucket names

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -113,7 +113,8 @@ data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
     ]
 
     resources = [
-      "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:db:${element(split(".", module.dps_rds.rds_instance_endpoint), 0)}"
+      "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:db:${element(split(".", module.dps_rds.rds_instance_endpoint), 0)}",
+      "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:snapshot:*",
     ]
   }
 
@@ -151,10 +152,12 @@ data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
     ]
 
     resources = [
+      "${module.pathfinder_rds_export_s3_bucket.bucket_arn}",
+      "${module.pathfinder_rds_export_s3_bucket.bucket_arn}/*",
       "${module.pathfinder_analytics_s3_bucket.bucket_arn}",
       "${module.pathfinder_analytics_s3_bucket.bucket_arn}/*",
-      "${module.pathfinder_reporting_s3_bucket.bucket_arn}",
-      "${module.pathfinder_reporting_s3_bucket.bucket_arn}/*"
+      "arn:aws:s3:::mojap-land/hmpps/pathfinder/",
+      "arn:aws:s3:::mojap-land/hmpps/pathfinder/*"
     ]
   }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -14,7 +14,7 @@ module "pathfinder_document_s3_bucket" {
   }
 }
 
-module "pathfinder_reporting_s3_bucket" {
+module "pathfinder_rds_export_s3_bucket" {
   source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.1"
   team_name              = var.team_name
   acl                    = "private"
@@ -26,7 +26,7 @@ module "pathfinder_reporting_s3_bucket" {
   infrastructure-support = var.infrastructure-support
 
   providers = {
-    aws = aws.london
+    aws = aws.ireland
   }
 }
 
@@ -60,17 +60,17 @@ resource "kubernetes_secret" "pathfinder_document_s3_bucket" {
   }
 }
 
-resource "kubernetes_secret" "pathfinder_reporting_s3_bucket" {
+resource "kubernetes_secret" "pathfinder_rds_export_s3_bucket" {
   metadata {
-    name      = "pathfinder-reporting-s3-bucket-output"
+    name      = "pathfinder-rds-export-s3-bucket-output"
     namespace = var.namespace
   }
 
   data = {
-    access_key_id     = module.pathfinder_reporting_s3_bucket.access_key_id
-    secret_access_key = module.pathfinder_reporting_s3_bucket.secret_access_key
-    bucket_arn        = module.pathfinder_reporting_s3_bucket.bucket_arn
-    bucket_name       = module.pathfinder_reporting_s3_bucket.bucket_name
+    access_key_id     = module.pathfinder_rds_export_s3_bucket.access_key_id
+    secret_access_key = module.pathfinder_rds_export_s3_bucket.secret_access_key
+    bucket_arn        = module.pathfinder_rds_export_s3_bucket.bucket_arn
+    bucket_name       = module.pathfinder_rds_export_s3_bucket.bucket_name
   }
 }
 


### PR DESCRIPTION
Rename of S3 bucket to match intended usage. Also having to use eu-west-1 for rds export features only available in Ireland region at the moment and to match up with AP s3 bucket