### PR TITLE
Add github repositories to namespace tags

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/00-namespace.yaml
@@ -9,4 +9,4 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "prisoner-content-hub"
     cloud-platform.justice.gov.uk/owner: "Prisoner Facing Services: thehub@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git,https://github.com/ministryofjustice/prisoner-content-hub-backend.git,https://github.com/ministryofjustice/prisoner-content-hub-frontend.git"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/00-namespace.yaml
@@ -9,4 +9,4 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "prisoner-content-hub"
     cloud-platform.justice.gov.uk/owner: "Prisoner Facing Services: thehub@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git,https://github.com/ministryofjustice/prisoner-content-hub-backend.git,https://github.com/ministryofjustice/prisoner-content-hub-frontend.git"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/00-namespace.yaml
@@ -9,4 +9,4 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "prisoner-content-hub"
     cloud-platform.justice.gov.uk/owner: "Prisoner Facing Services: thehub@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git,https://github.com/ministryofjustice/prisoner-content-hub-backend.git,https://github.com/ministryofjustice/prisoner-content-hub-frontend.git"


### PR DESCRIPTION
Adds frontend and backend service repositories, in order to enable Cloud Platform repository scanning. Both these components deploy into the same namespace.

Follows on from https://mojdt.slack.com/archives/C57UPMZLY/p1600162673012700?thread_ts=1600161581.012400&cid=C57UPMZLY