### PR TITLE
Increase memory limit for logging containers to 1G

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 300m
-      memory: 500Mi
+      memory: 1000Mi
     defaultRequest:
       cpu: 10m
       memory: 400Mi


### PR DESCRIPTION
The fluentd pod on the main master keeps getting OOM killed. So, even
though all the other fluentd pods consume 70m or less, this PR doubles
the memory limit for pods in the logging namespace to 1000m