### PR TITLE
Probation zone

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: probation-prod
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Cloud Platform"
+    cloud-platform.justice.gov.uk/application: "probation route53"
+    cloud-platform.justice.gov.uk/owner: "webops: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "n/a"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: probation-prod-admin
+  namespace: probation-prod
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: probation-prod
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: probation-prod
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: probation-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: probation-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/resources/route53.tf
@@ -18,7 +18,7 @@ resource "kubernetes_secret" "probation" {
   }
 
   data = {
-    zone_id   = aws_route53_zone.probation.zone_id
+    zone_id = aws_route53_zone.probation.zone_id
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/resources/route53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_zone" "probation" {
+  name = "probation.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = "Cloud Platform"
+    application            = "probation"
+    is-production          = "yes"
+    environment-name       = "prod"
+    owner                  = "cloud platform"
+    infrastructure-support = "cloud platform"
+  }
+}
+
+resource "kubernetes_secret" "probation" {
+  metadata {
+    name      = "probation-zone-output"
+    namespace = "probation-production"
+  }
+
+  data = {
+    zone_id   = aws_route53_zone.probation.zone_id
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This PR creates the standalone namespace `probation-prod`.
This NS is used to create the Route53 zone `probation.service.justice.gov.uk`, which is needed for subdomains.
