### PR TITLE
Fix dynamodb definition

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/resources/dynamodb.tf
@@ -10,7 +10,6 @@ module "hoodaw_dynamodb" {
   is-production          = "false"
 
   hash_key          = "filename"
-  range_key         = "filename"
   enable_encryption = "false"
   enable_autoscaler = "false"
   aws_region        = "eu-west-2"


### PR DESCRIPTION
Although plan was fine with the previous `dynamodb.tf` file, when
applied it resulted in this error:

```
Error: error creating DynamoDB Table: ValidationException: Invalid
KeySchema: Some index key attribute have no definition
        status code: 400, request id: XXX...
```

Removing the `range_key` line allowed `terraform apply ` to succeed.

NB: I have already applied this manually, so this PR is just to keep the
code in sync with the terraform state.
