### PR TITLE
Use latest S3 & RDS modules

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -1,6 +1,6 @@
 module "drupal_rds" {
   # We need to use at least 5.4, which introduces support for MariaDB by making `custom_parameters` overridable.
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.6"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name
@@ -14,7 +14,7 @@ module "drupal_rds" {
   db_engine_version = "10.4"
   rds_family        = "mariadb10.4"
 
-  # We need to explicitly set this to an empty list, otherwise the module 
+  # We need to explicitly set this to an empty list, otherwise the module
   # will add `rds.force_ssl`, which MariaDB doesn't support
   db_parameter = []
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -1,5 +1,5 @@
 module "drupal_content_storage" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.2"
 
   team_name              = var.team_name
   versioning             = true


### PR DESCRIPTION
The prisoner-content-hub-development namespace is using outdated
versions of our s3 & rds modules.

I've done a manual `terraform plan` with these changes, and there were
no changes reported to either the S3 bucket or the RDS instance.

There were some apparent changes planned to IAM policies, but those seem
to be a red herring - i.e. changes with no semantic impact.