### PR TITLE
Upgrade ingress-controller for prison-estate-prod and case-notes-to-probation-prod

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = "case-notes-to-probation-prod"
   is_production = var.is-production

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-prod/resources/ingress.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-estate-prod/resources/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace     = "prison-estate-prod"
   is_production = var.is-production


### PR DESCRIPTION
This is to get the ingress controller to use the upgraded version

Following this process to Zero-downtime Ingress Controller Upgrade
https://runbooks.cloud-platform.service.justice.gov.uk/zero-downtime-ingress-upgrade.html#zero-downtime-ingress-controller-upgrade