### PR TITLE
Add ingress controllers for prod mod-sec ns

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace     = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/variables.tf
@@ -1,0 +1,7 @@
+variable "namespace" {
+  default = "check-my-diary-prod"
+}
+
+variable "is_production" {
+  default = "true"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace     = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/variables.tf
@@ -38,6 +38,10 @@ variable "is-production" {
   default = "true"
 }
 
+variable "is_production" {
+  default = "true"
+}
+
 variable "rds-family" {
   default = "postgres11"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace     = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/variables.tf
@@ -41,3 +41,7 @@ variable "node-type" {
 variable "is-production" {
   default = "true"
 }
+
+variable "is_production" {
+  default = "true"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace     = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/variables.tf
@@ -33,3 +33,7 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
+
+variable "is_production" {
+  default = "true"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
@@ -1,0 +1,6 @@
+module "ingress_controller" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+
+  namespace     = var.namespace
+  is_production = var.is_production
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/variables.tf
@@ -44,3 +44,7 @@ variable "is-production" {
   default = "true"
 }
 
+variable "is_production" {
+  default = "true"
+}
+


### PR DESCRIPTION
DO NOT MERGE BEFORE CHECKING PLAN OUTPUT

This pr adds dedicated ingress controllers to all
the production namespaces which are currently
using mod-security

It also ensures that all these namespaces have a
"namespace" and "is_production" variable, with the
appropriate values.

related to https://github.com/ministryofjustice/cloud-platform-environments/pull/2966
