### PR TITLE
PAT-1167: Increase Pathfinder default memory limit in PREPROD namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1024Mi
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
       memory: 1024Mi


### PR DESCRIPTION
Already applied in DEV & PROD - this increases the memory limits for Pathfinder in PREPROD.