### PR TITLE
CFO queues for preprod/prod and perf queue/topic just for CFO

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/cfo-sub-queue-perf.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/cfo-sub-queue-perf.tf
@@ -1,0 +1,114 @@
+module "cfo_queue_perf" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name          = var.environment-name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure-support
+  application               = var.application
+  sqs_name                  = "cfo_queue_perf"
+  encrypt_sqs_kms           = "true"
+  message_retention_seconds = 1209600
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.cfo_dead_letter_queue_perf.sqs_arn}","maxReceiveCount": 3
+  }
+  
+EOF
+
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "cfo_queue_policy_perf" {
+  queue_url = module.cfo_queue_perf.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.cfo_queue_perf.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cfo_queue_perf.sqs_arn}",
+          "Action": "SQS:SendMessage",
+          "Condition":
+                      {
+                        "ArnEquals":
+                          {
+                            "aws:SourceArn": ["${module.offender_events.topic_arn}", "${module.probation_offender_events_perf.topic_arn}"]
+                          }
+                        }
+        }
+      ]
+  }
+   
+EOF
+
+}
+
+module "cfo_dead_letter_queue_perf" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
+  sqs_name               = "cfo_queue_dl_perf"
+  encrypt_sqs_kms        = "true"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "cfo_queue_perf" {
+  metadata {
+    name      = "cfo-sqs-instance-output-perf"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.cfo_queue_perf.access_key_id
+    secret_access_key = module.cfo_queue_perf.secret_access_key
+    sqs_cfo_url       = module.cfo_queue_perf.sqs_id
+    sqs_cfo_arn       = module.cfo_queue_perf.sqs_arn
+    sqs_cfo_name      = module.cfo_queue_perf.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "cfo_dead_letter_queue_perf" {
+  metadata {
+    name      = "cfo-sqs-dl-instance-output-perf"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.cfo_dead_letter_queue_perf.access_key_id
+    secret_access_key = module.cfo_dead_letter_queue_perf.secret_access_key
+    sqs_cfo_url       = module.cfo_dead_letter_queue_perf.sqs_id
+    sqs_cfo_arn       = module.cfo_dead_letter_queue_perf.sqs_arn
+    sqs_cfo_name      = module.cfo_dead_letter_queue_perf.sqs_name
+  }
+}
+
+resource "aws_sns_topic_subscription" "cfo_prison_subscription_perf" {
+  provider      = aws.london
+  topic_arn     = module.offender_events.topic_arn
+  protocol      = "sqs"
+  endpoint      = module.cfo_queue.sqs_arn
+  filter_policy = "{\"eventType\":[ \"EXTERNAL_MOVEMENT_RECORD-INSERTED\", \"OFFENDER_PROFILE_DETAILS-UPDATED\", \"ADDRESS-DELETED\", \"ADDRESS-UPDATED\", \"ALERT-DELETED\", \"ALERT-INSERTED\", \"ALERT-UPDATED\", \"BOOKING_NUMBER-CHANGED\", \"COURT_SENTENCE-CHANGED\", \"EXTERNAL_MOVEMENT_RECORD-DELETED\", \"EXTERNAL_MOVEMENT_RECORD-UPDATED\", \"IMPRISONMENT_STATUS-CHANGED\", \"OFFENDER_ADDRESS-DELETED\", \"OFFENDER_ADDRESS-UPDATED\", \"OFFENDER_ALIAS-CHANGED\", \"OFFENDER_BOOKING-CHANGED\", \"OFFENDER_BOOKING-INSERTED\", \"OFFENDER_BOOKING-REASSIGNED\", \"OFFENDER_DETAILS-CHANGED\", \"OFFENDER_IDENTIFIER-DELETED\", \"OFFENDER_IDENTIFIER-INSERTED\", \"OFFENDER_MOVEMENT-DISCHARGE\", \"OFFENDER_MOVEMENT-RECEPTION\", \"OFFENDER_PROFILE_DETAILS-INSERTED\", \"OFFENDER-UPDATED\", \"PERSON_ADDRESS-DELETED\", \"PERSON_ADDRESS-INSERTED\", \"PERSON_ADDRESS-UPDATED\", \"PHONE-DELETED\", \"PHONE-INSERTED\", \"PHONE-UPDATED\", \"RISK_SCORE-CHANGED\", \"RISK_SCORE-DELETED\", \"SENTENCE_CALCULATION_DATES-CHANGED\" ] }"
+}
+
+
+resource "aws_sns_topic_subscription" "cfo_probation_subscription_perf" {
+  provider      = aws.london
+  topic_arn     = module.probation_offender_events_perf.topic_arn
+  protocol      = "sqs"
+  endpoint      = module.cfo_queue.sqs_arn
+  filter_policy = "{\"eventType\":[ \"OFFENDER_CHANGED\"] }"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/cfo-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/cfo-sub-queue.tf
@@ -1,0 +1,113 @@
+module "cfo_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name          = var.environment-name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure-support
+  application               = var.application
+  sqs_name                  = "cfo_queue"
+  encrypt_sqs_kms           = "true"
+  message_retention_seconds = 1209600
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.cfo_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  
+EOF
+
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "cfo_queue_policy" {
+  queue_url = module.cfo_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.cfo_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cfo_queue.sqs_arn}",
+          "Action": "SQS:SendMessage",
+          "Condition":
+                      {
+                        "ArnEquals":
+                          {
+                            "aws:SourceArn": ["${module.offender_events.topic_arn}", "${module.probation_offender_events.topic_arn}"]
+                          }
+                        }
+        }
+      ]
+  }
+   
+EOF
+
+}
+
+module "cfo_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
+  sqs_name               = "cfo_queue_dl"
+  encrypt_sqs_kms        = "true"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "cfo_queue" {
+  metadata {
+    name      = "cfo-sqs-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.cfo_queue.access_key_id
+    secret_access_key = module.cfo_queue.secret_access_key
+    sqs_cfo_url       = module.cfo_queue.sqs_id
+    sqs_cfo_arn       = module.cfo_queue.sqs_arn
+    sqs_cfo_name      = module.cfo_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "cfo_dead_letter_queue" {
+  metadata {
+    name      = "cfo-sqs-dl-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.cfo_dead_letter_queue.access_key_id
+    secret_access_key = module.cfo_dead_letter_queue.secret_access_key
+    sqs_cfo_url       = module.cfo_dead_letter_queue.sqs_id
+    sqs_cfo_arn       = module.cfo_dead_letter_queue.sqs_arn
+    sqs_cfo_name      = module.cfo_dead_letter_queue.sqs_name
+  }
+}
+
+resource "aws_sns_topic_subscription" "cfo_prison_subscription" {
+  provider      = aws.london
+  topic_arn     = module.offender_events.topic_arn
+  protocol      = "sqs"
+  endpoint      = module.cfo_queue.sqs_arn
+  filter_policy = "{\"eventType\":[ \"EXTERNAL_MOVEMENT_RECORD-INSERTED\", \"OFFENDER_PROFILE_DETAILS-UPDATED\", \"ADDRESS-DELETED\", \"ADDRESS-UPDATED\", \"ALERT-DELETED\", \"ALERT-INSERTED\", \"ALERT-UPDATED\", \"BOOKING_NUMBER-CHANGED\", \"COURT_SENTENCE-CHANGED\", \"EXTERNAL_MOVEMENT_RECORD-DELETED\", \"EXTERNAL_MOVEMENT_RECORD-UPDATED\", \"IMPRISONMENT_STATUS-CHANGED\", \"OFFENDER_ADDRESS-DELETED\", \"OFFENDER_ADDRESS-UPDATED\", \"OFFENDER_ALIAS-CHANGED\", \"OFFENDER_BOOKING-CHANGED\", \"OFFENDER_BOOKING-INSERTED\", \"OFFENDER_BOOKING-REASSIGNED\", \"OFFENDER_DETAILS-CHANGED\", \"OFFENDER_IDENTIFIER-DELETED\", \"OFFENDER_IDENTIFIER-INSERTED\", \"OFFENDER_MOVEMENT-DISCHARGE\", \"OFFENDER_MOVEMENT-RECEPTION\", \"OFFENDER_PROFILE_DETAILS-INSERTED\", \"OFFENDER-UPDATED\", \"PERSON_ADDRESS-DELETED\", \"PERSON_ADDRESS-INSERTED\", \"PERSON_ADDRESS-UPDATED\", \"PHONE-DELETED\", \"PHONE-INSERTED\", \"PHONE-UPDATED\", \"RISK_SCORE-CHANGED\", \"RISK_SCORE-DELETED\", \"SENTENCE_CALCULATION_DATES-CHANGED\" ] }"
+}
+
+resource "aws_sns_topic_subscription" "cfo_probation_subscription" {
+  provider      = aws.london
+  topic_arn     = module.probation_offender_events.topic_arn
+  protocol      = "sqs"
+  endpoint      = module.cfo_queue.sqs_arn
+  filter_policy = "{\"eventType\":[ \"OFFENDER_CHANGED\"] }"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic-perf.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic-perf.tf
@@ -1,0 +1,20 @@
+module "probation_offender_events_perf" {
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  team_name          = var.team_name
+  topic_display_name = "probation-offender-events-perf"
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "probation_offender_events_perf" {
+  metadata {
+    name      = "probation-offender-events-topic-perf"
+    namespace = var.namespace
+  }
+  data = {
+    access_key_id     = module.probation_offender_events_perf.access_key_id
+    secret_access_key = module.probation_offender_events_perf.secret_access_key
+    topic_arn         = module.probation_offender_events_perf.topic_arn
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/cfo-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/cfo-sub-queue.tf
@@ -1,0 +1,113 @@
+module "cfo_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name          = var.environment-name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure-support
+  application               = var.application
+  sqs_name                  = "cfo_queue"
+  encrypt_sqs_kms           = "true"
+  message_retention_seconds = 1209600
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.cfo_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  
+EOF
+
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "cfo_queue_policy" {
+  queue_url = module.cfo_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.cfo_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cfo_queue.sqs_arn}",
+          "Action": "SQS:SendMessage",
+          "Condition":
+                      {
+                        "ArnEquals":
+                          {
+                            "aws:SourceArn": ["${module.offender_events.topic_arn}", "${module.probation_offender_events.topic_arn}"]
+                          }
+                        }
+        }
+      ]
+  }
+   
+EOF
+
+}
+
+module "cfo_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure-support
+  application            = var.application
+  sqs_name               = "cfo_queue_dl"
+  encrypt_sqs_kms        = "true"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "cfo_queue" {
+  metadata {
+    name      = "cfo-sqs-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.cfo_queue.access_key_id
+    secret_access_key = module.cfo_queue.secret_access_key
+    sqs_cfo_url       = module.cfo_queue.sqs_id
+    sqs_cfo_arn       = module.cfo_queue.sqs_arn
+    sqs_cfo_name      = module.cfo_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "cfo_dead_letter_queue" {
+  metadata {
+    name      = "cfo-sqs-dl-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.cfo_dead_letter_queue.access_key_id
+    secret_access_key = module.cfo_dead_letter_queue.secret_access_key
+    sqs_cfo_url       = module.cfo_dead_letter_queue.sqs_id
+    sqs_cfo_arn       = module.cfo_dead_letter_queue.sqs_arn
+    sqs_cfo_name      = module.cfo_dead_letter_queue.sqs_name
+  }
+}
+
+resource "aws_sns_topic_subscription" "cfo_prison_subscription" {
+  provider      = aws.london
+  topic_arn     = module.offender_events.topic_arn
+  protocol      = "sqs"
+  endpoint      = module.cfo_queue.sqs_arn
+  filter_policy = "{\"eventType\":[ \"EXTERNAL_MOVEMENT_RECORD-INSERTED\", \"OFFENDER_PROFILE_DETAILS-UPDATED\", \"ADDRESS-DELETED\", \"ADDRESS-UPDATED\", \"ALERT-DELETED\", \"ALERT-INSERTED\", \"ALERT-UPDATED\", \"BOOKING_NUMBER-CHANGED\", \"COURT_SENTENCE-CHANGED\", \"EXTERNAL_MOVEMENT_RECORD-DELETED\", \"EXTERNAL_MOVEMENT_RECORD-UPDATED\", \"IMPRISONMENT_STATUS-CHANGED\", \"OFFENDER_ADDRESS-DELETED\", \"OFFENDER_ADDRESS-UPDATED\", \"OFFENDER_ALIAS-CHANGED\", \"OFFENDER_BOOKING-CHANGED\", \"OFFENDER_BOOKING-INSERTED\", \"OFFENDER_BOOKING-REASSIGNED\", \"OFFENDER_DETAILS-CHANGED\", \"OFFENDER_IDENTIFIER-DELETED\", \"OFFENDER_IDENTIFIER-INSERTED\", \"OFFENDER_MOVEMENT-DISCHARGE\", \"OFFENDER_MOVEMENT-RECEPTION\", \"OFFENDER_PROFILE_DETAILS-INSERTED\", \"OFFENDER-UPDATED\", \"PERSON_ADDRESS-DELETED\", \"PERSON_ADDRESS-INSERTED\", \"PERSON_ADDRESS-UPDATED\", \"PHONE-DELETED\", \"PHONE-INSERTED\", \"PHONE-UPDATED\", \"RISK_SCORE-CHANGED\", \"RISK_SCORE-DELETED\", \"SENTENCE_CALCULATION_DATES-CHANGED\" ] }"
+}
+
+resource "aws_sns_topic_subscription" "cfo_probation_subscription" {
+  provider      = aws.london
+  topic_arn     = module.probation_offender_events.topic_arn
+  protocol      = "sqs"
+  endpoint      = module.cfo_queue.sqs_arn
+  filter_policy = "{\"eventType\":[ \"OFFENDER_CHANGED\"] }"
+}


### PR DESCRIPTION
1. Add preprod/prod queues for CFO
2. Create secondary versions for these queues that can be attached to Delius Perf environment (rather than creating a whole new namespace that will have nothing in except secrets for a couple of queues)