### PR TITLE
Add Form Builder services namespace in production for pen test

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-services/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-services-pentest-production
+  labels:
+    # for fb's own purposes
+    name: formbuilder-services-pentest-production
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest-production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-services"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/01-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: formbuilder-services/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-pentest-production-admins
+  namespace: formbuilder-services-pentest-production
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+# Bind admin role for namespace to team group & publisher ServiceAccount
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-services-pentest-production-service-account
+  namespace: formbuilder-services-pentest-production
+subjects:
+  # allow platformenv Publisher to deploy to this deploymentenv
+  - kind: ServiceAccount
+    name: formbuilder-publisher-workers-test
+    namespace: formbuilder-publisher-test
+  # ...but only the dev service token cache can read the dev
+  # service tokens
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-pentest-production
+    namespace: formbuilder-platform-pentest-production
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-services/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-services-pentest-production
+spec:
+  limits:
+  - default:
+      cpu: 150m
+      memory: 300Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-services-pentest-production
+spec:
+  hard:
+    pods: "100"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-services/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-services-pentest-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-services-pentest-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: tls-wildcard
+  namespace: formbuilder-services-pentest-production
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - '*.dev.test.form.service.justice.gov.uk'

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/circleci-service-account.yaml
@@ -1,0 +1,26 @@
+---
+# Source: formbuilder-services/templates/circleci-service-account.yaml
+---
+# Source: formbuilder-services/templates/circleci-service-account.yaml
+# auto-generated from fb-cloud-platform-environments
+# This service account allows circleci to deploy into this environment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-services-pentest-production
+  namespace: formbuilder-services-pentest-production
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-services-pentest-production
+  namespace: formbuilder-services-pentest-production
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-services-pentest-production
+  namespace: formbuilder-services-pentest-production
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+


### PR DESCRIPTION
This adds the Form Builder services namespace production required for the penetration testing.

https://trello.com/c/wV1szkzk/592-set-up-pentest-environment