### PR TITLE
Remove teams NLB

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.0"
-
-  namespace     = "manage-key-workers-prod"
-  is_production = var.is-production
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.0"
-
-  namespace     = var.namespace
-  is_production = var.is-production
-}


### PR DESCRIPTION
offender-categorisation-prod
manage-key-workers-prod

This is because we don't have AWS limit for NLB.

We will add this back once AWS increase then limit