### PR TITLE
Update CircleCI service account permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/serviceaccount-circleci.yaml
@@ -18,7 +18,7 @@ rules:
     verbs:
       - "*"
   - apiGroups:
-      - "certmanager.k8s.io"
+      - "cert-manager.io"
     resources:
       - "certificates"
     verbs:
@@ -27,6 +27,7 @@ rules:
       - "delete"
       - "create"
       - "patch"
+      - "list"
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
I've updated the CircleCI service account permissions to allow it to deploy Certificate resources. This follows a recent change to the MOJ Cloud Platform.