### PR TITLE
Add Form Builder github actions service account for product page

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/00-namespace.yaml
@@ -4,7 +4,7 @@ metadata:
   name: formbuilder-product-page-staging
   labels:
     cloud-platform.justice.gov.uk/is-production: "false"
-    cloud-platform.justice.gov.uk/environment-name: "statging"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "transformed-department"
     cloud-platform.justice.gov.uk/application: "Formbuilder Product Page"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/formbuilder-product-page-staging-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/formbuilder-product-page-staging-service-account.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-actions-formbuilder-product-page-staging
+  namespace: formbuilder-product-page-staging
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: github-actions-formbuilder-product-page-staging
+  namespace: formbuilder-product-page-staging
+subjects:
+- kind: ServiceAccount
+  name: github-actions-formbuilder-product-page-staging
+  namespace: formbuilder-product-page-staging
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
We are attempting to setup up Github Actions for one of our repos in staging. This service account will be used by Github Actions to access secrets and to apply changes etc.

Also fix typo

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>