### PR TITLE
Update ServiceAccount apiGroups permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-dev/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-dev/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/serviceaccount-circleci.yaml
@@ -27,6 +27,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"


### PR DESCRIPTION
To ensure everything continues to work after the Kubernetes 1.16 upgrade.