### PR TITLE
Remove A record from fox admin zone

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/route53.tf
@@ -22,13 +22,3 @@ resource "kubernetes_secret" "cla_backend_route53_zone_sec" {
   }
 }
 
-resource "aws_route53_record" "add_a_record" {
-  name    = "fox.civillegaladvice.service.gov.uk"
-  zone_id = aws_route53_zone.cla_backend_fox_admin_route53_zone.zone_id
-  type    = "A"
-  alias {
-    name                   = "dualstack.cla-backe-elbprodb-raqb3vvnvbvy-464626966.eu-west-1.elb.amazonaws.com."
-    zone_id                = "Z32O12XQLNTSW2"
-    evaluate_target_health = true
-  }
-}


### PR DESCRIPTION
The Ingress should populate this record when it sees it is not set
PR should be merged as close as possible to the migration completion
