### PR TITLE
Add route53 zone for Prisoner Content Hub

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "content_hub_route53_zone" {
+  name = "content-hub.prisoner.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
+  }
+}
+
+resource "kubernetes_secret" "content_hub_route53_zone_secret" {
+  metadata {
+    name      = "${var.application}-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id   = aws_route53_zone.content_hub_route53_zone.zone_id
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/route53.tf
@@ -18,6 +18,6 @@ resource "kubernetes_secret" "content_hub_route53_zone_secret" {
   }
 
   data = {
-    zone_id   = aws_route53_zone.content_hub_route53_zone.zone_id
+    zone_id = aws_route53_zone.content_hub_route53_zone.zone_id
   }
 }


### PR DESCRIPTION
The `prisoner.service.justice.gov.uk` domain is managed in Azure by a separate team.

We would like to sit the Prisoner Content Hub under `content-hub.prisoner.service.justice.gov.uk`, and shift management into Cloud Platform/route53.

This PR creates the Route53 zone for `content-hub.prisoner.service.justice.gov.uk`. Once it's been created, we'll need to set up delegation on the upstream name servers.