### PR TITLE
Increase RDS instance spec due to slow queries

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -19,8 +19,9 @@ module "cla_backend_rds" {
 
   db_name = "cla_backend"
   # Settings from current setup
-  db_instance_class    = "db.t2.medium"
-  db_allocated_storage = "250"
+  db_instance_class    = "db.t2.2xlarge"
+  db_allocated_storage = "100"
+  db_iops              = "3000"
 
   # change the postgres version as you see fit.
   db_engine_version      = "9.6"
@@ -58,8 +59,9 @@ module "cla_backend_replica" {
 
 
   # Settings from current setup
-  db_instance_class    = "db.t2.medium"
+  db_instance_class    = "db.t2.2xlarge"
   db_allocated_storage = "100"
+  db_iops              = "3000"
 
   # change the postgres version as you see fit.
   db_engine_version = "9.6"


### PR DESCRIPTION
Due to slow performing queries in the laa-cla-backend app we had to increase the spec of the RDS instance. The work to optimize these queries will be done after the migration process.