### PR TITLE
PAT-1167: Pathfinder increase default memory limit - PROD namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1024Mi
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
       memory: 1024Mi


### PR DESCRIPTION
Increase memory limit in PROD namespace.
This has already been applied successfully (and fixed the issue) in the DEV namespace.