### PR TITLE
Add Form Builder publisher namespace for pentest

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-publisher/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-publisher-pentest
+  labels:
+    # for fb's own purposes
+    name: formbuilder-publisher-pentest
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pentest"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/application: "formbuilder-publisher"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/fb-publisher"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/01-rbac.yaml
@@ -1,0 +1,21 @@
+---
+# Source: formbuilder-publisher/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-publisher-pentest-admins
+  namespace: formbuilder-publisher-pentest
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+# Further roles defined in:
+# - publisher-workers-service-account.yaml

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-publisher/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-publisher-pentest
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-publisher-pentest
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-publisher/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-publisher-pentest
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-publisher-pentest
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/circleci-service-account.yaml
@@ -1,0 +1,26 @@
+---
+# Source: formbuilder-publisher/templates/circleci-service-account.yaml
+---
+# Source: formbuilder-publisher/templates/circleci-service-account.yaml
+# auto-generated from fb-cloud-platform-environments
+# This service account allows circleci to deploy into this environment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-publisher-pentest
+  namespace: formbuilder-publisher-pentest
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-publisher-pentest
+  namespace: formbuilder-publisher-pentest
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-publisher-pentest
+  namespace: formbuilder-publisher-pentest
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/publisher-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/publisher-workers-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-publisher/templates/publisher-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the publisher worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-pentest-(deploymentEnvironment)
+# namespaces so that they can deploy services there
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-publisher-workers-pentest
+  namespace: formbuilder-publisher-pentest

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/main.tf
@@ -1,0 +1,15 @@
+# auto-generated from fb-cloud-platforms-environments
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/publisher.tf
@@ -1,0 +1,66 @@
+module "publisher-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.4"
+
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period
+  application                = "formbuilderpublisher"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
+  db_engine_version          = "10.9"
+  apply_method               = "immediate"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "publisher-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-publisher-${var.environment-name}"
+    namespace = "formbuilder-publisher-${var.environment-name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.publisher-rds-instance.database_username}:${module.publisher-rds-instance.database_password}@${module.publisher-rds-instance.rds_instance_endpoint}/${module.publisher-rds-instance.database_name}"
+  }
+}
+
+##################################################
+
+########################################################
+# Publisher Elasticache Redis (for resque + job logging)
+module "publisher-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.1"
+
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
+
+  application            = "formbuilderpublisher"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  engine_version         = "4.0.10"
+  parameter_group_name   = "default.redis4.0"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "publisher-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-publisher-${var.environment-name}"
+    namespace = "formbuilder-publisher-${var.environment-name}"
+  }
+
+  data = {
+    primary_endpoint_address = module.publisher-elasticache.primary_endpoint_address
+    auth_token               = module.publisher-elasticache.auth_token
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/variables.tf
@@ -1,0 +1,28 @@
+# auto-generated from fb-cloud-platforms-environments
+variable "environment-name" {
+  default = "pentest"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "db_backup_retention_period" {
+  default = "2"
+}
+
+variable "infrastructure-support" {
+  default = "Form Builder form-builder-team@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-pentest/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = "0.12.17"
+}


### PR DESCRIPTION
This adds the Form Builder publisher namespace required for the penetration testing.

https://trello.com/c/wV1szkzk/592-set-up-pentest-environment
