### PR TITLE
Template files referenced when creating namespace using cloud-platform CLI

### DIFF
--- a/namespace-resources-cli-template/00-namespace.yaml
+++ b/namespace-resources-cli-template/00-namespace.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Namespace }}
   labels:
     cloud-platform.justice.gov.uk/is-production: "{{ .IsProduction }}"
-    cloud-platform.justice.gov.uk/environment-name: "{{ .EnvironmentName }}"
+    cloud-platform.justice.gov.uk/environment-name: "{{ .Environment }}"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "{{ .BusinessUnit }}"
     cloud-platform.justice.gov.uk/slack-channel: "{{ .SlackChannel }}"

--- a/namespace-resources-cli-template/00-namespace.yaml
+++ b/namespace-resources-cli-template/00-namespace.yaml
@@ -11,3 +11,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "{{ .Application }}"
     cloud-platform.justice.gov.uk/owner: "{{ .Owner }}: {{ .InfrastructureSupport }}"
     cloud-platform.justice.gov.uk/source-code: "{{ .SourceCode }}"
+    cloud-platform.justice.gov.uk/team-name: "{{ .TeamName }}" 

--- a/namespace-resources-cli-template/00-namespace.yaml
+++ b/namespace-resources-cli-template/00-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "{{ .IsProduction }}"
+    cloud-platform.justice.gov.uk/environment-name: "{{ .EnvironmentName }}"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "{{ .BusinessUnit }}"
+    cloud-platform.justice.gov.uk/slack-channel: "{{ .SlackChannel }}"
+    cloud-platform.justice.gov.uk/application: "{{ .Application }}"
+    cloud-platform.justice.gov.uk/owner: "{{ .Owner }}: {{ .InfrastructureSupport }}"
+    cloud-platform.justice.gov.uk/source-code: "{{ .SourceCode }}"

--- a/namespace-resources-cli-template/00-namespace.yaml
+++ b/namespace-resources-cli-template/00-namespace.yaml
@@ -11,4 +11,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "{{ .Application }}"
     cloud-platform.justice.gov.uk/owner: "{{ .Owner }}: {{ .InfrastructureSupport }}"
     cloud-platform.justice.gov.uk/source-code: "{{ .SourceCode }}"
-    cloud-platform.justice.gov.uk/team-name: "{{ .TeamName }}" 
+    cloud-platform.justice.gov.uk/team-name: "{{ .GithubTeam }}" 

--- a/namespace-resources-cli-template/01-rbac.yaml
+++ b/namespace-resources-cli-template/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Namespace }}-admin
+  namespace: {{ .Namespace }}
+subjects:
+  - kind: Group
+    name: "github:{{ .GithubTeam }}"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespace-resources-cli-template/02-limitrange.yaml
+++ b/namespace-resources-cli-template/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: {{ .Namespace }}
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespace-resources-cli-template/03-resourcequota.yaml
+++ b/namespace-resources-cli-template/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: {{ .Namespace }}
+spec:
+  hard:
+    pods: "50"

--- a/namespace-resources-cli-template/04-networkpolicy.yaml
+++ b/namespace-resources-cli-template/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: {{ .Namespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: {{ .Namespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespace-resources-cli-template/resources/main.tf
+++ b/namespace-resources-cli-template/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespace-resources-cli-template/resources/variables.tf
+++ b/namespace-resources-cli-template/resources/variables.tf
@@ -7,7 +7,7 @@ variable "cluster_state_bucket" {
 
 variable "application" {
   description = "Name of Application you are deploying"
-  default = "{{ .Application }}"
+  default     = "{{ .Application }}"
 }
 
 variable "namespace" {
@@ -40,5 +40,5 @@ variable "is-production" {
 
 variable "is-production" {
   description = "Team slack channel to use if we need to contact your team"
-  default = "{{ .SlackChannel }}"
+  default     = "{{ .SlackChannel }}"
 }

--- a/namespace-resources-cli-template/resources/variables.tf
+++ b/namespace-resources-cli-template/resources/variables.tf
@@ -1,0 +1,39 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "application" {
+  default = "{{ .Application }}"
+}
+
+variable "namespace" {
+  default = "{{ .Namespace }}"
+}
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "{{ .BusinessUnit }}"
+}
+
+variable "team-name" {
+  description = "The name of your development team"
+  default     = "{{ .TeamName }}"
+}
+
+variable "environment-name" {
+  description = "The type of environment you're deploying to."
+  default     = "{{ .Environment }}"
+}
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "{{ .InfrastructureSupport }}"
+}
+
+variable "is-production" {
+  default = "false"
+}
+

--- a/namespace-resources-cli-template/resources/variables.tf
+++ b/namespace-resources-cli-template/resources/variables.tf
@@ -23,7 +23,7 @@ variable "team-name" {
   default     = "{{ .TeamName }}"
 }
 
-variable "environment-name" {
+variable "environment" {
   description = "The type of environment you're deploying to."
   default     = "{{ .Environment }}"
 }
@@ -34,6 +34,6 @@ variable "infrastructure-support" {
 }
 
 variable "is-production" {
-  default = "false"
+  default = "{{ .IsProduction }}"
 }
 

--- a/namespace-resources-cli-template/resources/variables.tf
+++ b/namespace-resources-cli-template/resources/variables.tf
@@ -6,6 +6,7 @@ variable "cluster_state_bucket" {
 }
 
 variable "application" {
+  description = "Name of Application you are deploying"
   default = "{{ .Application }}"
 }
 
@@ -20,7 +21,7 @@ variable "business-unit" {
 
 variable "team-name" {
   description = "The name of your development team"
-  default     = "{{ .TeamName }}"
+  default     = "{{ .GithubTeam }}"
 }
 
 variable "environment" {
@@ -37,3 +38,7 @@ variable "is-production" {
   default = "{{ .IsProduction }}"
 }
 
+variable "is-production" {
+  description = "Team slack channel to use if we need to contact your team"
+  default = "{{ .SlackChannel }}"
+}

--- a/namespace-resources-cli-template/resources/versions.tf
+++ b/namespace-resources-cli-template/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
These template files are used by the [cloud-platform-cli ](https://github.com/ministryofjustice/cloud-platform-moj-cp) to create namespace for end users of cloud platform

Related to: https://github.com/ministryofjustice/cloud-platform/issues/1961