### PR TITLE
PAT-998: Add DNS record for manage-soc-cases-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/route53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = var.domain
+
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {  
+    name      = "route53-zone-output"
+    namespace = var.namespace
+  }
+  
+  data = {    
+    zone_id = aws_route53_zone.route53_zone.zone_id
+  }
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/variables.tf
@@ -2,6 +2,10 @@ variable "application" {
   default = "manage-soc-cases"
 }
 
+variable "domain" {
+  default = "manage-soc-cases-dev.service.justice.gov.uk"
+}
+
 variable "namespace" {
   default = "manage-soc-cases-dev"
 }


### PR DESCRIPTION
As this service is only present in dev (until it undergoes pen test & DPIA process), the dev instance requires a DNS entry for ingress. 