### PR TITLE
Add slack channel to all book-secure-move ns

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-frontend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-frontend"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-frontend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-frontend"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-frontend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-frontend"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-frontend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-frontend"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_dev"


### PR DESCRIPTION
According to Miguel Afonso, #hmpps_dev is the best
channel to use if we need to contact this team.