### PR TITLE
Refactor ingress implementation

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/00-namespace.yaml
@@ -6,7 +6,6 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/can-use-loadbalancer-services: "true"
     cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
     cloud-platform.justice.gov.uk/slack-channel: "#cloud-platform"
     cloud-platform.justice.gov.uk/application: "Test Nginx Ingress"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/04-networkpolicy.yaml
@@ -17,8 +17,11 @@ metadata:
   name: allow-ingress-traffic
   namespace: mogaal-test
 spec:
-  podSelector:
-    matchLabels:
-      app: nginx-ingress
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress:
-  - from: []
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
@@ -1,6 +1,6 @@
 
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=main"
 
-  hostzone_name = "mogaal-test.cloud-platform.service.justice.gov.uk"
+  namespace = "mogaal-test"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
@@ -2,6 +2,5 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.1"
 
-  namespace     = "mogaal-test"
   hostzone_name = "mogaal-test.cloud-platform.service.justice.gov.uk"
 }


### PR DESCRIPTION
- Reverting network policies (not needed the custom one anymore)
- Not need to create LB within the team's namespace
- Testing the latest nginx ingress module