### PR TITLE
Increase BaSM staging memory limit on pods

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 250m
-      memory: 500Mi
+      memory: 1000Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
this increases the memory limit from 500mb to 1gb, as we are having some memory issues on our staging system