### PR TITLE
Update Prisoner Content Hub repo name

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/00-namespace.yaml
@@ -9,4 +9,4 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "prisoner-content-hub"
     cloud-platform.justice.gov.uk/owner: "Prisoner Facing Services: thehub@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/digital-hub.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git"


### PR DESCRIPTION
We recently renamed our repository from `digital-hub` to [`prisoner-content-hub` ](https://github.com/ministryofjustice/prisoner-content-hub). 

This PR updates the `prisoner-content-hub-production` namespace to use the new repo name.