### PR TITLE
Bugfix: Requiring a file that doesn't exist

### DIFF
--- a/bin/create-gitops-namespace-files.rb
+++ b/bin/create-gitops-namespace-files.rb
@@ -2,7 +2,7 @@
 
 require "yaml"
 require "fileutils"
-require_relative "./namespace_questions.rb"
+require_relative "./namespace_creation.rb"
 
 # TODO: default
 # TODO: question N of M


### PR DESCRIPTION
The 'namespace_questions.rb' file was renamed to 'namespace_creation.rb'
but I forgot to change it here.