### PR TITLE
prepare-a-case route53 and certificate change

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/07-certificates.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/07-certificates.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: prepareacase-probation.service.justice.gov.uk
+  name: prepare-case-probation.service.justice.gov.uk
   namespace: prepare-a-case-prod
 spec:
   secretName: prepare-a-case-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - prepareacase-probation.service.justice.gov.uk
+    - prepare-case-probation.service.justice.gov.uk

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/07-certificates.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/07-certificates.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: prepareacase.probation.service.justice.gov.uk
+  name: prepareacase-probation.service.justice.gov.uk
   namespace: prepare-a-case-prod
 spec:
   secretName: prepare-a-case-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - prepareacase.probation.service.justice.gov.uk
+    - prepareacase-probation.service.justice.gov.uk

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/resources/route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = var.domain
+
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/resources/variables.tf
@@ -1,5 +1,5 @@
 variable "domain" {
-  default = "prepareacase-probation.service.justice.gov.uk"
+  default = "prepare-case-probation.service.justice.gov.uk"
 }
 
 variable "application" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prepare-a-case-prod/resources/variables.tf
@@ -1,3 +1,7 @@
+variable "domain" {
+  default = "prepareacase-probation.service.justice.gov.uk"
+}
+
 variable "application" {
   default = "prepare-a-case"
 }


### PR DESCRIPTION
Changes domain to to prepareacase-probation.service.justice.gov.uk
Updated certificate.yaml to support change

Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>