### PR TITLE
GDPR-123 Assuming Analytical Platform Athena role

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/iam.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/iam.tf
@@ -2,6 +2,17 @@ resource "random_id" "id" {
   byte_length = 8
 }
 
+data "aws_iam_policy_document" "data_compliance_preprod_ap_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = [
+      "arn:aws:iam::593291632749:role/pulumi_typescript_nomis_gdpr_role-aa611b4",
+    ]
+  }
+}
+
 resource "aws_iam_user" "user" {
   name = "data-compliance-preprod-ap-user-${random_id.id.hex}"
   path = "/system/data-compliance-ap-users/"
@@ -9,6 +20,12 @@ resource "aws_iam_user" "user" {
 
 resource "aws_iam_access_key" "user" {
   user = aws_iam_user.user.name
+}
+
+resource "aws_iam_user_policy" "policy" {
+  name   = "data-compliance-ap-policy"
+  policy = data.aws_iam_policy_document.data_compliance_preprod_ap_policy.json
+  user   = aws_iam_user.user.name
 }
 
 resource "kubernetes_secret" "data_compliance_ap_user" {


### PR DESCRIPTION
The Analytical platform team have created a role which has a trust relationship with this user, therefore enabling this user to assume it.  The role allows the user to execute Athena queries and gives access to a limited and required set of S3 buckets.