### PR TITLE
Increase the CPU limit for logging containers

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/02-limitrange.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 300m
+      cpu: 1000m
       memory: 1000Mi
     defaultRequest:
       cpu: 10m


### PR DESCRIPTION
The previous memory limit increase seems to have helped accidentally,
but I was looking at the wrong column of figures, and what the pod
really wants is more CPU. Hence this change.