### PR TITLE
Non-prod ingress-controller module upgrade

### DIFF
--- a/namespace-resources-cli-template/resources/ingress.tf
+++ b/namespace-resources-cli-template/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = var.namespace
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "case-notes-to-probation-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "case-notes-to-probation-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "check-my-diary-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "check-my-diary-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "court-probation-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "court-probation-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = "dps-toolkit"
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "dstest"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "hmpps-book-secure-move-api-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "hmpps-book-secure-move-api-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "hmpps-book-secure-move-api-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "hmpps-book-secure-move-api-uat"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "hmpps-book-secure-move-frontend-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "hmpps-book-secure-move-frontend-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "hmpps-book-secure-move-frontend-uat"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = var.namespace
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "manage-hmpps-auth-accounts-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "manage-hmpps-auth-accounts-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = "manage-soc-cases-dev"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = "manage-soc-cases-preprod"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "offender-case-notes-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "offender-case-notes-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = var.namespace
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "offender-events-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "offender-events-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = "pathfinder-dev"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = "pathfinder-preprod"
   is_production = var.is_production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prison-data-compliance-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prison-data-compliance-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prison-estate-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prison-estate-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prison-to-nhs-update-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prison-to-nhs-update-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prison-to-probation-update-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prison-to-probation-update-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prisoner-content-hub-development"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prisoner-content-hub-staging"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prisoner-offender-search-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "prisoner-offender-search-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "probation-offender-search-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "probation-offender-search-preprod"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "token-verification-api-dev"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "token-verification-api-preprod"
 }


### PR DESCRIPTION
This change upgrades the ingress-controller module
for non-production namespaces which were on v0.1.1
to v0.1.2

This change should not cause terraform to make any
changes.