### PR TITLE
Updated prod namespaces to use the latest nginx version

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
 
   namespace     = "digital-prison-services-prod"
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
 
   namespace     = "keyworker-api-prod"
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
 
   namespace     = "prison-data-compliance-prod"
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
 
   namespace     = "whereabouts-api-prod"
   is_production = var.is-production


### PR DESCRIPTION
This version got a fix to remove validation web hooks, which caused issue creating ingress when there is a issue with one of validationwebhooks

This 3 prod namespaces still using the default ingress-class
digital-prison-services-prod
keyworker-api-prod
whereabouts-api-prod

prison-data-compliance-prod namesapce, spoke to Jon Brighton, he is happy for the change to apply
