### PR TITLE
2nd attempt at giving circle permission to wait for integration test job

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/serviceaccount-circleci.yaml
@@ -13,11 +13,8 @@ metadata:
 rules:
   - apiGroups:
       - ""
-      - "batch"
     resources:
       - "configmaps"
-      - "cronjobs"
-      - "jobs"
       - "pods/portforward"
       - "deployment"
       - "secrets"
@@ -30,6 +27,19 @@ rules:
       - "create"
       - "delete"
       - "list"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
   - apiGroups:
       - "extensions"
     resources:


### PR DESCRIPTION
Prison-visits-booking still can't wait for its integration tests on circle:ci. 
This is a second attempt to add the permission to make this possible - it adds a 'watch' verb (?!?) permission which I'm hoping will fix the problem