### PR TITLE
Create CompletedJobDeleter

### DIFF
--- a/bin/delete_completed_jobs.rb
+++ b/bin/delete_completed_jobs.rb
@@ -7,7 +7,7 @@ require File.join(".", File.dirname(__FILE__), "..", "lib", "cp_env")
 #   * not part of a Cronjobs
 #   * and job not set with ttlSecondsAfterFinished
 #
-# These completed jobs pods are taking up pod counts on each node 
+# These completed jobs pods are taking up pod counts on each node
 # creating too many pods per node get alerts as (limit set by KOPS is 100 per node)
 #
 # NB: The script has a 'dry-run' mode, in which jobs will be listed

--- a/bin/delete_completed_jobs.rb
+++ b/bin/delete_completed_jobs.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+require File.join(".", File.dirname(__FILE__), "..", "lib", "cp_env")
+
+# This script will delete completed jobs which are:
+#
+#   * not part of a Cronjobs
+#   * and job not set with ttlSecondsAfterFinished
+#
+# These completed jobs pods are taking up pod counts on each node 
+# creating too many pods per node get alerts as (limit set by KOPS is 100 per node)
+#
+# NB: The script has a 'dry-run' mode, in which jobs will be listed
+# but not deleted. To use this, pass the string `--dry-run` as the
+# first and only argument.
+#
+# The script requires the following environment variables:
+#
+#   export PIPELINE_CLUSTER=live-1.cloud-platform.service.justice.gov.uk
+#
+# It also needs to be able to run:
+#
+#   kubectl config use-context #{cluster}
+#
+
+cluster = ENV.fetch("PIPELINE_CLUSTER")
+
+dry_run = ARGV.shift == "--dry-run"
+
+if dry_run
+  log("green", "Dry run: detecting completed jobs in #{cluster}")
+else
+  log("green", "Deleting completed jobs in #{cluster}")
+end
+
+set_kube_context(cluster)
+
+CpEnv::CompletedJobDeleter.new(dry_run: dry_run).delete
+
+log("green", "Done.")

--- a/lib/cp_env.rb
+++ b/lib/cp_env.rb
@@ -23,3 +23,4 @@ require File.join(File.dirname(__FILE__), "cp_env", "gpg_keypair")
 require File.join(File.dirname(__FILE__), "cp_env", "gitops_gpg_keypair")
 
 require File.join(File.dirname(__FILE__), "cp_env", "manually_created_pod_deleter")
+require File.join(File.dirname(__FILE__), "cp_env", "completed_job_deleter")

--- a/lib/cp_env/completed_job_deleter.rb
+++ b/lib/cp_env/completed_job_deleter.rb
@@ -4,7 +4,7 @@ class CpEnv
   #   * not part of a Cronjobs
   #   * and job not set with ttlSecondsAfterFinished
   #
-  # These completed jobs pods are taking up pod count on each node 
+  # These completed jobs pods are taking up pod count on each node
   # creating too many pods per node get alerts (limit set by KOPS is 100 per node)
   #
   # To see a list of jobs that *would be* deleted, without actually

--- a/lib/cp_env/completed_job_deleter.rb
+++ b/lib/cp_env/completed_job_deleter.rb
@@ -1,0 +1,53 @@
+class CpEnv
+  # This script will delete completed jobs which are:
+  #
+  #   * not part of a Cronjobs
+  #   * and job not set with ttlSecondsAfterFinished
+  #
+  # These completed jobs pods are taking up pod count on each node 
+  # creating too many pods per node get alerts (limit set by KOPS is 100 per node)
+  #
+  # To see a list of jobs that *would be* deleted, without actually
+  # deleting any, pass `dry_run: true` to the `initialize` method.
+  class CompletedJobDeleter
+    attr_reader :executor, :dry_run
+
+    def initialize(args = {})
+      @executor = args.fetch(:executor) { Executor.new }
+      @dry_run = args.fetch(:dry_run, false)
+    end
+
+    def delete
+      jobs_to_delete = get_completed_jobs
+        .reject { |job| job.fetch("metadata").key?("ownerReferences") }
+        .reject { |job| job.fetch("spec").key?("ttlSecondsAfterFinished") }
+
+      jobs_to_delete.map { |job| delete_job(job) }
+    end
+
+    private
+
+    def get_jobs
+      stdout, _stderr, _status = executor.execute("kubectl get jobs --all-namespaces -o json", silent: true)
+      JSON.parse(stdout).fetch("items")
+    end
+
+    def get_completed_jobs
+      get_jobs.find_all { |job| completed_jobs(job) }
+    end
+
+    def completed_jobs(job)
+      job.dig("status", "succeeded") == 1
+    end
+
+    def delete_job(job)
+      namespace = job.dig("metadata", "namespace")
+      name = job.dig("metadata", "name")
+      if dry_run
+        log("blue", "dry run: would delete job #{name} from namespace #{namespace}")
+      else
+        executor.execute("kubectl -n #{namespace} delete job #{name}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This script will delete completed jobs which are:
* not part of a Cronjobs
  ( default .spec.successfulJobsHistoryLimit and .spec.failedJobsHistoryLimit set already)
   https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits

* and job not set with ttlSecondsAfterFinished
https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/#ttl-controller

This is related to [2113](https://github.com/ministryofjustice/cloud-platform/issues/2113)