### PR TITLE
Use default redis version (5)

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/redis.tf
@@ -26,8 +26,6 @@ module "redis_elasticache" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
-  engine_version         = "4.0.10"
-  parameter_group_name   = "default.redis4.0"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
I've spoken with the developer, and they're happy to stick with redis 5