### PR TITLE
Update to DNS name in certificates.yml

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/05-certificates.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/05-certificates.yml
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-  - crime-portal-mirror-gateway-dev.service.justice.gov.uk
+  - dev.crime-portal-mirror-gateway.service.justice.gov.uk


### PR DESCRIPTION
To fix the DNS name to dev.crime-portal-mirror-gateway.service.justice.gov.uk for certificates.yml 