### PR TITLE
Add provider & RDS family attributed to fix broken CI build

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
@@ -10,8 +10,13 @@ module "drupal_rds" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
 
+  providers = {
+    aws = aws.london
+  }
+
   db_engine         = "mariadb"
   db_engine_version = "10.4"
+  rds_family        = "mariadb10.4"
 
   # We need to explicitly set this to an empty list, otherwise the module 
   # will add `rds.force_ssl`, which MariaDB doesn't support


### PR DESCRIPTION
This PR adds the `rds_family` and `providers` arguments to fix the build issues seen this morning.

See https://mojdt.slack.com/archives/C57UPMZLY/p1591787541422500\?thread_ts\=1591720465.401700\&cid\=C57UPMZLY