### PR TITLE
Increase Form Builder platform continer resource memory

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/02-limitrange.yaml
@@ -10,7 +10,7 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 800Mi
+      memory: 1000Mi
     defaultRequest:
       cpu: 10m
       memory: 128Mi


### PR DESCRIPTION
We are expecting an increase in traffic across the form builder platform. Also according to Grafana the memory limit for the platform pods operate very close to the limit.

Allocate an additional 200MB for now. We will monitor and increase if required.

https://trello.com/c/3Wrgd4To/458-iterate-on-pa-efile-form-second-iteration