### PR TITLE
Add Role/RoleBinding to cica dev service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/serviceaccount.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/serviceaccount.yml
@@ -3,3 +3,62 @@ kind: ServiceAccount
 metadata:
   name: circleci
   namespace: claim-criminal-injuries-compensation-dev
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: claim-criminal-injuries-compensation-dev
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+  - apiGroups:
+      - "certmanager.k8s.io"
+    resources:
+      - "certificates"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: claim-criminal-injuries-compensation-dev
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: claim-criminal-injuries-compensation-dev
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Hi, I'm updating our manifest files for k8s 1.16 compatibility. Our current service accounts contain no Roles / RoleBindings. These are currently located in separate files: [Role](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/blob/master/kube_deploy/Dev/cirole.yml) and [RoleBinding](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/blob/master/kube_deploy/Dev/cirolebind.yml). I wasn't involved in configuring CircleCI so I'm not sure how these have been applied in the past.

This PR adds these to our service account and includes the additional "apps" and "networking.k8s.io" as per the [upgrade instructions](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html).

Is it safe to assume that once this is applied everything should just work? Or will CircleCI require any config changes?