### PR TITLE
modify the namespaceSelector label 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/04-networkpolicy.yaml
@@ -39,4 +39,4 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          component: court-probation-dev
+          cloud-platform.justice.gov.uk/namespace: "court-probation-dev"


### PR DESCRIPTION
This change should allow all traffic from the namespace labelled `court-probation-dev` to flow to the `crime-portal-mirror-gateway-dev` namespace