### PR TITLE
Add Form Builder product page production Service Account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/formbuilder-product-page-prod-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/formbuilder-product-page-prod-service-account.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-actions-formbuilder-product-page-prod
+  namespace: formbuilder-product-page-prod
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: github-actions-formbuilder-product-page-prod
+  namespace: formbuilder-product-page-prod
+subjects:
+- kind: ServiceAccount
+  name: github-actions-formbuilder-product-page-prod
+  namespace: formbuilder-product-page-prod
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This just adds the service account for the production namespace of the form builder product page