### PR TITLE
Update mogaal-test ingress to module v. 0.0.3

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
@@ -1,6 +1,6 @@
 
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
 
   namespace = "mogaal-test"
 }


### PR DESCRIPTION
I want to link to this in the user comms, so it needs to be in the correct state for people to copy/paste into their own namespaces.