### PR TITLE
shorten name fix `CSR doesn't contain a SAN short enough to fit in CN…

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-search-dev/09-certificates.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-search-dev/09-certificates.yml
@@ -1,12 +1,12 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: probation-offender-search-indexer-dev
+  name: probation-search-indexer-dev
   namespace: offender-search-dev
 spec:
-  secretName: probation-offender-search-indexer-cert
+  secretName: probation-search-indexer-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-  - probation-offender-search-indexer-dev.hmpps.service.justice.gov.uk
+  - probation-search-indexer-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
…` error