### PR TITLE
Update offender-events ns to sns-topic module v4.1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/topic.tf
@@ -1,5 +1,5 @@
 module "offender_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
 
   team_name          = var.team_name
   topic_display_name = "offender-events"
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "prison-data-compliance" {
 }
 
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
   team_name          = var.team_name
   topic_display_name = "probation-offender-events"
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic.tf
@@ -1,5 +1,5 @@
 module "offender_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
 
   team_name          = var.team_name
   topic_display_name = "offender-events"
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "prison-data-compliance" {
 }
 
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
   team_name          = var.team_name
   topic_display_name = "probation-offender-events"
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/topic.tf
@@ -1,5 +1,5 @@
 module "offender_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
 
   team_name          = var.team_name
   topic_display_name = "offender-events"
@@ -36,7 +36,7 @@ resource "kubernetes_secret" "offender_case_notes" {
 }
 
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
   team_name          = var.team_name
   topic_display_name = "probation-offender-events"
   providers = {


### PR DESCRIPTION
Module version 4.1 is the latest release.

This change brings these namespaces into line with
our policy of always using the latest version of
our terraform modules in all namespaces.

According to terraform plan, this change will
have no effect on their namespace.