### PR TITLE
Use 'pluto' in script to find deprecated objects

### DIFF
--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -92,7 +92,8 @@ end
 # Given a hash representing a kubernetes object, return a csv of the fields we
 # care about wrt. the API deprecation
 def object_csv(hash, namespaces)
-  namespace, team, repo = namespace_team_repo(hash, namespaces)
+  namespace = hash.dig("metadata", "namespace")
+  team, repo = namespace_team_repo(namespace, namespaces)
 
   [
     hash.fetch("kind"),
@@ -105,7 +106,8 @@ def object_csv(hash, namespaces)
 end
 
 def tiller_csv(pod, namespaces)
-  namespace, team, repo = namespace_team_repo(pod, namespaces)
+  namespace = pod.dig("metadata", "namespace")
+  team, repo = namespace_team_repo(namespace, namespaces)
 
   [
     "tiller",
@@ -117,14 +119,12 @@ def tiller_csv(pod, namespaces)
   ].join(", ")
 end
 
-def namespace_team_repo(hash, namespaces)
-  namespace = hash.dig("metadata", "namespace")
-
+def namespace_team_repo(namespace, namespaces)
   ns = namespaces[namespace]
   team = ns.nil? ? "" : ns[:team]
   repo = ns.nil? ? "" : ns[:repo]
 
-  [namespace, team, repo]
+  [team, repo]
 end
 
 def parsed_json_output(cmd)

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -83,11 +83,12 @@ def deprecated_api_objects
   stdout, _, _ = Open3.capture3(cmd)
 
   JSON.parse(stdout).fetch("items")
+    .filter { |obj| last_applied_api_version(obj) }
     .filter { |obj| uses_deprecated_apis?(obj) }
 end
 
 def uses_deprecated_apis?(obj)
-  api_version = last_applied_api_version(obj) || obj.fetch("apiVersion")
+  api_version = last_applied_api_version(obj)
   DEPRECATED_API_VERSIONS.include?(api_version)
 end
 

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -24,7 +24,7 @@ def main
 
   namespaces = namespace_details
 
-  deprecated_api_objects.each { |obj| puts object_csv(obj, namespaces) }
+  kubectl_api_objects.each { |obj| puts object_csv(obj, namespaces) }
 
   # TODO filter for tiller < 2.16.3
   tiller_pods = parsed_json_output("kubectl get pods --all-namespaces -o json").fetch("items", [])
@@ -32,6 +32,19 @@ def main
 
   tiller_pods.map { |pod| puts tiller_csv(pod, namespaces) }
   output_helm2_object_data(tiller_pods)
+  output_helm3_object_data(namespaces)
+end
+
+def helm3_deprecated_objects(namespace)
+  cmd = pluto_command(namespace, "3")
+  parsed_json_output(cmd).fetch("items", [])
+end
+
+def output_helm3_object_data(namespaces)
+  namespaces.keys.each do |namespace|
+    helm3_deprecated_objects(namespace)
+      .each { |object| puts helm_object_csv(object, namespaces) }
+  end
 end
 
 def output_helm2_object_data(tiller_pods)
@@ -109,7 +122,7 @@ def namespace_details
   rtn
 end
 
-def deprecated_api_objects
+def kubectl_api_objects
   # NB: double backslashes, compared to running the command from a terminal
   cmd = "kubectl get #{OBJECT_TYPES} --all-namespaces -o json"
 

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -5,6 +5,8 @@
 #
 # https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals
 # https://www.ibm.com/cloud/blog/announcements/kubernetes-version-1-16-removes-deprecated-apis
+#
+# Requires [pluto](https://github.com/FairwindsOps/pluto)
 
 require "json"
 require "open3"

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -64,7 +64,7 @@ end
 
 def helm2_deprecated_objects(namespace)
   # NB: takes approx 40 seconds to run
-  cmd = %(pluto detect-helm --namespace #{namespace} --helm-version 2 -o json)
+  cmd = pluto_command(namespace, "2")
   parsed_json_output(cmd).fetch("items", []).map do |obj|
     # 'name' is often something like "check-financial-eligibility/check-financial-eligibility"
     # so if it matches that pattern, simplify it.
@@ -78,6 +78,10 @@ def helm2_deprecated_objects(namespace)
       kind: obj.dig("api", "kind"),
     }
   end
+end
+
+def pluto_command(namespace, helm_version)
+  %(pluto detect-helm --namespace #{namespace} --helm-version #{helm_version} -o json)
 end
 
 def tiller?(pod)

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -33,7 +33,7 @@ def main
     .filter { |pod| tiller?(pod) }
 
   tiller_pods.map { |pod| puts tiller_csv(pod, namespaces) }
-  output_helm2_object_data(tiller_pods)
+  output_helm2_object_data(tiller_pods, namespaces)
   output_helm3_object_data(namespaces)
 end
 
@@ -49,7 +49,7 @@ def output_helm3_object_data(namespaces)
   end
 end
 
-def output_helm2_object_data(tiller_pods)
+def output_helm2_object_data(tiller_pods, namespaces)
   tiller_pod_namespaces = tiller_pods
     .map { |pod| pod.dig("metadata", "namespace") }
     .sort

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -45,17 +45,21 @@ def output_helm2_object_data(tiller_pods)
 
   tiller_pod_namespaces.each do |ns|
     helm2_deprecated_objects(ns).each do |obj|
-      team, repo = namespace_team_repo(obj[:namespace], namespaces)
-      puts [
-        obj[:kind],
-        obj[:api_version],
-        obj[:name],
-        obj[:namespace],
-        team,
-        repo
-      ].join(", ")
+      puts helm_object_csv(obj, namespaces)
     end
   end
+end
+
+def helm_object_csv(object, namespaces)
+  team, repo = namespace_team_repo(object[:namespace], namespaces)
+  [
+    object[:kind],
+    object[:api_version],
+    object[:name],
+    object[:namespace],
+    team,
+    repo
+  ].join(", ")
 end
 
 def helm2_deprecated_objects(namespace)

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -128,8 +128,12 @@ def namespace_team_repo(namespace, namespaces)
 end
 
 def parsed_json_output(cmd)
-  stdout, _, _ = Open3.capture3(cmd)
+  stdout, stderr, status = Open3.capture3(cmd)
+  $stderr.puts(stderr) unless status.success?
   JSON.parse(stdout)
+rescue JSON::ParserError
+  $stderr.puts("JSON::ParserError parsing:\n#{stdout}")
+  {}
 end
 
 

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -24,14 +24,12 @@ def main
 
   namespaces = namespace_details
 
-  deprecated_api_objects.each do |obj|
-    puts object_csv(obj, namespaces)
-  end
-
+  deprecated_api_objects.each { |obj| puts object_csv(obj, namespaces) }
 
   # TODO filter for tiller < 2.16.3
   tiller_pods = parsed_json_output("kubectl get pods --all-namespaces -o json").fetch("items", [])
     .filter { |pod| tiller?(pod) }
+
   tiller_pods.map { |pod| puts tiller_csv(pod, namespaces) }
   output_helm2_object_data(tiller_pods)
 end
@@ -41,7 +39,6 @@ def output_helm2_object_data(tiller_pods)
     .map { |pod| pod.dig("metadata", "namespace") }
     .sort
     .uniq
-
 
   tiller_pod_namespaces.each do |ns|
     helm2_deprecated_objects(ns).each do |obj|


### PR DESCRIPTION
This PR updates the `bin/find-deprecated-objects.rb` script to use
[pluto](https://github.com/FairwindsOps/pluto) to report on objects created via
Helm 2 & 3.