### PR TITLE
PAT-1216: Rename the queue manage_soc_cases_probation_offender_events

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/manage-soc-cases-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/manage-soc-cases-sub-queue.tf
@@ -182,7 +182,7 @@ module "manage_soc_cases_probation_offender_events_dead_letter_queue" {
   team_name              = var.team_name
   infrastructure-support = var.infrastructure-support
   application            = var.application
-  sqs_name               = "manage_soc_cases_probation_offender_events_queue_dl"
+  sqs_name               = "manage_soc_cases_probation_offender_events_dlq"
   encrypt_sqs_kms        = "true"
 
   providers = {


### PR DESCRIPTION
Old name:  manage_soc_cases_probation_offender_events_queue_dl
New name: manage_soc_cases_probation_offender_events_dlq 

Necessary to be consistent across all environments because the original exceeds an AWS resource limit (80 chars) when the name is combined with team-name and env-name in preprod.  It is already created in preprod and prod with the shorter name. 