### PR TITLE
Only run the specs when relevant files are changed

### DIFF
--- a/.github/workflows/bin-rspec.yml
+++ b/.github/workflows/bin-rspec.yml
@@ -4,9 +4,18 @@ on:
   pull_request:
     branches:
       - 'main'
+    paths:
+      - "bin/**"
+      - "lib/**"
+      - "spec/**"
+
   push:
     branches:
       - 'main'
+    paths:
+      - "bin/**"
+      - "lib/**"
+      - "spec/**"
 
 jobs:
   build:


### PR DESCRIPTION
The vast majority of the commits and PRs to this repo are to
sub-directories of `namespaces/` For these changes, there is no point
running the specs because they're not relevant.
Github action execution minutes are a limited resource, so we don't want
to waste them. Running unnecessary checks also means we have to wait
longer before we can approve a PR.
This change restricts this github action to only run when *relevant*
changes are proposed/made.