### PR TITLE
Allow CircleCI to fetch pods logs

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/06-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/06-serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "pods/log"
     verbs:
       - "patch"
       - "get"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/06-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/06-serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "pods/log"
     verbs:
       - "patch"
       - "get"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "pods/log"
     verbs:
       - "patch"
       - "get"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "pods/log"
     verbs:
       - "patch"
       - "get"


### PR DESCRIPTION
Hi, 
adding some more  permission to our CircleCI service account so that it can pull logs.
Useful to inspect the outcome of one-off jobs, such as migrations. 