### PR TITLE
Updated prisoner-content-hub-development namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/main.tf
@@ -4,7 +4,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  region = "eu-west-2"
 }
 
 # To be use in case the resources need to be created in London


### PR DESCRIPTION
changed default region to "eu-west-2".

This will fix the pipeline failure.
Error: Error creating Security Group: InvalidVpcID.NotFound