### PR TITLE
Update path to empty main.tf file

### DIFF
--- a/lib/cp_env/namespace_deleter.rb
+++ b/lib/cp_env/namespace_deleter.rb
@@ -19,7 +19,7 @@ class CpEnv
     NAMEPACES_DIR = "namespaces/#{CLUSTER}"
     PRODUCTION_LABEL = "cloud-platform.justice.gov.uk/is-production"
     LABEL_TRUE = "true"
-    EMPTY_MAIN_TF_URL = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources/resources/main.tf"
+    EMPTY_MAIN_TF_URL = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template/resources/main.tf"
 
     def initialize(args)
       @namespace = args.fetch(:namespace)


### PR DESCRIPTION
The namespace deleter script fetches an empty main.tf file from our
environments repo, but the previous version was deleted by #2922

This change points to the new location of an empty main.tf file.
