### PR TITLE
Contact MOJ Prod Add Route 53

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/route53.tf
@@ -1,0 +1,29 @@
+################################################################################
+# contact-moj
+# Route53 domain zone settings
+#################################################################################
+
+resource "aws_route53_zone" "contact-moj_route53_zone" {
+  name = var.domain
+
+  tags = {
+    business-unit          = "Central Digital"
+    application            = "contact-moj"
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = "Staff Services"
+    infrastructure-support = "staffservices@digital.justice.gov.uk"
+  }
+}
+
+resource "kubernetes_secret" "contact-moj_route53_zone_sec" {
+  metadata {
+    name      = "contact-moj-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id      = aws_route53_zone.contact-moj_route53_zone.zone_id
+    name_servers = join("\n", aws_route53_zone.contact-moj_route53_zone.name_servers)
+  }
+}


### PR DESCRIPTION
Note that I'm adding Route53 for a new domain, the new domain is:
 contact-moj.service.justice.gov.uk
I'm planning to use Ingress for these as well:
development.contact-moj.service.justice.gov.uk
staging.contact-moj.service.justice.gov.uk

The domain needs setting up. There is a ticket here for that:
https://github.com/ministryofjustice/cloud-platform/issues/1825