### PR TITLE
Remove the rds-snapshot RDS instance

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -23,35 +23,3 @@ resource "kubernetes_secret" "rds-instance" {
     url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
-
-module "rds-snapshot" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
-
-  cluster_name         = var.cluster_name
-  cluster_state_bucket = var.cluster_state_bucket
-
-  application            = var.application
-  environment-name       = var.environment-name
-  is-production          = var.is-production
-  infrastructure-support = var.infrastructure-support
-  team_name              = var.team_name
-  force_ssl              = "false"
-
-  providers = {
-    # Can be either "aws.london" or "aws.ireland"
-    aws = aws.london
-  }
-}
-
-resource "kubernetes_secret" "rds-snapshot" {
-  metadata {
-    name      = "rds-snapshot-production"
-    namespace = var.preprod_namespace
-  }
-
-  data = {
-    access_key_id     = module.rds-instance.access_key_id
-    secret_access_key = module.rds-instance.secret_access_key
-    url               = "postgres://${module.rds-snapshot.database_username}:${module.rds-snapshot.database_password}@${module.rds-snapshot.rds_instance_endpoint}/${module.rds-snapshot.database_name}"
-  }
-}


### PR DESCRIPTION
This instance is no longer required.

It was breaking the build pipeline with this error:

```
Error: error deleting Database Instance
"cloud-platform-a23ffc9abc15d8ba": DBSnapshotAlreadyExists: Cannot
create the snapshot because a snapshot with the identifier
cloud-platform-a23ffc9abc15d8ba-finalsnapshot already exists.
```

I have manually deleted the snapshot and run `terraform apply` to remove
the RDS instance. So this commit brings the code in the repository into
line with the state of AWS and the cluster.