### PR TITLE
Use tools image 1.18

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.17
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.18
 
 namespace-report.json: bin/namespace-reporter.rb namespaces/live-1.cloud-platform.service.justice.gov.uk/*/*.yaml
 	./bin/namespace-reporter.rb -o json -n '.*' > namespace-report.json

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/provider.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/provider.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: cloud-platform-tools
-        image: ministryofjustice/cloud-platform-tools:1.17
+        image: ministryofjustice/cloud-platform-tools:1.18
         securityContext:
           runAsUser: 1000
         env:


### PR DESCRIPTION
This version pins the gov.uk concourse provider to v5.8.0, which should
fix a problem where the apply pipeline breaks for 'gitops' namespaces.