### PR TITLE
Update CCCD namespaces to sns-topic module v4.1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
 
   team_name          = var.team_name
   topic_display_name = "cccd-claims-submitted"
@@ -24,7 +24,7 @@ module "claims_for_ccr" {
   {
     "deadLetterTargetArn": "${module.ccr_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 
@@ -47,9 +47,9 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
           "Principal": {"AWS": "*"},
           "Resource": "${module.claims_for_ccr.sqs_arn}",
           "Action": "SQS:SendMessage",
-          "Condition": 
+          "Condition":
             {
-              "ArnEquals": 
+              "ArnEquals":
                 {
                   "aws:SourceArn": "${module.cccd_claims_submitted.topic_arn}"
                 }
@@ -57,7 +57,7 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
         }
       ]
   }
-  
+
 EOF
 
 }
@@ -77,7 +77,7 @@ module "claims_for_cclf" {
   {
     "deadLetterTargetArn": "${module.cclf_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 
@@ -100,9 +100,9 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
           "Principal": {"AWS": "*"},
           "Resource": "${module.claims_for_cclf.sqs_arn}",
           "Action": "SQS:SendMessage",
-          "Condition": 
+          "Condition":
             {
-              "ArnEquals": 
+              "ArnEquals":
                 {
                   "aws:SourceArn": "${module.cccd_claims_submitted.topic_arn}"
                 }
@@ -110,7 +110,7 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
         }
       ]
   }
-  
+
 EOF
 
 }
@@ -130,7 +130,7 @@ module "responses_for_cccd" {
   {
     "deadLetterTargetArn": "${module.cccd_response_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
 
   team_name          = var.team_name
   topic_display_name = "cccd-claims-submitted"
@@ -24,7 +24,7 @@ module "claims_for_ccr" {
   {
     "deadLetterTargetArn": "${module.ccr_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 
@@ -47,9 +47,9 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
           "Principal": {"AWS": "*"},
           "Resource": "${module.claims_for_ccr.sqs_arn}",
           "Action": "SQS:SendMessage",
-          "Condition": 
+          "Condition":
             {
-              "ArnEquals": 
+              "ArnEquals":
                 {
                   "aws:SourceArn": "${module.cccd_claims_submitted.topic_arn}"
                 }
@@ -57,7 +57,7 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
         }
       ]
   }
-  
+
 EOF
 
 }
@@ -77,7 +77,7 @@ module "claims_for_cclf" {
   {
     "deadLetterTargetArn": "${module.cclf_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 
@@ -100,9 +100,9 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
           "Principal": {"AWS": "*"},
           "Resource": "${module.claims_for_cclf.sqs_arn}",
           "Action": "SQS:SendMessage",
-          "Condition": 
+          "Condition":
             {
-              "ArnEquals": 
+              "ArnEquals":
                 {
                   "aws:SourceArn": "${module.cccd_claims_submitted.topic_arn}"
                 }
@@ -110,7 +110,7 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
         }
       ]
   }
-  
+
 EOF
 
 }
@@ -130,7 +130,7 @@ module "responses_for_cccd" {
   {
     "deadLetterTargetArn": "${module.cccd_response_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
 
   team_name          = "laa-get-paid"
   topic_display_name = "cccd-claims-submitted"
@@ -24,7 +24,7 @@ module "claims_for_ccr" {
   {
     "deadLetterTargetArn": "${module.ccr_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 
@@ -47,9 +47,9 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
           "Principal": {"AWS": "*"},
           "Resource": "${module.claims_for_ccr.sqs_arn}",
           "Action": "SQS:SendMessage",
-          "Condition": 
+          "Condition":
             {
-              "ArnEquals": 
+              "ArnEquals":
                 {
                   "aws:SourceArn": "${module.cccd_claims_submitted.topic_arn}"
                 }
@@ -57,7 +57,7 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
         }
       ]
   }
-  
+
 EOF
 
 }
@@ -77,7 +77,7 @@ module "claims_for_cclf" {
   {
     "deadLetterTargetArn": "${module.cclf_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 
@@ -100,9 +100,9 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
           "Principal": {"AWS": "*"},
           "Resource": "${module.claims_for_cclf.sqs_arn}",
           "Action": "SQS:SendMessage",
-          "Condition": 
+          "Condition":
             {
-              "ArnEquals": 
+              "ArnEquals":
                 {
                   "aws:SourceArn": "${module.cccd_claims_submitted.topic_arn}"
                 }
@@ -110,7 +110,7 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
         }
       ]
   }
-  
+
 EOF
 
 }
@@ -130,7 +130,7 @@ module "responses_for_cccd" {
   {
     "deadLetterTargetArn": "${module.cccd_response_dead_letter_queue.sqs_arn}","maxReceiveCount": 1
   }
-  
+
 EOF
 
 


### PR DESCRIPTION
Module version 4.1 is the latest release.

This change brings these namespaces into line with
our policy of always using the latest version of
our terraform modules in all namespaces.

According to `terraform plan`, this change will 
have no effect on their namespace.