### PR TITLE
New Form Builder Submitter ECR repo

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -201,6 +201,30 @@ resource "kubernetes_secret" "ecr-repo-fb-submitter-worke" {
   }
 }
 
+module "ecr-repo-fb-submitter-workers" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
+
+  team_name = "formbuilder"
+  repo_name = "fb-submitter-workers"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "ecr-repo-fb-submitter-workers" {
+  metadata {
+    name      = "ecr-repo-fb-submitter-workers"
+    namespace = "formbuilder-repos"
+  }
+
+  data = {
+    repo_url          = module.ecr-repo-fb-submitter-workers.repo_url
+    access_key_id     = module.ecr-repo-fb-submitter-workers.access_key_id
+    secret_access_key = module.ecr-repo-fb-submitter-workers.secret_access_key
+  }
+}
+
 ##################################################
 
 # User Datastore ECR Repos


### PR DESCRIPTION
We have some inconsistencies with naming conventions across our platform. We predominantly use the plural 'workers'.

To try an address this we need a new ECR repo with the correct name. We will remove the old repo once we have transitioned to using the new one.