### PR TITLE
Update HOODAW web app. to version 2.11

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: how-out-of-date-are-we
-          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.9
+          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.11
           env:
             - name: RACK_ENV
               value: "production"


### PR DESCRIPTION
related to
https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/pull/36

part of
https://github.com/ministryofjustice/cloud-platform/issues/1928