### PR TITLE
Add rescue block in delete completed jobs loop

### DIFF
--- a/lib/cp_env/completed_job_deleter.rb
+++ b/lib/cp_env/completed_job_deleter.rb
@@ -21,7 +21,13 @@ class CpEnv
       jobs_to_delete = get_completed_jobs
         .reject { |job| job.fetch("spec").key?("ttlSecondsAfterFinished") }
 
-      jobs_to_delete.map { |job| delete_job(job) }
+      jobs_to_delete.map do |job|
+        delete_job(job)
+      rescue Exception => e
+        # Job might have been deleted since we read the list
+        puts "Caught error #{e}:\n#{e.message}"
+        puts "Continuing..."
+      end
     end
 
     private


### PR DESCRIPTION
It's possible that a job gets deleted between the script determining the
list of jobs to delete, and actually deleting that specific job. In that
case, without a `rescue` clause, the whole script terminates.

This change adds a rescue inside the loop, so that even if one job fails
to be deleted successfully, the script carries on and tries to delete
all the following jobs.

Example of error:

```
executing: kubectl -n laa-apply-for-legalaid-staging delete job apply-for-legal-aid-metrics-1598255400
Command: kubectl -n laa-apply-for-legalaid-staging delete job apply-for-legal-aid-metrics-1598255400 failed.
Error from server (NotFound): jobs.batch "apply-for-legal-aid-metrics-1598255400" not found
Traceback (most recent call last):
	5: from ./bin/delete_completed_jobs.rb:38:in `<main>'
	4: from /tmp/build/d37a0401/cloud-platform-environments-repo/lib/cp_env/completed_job_deleter.rb:24:in `delete'
	3: from /tmp/build/d37a0401/cloud-platform-environments-repo/lib/cp_env/completed_job_deleter.rb:24:in `map'
	2: from /tmp/build/d37a0401/cloud-platform-environments-repo/lib/cp_env/completed_job_deleter.rb:24:in `block in delete'
	1: from /tmp/build/d37a0401/cloud-platform-environments-repo/lib/cp_env/completed_job_deleter.rb:48:in `delete_job'
/tmp/build/d37a0401/cloud-platform-environments-repo/lib/cp_env/executor.rb:11:in `execute': unhandled exception
```
