### PR TITLE
Adding LAA Status Job Queues on Non Dev Environments

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
@@ -292,7 +292,7 @@ module "cp_laa_status_job_queue" {
   infrastructure-support    = var.infrastructure_support
   application               = var.application
   sqs_name                  = "cp-laa-status-job-queue"
-  existing_user_name        =  module.create_link_queue.user_name
+  existing_user_name        = module.create_link_queue.user_name
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
 
@@ -343,7 +343,7 @@ module "cp_laa_status_job_dead_letter_queue" {
   infrastructure-support = var.infrastructure_support
   application            = var.application
   sqs_name               = "cp-laa-status-job-queue-dl"
-  existing_user_name     =  module.create_link_queue.user_name
+  existing_user_name     = module.create_link_queue.user_name
   encrypt_sqs_kms        = var.encrypt_sqs_kms
 
   providers = {
@@ -358,32 +358,32 @@ resource "kubernetes_secret" "create_link_queue" {
   }
 
   data = {
-    access_key_id               = module.create_link_queue.access_key_id
-    secret_access_key           = module.create_link_queue.secret_access_key
-    sqs_url_link                = module.create_link_queue.sqs_id
-    sqs_arn_link                = module.create_link_queue.sqs_arn
-    sqs_name_link               = module.create_link_queue.sqs_name
-    sqs_url_d_link              = module.create_link_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_link              = module.create_link_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_link             = module.create_link_queue_dead_letter_queue.sqs_name
-    sqs_url_unlink              = module.unlink_queue.sqs_id
-    sqs_arn_unlink              = module.unlink_queue.sqs_arn
-    sqs_name_unlink             = module.unlink_queue.sqs_name
-    sqs_url_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_unlink           = module.unlink_queue_dead_letter_queue.sqs_name
-    sqs_url_laa_status          = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status          = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status         = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status       = module.laa_status_update_dead_letter_queue.sqs_name
-    sqs_url_hearing_resulted    = module.hearing_resulted_queue.sqs_id
-    sqs_arn_hearing_resulted    = module.hearing_resulted_queue.sqs_arn
-    sqs_name_hearing_resulted   = module.hearing_resulted_queue.sqs_name
-    sqs_url_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_id
-    sqs_arn_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_arn
-    sqs_name_d_hearing_resulted = module.hearing_resulted_dead_letter_queue.sqs_name
+    access_key_id                = module.create_link_queue.access_key_id
+    secret_access_key            = module.create_link_queue.secret_access_key
+    sqs_url_link                 = module.create_link_queue.sqs_id
+    sqs_arn_link                 = module.create_link_queue.sqs_arn
+    sqs_name_link                = module.create_link_queue.sqs_name
+    sqs_url_d_link               = module.create_link_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_link               = module.create_link_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_link              = module.create_link_queue_dead_letter_queue.sqs_name
+    sqs_url_unlink               = module.unlink_queue.sqs_id
+    sqs_arn_unlink               = module.unlink_queue.sqs_arn
+    sqs_name_unlink              = module.unlink_queue.sqs_name
+    sqs_url_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_name
+    sqs_url_laa_status           = module.laa_status_update_queue.sqs_id
+    sqs_arn_laa_status           = module.laa_status_update_queue.sqs_arn
+    sqs_name_laa_status          = module.laa_status_update_queue.sqs_name
+    sqs_url_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_id
+    sqs_arn_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_arn
+    sqs_name_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_name
+    sqs_url_hearing_resulted     = module.hearing_resulted_queue.sqs_id
+    sqs_arn_hearing_resulted     = module.hearing_resulted_queue.sqs_arn
+    sqs_name_hearing_resulted    = module.hearing_resulted_queue.sqs_name
+    sqs_url_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_id
+    sqs_arn_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_arn
+    sqs_name_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_name
     sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
     sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
     sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
@@ -284,6 +284,72 @@ module "hearing_resulted_dead_letter_queue" {
   }
 }
 
+module "cp_laa_status_job_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "cp-laa-status-job-queue"
+  existing_user_name        =  module.create_link_queue.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.cp_laa_status_job_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "cp_laa_status_job_queue_policy" {
+  queue_url = module.cp_laa_status_job_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.cp_laa_status_job_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cp_laa_status_job_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cp_laa_status_job_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
+module "cp_laa_status_job_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "cp-laa-status-job-queue-dl"
+  existing_user_name     =  module.create_link_queue.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+
+  providers = {
+    aws = aws.london
+  }
+}
 
 resource "kubernetes_secret" "create_link_queue" {
   metadata {
@@ -318,5 +384,11 @@ resource "kubernetes_secret" "create_link_queue" {
     sqs_url_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_id
     sqs_arn_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_arn
     sqs_name_d_hearing_resulted = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
+    sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
+    sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name
+    sqs_url_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_id
+    sqs_arn_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_arn
+    sqs_name_d_cp_laa_status_job = module.cp_laa_status_job_dead_letter_queue.sqs_name
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/messaging-queues.tf
@@ -284,6 +284,73 @@ module "hearing_resulted_dead_letter_queue" {
   }
 }
 
+module "cp_laa_status_job_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "cp-laa-status-job-queue"
+  existing_user_name        =  module.create_link_queue.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.cp_laa_status_job_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "cp_laa_status_job_queue_policy" {
+  queue_url = module.cp_laa_status_job_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.cp_laa_status_job_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cp_laa_status_job_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cp_laa_status_job_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
+module "cp_laa_status_job_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "cp-laa-status-job-queue-dl"
+  existing_user_name     =  module.create_link_queue.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+
+  providers = {
+    aws = aws.london
+  }
+}
+
 
 resource "kubernetes_secret" "create_link_queue" {
   metadata {
@@ -318,5 +385,11 @@ resource "kubernetes_secret" "create_link_queue" {
     sqs_url_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_id
     sqs_arn_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_arn
     sqs_name_d_hearing_resulted = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
+    sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
+    sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name
+    sqs_url_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_id
+    sqs_arn_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_arn
+    sqs_name_d_cp_laa_status_job = module.cp_laa_status_job_dead_letter_queue.sqs_name
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/messaging-queues.tf
@@ -292,7 +292,7 @@ module "cp_laa_status_job_queue" {
   infrastructure-support    = var.infrastructure_support
   application               = var.application
   sqs_name                  = "cp-laa-status-job-queue"
-  existing_user_name        =  module.create_link_queue.user_name
+  existing_user_name        = module.create_link_queue.user_name
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
 
@@ -343,7 +343,7 @@ module "cp_laa_status_job_dead_letter_queue" {
   infrastructure-support = var.infrastructure_support
   application            = var.application
   sqs_name               = "cp-laa-status-job-queue-dl"
-  existing_user_name     =  module.create_link_queue.user_name
+  existing_user_name     = module.create_link_queue.user_name
   encrypt_sqs_kms        = var.encrypt_sqs_kms
 
   providers = {
@@ -359,32 +359,32 @@ resource "kubernetes_secret" "create_link_queue" {
   }
 
   data = {
-    access_key_id               = module.create_link_queue.access_key_id
-    secret_access_key           = module.create_link_queue.secret_access_key
-    sqs_url_link                = module.create_link_queue.sqs_id
-    sqs_arn_link                = module.create_link_queue.sqs_arn
-    sqs_name_link               = module.create_link_queue.sqs_name
-    sqs_url_d_link              = module.create_link_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_link              = module.create_link_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_link             = module.create_link_queue_dead_letter_queue.sqs_name
-    sqs_url_unlink              = module.unlink_queue.sqs_id
-    sqs_arn_unlink              = module.unlink_queue.sqs_arn
-    sqs_name_unlink             = module.unlink_queue.sqs_name
-    sqs_url_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_unlink           = module.unlink_queue_dead_letter_queue.sqs_name
-    sqs_url_laa_status          = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status          = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status         = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status       = module.laa_status_update_dead_letter_queue.sqs_name
-    sqs_url_hearing_resulted    = module.hearing_resulted_queue.sqs_id
-    sqs_arn_hearing_resulted    = module.hearing_resulted_queue.sqs_arn
-    sqs_name_hearing_resulted   = module.hearing_resulted_queue.sqs_name
-    sqs_url_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_id
-    sqs_arn_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_arn
-    sqs_name_d_hearing_resulted = module.hearing_resulted_dead_letter_queue.sqs_name
+    access_key_id                = module.create_link_queue.access_key_id
+    secret_access_key            = module.create_link_queue.secret_access_key
+    sqs_url_link                 = module.create_link_queue.sqs_id
+    sqs_arn_link                 = module.create_link_queue.sqs_arn
+    sqs_name_link                = module.create_link_queue.sqs_name
+    sqs_url_d_link               = module.create_link_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_link               = module.create_link_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_link              = module.create_link_queue_dead_letter_queue.sqs_name
+    sqs_url_unlink               = module.unlink_queue.sqs_id
+    sqs_arn_unlink               = module.unlink_queue.sqs_arn
+    sqs_name_unlink              = module.unlink_queue.sqs_name
+    sqs_url_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_name
+    sqs_url_laa_status           = module.laa_status_update_queue.sqs_id
+    sqs_arn_laa_status           = module.laa_status_update_queue.sqs_arn
+    sqs_name_laa_status          = module.laa_status_update_queue.sqs_name
+    sqs_url_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_id
+    sqs_arn_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_arn
+    sqs_name_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_name
+    sqs_url_hearing_resulted     = module.hearing_resulted_queue.sqs_id
+    sqs_arn_hearing_resulted     = module.hearing_resulted_queue.sqs_arn
+    sqs_name_hearing_resulted    = module.hearing_resulted_queue.sqs_name
+    sqs_url_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_id
+    sqs_arn_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_arn
+    sqs_name_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_name
     sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
     sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
     sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
@@ -292,7 +292,7 @@ module "cp_laa_status_job_queue" {
   infrastructure-support    = var.infrastructure_support
   application               = var.application
   sqs_name                  = "cp-laa-status-job-queue"
-  existing_user_name        =  module.create_link_queue.user_name
+  existing_user_name        = module.create_link_queue.user_name
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
 
@@ -343,7 +343,7 @@ module "cp_laa_status_job_dead_letter_queue" {
   infrastructure-support = var.infrastructure_support
   application            = var.application
   sqs_name               = "cp-laa-status-job-queue-dl"
-  existing_user_name     =  module.create_link_queue.user_name
+  existing_user_name     = module.create_link_queue.user_name
   encrypt_sqs_kms        = var.encrypt_sqs_kms
 
   providers = {
@@ -358,32 +358,32 @@ resource "kubernetes_secret" "create_link_queue" {
   }
 
   data = {
-    access_key_id               = module.create_link_queue.access_key_id
-    secret_access_key           = module.create_link_queue.secret_access_key
-    sqs_url_link                = module.create_link_queue.sqs_id
-    sqs_arn_link                = module.create_link_queue.sqs_arn
-    sqs_name_link               = module.create_link_queue.sqs_name
-    sqs_url_d_link              = module.create_link_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_link              = module.create_link_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_link             = module.create_link_queue_dead_letter_queue.sqs_name
-    sqs_url_unlink              = module.unlink_queue.sqs_id
-    sqs_arn_unlink              = module.unlink_queue.sqs_arn
-    sqs_name_unlink             = module.unlink_queue.sqs_name
-    sqs_url_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_unlink           = module.unlink_queue_dead_letter_queue.sqs_name
-    sqs_url_laa_status          = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status          = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status         = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status       = module.laa_status_update_dead_letter_queue.sqs_name
-    sqs_url_hearing_resulted    = module.hearing_resulted_queue.sqs_id
-    sqs_arn_hearing_resulted    = module.hearing_resulted_queue.sqs_arn
-    sqs_name_hearing_resulted   = module.hearing_resulted_queue.sqs_name
-    sqs_url_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_id
-    sqs_arn_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_arn
-    sqs_name_d_hearing_resulted = module.hearing_resulted_dead_letter_queue.sqs_name
+    access_key_id                = module.create_link_queue.access_key_id
+    secret_access_key            = module.create_link_queue.secret_access_key
+    sqs_url_link                 = module.create_link_queue.sqs_id
+    sqs_arn_link                 = module.create_link_queue.sqs_arn
+    sqs_name_link                = module.create_link_queue.sqs_name
+    sqs_url_d_link               = module.create_link_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_link               = module.create_link_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_link              = module.create_link_queue_dead_letter_queue.sqs_name
+    sqs_url_unlink               = module.unlink_queue.sqs_id
+    sqs_arn_unlink               = module.unlink_queue.sqs_arn
+    sqs_name_unlink              = module.unlink_queue.sqs_name
+    sqs_url_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_name
+    sqs_url_laa_status           = module.laa_status_update_queue.sqs_id
+    sqs_arn_laa_status           = module.laa_status_update_queue.sqs_arn
+    sqs_name_laa_status          = module.laa_status_update_queue.sqs_name
+    sqs_url_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_id
+    sqs_arn_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_arn
+    sqs_name_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_name
+    sqs_url_hearing_resulted     = module.hearing_resulted_queue.sqs_id
+    sqs_arn_hearing_resulted     = module.hearing_resulted_queue.sqs_arn
+    sqs_name_hearing_resulted    = module.hearing_resulted_queue.sqs_name
+    sqs_url_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_id
+    sqs_arn_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_arn
+    sqs_name_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_name
     sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
     sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
     sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
@@ -284,6 +284,72 @@ module "hearing_resulted_dead_letter_queue" {
   }
 }
 
+module "cp_laa_status_job_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "cp-laa-status-job-queue"
+  existing_user_name        =  module.create_link_queue.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.cp_laa_status_job_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "cp_laa_status_job_queue_policy" {
+  queue_url = module.cp_laa_status_job_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.cp_laa_status_job_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cp_laa_status_job_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cp_laa_status_job_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
+module "cp_laa_status_job_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "cp-laa-status-job-queue-dl"
+  existing_user_name     =  module.create_link_queue.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+
+  providers = {
+    aws = aws.london
+  }
+}
 
 resource "kubernetes_secret" "create_link_queue" {
   metadata {
@@ -318,5 +384,11 @@ resource "kubernetes_secret" "create_link_queue" {
     sqs_url_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_id
     sqs_arn_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_arn
     sqs_name_d_hearing_resulted = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
+    sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
+    sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name
+    sqs_url_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_id
+    sqs_arn_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_arn
+    sqs_name_d_cp_laa_status_job = module.cp_laa_status_job_dead_letter_queue.sqs_name
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/messaging-queues.tf
@@ -284,6 +284,73 @@ module "hearing_resulted_dead_letter_queue" {
   }
 }
 
+module "cp_laa_status_job_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "cp-laa-status-job-queue"
+  existing_user_name        =  module.create_link_queue.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.cp_laa_status_job_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "cp_laa_status_job_queue_policy" {
+  queue_url = module.cp_laa_status_job_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.cp_laa_status_job_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cp_laa_status_job_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.cp_laa_status_job_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
+module "cp_laa_status_job_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.0"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "cp-laa-status-job-queue-dl"
+  existing_user_name     =  module.create_link_queue.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+
+  providers = {
+    aws = aws.london
+  }
+}
+
 
 resource "kubernetes_secret" "create_link_queue" {
   metadata {
@@ -318,5 +385,11 @@ resource "kubernetes_secret" "create_link_queue" {
     sqs_url_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_id
     sqs_arn_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_arn
     sqs_name_d_hearing_resulted = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
+    sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
+    sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name
+    sqs_url_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_id
+    sqs_arn_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_arn
+    sqs_name_d_cp_laa_status_job = module.cp_laa_status_job_dead_letter_queue.sqs_name
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/messaging-queues.tf
@@ -292,7 +292,7 @@ module "cp_laa_status_job_queue" {
   infrastructure-support    = var.infrastructure_support
   application               = var.application
   sqs_name                  = "cp-laa-status-job-queue"
-  existing_user_name        =  module.create_link_queue.user_name
+  existing_user_name        = module.create_link_queue.user_name
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
 
@@ -343,7 +343,7 @@ module "cp_laa_status_job_dead_letter_queue" {
   infrastructure-support = var.infrastructure_support
   application            = var.application
   sqs_name               = "cp-laa-status-job-queue-dl"
-  existing_user_name     =  module.create_link_queue.user_name
+  existing_user_name     = module.create_link_queue.user_name
   encrypt_sqs_kms        = var.encrypt_sqs_kms
 
   providers = {
@@ -359,32 +359,32 @@ resource "kubernetes_secret" "create_link_queue" {
   }
 
   data = {
-    access_key_id               = module.create_link_queue.access_key_id
-    secret_access_key           = module.create_link_queue.secret_access_key
-    sqs_url_link                = module.create_link_queue.sqs_id
-    sqs_arn_link                = module.create_link_queue.sqs_arn
-    sqs_name_link               = module.create_link_queue.sqs_name
-    sqs_url_d_link              = module.create_link_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_link              = module.create_link_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_link             = module.create_link_queue_dead_letter_queue.sqs_name
-    sqs_url_unlink              = module.unlink_queue.sqs_id
-    sqs_arn_unlink              = module.unlink_queue.sqs_arn
-    sqs_name_unlink             = module.unlink_queue.sqs_name
-    sqs_url_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_unlink           = module.unlink_queue_dead_letter_queue.sqs_name
-    sqs_url_laa_status          = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status          = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status         = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status       = module.laa_status_update_dead_letter_queue.sqs_name
-    sqs_url_hearing_resulted    = module.hearing_resulted_queue.sqs_id
-    sqs_arn_hearing_resulted    = module.hearing_resulted_queue.sqs_arn
-    sqs_name_hearing_resulted   = module.hearing_resulted_queue.sqs_name
-    sqs_url_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_id
-    sqs_arn_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_arn
-    sqs_name_d_hearing_resulted = module.hearing_resulted_dead_letter_queue.sqs_name
+    access_key_id                = module.create_link_queue.access_key_id
+    secret_access_key            = module.create_link_queue.secret_access_key
+    sqs_url_link                 = module.create_link_queue.sqs_id
+    sqs_arn_link                 = module.create_link_queue.sqs_arn
+    sqs_name_link                = module.create_link_queue.sqs_name
+    sqs_url_d_link               = module.create_link_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_link               = module.create_link_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_link              = module.create_link_queue_dead_letter_queue.sqs_name
+    sqs_url_unlink               = module.unlink_queue.sqs_id
+    sqs_arn_unlink               = module.unlink_queue.sqs_arn
+    sqs_name_unlink              = module.unlink_queue.sqs_name
+    sqs_url_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_name
+    sqs_url_laa_status           = module.laa_status_update_queue.sqs_id
+    sqs_arn_laa_status           = module.laa_status_update_queue.sqs_arn
+    sqs_name_laa_status          = module.laa_status_update_queue.sqs_name
+    sqs_url_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_id
+    sqs_arn_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_arn
+    sqs_name_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_name
+    sqs_url_hearing_resulted     = module.hearing_resulted_queue.sqs_id
+    sqs_arn_hearing_resulted     = module.hearing_resulted_queue.sqs_arn
+    sqs_name_hearing_resulted    = module.hearing_resulted_queue.sqs_name
+    sqs_url_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_id
+    sqs_arn_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_arn
+    sqs_name_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_name
     sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
     sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
     sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name


### PR DESCRIPTION
Adding LAA Status Job Queues on Non Dev Environments. The same queue is already available on Dev Environment,  