### PR TITLE
Add template serviceaccount file to cli templates

### DIFF
--- a/namespace-resources-cli-template/05-serviceaccount.yaml
+++ b/namespace-resources-cli-template/05-serviceaccount.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ .Name }}"
+  namespace: "{{ .Namespace }}"
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "{{ .Name }}"
+  namespace: "{{ .Namespace }}"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "{{ .Name }}"
+  namespace: "{{ .Namespace }}"
+subjects:
+- kind: ServiceAccount
+  name: "{{ .Name }}"
+  namespace: "{{ .Namespace }}"
+roleRef:
+  kind: Role
+  name: "{{ .Name }}"
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This file will be used by the `cloud-platform-cli` tool and links to
issue https://github.com/ministryofjustice/cloud-platform/issues/2059.