### PR TITLE
Correct the parameter_group_name

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/redis5.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/redis5.tf
@@ -10,7 +10,7 @@ module "dstest_elasticache_redis5" {
   team_name              = var.team_name
 
   engine_version        = "5.0.6"
-  parameter_group_name  = "default.redis5.0.6"
+  parameter_group_name  = "default.redis5.0"
   number_cache_clusters = "2"
   node_type             = "cache.t2.micro"
 }


### PR DESCRIPTION
AWS seems to be picky about the value of parameter_group_name

This value works, but the previous `default.redis5.0.6` fails with

```
Error creating Elasticache Replication Group: CacheParameterGroupNotFound: CacheParameterGroup not found: default.redis5.0.6
```