### PR TITLE
Raise an error when we can't delete a namespace

### DIFF
--- a/lib/cp_env/namespace_deleter.rb
+++ b/lib/cp_env/namespace_deleter.rb
@@ -28,11 +28,13 @@ class CpEnv
     end
 
     def delete
-      if safe_to_delete?
-        destroy_aws_resources
-        delete_namespace
-        clean_up
+      unless safe_to_delete?
+        raise "ERROR: Unable to delete namespace #{namespace}"
       end
+
+      destroy_aws_resources
+      delete_namespace
+      clean_up
     end
 
     private

--- a/spec/namespace_deleter_spec.rb
+++ b/spec/namespace_deleter_spec.rb
@@ -25,7 +25,7 @@ describe CpEnv::NamespaceDeleter do
   let(:params) {
     {
       namespace: namespace,
-      k8s_client: k8s_client,
+      k8s_client: k8s_client
     }
   }
 

--- a/spec/namespace_deleter_spec.rb
+++ b/spec/namespace_deleter_spec.rb
@@ -47,12 +47,16 @@ describe CpEnv::NamespaceDeleter do
 
     it "does not delete AWS resources" do
       expect(terraform).to_not receive(:apply)
-      deleter.delete
+      expect {
+        deleter.delete
+      }.to raise_error("ERROR: Unable to delete namespace #{namespace}")
     end
 
     it "does not delete the namespace" do
       expect(k8s_client).to_not receive(:delete_namespace)
-      deleter.delete
+      expect {
+        deleter.delete
+      }.to raise_error("ERROR: Unable to delete namespace #{namespace}")
     end
   end
 
@@ -63,12 +67,16 @@ describe CpEnv::NamespaceDeleter do
 
     it "does not delete AWS resources" do
       expect(terraform).to_not receive(:apply)
-      deleter.delete
+      expect {
+        deleter.delete
+      }.to raise_error("ERROR: Unable to delete namespace #{namespace}")
     end
 
     it "does not delete the namespace" do
       expect(k8s_client).to_not receive(:delete_namespace)
-      deleter.delete
+      expect {
+        deleter.delete
+      }.to raise_error("ERROR: Unable to delete namespace #{namespace}")
     end
   end
 
@@ -77,12 +85,16 @@ describe CpEnv::NamespaceDeleter do
 
     it "does not delete AWS resources" do
       expect(terraform).to_not receive(:apply)
-      deleter.delete
+      expect {
+        deleter.delete
+      }.to raise_error("ERROR: Unable to delete namespace #{namespace}")
     end
 
     it "does not delete the namespace" do
       expect(k8s_client).to_not receive(:delete_namespace)
-      deleter.delete
+      expect {
+        deleter.delete
+      }.to raise_error("ERROR: Unable to delete namespace #{namespace}")
     end
   end
 

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -81,10 +81,10 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
   end
 
   it "get namespaces changed by pr" do
-    expect(ENV).to receive(:fetch).with("master_base_sha").and_return("master")
+    expect(ENV).to receive(:fetch).with("main_base_sha").and_return("main")
     expect(ENV).to receive(:fetch).with("branch_head_sha").and_return("branch")
 
-    cmd = "git diff --no-commit-id --name-only -r master...branch"
+    cmd = "git diff --no-commit-id --name-only -r main...branch"
     expect_execute(cmd, files, success)
     expect($stdout).to receive(:puts).at_least(:once)
 


### PR DESCRIPTION
The namespace deleter will not delete a production namespace, but the
concourse pipeline still shows as successful, so we don't get a slack alert
to go and clean up the namespace manually.

This change fixes that.

fixes https://github.com/ministryofjustice/cloud-platform/issues/2047