### PR TITLE
Updated CompletedJobDeleter

### DIFF
--- a/lib/cp_env/completed_job_deleter.rb
+++ b/lib/cp_env/completed_job_deleter.rb
@@ -19,7 +19,6 @@ class CpEnv
 
     def delete
       jobs_to_delete = get_completed_jobs
-        .reject { |job| job.fetch("metadata").key?("ownerReferences") }
         .reject { |job| job.fetch("spec").key?("ttlSecondsAfterFinished") }
 
       jobs_to_delete.map { |job| delete_job(job) }


### PR DESCRIPTION
To remove completed cronjobs, if "ttlSecondsAfterFinished" is not set.