### PR TITLE
Add dns name for cccd-dev-lgfs ingress

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/certificate.yaml
@@ -10,3 +10,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
   - dev-lgfs.claim-crown-court-defence.service.justice.gov.uk
+  - dev-clar.claim-crown-court-defence.service.justice.gov.uk


### PR DESCRIPTION
Extend certificate to cover additional dnsname for cccd-dev-lgfs

Repurposing of environment for spike work related
to Civil legal aid review (CLAR) - to enable tester/users to 
access site at subdomain `dev-clar`.
