### PR TITLE
Add a working "hello world" web application

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: helloworld-dstest.live-1.cloud-platform.service.justice.gov.uk
+  namespace: dstest
+spec:
+  secretName: dstest-ssl-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - helloworld-dstest.live-1.cloud-platform.service.justice.gov.uk

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloworld-rubyapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helloworld-rubyapp
+  template:
+    metadata:
+      labels:
+        app: helloworld-rubyapp
+    spec:
+      containers:
+      - name: rubyapp
+        image: ministryofjustice/cloud-platform-helloworld-ruby:1.1
+        ports:
+        - containerPort: 4567

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: helloworld-rubyapp-ingress
+  annotations:
+    kubernetes.io/ingress.class: dstest
+spec:
+  tls:
+  - hosts:
+    - helloworld-dstest.live-1.cloud-platform.service.justice.gov.uk
+    secretName: dstest-ssl-cert
+  rules:
+  - host: helloworld-dstest.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: rubyapp-service
+          servicePort: 4567

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/service.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rubyapp-service
+  labels:
+    app: rubyapp-service
+spec:
+  ports:
+  - port: 4567
+    name: http
+    targetPort: 4567
+  selector:
+    app: helloworld-rubyapp


### PR DESCRIPTION
This commit adds files to the `dstest` namespace folder so that I can
link to these files in the user comms about changing to dedicated
ingress controllers per namespace.

related to
https://github.com/ministryofjustice/cloud-platform/issues/2224
