### PR TITLE
Add slack channel annotation to laa namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/00-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "LAA Apply slack bot"
     cloud-platform.justice.gov.uk/owner: "Apply: apply@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/colinbruce/laa-apply-bot"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/00-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/00-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "uat"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"


### PR DESCRIPTION
Apparently `apply-dev` is the right slack channel to use if we need to
contact the team which owns these namespaces.

https://mojdt.slack.com/archives/C57UPMZLY/p1597761057454200
