### PR TITLE
Increase production database size to get better base performance iops

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -20,7 +20,7 @@ module "cla_backend_rds" {
   db_name = "cla_backend"
   # Settings from current setup
   db_instance_class    = "db.t2.medium"
-  db_allocated_storage = "100"
+  db_allocated_storage = "250"
 
   # change the postgres version as you see fit.
   db_engine_version      = "9.6"


### PR DESCRIPTION
This should give us 750 Base Performance (IOPS) according to https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html