### PR TITLE
Add laa-cla-public permissions in new apiGroups

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/05-serviceaccount-circleci.yaml
@@ -40,6 +40,28 @@ rules:
       - "create"
       - "patch"
   - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+  - apiGroups:
       - "batch"
     resources:
       - "jobs"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/05-serviceaccount-circleci.yaml
@@ -40,6 +40,28 @@ rules:
       - "create"
       - "patch"
   - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+  - apiGroups:
       - "batch"
     resources:
       - "jobs"


### PR DESCRIPTION
Adds 'deployments' in 'apps' and 'ingresses' in 'networking.k8s.io' for
new setup.
Keeps the old permissions (in apiGroup 'extensions') around for now,
until our Helm deploy has fully replaced our existing k8s one and the
existing objects are no longer needed.