### PR TITLE
Add report security incident pingdom check

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
@@ -2,12 +2,13 @@ provider "pingdom" {}
 
 locals {
   forms = {
-    apply-financial-deputy = "apply-financial-deputy.form.service.justice.gov.uk",
-    childrens-funeral-fund = "claim-for-costs-of-a-childs-funeral.form.service.justice.gov.uk",
-    cica                   = "same-roof-rule.form.service.justice.gov.uk",
-    hmcts-complaints       = "complain-about-a-court-or-tribunal.form.service.justice.gov.uk",
-    leavers-form           = "leavers.form.service.justice.gov.uk",
-    let-us-know            = "let-us-know.form.service.justice.gov.uk"
+    apply-financial-deputy   = "apply-financial-deputy.form.service.justice.gov.uk",
+    childrens-funeral-fund   = "claim-for-costs-of-a-childs-funeral.form.service.justice.gov.uk",
+    cica                     = "same-roof-rule.form.service.justice.gov.uk",
+    hmcts-complaints         = "complain-about-a-court-or-tribunal.form.service.justice.gov.uk",
+    leavers-form             = "leavers.form.service.justice.gov.uk",
+    let-us-know              = "let-us-know.form.service.justice.gov.uk",
+    report-security-incident = "report-security-incident.form.service.gov.uk"
   }
   names = keys(local.forms)
   hosts = values(local.forms)


### PR DESCRIPTION
New form is going live for reporting security incidents. This adds the pingdom check for the live form.

https://trello.com/c/U9pnDhSS/569-plan-delivery-of-security-incident-form-with-stakeholders