### PR TITLE
Fix formbuilder publisher service accounts for pentest namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/01-rbac.yaml
@@ -25,8 +25,8 @@ metadata:
 subjects:
   # allow platformenv Publisher to deploy to this deploymentenv
   - kind: ServiceAccount
-    name: formbuilder-publisher-workers-test
-    namespace: formbuilder-publisher-test
+    name: formbuilder-publisher-workers-pentest
+    namespace: formbuilder-publisher-pentest
   # ...but only the dev service token cache can read the dev
   # service tokens
   - kind: ServiceAccount

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/01-rbac.yaml
@@ -25,8 +25,8 @@ metadata:
 subjects:
   # allow platformenv Publisher to deploy to this deploymentenv
   - kind: ServiceAccount
-    name: formbuilder-publisher-workers-test
-    namespace: formbuilder-publisher-test
+    name: formbuilder-publisher-workers-pentest
+    namespace: formbuilder-publisher-pentest
   # ...but only the dev service token cache can read the dev
   # service tokens
   - kind: ServiceAccount


### PR DESCRIPTION
## Context

The "formbuilder-publisher-pentest" namespace was not having access to "formbuilder-services-pentest-dev" and "formbuilder-services-pentest-production" namespace.

We are suspecting that this will solve the problem.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
