### PR TITLE
add network policy to accept traffic from court-probation-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-court-probation
+  namespace: crime-portal-mirror-gateway-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: court-probation-dev


### PR DESCRIPTION
This network policy is allowing traffic from court-probation-dev to crime-portal-mirror-gateway-dev.