### PR TITLE
Use v0.0.7 of the ingress-controller module

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "check-my-diary-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "check-my-diary-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "court-probation-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "court-probation-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "hmpps-book-secure-move-api-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "hmpps-book-secure-move-api-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "hmpps-book-secure-move-api-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "hmpps-book-secure-move-api-uat"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "hmpps-book-secure-move-frontend-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "hmpps-book-secure-move-frontend-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "hmpps-book-secure-move-frontend-uat"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "manage-hmpps-auth-accounts-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "manage-hmpps-auth-accounts-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "manage-soc-cases-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "manage-soc-cases-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace     = "manage-soc-cases-prod"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
@@ -1,6 +1,5 @@
-
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "mogaal-test"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-development/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "oasys-keycloak-development"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "offender-case-notes-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "pathfinder-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "prisoner-content-hub-development"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "prisoner-content-hub-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "sentence-planning-development"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "sentence-planning-preprod"
 }


### PR DESCRIPTION
This is the version which enables teams to use the
`*.apps.live-1.cloud-platform.service.justice.gov.uk` wildcard certificate from
the `ingress-controllers` namespace (by not adding a `certificate.yaml` to their
namespace, and not specifying a `secretName` in their ingress definition).
