### PR TITLE
Add Form Builder Publisher pingdom check

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
@@ -9,6 +9,7 @@ locals {
     hmcts-complaints         = "complain-about-a-court-or-tribunal.form.service.justice.gov.uk",
     leavers-form             = "leavers.form.service.justice.gov.uk",
     let-us-know              = "let-us-know.form.service.justice.gov.uk",
+    publisher                = "fb-publisher-live.apps.live-1.cloud-platform.service.justice.gov.uk",
     report-security-incident = "report-security-incident.form.service.justice.gov.uk"
   }
   names = keys(local.forms)


### PR DESCRIPTION
This adds a Pingdom check for the Form Builder publisher in production