### PR TITLE
Add Dashboard to show pods per node

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/dashboard-pods-per-node.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/dashboard-pods-per-node.yaml
@@ -1,0 +1,165 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-pods-per-node
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "pods-per-node"
+data:
+  pods-per-node-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Display number of pods per Node in cluster.",
+      "editable": true,
+      "gnetId": 9766,
+      "graphTooltip": 0,
+      "id": 73,
+      "iteration": 1599588956317,
+      "links": [],
+      "panels": [
+        {
+          "datasource": null,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": null
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 105
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 30,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 18,
+          "links": [],
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "values": false
+            }
+          },
+          "pluginVersion": "7.0.2",
+          "targets": [
+            {
+              "expr": "avg(kube_node_status_allocatable_pods)",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Max Pods Per Node",
+              "refId": "D"
+            },
+            {
+              "expr": "sort_desc(sum by (instance) (kubelet_running_pod_count))",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Pod count {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Pods per node",
+          "type": "stat"
+        }
+      ],
+      "refresh": false,
+      "schemaVersion": 25,
+      "style": "dark",
+      "tags": [
+        "kubernetes"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "No data sources found",
+              "value": ""
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Cluster",
+            "multi": false,
+            "name": "source",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "/k8s/",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "Kubernetes Number of Pods per Node",
+      "uid": "anzGBBJHiz",
+      "version": 561
+    }


### PR DESCRIPTION
We have had a few alerts of "TooManyPods" on node recently. 
We have made a few changes to cleaning up completed pods.


This is a quick clean dashboard to show how many pods per node are running at any time, also showing the max pod count for info