### PR TITLE
Set force_ssl: true  on cla_backend_rds instances

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -39,6 +39,15 @@ module "cla_backend_rds" {
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
 
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
+
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -39,14 +39,6 @@ module "cla_backend_rds" {
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
 
-  db_parameter = [
-    {
-      name         = "rds.force_ssl"
-      value        = "1"
-      apply_method = "pending-reboot"
-    }
-  ]
-
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
@@ -34,6 +34,15 @@ module "cla_backend_rds" {
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
 
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
+
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
@@ -34,6 +34,14 @@ module "cla_backend_rds" {
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
 
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london


### PR DESCRIPTION
Since we created the staging and production databases, the default value
of force_ssl has been changed to true, but with an apply_method that is
incompatible with our db engine. Therefore we need to respecify it. This
was stopping the db being created in our training namespace, but we
should specify it in the other two namespaces to avoid confusion

Hopefully I can get an exception to the single-namespace check here