### PR TITLE
Remove `--depth 1` from `git clone` command

### DIFF
--- a/lib/cp_env/sonar_qube_scanner.rb
+++ b/lib/cp_env/sonar_qube_scanner.rb
@@ -40,7 +40,7 @@ class CpEnv
     end
 
     def checkout_repo(url)
-      system("GIT_TERMINAL_PROMPT=0 git clone --depth 1 #{url}")
+      system("GIT_TERMINAL_PROMPT=0 git clone #{url}")
       $?.success? # If the command failed then the reop is invalid, private or already cloned. Skip to next.
     end
 


### PR DESCRIPTION
Although using `--depth 1` makes the git checkout faster, it also means that sonarqube cannot supply any `git blame` information. You can see this in the logs:

```
WARN: Shallow clone detected, no blame information will be provided...
```

Since this job takes a long time to run anyway, adding a bit more time in order to have more information in the final reports seems like a worthwhile trade-off.