### PR TITLE
Form Builder pingdom for Apply Financial Deputy Form

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
@@ -2,6 +2,7 @@ provider "pingdom" {}
 
 locals {
   forms = {
+    apply-financial-deputy = "apply-financial-deputy.form.service.justice.gov.uk",
     childrens-funeral-fund = "claim-for-costs-of-a-childs-funeral.form.service.justice.gov.uk",
     cica                   = "same-roof-rule.form.service.justice.gov.uk",
     contact-us-form        = "contact.form.service.justice.gov.uk",


### PR DESCRIPTION
The Apply to be a Financial Deputy form is going live today. This just
adds the pingdom check for when it is published.