### PR TITLE
PVB production: Grant CircleCI access to new Kube 1.16 APIs

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/serviceaccount-circleci.yaml
@@ -31,6 +31,8 @@ rules:
       - "list"
   - apiGroups:
       - "extensions"
+      - "apps"
+      - "networking.k8s.io"
     resources:
       - "deployments"
       - "ingresses"


### PR DESCRIPTION
Namespace: `prison-visits-booking-production`

To support the upgrade to Kubernetes 1.16 and removal of deprecated APIs, our CircleCI ServiceAccount needs updated permissions.

I've made changes as described in the Cloud Platform docs:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html#update-serviceaccount