### PR TITLE
PAT-1168: Increase default memory limit to 2Gb for manage-soc-cases - DEV namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1024Mi
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
       memory: 1024Mi


### PR DESCRIPTION
The same issue as affected Pathfinder also affects Manage SOC cases - but this only has a DEV namespace.
Increases default memory limit from 1Gb to 2Gb to cater for increased demand of the clamav pods.