### PR TITLE
Remove nlb non usage

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.9"
-
-  namespace     = var.namespace
-  is_production = var.is_production
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.9"
-
-  namespace     = var.namespace
-  is_production = var.is_production
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace     = "davidread-dev"
-  is_production = var.is_production
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace     = "digital-prison-services-prod"
-  is_production = var.is-production
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace     = "keyworker-api-prod"
-  is_production = var.is-production
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/ingress.tf
@@ -1,5 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace = "manage-key-workers-dev"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/ingress.tf
@@ -1,5 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace = "manage-key-workers-preprod"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/ingress.tf
@@ -1,5 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace = "mogaal-test"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-development/resources/ingress.tf
@@ -1,5 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace = "oasys-keycloak-development"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.9"
-
-  namespace     = var.namespace
-  is_production = var.is_production
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.9"
-
-  namespace     = var.namespace
-  is_production = var.is_production
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/ingress.tf
@@ -1,5 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace = "sentence-planning-development"
-}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/ingress.tf
@@ -1,5 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
-
-  namespace = "sentence-planning-preprod"
-}


### PR DESCRIPTION
If users created a dedicated ingress controller, but not using it yet, this PR will delete it.
(to reduce the number of NLBs, which is a limited, shared resource)

Also Remove ingress controller for users not using it and enabled mod-security, as for ingresses where people need mod-security, we will create a pool of ingress controllers, and distribute ingresses so that no one ingress controller is handling more than N ingresses.