### PR TITLE
Sort lists of files before comparing

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,8 +108,8 @@ def expect_execute(cmd, stdout, status)
 end
 
 def expect_same_files(expected_dir, actual_dir)
-  expected_files = Dir["#{expected_dir}/**/*"].map { |f| f.sub(expected_dir, "") }
-  actual_files = Dir["#{actual_dir}/**/*"].map { |f| f.sub(actual_dir, "") }
+  expected_files = Dir["#{expected_dir}/**/*"].map { |f| f.sub(expected_dir, "") }.sort
+  actual_files = Dir["#{actual_dir}/**/*"].map { |f| f.sub(actual_dir, "") }.sort
 
   expect(expected_files).to eq(actual_files)
 end


### PR DESCRIPTION
This helper method is supposed to check that one directory
matches another, in terms of the names of the files in each directory.
But, the ordering of files returned by `Dir[]` is not guaranteed, so
sometimes the check fails because, e.g.

```
[a, b, c] != [b, a, c]
```

This change sorts each list before comparing, which should prevent these
kinds of false failures.