### PR TITLE
New GH action to reject multi-namespace PR

### DIFF
--- a/.github/workflows/reject-multi-namespace-prs.yml
+++ b/.github/workflows/reject-multi-namespace-prs.yml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  reject-multi-namespace-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: ministryofjustice/github-actions/reject-multi-namespace-prs@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/reject-multi-namespace-prs.yml
+++ b/.github/workflows/reject-multi-namespace-prs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/reject-multi-namespace-prs@master
+      - uses: ministryofjustice/github-actions/reject-multi-namespace-prs@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR enables a new github action, which prevent PRs from spanning multiple namespaces. 