### PR TITLE
Form builder repos: Add list permission to circle service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/serviceaccount-circleci.yaml
@@ -16,6 +16,7 @@ rules:
       - "secrets"
     verbs:
       - "get"
+      - "list"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
## Context

On CircleCI, when we try to run the command `kubectl get secrets -n formbuilder-repos` we are receiving the error message on our builds: Error from server (Forbidden): secrets is forbidden: User "********..." cannot list resource "secrets" in API group "" in the namespace "formbuilder-repos".

So this PR adds the list permission that will make us able list the secret names from formbuilder repos.