### PR TITLE
Add a logger class for the concourse pipelines

### DIFF
--- a/lib/cp_env.rb
+++ b/lib/cp_env.rb
@@ -11,6 +11,7 @@ require "tmpdir"
 class CpEnv
 end
 
+require File.join(File.dirname(__FILE__), "cp_env", "logger")
 require File.join(File.dirname(__FILE__), "cp_env", "executor")
 require File.join(File.dirname(__FILE__), "cp_env", "pipeline")
 require File.join(File.dirname(__FILE__), "cp_env", "terraform")

--- a/lib/cp_env/executor.rb
+++ b/lib/cp_env/executor.rb
@@ -7,11 +7,11 @@ class CpEnv
 
       unless can_fail || status.success?
         log("red", "Command: #{cmd} failed.")
-        puts stderr
+        log("red", stderr)
         raise
       end
 
-      puts stdout unless silent
+      log("green", stdout) unless silent
 
       [stdout, stderr, status]
     end

--- a/lib/cp_env/logger.rb
+++ b/lib/cp_env/logger.rb
@@ -1,0 +1,43 @@
+class CpEnv
+  class Logger
+    FILTER_LIST = %w[
+      password
+      secret
+      token
+      key
+    ]
+
+    def log(colour, message)
+      colour_code = case colour
+                    when "red"
+                      31
+                    when "blue"
+                      34
+                    when "green"
+                      32
+                    else
+                      raise "Unknown colour #{colour} passed to 'log' method"
+      end
+
+      redacted_message(message).split("\n").each do |line|
+        puts "\e[#{colour_code}m#{line}\e[0m"
+      end
+    end
+
+    private
+
+    def redacted_message(message)
+      message
+        .split("\n")
+        .map { |line| redacted_line(line) }
+        .join("\n")
+    end
+
+    def redacted_line(line)
+      FILTER_LIST.each do |term|
+        line.sub!(/#{term}.*/, "#{term} REDACTED")
+      end
+      line
+    end
+  end
+end

--- a/lib/cp_env/pipeline.rb
+++ b/lib/cp_env/pipeline.rb
@@ -83,16 +83,5 @@ def execute(cmd, can_fail: false, silent: false)
 end
 
 def log(colour, message)
-  colour_code = case colour
-  when "red"
-    31
-  when "blue"
-    34
-  when "green"
-    32
-  else
-    raise "Unknown colour #{colour} passed to 'log' method"
-  end
-
-  puts "\e[#{colour_code}m#{message}\e[0m"
+  CpEnv::Logger.new.log(colour, message)
 end

--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -67,7 +67,7 @@ class CpEnv
         last: %(-auto-approve)
       )
 
-      execute("cd #{tf_dir}; #{cmd} | grep -v password | grep -v auth_token |  grep -v secret | grep -v token | grep -v key")
+      execute("cd #{tf_dir}; #{cmd}")
     end
 
     def tf_plan
@@ -76,7 +76,7 @@ class CpEnv
         last: " "
       )
 
-      execute("cd #{tf_dir}; #{cmd} | grep -v password | grep -v auth_token |  grep -v secret | grep -v token | grep -v key")
+      execute("cd #{tf_dir}; #{cmd}")
     end
 
     def tf_dir

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe CpEnv::Logger do
+  subject(:logger) { described_class.new }
+
+  context "colour coding" do
+    specify "red" do
+      expect($stdout).to receive(:puts).with("\e[31mwibble\e[0m")
+      logger.log("red", "wibble")
+    end
+
+    specify "green" do
+      expect($stdout).to receive(:puts).with("\e[32mwibble\e[0m")
+      logger.log("green", "wibble")
+    end
+
+    specify "blue" do
+      expect($stdout).to receive(:puts).with("\e[34mwibble\e[0m")
+      logger.log("blue", "wibble")
+    end
+
+    it "barfs if colour is unknown" do
+      expect {
+        logger.log("nosuchcolour", "wibble")
+      }.to raise_error(RuntimeError, "Unknown colour nosuchcolour passed to 'log' method")
+    end
+  end
+
+  context "filtering" do
+    CpEnv::Logger::FILTER_LIST.each do |keyword|
+      it "redacts sensitive terms" do
+        expect($stdout).to receive(:puts).with("\e[32mwibble #{keyword} REDACTED\e[0m")
+        logger.log("green", "wibble #{keyword} whatever")
+      end
+    end
+  end
+end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -13,7 +13,7 @@ describe "pipeline" do
       "PIPELINE_STATE_REGION" => "region",
       "TF_VAR_cluster_name" => cluster,
       "TF_VAR_cluster_state_bucket" => "cloud-platform-terraform-state",
-      "TF_VAR_cluster_state_key" => "cloud-platform/live-1/terraform.tfstate",
+      "TF_VAR_cluster_state_key" => "cloud-platform/live-1/terraform.tfstate"
     }
   }
 
@@ -34,7 +34,7 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
       "offender-management-preprod",
       "offender-management-staging",
       "pecs-move-platform-backend-staging",
-      "poornima-dev",
+      "poornima-dev"
     ]
   }
 
@@ -43,6 +43,10 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
   let(:dir) { "namespaces/#{cluster}/#{namespace}" }
 
   let(:tf) { double(CpEnv::Terraform) }
+
+  before do
+    allow($stdout).to receive(:puts)
+  end
 
   it "runs terraform plan" do
     allow(FileTest).to receive(:directory?).and_return(true)
@@ -92,7 +96,6 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
 
     it "gets dirs from latest commit" do
       expect_execute(cmd, files, success)
-      expect($stdout).to receive(:puts).with(files)
       expect(changed_namespace_dirs(cluster)).to eq(namespace_dirs)
     end
   end
@@ -110,7 +113,6 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
 
     it "gets deleted namespaces" do
       expect_execute(cmd, files, success)
-      expect($stdout).to receive(:puts).with(files)
       expect(deleted_namespaces(cluster)).to eq([deleted])
     end
   end

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -40,11 +40,11 @@ describe CpEnv::Terraform do
 
       tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-      tf_plan = "cd #{tf_dir}; terraform plan   | grep -v password | grep -v auth_token |  grep -v secret | grep -v token | grep -v key"
+      tf_plan = "cd #{tf_dir}; terraform plan  "
 
       expect_execute(tf_init, "", success)
       expect_execute(tf_plan, "", success)
-      expect($stdout).to receive(:puts)
+      expect($stdout).to receive(:puts).at_least(:once)
 
       tf.plan
     end
@@ -59,11 +59,11 @@ describe CpEnv::Terraform do
       tf_dir = "#{dir}/resources"
       tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-      tf_apply = "cd #{tf_dir}; terraform apply -auto-approve | grep -v password | grep -v auth_token |  grep -v secret | grep -v token | grep -v key"
+      tf_apply = "cd #{tf_dir}; terraform apply -auto-approve"
 
       expect_execute(tf_init, "", success)
       expect_execute(tf_apply, "", success)
-      expect($stdout).to receive(:puts)
+      expect($stdout).to receive(:puts).at_least(:once)
 
       tf.apply
     end


### PR DESCRIPTION
This class acts as a single "choke point" for all
command output, so we can locate all of our log
filtering logic there, instead of having to
duplicate it in the Terraform class.

fixes ministryofjustice/cloud-platform#1776