### PR TITLE
shorten DNS name to be within 63 characters

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-search-dev/09-certificates.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-search-dev/09-certificates.yml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: probation-offender-search-indexer-dev.hmpps.service.justice.gov.uk
+  name: probation-offender-search-indexer-dev
   namespace: offender-search-dev
 spec:
   secretName: probation-offender-search-indexer-cert


### PR DESCRIPTION
I was getting "CSR doesn't contain a SAN short enough to fit in CN" error with the old name which was 67 characters