### PR TITLE
Update replica with source rds family and db_engine_version.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
@@ -57,6 +57,9 @@ module "cla_backend_replica" {
 
   # Set the database_name of the source db
   db_name = module.cla_backend_rds.database_name
+  rds_family = "postgres9.6"
+  db_engine_version      = "9.6"
+  
 
   # Set the db_identifier of the source db
   replicate_source_db = module.cla_backend_rds.db_identifier

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
@@ -56,10 +56,10 @@ module "cla_backend_replica" {
   # It is mandatory to set the below values to create read replica instance
 
   # Set the database_name of the source db
-  db_name = module.cla_backend_rds.database_name
-  rds_family = "postgres9.6"
-  db_engine_version      = "9.6"
-  
+  db_name           = module.cla_backend_rds.database_name
+  rds_family        = "postgres9.6"
+  db_engine_version = "9.6"
+
 
   # Set the db_identifier of the source db
   replicate_source_db = module.cla_backend_rds.db_identifier


### PR DESCRIPTION
This fixes the rds instance creating the replica with default parameters instead of source RDS values.