### PR TITLE
Remove rds-snapshot RDS instance

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -31,20 +31,6 @@ resource "random_password" "readonly-password" {
   special = false
 }
 
-resource "postgresql_role" "readonly_role" {
-  login    = true
-  name     = "readonly-database-user"
-  password = random_password.readonly-password.result
-}
-
-resource "postgresql_grant" "readonly_tables" {
-  database    = "${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
-  role        = postgresql_role.readonly_role.name
-  schema      = "public"
-  object_type = "table"
-  privileges  = ["SELECT"]
-}
-
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-instance-hmpps-book-secure-move-api-staging"
@@ -57,47 +43,3 @@ resource "kubernetes_secret" "rds-instance" {
     url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
-
-module "rds-snapshot" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
-
-  cluster_name         = var.cluster_name
-  cluster_state_bucket = var.cluster_state_bucket
-
-  application            = var.application
-  environment-name       = var.environment-name
-  is-production          = var.is-production
-  infrastructure-support = var.infrastructure-support
-  team_name              = var.team_name
-  force_ssl              = "false"
-
-  providers = {
-    # Can be either "aws.london" or "aws.ireland"
-    aws = aws.london
-  }
-}
-
-resource "kubernetes_secret" "rds-snapshot" {
-  metadata {
-    name      = "rds-snapshot-staging"
-    namespace = var.dev_namespace
-  }
-
-  data = {
-    access_key_id     = module.rds-instance.access_key_id
-    secret_access_key = module.rds-instance.secret_access_key
-    url               = "postgres://${module.rds-snapshot.database_username}:${module.rds-snapshot.database_password}@${module.rds-snapshot.rds_instance_endpoint}/${module.rds-snapshot.database_name}"
-  }
-}
-
-resource "kubernetes_secret" "ro-rds-access" {
-  metadata {
-    name      = "rds-instance-hmpps-book-secure-move-api-staging-ro"
-    namespace = var.dev_namespace
-  }
-
-  data = {
-    url = "postgres://${postgresql_role.readonly_role.name}:${postgresql_role.readonly_role.password}}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
-  }
-}
-


### PR DESCRIPTION
This instance is no longer required.

It was breaking the build pipeline with this error:

```
Error: error deleting Database Instance "cloud-platform-2f8c3c1ceaf0a05d": DBSnapshotAlreadyExists: Cannot create the snapshot because a snapshot with the identifier cloud-platform-2f8c3c1ceaf0a05d-finalsnapshot already exists.
	status code: 400, request id: 810dcddc-71e8-454f-96b0-2afc4c6b426b
```