### PR TITLE
Update RDS module for Prisoner Money namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
@@ -4,7 +4,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.5"
 
   providers = {
     aws = aws.london
@@ -28,7 +28,6 @@ module "rds" {
   db_name              = "mtp_api"
 
   allow_major_version_upgrade = false
-  apply_method                = "pending-reboot"
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -4,7 +4,7 @@ variable "cluster_name" {}
 variable "cluster_state_bucket" {}
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.5"
 
   providers = {
     aws = aws.london
@@ -28,7 +28,6 @@ module "rds" {
   db_name              = "mtp_api"
 
   allow_major_version_upgrade = false
-  apply_method                = "immediate"
 }
 
 resource "kubernetes_secret" "rds" {


### PR DESCRIPTION
… removing `apply_method` parameter which did nothing since it only applied to `force_ssl` which is on by default (and therefore already applied to all instances)