### PR TITLE
PAT-818  - Allow Pathfinder service to set/view bucket lifecycle policy

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -8,11 +8,39 @@ module "pathfinder_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
-  user_policy            = var.document_bucket_user_policy
 
   providers = {
     aws = aws.london
   }
+
+  user_policy            = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow", 
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetLifecycleConfiguration",
+        "s3:PutLifecycleConfiguration"
+      ],
+      "Resource": "$${bucket_arn}"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+        "s3:DeleteObject",
+        "s3:PutObject"
+      ],
+      "Resource": "$${bucket_arn}/*"
+    }
+  ]
+}
+EOF
+
 }
 
 module "pathfinder_rds_export_s3_bucket" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -13,31 +13,31 @@ module "pathfinder_document_s3_bucket" {
     aws = aws.london
   }
 
-  user_policy            = <<EOF
+  user_policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow", 
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetLifecycleConfiguration",
-        "s3:PutLifecycleConfiguration"
-      ],
-      "Resource": "$${bucket_arn}"
-    },
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject"
-        "s3:DeleteObject",
-        "s3:PutObject"
-      ],
-      "Resource": "$${bucket_arn}/*"
-    }
-  ]
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow", 
+    "Action": [
+      "s3:ListBucket",
+      "s3:GetLifecycleConfiguration",
+      "s3:PutLifecycleConfiguration"
+    ],
+    "Resource": "$${bucket_arn}"
+  },
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
 }
 EOF
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -21,7 +21,10 @@ module "pathfinder_document_s3_bucket" {
     "Sid": "",
     "Effect": "Allow",
     "Action": [
+      "s3:GetBucketLocation",
       "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:ListBucketMultipartUploads",
       "s3:GetLifecycleConfiguration",
       "s3:PutLifecycleConfiguration"
     ],
@@ -32,7 +35,24 @@ module "pathfinder_document_s3_bucket" {
     "Effect": "Allow",
     "Action": [
       "s3:GetObject",
+      "s3:GetObjectVersionTagging",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectAcl",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionTorrent",
+      "s3:GetObjectTorrent",
       "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:DeleteObjectVersionTagging",
+      "s3:DeleteObjectTagging",
+      "s3:RestoreObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObjectVersionTagging",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionAcl",
+      "s3:PutObjectAcl",
       "s3:PutObject"
     ],
     "Resource": "$${bucket_arn}/*"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -8,6 +8,7 @@ module "pathfinder_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  user_policy            = var.document_bucket_user_policy
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -19,7 +19,7 @@ module "pathfinder_document_s3_bucket" {
 "Statement": [
   {
     "Sid": "",
-    "Effect": "Allow", 
+    "Effect": "Allow",
     "Action": [
       "s3:ListBucket",
       "s3:GetLifecycleConfiguration",

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/variables.tf
@@ -34,3 +34,31 @@ variable "number_cache_clusters" {
   default = "2"
 }
 
+variable "document_bucket_user_policy" = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetLifecycleConfiguration",
+        "s3:PutLifecycleConfiguration"
+      ],
+      "Resource": "$${bucket_arn}"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+        "s3:DeleteObject",
+        "s3:PutObject"
+      ],
+      "Resource": "$${bucket_arn}/*"
+    }
+  ]
+}
+EOF
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/variables.tf
@@ -34,31 +34,3 @@ variable "number_cache_clusters" {
   default = "2"
 }
 
-variable "document_bucket_user_policy" <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetLifecycleConfiguration",
-        "s3:PutLifecycleConfiguration"
-      ],
-      "Resource": "$${bucket_arn}"
-    },
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject"
-        "s3:DeleteObject",
-        "s3:PutObject"
-      ],
-      "Resource": "$${bucket_arn}/*"
-    }
-  ]
-}
-EOF
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/variables.tf
@@ -34,7 +34,7 @@ variable "number_cache_clusters" {
   default = "2"
 }
 
-variable "document_bucket_user_policy" = <<EOF
+variable "document_bucket_user_policy" <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [


### PR DESCRIPTION
Pathfinder has an S3 bucket to hold documents uploaded and associated with its cases. When a document is deleted by a service user, it is moved to a DELETED/ prefix where a lifecycle policy is set, with a filter, to expire them after x number of days. The Pathfinder service needs to set the expiry days based on configuration so that it can be different in different environments, and when running locally for development. This PR sets a user_policy on the Pathfinder document bucket to allow the life cycle policy to be set and viewed via AWS CLI (for support reasons) and programatically by the service to match-up with its configured expiry time.

Affects - only the Pathfinder document s3 bucket permissions.