### PR TITLE
Add GitHub Action to comment on PR if sufficient

### DIFF
--- a/.github/workflows/auto-approve-pr.yaml
+++ b/.github/workflows/auto-approve-pr.yaml
@@ -1,0 +1,47 @@
+name: Auto-approve a pull request
+
+on:
+  pull_request
+
+jobs:
+  checksum-compare:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@master
+
+      - name: Get changes and save to json
+        id: get_changes
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        with:
+          token: "${{ secrets.GITHUB_TOKEN  }}"
+
+      - name: Copy json so dir_hash can read contents
+        run: |
+          mkdir ${HOME}/work/_temp/_github_home
+          cp ${HOME}/files.json ${HOME}/work/_temp/_github_home/.
+
+      - name: Run check
+        id: dir_hash
+        uses: ministryofjustice/cloud-platform-directory-hash@main
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@master
+
+        if: steps.dir_hash.outputs.checksum_match == 'true'
+        with:
+          message: 'Auto-approve has deemed this PR worthy!'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # When we're ready to auto-approve the PR
+      # - name: Approving PR
+      #   uses: hmarr/auto-approve-action@v2.0.0
+
+      #   if: steps.dir_hash.outputs.checksum_match == 'true'
+      #   with:
+      #     github-token: "${{ secrets.GITHUB_TOKEN  }}"


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/1931 and relates to the eventual auto-approval of a PR that is deemed sufficiently standard.

The action will trigger upon pull request, checkout the users branch, create a hash of the users newly created namespace and then add a comment on its suitability. More information on its design can be found
here:
https://github.com/ministryofjustice/cloud-platform-directory-hash/#solution

When the team are comfortable with this solution we can remove the comment section in this action and uncomment the auto-approval.

To see a live demo of this action working, please see the checks in this PR. 