### PR TITLE
Add Form Builder pentest dev platform environment

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-platform/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-platform-pentest-dev
+  labels:
+    # for fb's own purposes
+    name: formbuilder-platform-pentest-dev
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest-dev"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-platform"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/01-rbac.yaml
@@ -1,0 +1,27 @@
+---
+# Source: formbuilder-platform/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-platform-pentest-dev-admins
+  namespace: formbuilder-platform-pentest-dev
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-pentest-dev
+    namespace: formbuilder-platform-pentest-dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+# Further roles defined in:
+# - service-token-cache-service-account.yaml
+# - submitter-workers-service-account.yaml
+# - user-datastore-service-account.yaml
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-platform/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-platform-pentest-dev
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-platform-pentest-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-platform/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-platform-pentest-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-platform-pentest-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/av-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/av-service-account.yaml
@@ -1,0 +1,14 @@
+---
+# Source: formbuilder-platform/templates/av-service-account.yaml
+---
+# Source: formbuilder-platform/templates/user-filestore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user filestore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-av-pentest-dev
+  namespace: formbuilder-platform-pentest-dev
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/circleci-service-account.yaml
@@ -1,0 +1,26 @@
+---
+# Source: formbuilder-platform/templates/circleci-service-account.yaml
+---
+# Source: formbuilder-platform/templates/circleci-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# This service account allows circleci to deploy into this environment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-platform-pentest-dev
+  namespace: formbuilder-platform-pentest-dev
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-platform-pentest-dev
+  namespace: formbuilder-platform-pentest-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-platform-pentest-dev
+  namespace: formbuilder-platform-pentest-dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/pdf-generator-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/pdf-generator-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-platform/templates/pdf-generator-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-pdf-generator-pentest-dev
+  namespace: formbuilder-platform-pentest-dev
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/json-output-attachments-s3.tf
@@ -1,0 +1,68 @@
+module "json-output-attachments-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.1"
+
+  team_name              = var.team_name
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+
+  providers = {
+    aws = aws.london
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-7d"
+      prefix                                 = "7d/"
+      abort_incomplete_multipart_upload_days = 7
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
+  metadata {
+    name      = "json-output-attachments-s3-bucket-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data = {
+    access_key_id     = module.json-output-attachments-s3-bucket.access_key_id
+    bucket_arn        = module.json-output-attachments-s3-bucket.bucket_arn
+    bucket_name       = module.json-output-attachments-s3-bucket.bucket_name
+    secret_access_key = module.json-output-attachments-s3-bucket.secret_access_key
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/main.tf
@@ -1,0 +1,15 @@
+# auto-generated from fb-cloud-platforms-environments
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/service_token_cache.tf
@@ -1,0 +1,31 @@
+module "service-token-cache-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.1"
+
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
+
+  application            = "formbuilderservice-token-cache"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  engine_version         = "4.0.10"
+  parameter_group_name   = "default.redis4.0"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "service-token-cache-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-service-token-cache-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data = {
+    primary_endpoint_address = module.service-token-cache-elasticache.primary_endpoint_address
+    auth_token               = module.service-token-cache-elasticache.auth_token
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/submitter.tf
@@ -1,0 +1,32 @@
+module "submitter-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
+
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_submitter
+  application                = "formbuildersubmitter"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
+  force_ssl                  = true
+  db_engine_version          = "10.9"
+  apply_method               = "immediate"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "submitter-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-submitter-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.submitter-rds-instance.database_username}:${module.submitter-rds-instance.database_password}@${module.submitter-rds-instance.rds_instance_endpoint}/${module.submitter-rds-instance.database_name}"
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.4"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-datastore.tf
@@ -1,0 +1,32 @@
+module "user-datastore-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
+
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period_user_datastore
+  application                = "formbuilderuserdatastore"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
+  force_ssl                  = true
+  db_engine_version          = "10.9"
+  apply_method               = "immediate"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "user-datastore-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-user-datastore-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/user-filestore.tf
@@ -1,0 +1,100 @@
+# auto-generated from fb-cloud-platforms-environments
+##################################################
+# User Filestore S3
+module "user-filestore-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.1"
+
+  team_name              = var.team_name
+  acl                    = "private"
+  versioning             = false
+  business-unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+
+  providers = {
+    aws = aws.london
+  }
+
+  user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
+      "s3:GetLifecycleConfiguration",
+      "s3:PutLifecycleConfiguration"
+    ],
+    "Resource": "$${bucket_arn}"
+  },
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersion",
+      "s3:DeleteObjectVersionTagging",
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionAcl",
+      "s3:PutObjectVersionTagging",
+      "s3:RestoreObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+
+  lifecycle_rule = [
+    {
+      enabled                                = true
+      id                                     = "expire-28d"
+      prefix                                 = "28d/"
+      abort_incomplete_multipart_upload_days = 28
+      expiration = [
+        {
+          days = 28
+        },
+      ]
+      noncurrent_version_expiration = [
+        {
+          days = 28
+        },
+      ]
+    },
+  ]
+}
+
+resource "kubernetes_secret" "user-filestore-s3-bucket" {
+  metadata {
+    name      = "s3-formbuilder-user-filestore-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data = {
+    access_key_id     = module.user-filestore-s3-bucket.access_key_id
+    bucket_arn        = module.user-filestore-s3-bucket.bucket_arn
+    bucket_name       = module.user-filestore-s3-bucket.bucket_name
+    secret_access_key = module.user-filestore-s3-bucket.secret_access_key
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/variables.tf
@@ -1,0 +1,32 @@
+# auto-generated from fb-cloud-platforms-environments
+variable "environment-name" {
+  default = "pentest-dev"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "db_backup_retention_period_submitter" {
+  default = "2"
+}
+
+variable "db_backup_retention_period_user_datastore" {
+  default = "2"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "infrastructure-support" {
+  default = "Form Builder form-builder-team@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = "0.12.17"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/service-token-cache-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/service-token-cache-service-account.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/service-token-cache-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-service-token-cache-pentest-dev
+  namespace: formbuilder-platform-pentest-dev

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/submitter-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/submitter-workers-service-account.yaml
@@ -1,0 +1,8 @@
+---
+# Source: formbuilder-platform/templates/submitter-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-submitter-workers-pentest-dev
+  namespace: formbuilder-platform-pentest-dev

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/user-datastore-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/user-datastore-service-account.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/user-datastore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-user-datastore-pentest-dev
+  namespace: formbuilder-platform-pentest-dev

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/user-filestore-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-pentest-dev/user-filestore-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-platform/templates/user-filestore-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user filestore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-pentest-dev namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-user-filestore-pentest-dev
+  namespace: formbuilder-platform-pentest-dev
+


### PR DESCRIPTION
Form Builder is going to have penetration testing done on their platform and services. This adds the dev namespace for that purpose.

https://trello.com/c/wV1szkzk/592-set-up-pentest-environment

Co-authored-by Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by Tomas Destefi <tomas.destefi@digital.justice.gov.uk>