### PR TITLE
Use HOODAW v2.19

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: how-out-of-date-are-we
-          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.18
+          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.19
           env:
             - name: RACK_ENV
               value: "production"


### PR DESCRIPTION
This adds the namespace costs page, as per:
https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/pull/46