### PR TITLE
Added labels for Prometheus split

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/prometheus.yml
@@ -18,6 +18,7 @@ metadata:
   namespace: c100-application-production
   labels:
     role: alert-rules
+    prometheus: cloud-platform
 spec:
   groups:
   - name: application-rules

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: check-my-diary-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: check-my-diary-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/prometheus-custom-alerts-ccic-dev.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/prometheus-custom-alerts-ccic-dev.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: claim-criminal-injuries-compensation-dev
   labels:
     role: alert-rules
+    prometheus: cloud-platform
   name: prometheus-custom-rules-data-dev
 spec:
   groups:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/prometheus-custom-alerts-ccic-prod.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/prometheus-custom-alerts-ccic-prod.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: claim-criminal-injuries-compensation-prod
   labels:
     role: alert-rules
+    prometheus: cloud-platform
   name: prometheus-custom-rules-data-prod
 spec:
   groups:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: digital-prison-services-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: digital-prison-services-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-toolkit/07-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-toolkit/07-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: dps-toolkit
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: dps-toolkit
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/prometheus-custom-rules-hmpps-book-a-secure-move-api.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/prometheus-custom-rules-hmpps-book-a-secure-move-api.yml
@@ -14,6 +14,7 @@ metadata:
   namespace: hmpps-book-secure-move-api-staging
   labels:
     role: alert-rules
+    prometheus: cloud-platform
 spec:
   groups:
   - name: application-rules

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: keyworker-api-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: keyworker-api-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: licences-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: licences-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/monitoring.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/monitoring.yaml
@@ -4,6 +4,8 @@ kind: PrometheusRule
 metadata:
   name: fluentd-es
   namespace: logging
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: fluentd

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: manage-hmpps-auth-accounts-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: manage-hmpps-auth-accounts-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: manage-key-workers-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: manage-key-workers-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: offender-case-notes-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: offender-case-notes-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: offender-categorisation-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: offender-categorisation-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: offender-events-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: offender-events-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/09-prometheus-sqs-sns.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/09-prometheus-sqs-sns.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: offender-events-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules-sqs
   namespace: offender-events-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/prometheus-custom-alerts-moic-preprod.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/prometheus-custom-alerts-moic-preprod.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: offender-management-alerting-preprod
   namespace: offender-management-preprod
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: moic-preprod

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/prometheus-custom-alerts-moic-production.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/prometheus-custom-alerts-moic-production.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: offender-management-alerting-production
   namespace: offender-management-production
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: moic-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/prometheus-custom-alerts-moic-staging.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/prometheus-custom-alerts-moic-staging.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: offender-management-alerting-staging
   namespace: offender-management-staging
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: moic-staging

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: pathfinder-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: pathfinder-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-api-certificates/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-api-certificates/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: prison-api-certificates
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: prison-api-certificates
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-api-certificates/30-cronjob-prometheus-alert.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-api-certificates/30-cronjob-prometheus-alert.yaml
@@ -4,6 +4,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: dps-cert-export-cronjob
+    prometheus: cloud-platform
   name: dps-cert-export-cronjob
 spec:
   groups:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: prison-data-compliance-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: prison-data-compliance-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: prison-estate-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: prison-estate-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-prod/07-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-prod/07-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: prison-to-nhs-update-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: prison-to-nhs-update-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-prod/07-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-prod/07-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: prison-to-probation-update-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: prison-to-probation-update-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/prometheus-custom-alerts-pvb-production.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/prometheus-custom-alerts-pvb-production.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: prison-visits-booking-alerting-production
   namespace: prison-visits-booking-production
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: pvb-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/prometheus-custom-alerts-pvb-staging.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/prometheus-custom-alerts-pvb-staging.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: prison-visits-booking-alerting-staging
   namespace: prison-visits-booking-staging
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: pvb-staging

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: prisoner-offender-search-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: prisoner-offender-search-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/09-prometheus-elastic-search.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/09-prometheus-elastic-search.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: prisoner-offender-search-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules-elasticsearch
   namespace: prisoner-offender-search-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/10-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/10-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: probation-offender-search-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: probation-offender-search-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/11-prometheus-elastic-search.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/11-prometheus-elastic-search.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: probation-offender-search-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules-elasticsearch
   namespace: probation-offender-search-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: token-verification-api-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: token-verification-api-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: use-of-force-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: use-of-force-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/08-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/08-prometheus.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: whereabouts-api-prod
+    prometheus: cloud-platform
   name: dps-prometheus-rules
   namespace: whereabouts-api-prod
 spec:


### PR DESCRIPTION
In order to tell Prometheus what to scrap and what to ignore we need to have labels everywhere.