### PR TITLE
Use var.namespace in ingress.tf

### DIFF
--- a/namespace-resources-cli-template/resources/ingress.tf
+++ b/namespace-resources-cli-template/resources/ingress.tf
@@ -1,6 +1,6 @@
 module "ingress_controller" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace     = "{{ .Namespace }}"
+  namespace     = var.namespace
   is_production = var.is_production
 }


### PR DESCRIPTION
We don't need to do any template interpolation here - we can just use the existing terraform variable to supply the namespace at plan/apply time.