### PR TITLE
Run the rpec tests on PRs

### DIFF
--- a/.github/workflows/bin-rspec.yml
+++ b/.github/workflows/bin-rspec.yml
@@ -3,10 +3,10 @@ name: Rspec Tests for bin directory
 on:
   pull_request:
     branches:
-      - 'master'
+      - 'main'
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   build:

--- a/spec/fixtures/make-gitops-namespace-test-dev/resources/gitops.tf
+++ b/spec/fixtures/make-gitops-namespace-test-dev/resources/gitops.tf
@@ -3,7 +3,7 @@ module "concourse-gitops" {
   source_code_url               = "https://foo.bar.baz"
   github_team                   = "webops"
   namespace                     = "make-gitops-namespace-test-dev"
-  branch                        = "master"
+  branch                        = "main"
   concourse_basic_auth_username = var.concourse_basic_auth_username
   concourse_url                 = var.concourse_url
   concourse_basic_auth_password = var.concourse_basic_auth_password

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -81,10 +81,10 @@ namespaces/#{cluster}/poornima-dev/resources/elasticsearch.tf"
   end
 
   it "get namespaces changed by pr" do
-    expect(ENV).to receive(:fetch).with("master_base_sha").and_return("master")
+    expect(ENV).to receive(:fetch).with("main_base_sha").and_return("main")
     expect(ENV).to receive(:fetch).with("branch_head_sha").and_return("branch")
 
-    cmd = "git diff --no-commit-id --name-only -r master...branch"
+    cmd = "git diff --no-commit-id --name-only -r main...branch"
     expect_execute(cmd, files, success)
     expect($stdout).to receive(:puts).at_least(:once)
 


### PR DESCRIPTION
This workflow was only monitoring the "master" branch, so after the
switch to "main" the rspec tests have not been running.