### PR TITLE
Add service account perms for new api resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/05-serviceaccount-circleci.yaml
@@ -26,6 +26,26 @@ rules:
       - "delete"
       - "list"
   - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+  - apiGroups:
       - "extensions"
     resources:
       - "deployments"


### PR DESCRIPTION
Keep existing permissions until we no longer have any of those objects
around and can clean up