### PR TITLE
Include helm-created objects in finder script

### DIFF
--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -79,20 +79,12 @@ end
 
 def deprecated_api_objects
   # NB: double backslashes, compared to running the command from a terminal
-  cmd = %(
-    kubectl get #{OBJECT_TYPES} --all-namespaces
-    -o 'jsonpath={range.items[*]}{.metadata.annotations.kubectl\\.kubernetes\\.io/last-applied-configuration}{"\\n"}{end}'
-  ).tr("\n", " ").strip
+  cmd = "kubectl get #{OBJECT_TYPES} --all-namespaces -o json"
 
   stdout, _, _ = Open3.capture3(cmd)
-  # stdout = File.read("objects.json")
 
-  objects = stdout.split("\n").map { |line|
-    next if line == ""
-    JSON.parse(line)
-  }.compact
-
-  objects.filter { |obj| DEPRECATED_API_VERSIONS.include?(obj.fetch("apiVersion")) }
+  JSON.parse(stdout).fetch("items")
+    .filter { |obj| DEPRECATED_API_VERSIONS.include?(obj.fetch("apiVersion")) }
 end
 
 # Given a hash representing a kubernetes object, return a csv of the fields we
@@ -106,7 +98,7 @@ def object_csv(hash, namespaces)
     hash.dig("metadata", "name"),
     namespace,
     team,
-    repo
+    repo,
   ].join(", ")
 end
 
@@ -119,7 +111,7 @@ def tiller_csv(pod, namespaces)
     pod.dig("metadata", "name"),
     namespace,
     team,
-    repo
+    repo,
   ].join(", ")
 end
 


### PR DESCRIPTION
The find-deprecated-objects.rb script was omitting objects created by
some helm charts, because they don't have a `last-applied-configuration`

This change iterates over every relevant object in the cluster, so that
any such objects are now included in the list.

NB: This means we now have several *thousand* ReplicaSet objects in the
report, but I would expect those to disappear as the underlying
Deployments are updated.