### PR TITLE
Add CircleCI service account to form builder adapter base test

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/circleci-service-account.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-base-adapter-test
+  namespace: formbuilder-base-adapter-test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-base-adapter-test
+  namespace: formbuilder-base-adapter-test
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-base-adapter-test
+  namespace: formbuilder-base-adapter-test
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Context

Add CircleCI as service account for formbuilder base adapter in test environment.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>