### PR TITLE
pic-412 added circleci service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/05-serviceaccount-circleci.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: crime-portal-mirror-gateway-dev
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: crime-portal-mirror-gateway-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: crime-portal-mirror-gateway-dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Creates a circle ci service account. I have read the page here https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/use-circleci-to-upgrade-app.html#requirements but that links to K8S web page rather than terraform. 

Please let me know what else I need to do or what else I need to read thanks