### PR TITLE
Add a dedicated ingress controller to dstest ns

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+
+  namespace = "dstest"
+}


### PR DESCRIPTION
I will add a helloworld deployment, service and ingress definition so
that I can link to it as an example for the changes users will have to
make to their own ingress definitions, in our user comms relating to the
switch to dedicated ingress controllers.
