### PR TITLE
Update RBAC role for prisoner money pod service account in production namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/05-service-accounts.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/05-service-accounts.yaml
@@ -11,16 +11,13 @@ metadata:
   name: pod-internal
   namespace: money-to-prisoners-prod
 rules:
-  - apiGroups:
-      - ""
+  - apiGroups: [""]
     resources:
-      - deployment
       - pods
     verbs:
       - get
       - list
-  - apiGroups:
-      - extensions
+  - apiGroups: [extensions, apps]
     resources:
       - deployments
     verbs:


### PR DESCRIPTION
…to allow access to deployments in both legacy "extensions" and new "apps" api groups.

#2551 already did this for the test namespace