### PR TITLE
Prison Visis Staging Add pods/log resource access to circle service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/serviceaccount-circleci.yaml
@@ -23,6 +23,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "pods/log"
     verbs:
       - "patch"
       - "get"


### PR DESCRIPTION
We need to be able to track job progress when running remove interation tests via circle.
This PR adds the permission I think we need in order for that to be allowed via circle