### PR TITLE
silence alert until authorized-keys-provider procedure modified

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/provider.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/authorized-keys-provider/provider.yaml
@@ -50,7 +50,7 @@ metadata:
   name: authorized-keys-provider
   namespace: authorized-keys-provider
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: authorized-keys-provider


### PR DESCRIPTION
Why:
Ticket [KubeDeploymentReplicaMismatch#2119](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2119)
Temporarily set replica's to zero - to silence this alert - whilst work being carried out re authorized-keys-provider