### PR TITLE
Ingress controllers for non-prod mod-sec namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "check-my-diary-dev"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "check-my-diary-preprod"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "court-probation-dev"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "court-probation-preprod"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "manage-hmpps-auth-accounts-dev"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "manage-hmpps-auth-accounts-preprod"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "manage-soc-cases-dev"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "manage-soc-cases-preprod"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-development/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "oasys-keycloak-development"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "offender-case-notes-dev"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "pathfinder-dev"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "prisoner-content-hub-development"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "prisoner-content-hub-staging"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "sentence-planning-development"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "sentence-planning-preprod"
+}


### PR DESCRIPTION
This PR will create a separate AWS load-balancer
and ingress controller for each namespace, so that
the teams can add the ingress class annotation to
their ingress definitions to start routing traffic
through the new ingresses.

As soon as all of these namespaces have migrated
their traffic, we will disable mod-security on the
default ingress, which should reduce the problems
we are seeing where the ingress pods are running
out of shared memory.

Related to ministryofjustice/cloud-platform#2224