### PR TITLE
Bugfix: interpolate slack channel correctly

### DIFF
--- a/gitops-namespace-resources/00-namespace.yaml
+++ b/gitops-namespace-resources/00-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "${environment}"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "${business-unit}"
-    cloud-platform.justice.gov.uk/slack-channel: "${slack_channel}"
+    cloud-platform.justice.gov.uk/slack-channel: "${slack-channel}"
     cloud-platform.justice.gov.uk/application: "${application}"
     cloud-platform.justice.gov.uk/owner: "${owner}: ${contact_email}"
     cloud-platform.justice.gov.uk/source-code: "${source_code_url}"

--- a/namespace-resources/00-namespace.yaml
+++ b/namespace-resources/00-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "${environment}"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "${business-unit}"
-    cloud-platform.justice.gov.uk/slack-channel: "${slack_channel}"
+    cloud-platform.justice.gov.uk/slack-channel: "${slack-channel}"
     cloud-platform.justice.gov.uk/application: "${application}"
     cloud-platform.justice.gov.uk/owner: "${owner}: ${contact_email}"
     cloud-platform.justice.gov.uk/source-code: "${source_code_url}"

--- a/spec/fixtures/make-gitops-namespace-answers.yaml
+++ b/spec/fixtures/make-gitops-namespace-answers.yaml
@@ -3,6 +3,7 @@ answers:
   namespace: make-gitops-namespace-test-dev
   github_team: webops
   business-unit: MoJD
+  slack-channel: my-team-slack
   is-production: "false"
   environment: development
   application: gitops-test-app

--- a/spec/fixtures/make-gitops-namespace-test-dev/00-namespace.yaml
+++ b/spec/fixtures/make-gitops-namespace-test-dev/00-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "MoJD"
+    cloud-platform.justice.gov.uk/slack-channel: "my-team-slack"
     cloud-platform.justice.gov.uk/application: "gitops-test-app"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://foo.bar.baz"

--- a/spec/fixtures/make-namespace-answers.yaml
+++ b/spec/fixtures/make-namespace-answers.yaml
@@ -2,6 +2,7 @@ answers:
   namespace: make-namespace-test-dev
   github_team: webops
   business-unit: MoJD
+  slack-channel: my-team-slack
   is-production: "false"
   environment: development
   application: wibble

--- a/spec/fixtures/make-namespace-test-dev/00-namespace.yaml
+++ b/spec/fixtures/make-namespace-test-dev/00-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "MoJD"
+    cloud-platform.justice.gov.uk/slack-channel: "my-team-slack"
     cloud-platform.justice.gov.uk/application: "wibble"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://foo.bar.baz"


### PR DESCRIPTION
it should be "slack-channel" throughout, not
"slack_channel" for the key but "slack-channel" as
the value.

Also, I forgot we had rspec tests for this, so
I've slapped myself on the wrist.