### PR TITLE
Always log affected DNS records

### DIFF
--- a/bin/delete_unused_dns_records.rb
+++ b/bin/delete_unused_dns_records.rb
@@ -28,14 +28,18 @@ def main(options)
   keepers = required_dns_records
   records_to_delete = unneeded_txt_records(recordsets, keepers) + unneeded_a_records(recordsets, keepers)
 
-  if options[:list_only]
-    records_to_delete.each { |record| puts [record["Type"], record["Name"]].join(", ") }
-  else
+  log_records(records_to_delete)
+
+  unless options[:list_only]
     records_to_delete.each_slice(100) do |records|
       delete_records(records)
       sleep 2
     end
   end
+end
+
+def log_records(records)
+  records.each { |record| puts [record["Type"], record["Name"]].join(", ") }
 end
 
 # Fetch all of the resource recordsets in a zone, a page at a time


### PR DESCRIPTION
It will be useful to have the list of records the script tried to delete
in the concourse job logs. So, we can always log the records, and just
do nothing else if the "-l" or "--list" flag was supplied.