### PR TITLE
Swaps out email address for team name in Pingdom resource.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/pingdom.tf
@@ -19,7 +19,7 @@ resource "pingdom_check" "prisoner-content-hub-production-checks" {
   url                      = "/"
   encryption               = true
   port                     = 443
-  tags                     = "businessunit_${var.business-unit},application_${var.application},component_healthcheck,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_${var.infrastructure-support}"
+  tags                     = "businessunit_${var.business-unit},application_${var.application},component_healthcheck,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_${var.team_name}"
   probefilters             = "region:EU"
   publicreport             = "true"
 


### PR DESCRIPTION
The email address may be the cause of the build failure in https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-namespace-changes-live-1/builds/284\#L5f2aeb61:135. This swaps it out for a dns-compliant team name.

While this isn't ideal (because `pfs` isn't that meaningful and doesn't have an email address), in the context of the other tags you could _probably_ end up in the right place. It also looks like other teams have taken this approach.