### PR TITLE
PAT 1230 - ingress controllers for pathfinder namespaces + small changes to manage-soc-cases for consistency

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "manage-soc-cases-dev"
+  namespace     = "manage-soc-cases-dev"
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "manage-soc-cases-dev"
+  namespace     = "manage-soc-cases-dev"
   is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
@@ -2,4 +2,5 @@ module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "manage-soc-cases-dev"
+  is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace     = "manage-soc-cases-dev"
-  is_production = var.is-production
+  namespace = "manage-soc-cases-dev"
+  is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/variables.tf
@@ -30,6 +30,10 @@ variable "is-production" {
   default = "false"
 }
 
+variable "is_production" {
+  default = "false"
+}
+
 variable "number_cache_clusters" {
   default = "2"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "manage-soc-cases-preprod"
+  namespace     = "manage-soc-cases-preprod"
   is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace     = "manage-soc-cases-preprod"
-  is_production = var.is-production
+  namespace = "manage-soc-cases-preprod"
+  is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "manage-soc-cases-preprod"
+  namespace     = "manage-soc-cases-preprod"
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/variables.tf
@@ -30,6 +30,10 @@ variable "is-production" {
   default = "false"
 }
 
+variable "is_production" {
+  default = "false"
+}
+
 variable "number_cache_clusters" {
   default = "2"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "manage-soc-cases-prod"
+  namespace     = "manage-soc-cases-prod"
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace     = "manage-soc-cases-prod"
-  is_production = var.is-production
+  namespace = "manage-soc-cases-prod"
+  is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
@@ -2,5 +2,5 @@ module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace     = "manage-soc-cases-prod"
-  is_production = var.is_production
+  is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/variables.tf
@@ -30,6 +30,10 @@ variable "is-production" {
   default = "true"
 }
 
+variable "is_production" {
+  default = "true"
+}
+
 variable "number_cache_clusters" {
   default = "3"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/variables.tf
@@ -30,25 +30,6 @@ variable "is-production" {
   default = "true"
 }
 
-variable "business_unit" {
-  description = "Area of the MOJ responsible for the service."
-  default     = "HMPPS"
-}
-
-variable "environment_name" {
-  description = "The type of environment you're deploying to."
-  default     = "prod"
-}
-
-variable "infrastructure_support" {
-  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "dps-hmpps@digital.justice.gov.uk"
-}
-
-variable "is_production" {
-  default = "true"
-}
-
 variable "number_cache_clusters" {
   default = "3"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
@@ -2,4 +2,5 @@ module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = "pathfinder-dev"
+  is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "pathfinder-dev"
+  namespace     = "pathfinder-dev"
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace     = "pathfinder-dev"
-  is_production = var.is-production
+  namespace = "pathfinder-dev"
+  is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "pathfinder-dev"
+  namespace     = "pathfinder-dev"
   is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/variables.tf
@@ -30,6 +30,10 @@ variable "is-production" {
   default = "false"
 }
 
+variable "is_production" {
+  default = "false"
+}
+
 variable "number_cache_clusters" {
   default = "2"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "manage-soc-cases-preprod"
+  namespace     = "pathfinder-preprod"
   is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace     = "pathfinder-preprod"
-  is_production = var.is-production
+  namespace = "pathfinder-preprod"
+  is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "pathfinder-preprod"
+  namespace     = "pathfinder-preprod"
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/variables.tf
@@ -30,6 +30,10 @@ variable "is-production" {
   default = "false"
 }
 
+variable "is_production" {
+  default = "false"
+}
+
 variable "number_cache_clusters" {
   default = "2"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "manage-soc-cases-preprod"
+  namespace     = "pathfinder-prod"
   is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace     = "pathfinder-prod"
-  is_production = var.is-production
+  namespace = "pathfinder-prod"
+  is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = "pathfinder-prod"
+  namespace     = "pathfinder-prod"
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/variables.tf
@@ -34,6 +34,10 @@ variable "is-production" {
   default = "true"
 }
 
+variable "is_production" {
+  default = "true"
+}
+
 variable "number_cache_clusters" {
   default = "3"
 }


### PR DESCRIPTION
* Adds ingress controllers to pathfinder-dev, -preprod and -prod namespaces.
* Small changes to manage-soc-cases - to make it consistent with others
* Removed some unused variables
* Set is_production = var.is-production in all ingress definitions