### PR TITLE
Add Pingdom check to laa-court-data-adaptor-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/pingdom.tf
@@ -1,0 +1,18 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "laa-court-data-adaptor-dev" {
+  type                     = "http"
+  name                     = "LAA Court Data Adaptor - dev"
+  host                     = "laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 3
+  notifyagainevery         = 0
+  url                      = "/status"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_laa,application_court-data-adaptor,component_ping,isproduction_false,environment_dev,owner_crimeapps-laa@digital.justice.gov.uk"
+  probefilters             = "region:EU"
+  publicreport             = "true"
+}


### PR DESCRIPTION
Add `resources/pingdom.tf` to enable pingdom checks for the `laa-court-data-adaptor-dev`.