### PR TITLE
Restore usage of db.m4.4xlarge instance size

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -19,7 +19,7 @@ module "cla_backend_rds" {
 
   db_name = "cla_backend"
   # Settings from current setup
-  db_instance_class    = "db.t2.2xlarge"
+  db_instance_class    = "db.m4.4xlarge"
   db_allocated_storage = "1000"
   db_iops              = "3000"
 
@@ -59,7 +59,7 @@ module "cla_backend_replica" {
 
 
   # Settings from current setup
-  db_instance_class    = "db.t2.2xlarge"
+  db_instance_class    = "db.m4.4xlarge"
   db_allocated_storage = "1000"
   db_iops              = "3000"
 


### PR DESCRIPTION
Preliminary tests with 3 concurrent users seem to have significant decrease of site response times. Restoring current database specs to carry out further testing