### PR TITLE
Add ingress.tf to non-prod book-secure-move ns

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+
+  namespace = "hmpps-book-secure-move-api-dev"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+
+  namespace = "hmpps-book-secure-move-api-preprod"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+
+  namespace = "hmpps-book-secure-move-api-staging"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+
+  namespace = "hmpps-book-secure-move-api-uat"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+
+  namespace = "hmpps-book-secure-move-frontend-preprod"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+
+  namespace = "hmpps-book-secure-move-frontend-staging"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+
+  namespace = "hmpps-book-secure-move-frontend-uat"
+}


### PR DESCRIPTION
This change adds an ingress.tf file to all the
non-production "book a secure move" namespaces.

A later PR will do the same for production
namespaces, after the team have validated this
change.