### PR TITLE
Update ingress controller modules to v0.0.8

### DIFF
--- a/namespace-resources-cli-template/resources/ingress.tf
+++ b/namespace-resources-cli-template/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "{{ .Namespace }}"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "check-my-diary-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "check-my-diary-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "court-probation-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "court-probation-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "davidread-dev"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "dstest"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "hmpps-book-secure-move-api-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "hmpps-book-secure-move-api-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "hmpps-book-secure-move-api-production"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "hmpps-book-secure-move-api-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "hmpps-book-secure-move-api-uat"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "hmpps-book-secure-move-frontend-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "hmpps-book-secure-move-frontend-production"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "hmpps-book-secure-move-frontend-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "hmpps-book-secure-move-frontend-uat"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "manage-hmpps-auth-accounts-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "manage-hmpps-auth-accounts-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "manage-soc-cases-dev"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "manage-soc-cases-preprod"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "manage-soc-cases-prod"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "mogaal-test"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-development/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "oasys-keycloak-development"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "offender-case-notes-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "pathfinder-dev"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "pathfinder-preprod"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "pathfinder-prod"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "prison-estate-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "prison-estate-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "prison-estate-prod"
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "prison-to-nhs-update-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "prison-to-nhs-update-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = "prison-to-nhs-update-prod"
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "prisoner-content-hub-development"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace     = var.namespace
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "prisoner-content-hub-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "sentence-planning-development"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.8"
 
   namespace = "sentence-planning-preprod"
 }


### PR DESCRIPTION
We've released a new version of the module, so all our existing deployments,
and the template file, need to be updated.

```
ag -l
"github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller.ref=0.0.7"
| xargs sed -i '' 's/ref=0.0.7/ref=0.0.8/'
```
