### PR TITLE
Use version 2.0 of the HOODAW image

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: how-out-of-date-are-we
-          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:1.4
+          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.0
           env:
             - name: RACK_ENV
               value: "production"


### PR DESCRIPTION
This version displays helm release data for both the live-1 and manager
clusters.