### PR TITLE
Add certificates for prisoner content hub CMS and frontend

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/06-certificates-cms.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/06-certificates-cms.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: prisoner-content-hub-production-cms-certificate
+  namespace: prisoner-content-hub-production
+spec:
+  secretName: prisoner-content-hub-cms-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - manage.content-hub.prisoner.service.justice.gov.uk

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/07-certificates-frontend.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/07-certificates-frontend.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: prisoner-content-hub-production-frontend-certificate
+  namespace: prisoner-content-hub-production
+spec:
+  secretName: prisoner-content-hub-frontend-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - berwyn.content-hub.prisoner.service.justice.gov.uk
+  - cookhamwood.content-hub.prisoner.service.justice.gov.uk
+  - wayland.content-hub.prisoner.service.justice.gov.uk


### PR DESCRIPTION
We created a Route53 zone in #2821.

This PR adds two certificates, one for the CMS application and another for the Node frontend.

The frontend certificate has multiple hostnames (one for each prison we support).