### PR TITLE
Update namespace deleter wrt. "master" -> "main"

### DIFF
--- a/lib/cp_env/namespace_deleter.rb
+++ b/lib/cp_env/namespace_deleter.rb
@@ -19,7 +19,7 @@ class CpEnv
     NAMEPACES_DIR = "namespaces/#{CLUSTER}"
     PRODUCTION_LABEL = "cloud-platform.justice.gov.uk/is-production"
     LABEL_TRUE = "true"
-    EMPTY_MAIN_TF_URL = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/master/namespace-resources/resources/main.tf"
+    EMPTY_MAIN_TF_URL = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources/resources/main.tf"
 
     def initialize(args)
       @namespace = args.fetch(:namespace)

--- a/lib/cp_env/namespace_deleter.rb
+++ b/lib/cp_env/namespace_deleter.rb
@@ -102,7 +102,7 @@ class CpEnv
         ),
         bucket: env("KUBECONFIG_S3_BUCKET"),
         key: env("KUBECONFIG_S3_KEY"),
-        local_target: env("KUBE_CONFIG"),
+        local_target: env("KUBE_CONFIG")
       }
       config_file = Kubeconfig.new(kubeconfig).fetch_and_store
 


### PR DESCRIPTION
The namespace deleter fetches an "empty" `main.tf` file from github. Now
that we have changed the default branch of the environments repo to
"main", the URL to fetch that file was incorrect. This PR fixes that.