### PR TITLE
Amend cccd-dev SNS filter policy to allow new claim types

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
@@ -223,7 +223,7 @@ resource "aws_sns_topic_subscription" "ccr-queue-subscription" {
   topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
   endpoint      = module.claims_for_ccr.sqs_arn
-  filter_policy = "{\"claim_type\": [\"Claim::AdvocateClaim\", \"Claim::AdvocateInterimClaim\", \"Claim::AdvocateSupplementaryClaim\"]}"
+  filter_policy = "{\"claim_type\": [\"Claim::AdvocateClaim\", \"Claim::AdvocateInterimClaim\", \"Claim::AdvocateSupplementaryClaim\", \"Claim::AdvocateHardshipClaim\"]}"
 }
 
 resource "aws_sns_topic_subscription" "cclf-queue-subscription" {
@@ -231,6 +231,6 @@ resource "aws_sns_topic_subscription" "cclf-queue-subscription" {
   topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
   endpoint      = module.claims_for_cclf.sqs_arn
-  filter_policy = "{\"claim_type\": [\"Claim::LitigatorClaim\", \"Claim::InterimClaim\", \"Claim::TransferClaim\"]}"
+  filter_policy = "{\"claim_type\": [\"Claim::LitigatorClaim\", \"Claim::InterimClaim\", \"Claim::TransferClaim\", \"Claim::LitigatorHardshipClaim\"]}"
 }
 


### PR DESCRIPTION
New covid-19 related "hardship" claim types to be filtered onto relevant queues.