### PR TITLE
Add ECR repo for prison-visits-integration-tests

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-tests.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-tests.tf
@@ -1,0 +1,20 @@
+module "ecr-repo-prison-visits-tests" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+
+  team_name = var.team_name
+  repo_name = "prison-visits-integration-tests"
+}
+
+resource "kubernetes_secret" "ecr-repo-prison-visits-tests" {
+  metadata {
+    name      = "ecr-repo-prison-visits-tests"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_url          = module.ecr-repo-prison-visits-tests.repo_url
+    access_key_id     = module.ecr-repo-prison-visits-tests.access_key_id
+    secret_access_key = module.ecr-repo-prison-visits-tests.secret_access_key
+  }
+}
+


### PR DESCRIPTION
The PVB team are moving the integration and smoke tests from Jenkins to Circle:CI, but the tests need to run inside the K8S cluster. This repo is where we store the images for those tests