### PR TITLE
Add `--depth 1` to speed up sonarqube scanning

### DIFF
--- a/lib/cp_env/sonar_qube_scanner.rb
+++ b/lib/cp_env/sonar_qube_scanner.rb
@@ -37,7 +37,7 @@ class CpEnv
     end
 
     def checkout_repo(url)
-      system("GIT_TERMINAL_PROMPT=0 git clone #{url}")
+      system("GIT_TERMINAL_PROMPT=0 git clone --depth 1 #{url}")
       $?.success? # If the command failed then the reop is invalid, private or already cloned. Skip to next.
     end
 


### PR DESCRIPTION
We only need to scan the latest version of the code, so we can used `--depth 1` to avoid checking out the full history of every repo we scan.