### PR TITLE
Update SNS module to version 4.1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/topic.tf
@@ -1,5 +1,5 @@
 module "intervention_reference_data_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
 
   team_name          = var.team_name
   topic_display_name = "intervention-reference-data-events"


### PR DESCRIPTION
When I approved the PR that added this topic, I didn't notice that they
were using an older version of the SNS module.

I've checked using terraform plan, and this change applies without
terraform doing anything to their SNS topic.