### PR TITLE
Add elasticsearch to Prisoner content hub

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -10,5 +10,5 @@ module "content_hub_elasticsearch" {
   team_name              = var.team_name
   elasticsearch-domain   = "prisoner-content-hub-search"
   namespace              = var.namespace
-  elasticsearch_version  = "5.6"
+  elasticsearch_version  = "7.1"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -8,7 +8,7 @@ module "content_hub_elasticsearch" {
   infrastructure-support = var.infrastructure-support
   is-production          = var.is-production
   team_name              = var.team_name
-  elasticsearch-domain   = "prisoner-content-hub-search"
+  elasticsearch-domain   = "hub-search"
   namespace              = var.namespace
   elasticsearch_version  = "7.1"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -1,0 +1,14 @@
+module "content_hub_elasticsearch" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  business-unit          = var.business-unit
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+  is-production          = var.is-production
+  team_name              = var.team_name
+  elasticsearch-domain   = "prisoner-content-hub-search"
+  namespace              = var.namespace
+  elasticsearch_version  = "7.1"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -10,5 +10,5 @@ module "content_hub_elasticsearch" {
   team_name              = var.team_name
   elasticsearch-domain   = "prisoner-content-hub-search"
   namespace              = var.namespace
-  elasticsearch_version  = "7.1"
+  elasticsearch_version  = "5.6"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/variables.tf
@@ -10,14 +10,21 @@ variable "namespace" {
   default = "prisoner-content-hub-production"
 }
 
+# this is injected by Cloud Platform automatically so we do not need to populate it here
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service."
   default     = "HMPPS"
 }
 
 variable "team_name" {
-  description = "The name of your development team"
-  default     = "Prisoner Facing Services"
+  description = "DNS compliant name of the development team"
+  default     = "prisoner-facing-services"
 }
 
 variable "environment-name" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/variables.tf
@@ -22,9 +22,12 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
+# We chose pfs because this variable is used to create domain names for resources
+# e.g. ElasticSearch. When concatenated with the environment name and unique name,
+# this only leaves a handful of characters for the team_name.
 variable "team_name" {
   description = "DNS compliant name of the development team"
-  default     = "prisoner-facing-services"
+  default     = "pfs"
 }
 
 variable "environment-name" {


### PR DESCRIPTION
We need to add elasticsearch to support the migration of the content hub into cloud platform.

This PR: 

- fixes the team name to ensure it is dash separated and works with the elasticsearch module
- Added elasticsearch module
