### PR TITLE
Add a template ingress.tf file

### DIFF
--- a/namespace-resources-cli-template/resources/ingress.tf
+++ b/namespace-resources-cli-template/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+
+  namespace = "{{ .Namespace }}"
+}


### PR DESCRIPTION
This will allow a later change to the cloud platform CLI, to create a
dedicated ingress controller with each new namespace.

related to
https://github.com/ministryofjustice/cloud-platform/issues/2224
