### PR TITLE
New network policy and ingress controller module

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/04-networkpolicy.yaml
@@ -14,14 +14,11 @@ spec:
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: allow-ingress-controllers
+  name: allow-ingress-traffic
   namespace: mogaal-test
 spec:
-  podSelector: {}
-  policyTypes:
-  - Ingress
+  podSelector:
+    matchLabels:
+      app: nginx-ingress
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          component: ingress-controllers
+  - from: []

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
@@ -1,0 +1,7 @@
+
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller"
+
+  namespace     = "mogaal-test"
+  hostzone_name = "mogaal-test.cloud-platform.service.justice.gov.uk"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/main.tf
@@ -17,3 +17,8 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "helm" {
+  version = "1.1.0"
+  kubernetes {
+  }
+}


### PR DESCRIPTION
- New network policy which accepts all traffic to ingress controller pods (nginx)
- Added the ingress controller terraform module
