### PR TITLE
Update the find-deprecated-objects script

### DIFF
--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -14,7 +14,6 @@ require "open3"
 OBJECT_TYPES = %w[
   DaemonSet
   Deployment
-  Ingress
   NetworkPolicy
   PodSecurityPolicy
 ].join(",")
@@ -26,7 +25,11 @@ def main
 
   namespaces = namespace_details
 
-  kubectl_api_objects.each { |obj| puts object_csv(obj, namespaces) }
+  kubectl_api_objects.each { |obj|
+    if obj.fetch("apiVersion") == last_applied_api_version(obj)
+      puts object_csv(obj, namespaces)
+    end
+  }
 
   # TODO filter for tiller < 2.16.3
   tiller_pods = parsed_json_output("kubectl get pods --all-namespaces -o json").fetch("items", [])
@@ -35,6 +38,11 @@ def main
   tiller_pods.map { |pod| puts tiller_csv(pod, namespaces) }
   output_helm2_object_data(tiller_pods, namespaces)
   output_helm3_object_data(namespaces)
+end
+
+def last_applied_api_version(obj)
+  json = obj.dig("metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration")
+  JSON.parse(json)["apiVersion"]
 end
 
 def helm3_deprecated_objects(namespace)

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -25,18 +25,28 @@ def main
 
   namespaces = namespace_details
 
+  puts "Kubectl Data ------------------------------------------------------"
+
   kubectl_api_objects.each { |obj|
     if obj.fetch("apiVersion") == last_applied_api_version(obj)
       puts object_csv(obj, namespaces)
     end
   }
 
+  puts "Tiller pods -------------------------------------------------------"
+
   # TODO filter for tiller < 2.16.3
   tiller_pods = parsed_json_output("kubectl get pods --all-namespaces -o json").fetch("items", [])
     .filter { |pod| tiller?(pod) }
 
   tiller_pods.map { |pod| puts tiller_csv(pod, namespaces) }
+
+  puts "Helm2 data -------------------------------------------------------"
+
   output_helm2_object_data(tiller_pods, namespaces)
+
+  puts "Helm3 data -------------------------------------------------------"
+
   output_helm3_object_data(namespaces)
 end
 

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -12,6 +12,7 @@ require "json"
 require "open3"
 
 OBJECT_TYPES = %w[
+  Ingress
   DaemonSet
   Deployment
   NetworkPolicy

--- a/bin/find-deprecated-objects.rb
+++ b/bin/find-deprecated-objects.rb
@@ -28,7 +28,7 @@ def main
 
   puts "Kubectl Data ------------------------------------------------------"
 
-  kubectl_api_objects.each { |obj|
+  kubectl_api_objects.each do |obj|
     if obj.fetch("apiVersion") == last_applied_api_version(obj)
       puts object_csv(obj, namespaces)
     end


### PR DESCRIPTION
* Stop searching for Ingresses with kubectl

All ingresses show up as using the deprecated APIs
Some of the time this might be valid, but a lot of
the time it's not, and there's no easy way to tell
which is which. So this change simply stops
searching for Ingresses in this way, to avoid a
lot of false alerts.

* Only report kubectl objects when the api version
matches the one in the last-applied-configuration

This should avoid false alerts about helm 
deployments which *have* been updated, but the
object still shows up as using the old API
(because kubernetes sees the update as a noop, 
since the old API is still valid).