### PR TITLE
Production mod-security ingress controllers

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = var.namespace
+  namespace     = var.namespace
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/variables.tf
@@ -1,0 +1,7 @@
+variable "namespace" {
+  default = "check-my-diary-prod"
+}
+
+variable "is_production" {
+  default = "true"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = var.namespace
+  namespace     = var.namespace
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/variables.tf
@@ -38,6 +38,10 @@ variable "is-production" {
   default = "true"
 }
 
+variable "is_production" {
+  default = "true"
+}
+
 variable "rds-family" {
   default = "postgres11"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/ingress.tf
@@ -3,4 +3,95 @@ module "ingress_controller" {
 
   namespace     = "hmpps-book-secure-move-frontend-production"
   is_production = var.is_production
+
+  custom_values = true
+  custom_values_content = <<EOF
+nameOverride: "nx"
+controller:
+  name: ic
+  replicaCount: 2
+  ingressClass: hmpps-book-secure-move-frontend-production
+  electionID: ingress-controller-leader-hmpps-book-secure-move-api-production
+  config:
+    enable-modsecurity: "true"
+    custom-http-errors: 413,502,503,504
+    generate-request-id: "true"
+    proxy-buffer-size: "16k"
+    proxy-body-size: "50m"
+    ssl-ciphers: "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA"
+    ssl-protocols: "TLSv1 TLSv1.1 TLSv1.2"
+    server-snippet: |
+      if ($scheme != 'https') {
+        return 308 https://$host$request_uri;
+      }
+    #
+    # For a list of available variables please check the documentation on
+    # `log-format-upstream` and also the relevant nginx document:
+    # - https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/log-format/
+    # - https://nginx.org/en/docs/varindex.html
+    #
+    log-format-escape-json: "true"
+    log-format-upstream: >-
+      {
+      "time": "$time_iso8601",
+      "body_bytes_sent": $body_bytes_sent,
+      "bytes_sent": $bytes_sent,
+      "http_host": "$host",
+      "http_referer": "$http_referer",
+      "http_user_agent": "$http_user_agent",
+      "http_x_real_ip": "$http_x_real_ip",
+      "http_x_forwarded_for": "$http_x_forwarded_for",
+      "http_x_forwarded_proto": "$http_x_forwarded_proto",
+      "kubernetes_namespace": "$namespace",
+      "kubernetes_ingress_name": "$ingress_name",
+      "kubernetes_service_name": "$service_name",
+      "kubernetes_service_port": "$service_port",
+      "proxy_upstream_name": "$proxy_upstream_name",
+      "proxy_protocol_addr": "$proxy_protocol_addr",
+      "remote_addr": "$remote_addr",
+      "remote_user": "$remote_user",
+      "request_id": "$req_id",
+      "request_length": $request_length,
+      "request_method": "$request_method",
+      "request_path": "$uri",
+      "request_proto": "$server_protocol",
+      "request_query": "$args",
+      "request_time": "$request_time",
+      "request_uri": "$request_uri",
+      "response_http_location": "$sent_http_location",
+      "server_name": "$server_name",
+      "server_port": $server_port,
+      "ssl_cipher": "$ssl_cipher",
+      "ssl_client_s_dn": "$ssl_client_s_dn",
+      "ssl_protocol": "$ssl_protocol",
+      "ssl_session_id": "$ssl_session_id",
+      "status": $status,
+      "upstream_addr": "$upstream_addr",
+      "upstream_response_length": $upstream_response_length,
+      "upstream_response_time": $upstream_response_time,
+      "upstream_status": $upstream_status
+      }
+  publishService:
+    enabled: true
+  stats:
+    enabled: true
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: hmpps-book-secure-move-api-production
+  extraArgs:
+    default-ssl-certificate: ingress-controllers/default-certificate
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    externalTrafficPolicy: "Local"
+defaultBackend:
+  image:
+    repository: ministryofjustice/cloud-platform-custom-error-pages
+    tag: "0.4"
+rbac:
+  create: true
+EOF
+
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/ingress.tf
@@ -4,7 +4,7 @@ module "ingress_controller" {
   namespace     = "hmpps-book-secure-move-frontend-production"
   is_production = var.is_production
 
-  custom_values = true
+  custom_values         = true
   custom_values_content = <<EOF
 nameOverride: "nx"
 controller:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace = var.namespace
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = var.namespace
+  namespace     = var.namespace
   is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/ingress.tf
@@ -2,4 +2,5 @@ module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace = var.namespace
+  is_production = var.is-production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/ingress.tf
@@ -1,0 +1,5 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace = var.namespace
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = var.namespace
+  namespace     = var.namespace
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/variables.tf
@@ -41,3 +41,7 @@ variable "node-type" {
 variable "is-production" {
   default = "true"
 }
+
+variable "is_production" {
+  default = "true"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = var.namespace
+  namespace     = var.namespace
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/variables.tf
@@ -33,3 +33,7 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
+
+variable "is_production" {
+  default = "true"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace = var.namespace
+  namespace     = var.namespace
   is_production = var.is_production
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/variables.tf
@@ -44,3 +44,7 @@ variable "is-production" {
   default = "true"
 }
 
+variable "is_production" {
+  default = "true"
+}
+


### PR DESCRIPTION
CHECK PLAN OUTPUT BEFORE MERGING

Add ingress controllers for prod mod-sec ns

This pr adds dedicated ingress controllers to all
the production namespaces which are currently
using mod-security

It also ensures that all these namespaces have a
"namespace" and "is_production" variable, with the
appropriate values.

related to https://github.com/ministryofjustice/cloud-platform-environments/pull/2966

