### PR TITLE
Use HOODAW docker image v2.9

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: how-out-of-date-are-we
-          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.8
+          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.9
           env:
             - name: RACK_ENV
               value: "production"


### PR DESCRIPTION
There are no changes to the web application, but this keeps the version
numbers in sync between this namespace and the concourse pipeline.