### PR TITLE
Remove ingress_controller in whereabouts-api-*

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/ingress.tf
@@ -1,5 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace = "whereabouts-api-dev"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/ingress.tf
@@ -1,5 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace = "whereabouts-api-preprod"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace     = "whereabouts-api-prod"
-  is_production = var.is-production
-}


### PR DESCRIPTION
We hit the limit of AWS NLB, we can add back once we get the limit increase

Pipeline failing with below reason

Command: cd namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources; terraform apply -auto-approve failed.

Error: timed out waiting for the condition

But actual issue from the events.

Error syncing load balancer: failed to ensure load balancer: error creating load balancer: "TooManyLoadBalancers: The maximum number of load balancers has been reached.

Spoke to Nevelina Aleksandrova , she is happy for them to be added back once we got the limit increase
