### PR TITLE
Update formbuilder pentest cert DNS Names

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-dev/certificate.yaml
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-  - '*.dev.test.form.service.justice.gov.uk'
+  - '*.dev.pentest.form.service.justice.gov.uk'

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-pentest-production/certificate.yaml
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-  - '*.dev.test.form.service.justice.gov.uk'
+  - '*.pentest.form.service.justice.gov.uk'


### PR DESCRIPTION
The pentest environments had the wrong DNS names

Co-authored-by Tomas Destefi <tomas.destifi@digital.justice.gov.uk>
Co-authored-by Matt Tei <matt.tei@digital.justice.gov.uk>