### PR TITLE
Amend cccd-production SNS filtering for litigator hardship claims

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
@@ -231,6 +231,6 @@ resource "aws_sns_topic_subscription" "cclf-queue-subscription" {
   topic_arn     = module.cccd_claims_submitted.topic_arn
   protocol      = "sqs"
   endpoint      = module.claims_for_cclf.sqs_arn
-  filter_policy = "{\"claim_type\": [\"Claim::LitigatorClaim\", \"Claim::InterimClaim\", \"Claim::TransferClaim\"]}"
+  filter_policy = "{\"claim_type\": [\"Claim::LitigatorClaim\", \"Claim::InterimClaim\", \"Claim::TransferClaim\", \"Claim::LitigatorHardshipClaim\"]}"
 }
 


### PR DESCRIPTION
#### What
Amend cccd-production SNS filtering for litigator hardship claims

#### Why
Activates "data injection" of litigator hardship claims (only)
from CCCD into CCLF.

This is a new claim type that has only recently been added
to handle covid-19 impact on provider cash flow.