### PR TITLE
Create development environment for Prisoner Content Hub

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/00-namespace.yaml
@@ -9,4 +9,4 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "prisoner-content-hub"
     cloud-platform.justice.gov.uk/owner: "Prisoner Facing Services: thehub@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/digital-hub.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/00-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prisoner-content-hub-development
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/application: "prisoner-content-hub"
+    cloud-platform.justice.gov.uk/owner: "Prisoner Facing Services: thehub@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/digital-hub.git"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prisoner-content-hub-development-admin
+  namespace: prisoner-content-hub-development
+subjects:
+  - kind: Group
+    name: "github:prisoner-content-hub-developers"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: prisoner-content-hub-development
+spec:
+  limits:
+  - default:
+      cpu: 360m
+      memory: 1024Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 512Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: prisoner-content-hub-development
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: prisoner-content-hub-development
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: prisoner-content-hub-development
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/05-serviceaccount-circleci.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: prisoner-content-hub-development
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: prisoner-content-hub-development
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: prisoner-content-hub-development
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
@@ -1,0 +1,14 @@
+module "content_hub_elasticsearch" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.0"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  business-unit          = var.business-unit
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+  is-production          = var.is-production
+  team_name              = var.team_name
+  elasticsearch-domain   = "hub-search"
+  namespace              = var.namespace
+  elasticsearch_version  = "7.1"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+# To be use in case the resources need to be created in London
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in Ireland
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -1,0 +1,44 @@
+module "drupal_rds" {
+  # We need to use at least 5.4, which introduces support for MariaDB by making `custom_parameters` overridable.
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.4"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+
+  providers = {
+    aws = aws.london
+  }
+
+  db_engine         = "mariadb"
+  db_engine_version = "10.4"
+  rds_family        = "mariadb10.4"
+
+  # We need to explicitly set this to an empty list, otherwise the module 
+  # will add `rds.force_ssl`, which MariaDB doesn't support
+  db_parameter = []
+}
+
+resource "kubernetes_secret" "drupal_rds" {
+  metadata {
+    name      = "drupal-rds"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.drupal_rds.rds_instance_endpoint
+    database_name         = module.drupal_rds.database_name
+    database_username     = module.drupal_rds.database_username
+    database_password     = module.drupal_rds.database_password
+    rds_instance_address  = module.drupal_rds.rds_instance_address
+    access_key_id         = module.drupal_rds.access_key_id
+    secret_access_key     = module.drupal_rds.secret_access_key
+
+    # This may be a nicer way to represent the DB URL, but I don't _think_ we use it
+    # url                   = "postgres://${module.drupal_rds.database_username}:${module.drupal_rds.database_password}@${module.drupal_rds.rds_instance_endpoint}/${module.drupal_rds.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -1,0 +1,25 @@
+module "drupal_content_storage" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.1"
+
+  team_name              = var.team_name
+  versioning             = true
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+}
+
+resource "kubernetes_secret" "drupal_content_storage_secret" {
+  metadata {
+    name      = "drupal-s3"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.drupal_content_storage.access_key_id
+    secret_access_key = module.drupal_content_storage.secret_access_key
+    bucket_arn        = module.drupal_content_storage.bucket_arn
+    bucket_name       = module.drupal_content_storage.bucket_name
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
@@ -1,0 +1,46 @@
+variable "domain" {
+  default = "content-hub.prisoner.service.justice.gov.uk/ "
+}
+
+variable "application" {
+  default = "prisoner-content-hub"
+}
+
+variable "namespace" {
+  default = "prisoner-content-hub-development"
+}
+
+# this is injected by Cloud Platform automatically so we do not need to populate it here
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+# We chose pfs because this variable is used to create domain names for resources
+# e.g. ElasticSearch. When concatenated with the environment name and unique name,
+# this only leaves a handful of characters for the team_name.
+variable "team_name" {
+  description = "DNS compliant name of the development team"
+  default     = "pfs"
+}
+
+variable "environment-name" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "thehub@digital.justice.gov.uk"
+}
+
+variable "is-production" {
+  default = "true"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = "0.12.17"
+}


### PR DESCRIPTION
This PR copies [prisoner-content-hub-production](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production) to create a development namespace.

Differences to `production`:
- `is-production` is `false`
- names containing `production` updated to `development `

This is the partner to #2724, which does the same thing for `staging`.