### PR TITLE
Allow comma-sep. lists of URLs in "source-code"

### DIFF
--- a/lib/cp_env/sonar_qube_scanner.rb
+++ b/lib/cp_env/sonar_qube_scanner.rb
@@ -26,6 +26,9 @@ class CpEnv
     def repo_urls
       get_namespaces
         .map { |namespace| namespace.dig("metadata", "annotations", "cloud-platform.justice.gov.uk/source-code") }
+        .map { |str| str.to_s.split(",") }
+        .flatten
+        .map(&:strip)
         .compact
         .uniq
         .find_all { |url| REPO_REGEXP.match?(url) }


### PR DESCRIPTION
Prior to this change, only single, github repo. URLs would be considered
for sonarqube scanning. However, some namespaces have multiple
repositories they would like to be scanned (e.g. #3109), so this change
will allow comma-separated lists of github repo. URLs in the source-code
annotation.
