### PR TITLE
bump s3 module to version 4.4 for all non-prod namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/s3.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.cluster_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/s3.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.cluster_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "hmpps_pin_phone_monitor_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -64,7 +64,7 @@ EOF
 }
 
 module "hmpps_pin_phone_monitor_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "hmpps_submit_information_report_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/s3.tf
@@ -96,15 +96,15 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
-  acl                    = "public-read"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  acl                           = "public-read"
   enable_allow_block_pub_access = false
-  team_name              = var.team_name
-  business-unit          = var.business-unit
-  application            = var.application
-  is-production          = var.is-production
-  environment-name       = var.environment-name
-  infrastructure-support = var.infrastructure-support
+  team_name                     = var.team_name
+  business-unit                 = var.business-unit
+  application                   = var.application
+  is-production                 = var.is-production
+  environment-name              = var.environment-name
+  infrastructure-support        = var.infrastructure-support
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_backend_private_reports_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   acl    = "private"
 
   team_name              = var.team_name
@@ -49,7 +49,7 @@ EOF
 }
 
 module "cla_backend_deleted_objects_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   acl    = "private"
 
   team_name              = var.team_name
@@ -96,7 +96,7 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   acl                    = "public-read"
   enable_allow_block_pub_access = false
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
@@ -96,15 +96,15 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
-  acl                    = "public-read"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  acl                           = "public-read"
   enable_allow_block_pub_access = false
-  team_name              = var.team_name
-  business-unit          = var.business-unit
-  application            = var.application
-  is-production          = var.is-production
-  environment-name       = var.environment-name
-  infrastructure-support = var.infrastructure-support
+  team_name                     = var.team_name
+  business-unit                 = var.business-unit
+  application                   = var.application
+  is-production                 = var.is-production
+  environment-name              = var.environment-name
+  infrastructure-support        = var.infrastructure-support
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_backend_private_reports_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   acl    = "private"
 
   team_name              = var.team_name
@@ -49,7 +49,7 @@ EOF
 }
 
 module "cla_backend_deleted_objects_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   acl    = "private"
 
   team_name              = var.team_name
@@ -96,7 +96,7 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   acl                    = "public-read"
   enable_allow_block_pub_access = false
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "manage_soc_cases_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -64,7 +64,7 @@ EOF
 }
 
 module "manage_soc_cases_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "mps_storage_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "mps_storage_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "pathfinder_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -64,7 +64,7 @@ EOF
 }
 
 module "pathfinder_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "pathfinder_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -64,7 +64,7 @@ EOF
 }
 
 module "pathfinder_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -1,5 +1,5 @@
 module "drupal_content_storage" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   versioning             = true

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "drupal_content_storage" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = var.team_name
   versioning             = true

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"


### PR DESCRIPTION
This new version of S3 enables the use of the `bucket_name` variable.
Bumping the version of all non-prod namespaces now.