### PR TITLE
Start adding Rego policies for namespaces

### DIFF
--- a/makefile
+++ b/makefile
@@ -47,4 +47,13 @@ tools-shell-in-cluster:
 		--env="AWS_DEFAULT_REGION=eu-west-2" \
 		bash
 
+
+### Conftest
+
+# Test all the kubernetes yaml files against all the policies defined in the `policy` directory
+conftest:
+	ls -1 namespaces/live-1.cloud-platform.service.justice.gov.uk/*/*.yaml \
+		| xargs -n 200 conftest test \
+		| grep FAIL
+
 .PHONY: pull-tools tools-shell tools-shell-in-cluster

--- a/makefile
+++ b/makefile
@@ -52,8 +52,6 @@ tools-shell-in-cluster:
 
 # Test all the kubernetes yaml files against all the policies defined in the `policy` directory
 conftest:
-	ls -1 namespaces/live-1.cloud-platform.service.justice.gov.uk/*/*.yaml \
-		| xargs -n 200 conftest test \
-		| grep FAIL
+	ls -1 namespaces/live-1.cloud-platform.service.justice.gov.uk/*/*.yaml | xargs -n 200 conftest test
 
-.PHONY: pull-tools tools-shell tools-shell-in-cluster
+.PHONY: pull-tools tools-shell tools-shell-in-cluster conftest

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-bots/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-bots/00-namespace.yaml
@@ -10,3 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Cloud Platform bots"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-slack-answerbot"
+    cloud-platform.justice.gov.uk/slack-channel: "cloud-platform"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/00-namespace.yaml
@@ -14,5 +14,5 @@ metadata:
     cloud-platform.justice.gov.uk/github_team: "formbuilder"
     cloud-platform.justice.gov.uk/namespace: "formbuilder-monitoring"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source_code_url: "https://github.com/ministryofjustice/fb-monitoring"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/fb-monitoring"
     cloud-platform.justice.gov.uk/slack-channel: "form-builder-alerts"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
@@ -2,7 +2,15 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-system
-  labels: 
+  labels:
     openpolicyagent.org/webhook: "ignore"
     component: kube-system
+    cloud-platform.justice.gov.uk/slack-channel: "cloud-platform"
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "Cloud Platform"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-infrastructure"
     cloud-platform.justice.gov.uk/slack-channel: "cloud-platform"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-api-certificates/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-api-certificates/00-namespace.yaml
@@ -13,3 +13,4 @@ metadata:
     cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts"
     cloud-platform.justice.gov.uk/slack-channel: "dps_tech_team"
     cloud-platform.justice.gov.uk/team-name: "dps-tech-team"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"

--- a/policy/namespace.rego
+++ b/policy/namespace.rego
@@ -4,88 +4,58 @@ package main
 
 # Annotations
 
+has_cp_annotation(annotation) {
+  cp_annotation := concat("/", ["cloud-platform.justice.gov.uk", annotation])
+  input.metadata.annotations[cp_annotation]
+  input.metadata.annotations[cp_annotation] != ""
+}
+
+has_cp_label(label) {
+  cp_label := concat("/", ["cloud-platform.justice.gov.uk", label])
+  input.metadata.labels[cp_label]
+  input.metadata.labels[cp_label] != ""
+}
+
 deny[msg] {
   input.kind == "Namespace"
-  not input.metadata.annotations["cloud-platform.justice.gov.uk/business-unit"]
+  not has_cp_annotation("business-unit")
   msg := "Namespace must have business-unit annotation"
 }
 
 deny[msg] {
   input.kind == "Namespace"
-  input.metadata.annotations["cloud-platform.justice.gov.uk/business-unit"] == ""
-  msg := "Namespace business-unit annotation must not be empty string"
-}
-
-deny[msg] {
-  input.kind == "Namespace"
-  not input.metadata.annotations["cloud-platform.justice.gov.uk/application"]
+  not has_cp_annotation("application")
   msg := "Namespace must have application annotation"
 }
 
 deny[msg] {
   input.kind == "Namespace"
-  input.metadata.annotations["cloud-platform.justice.gov.uk/application"] == ""
-  msg := "Namespace application annotation must not be empty string"
-}
-
-deny[msg] {
-  input.kind == "Namespace"
-  not input.metadata.annotations["cloud-platform.justice.gov.uk/owner"]
+  not has_cp_annotation("owner")
   msg := "Namespace must have owner annotation"
 }
 
 deny[msg] {
   input.kind == "Namespace"
-  input.metadata.annotations["cloud-platform.justice.gov.uk/owner"] == ""
-  msg := "Namespace owner annotation must not be empty string"
-}
-
-deny[msg] {
-  input.kind == "Namespace"
-  not input.metadata.annotations["cloud-platform.justice.gov.uk/source-code"]
+  not has_cp_annotation("source-code")
   msg := "Namespace must have source-code annotation"
 }
 
 deny[msg] {
   input.kind == "Namespace"
-  input.metadata.annotations["cloud-platform.justice.gov.uk/source-code"] == ""
-  msg := "Namespace source-code annotation must not be empty string"
-}
-
-deny[msg] {
-  input.kind == "Namespace"
-  not input.metadata.annotations["cloud-platform.justice.gov.uk/slack-channel"]
+  not has_cp_annotation("slack-channel")
   msg := "Namespace must have slack-channel annotation"
-}
-
-deny[msg] {
-  input.kind == "Namespace"
-  input.metadata.annotations["cloud-platform.justice.gov.uk/slack-channel"] == ""
-  msg := "Namespace slack-channel annotation must not be empty string"
 }
 
 # Labels
 
 deny[msg] {
   input.kind == "Namespace"
-  not input.metadata.labels["cloud-platform.justice.gov.uk/is-production"]
+  not has_cp_label("is-production")
   msg := "Namespace must have is-production label"
 }
 
 deny[msg] {
   input.kind == "Namespace"
-  input.metadata.labels["cloud-platform.justice.gov.uk/is-production"] == ""
-  msg := "Namespace is-production label must not be empty string"
-}
-
-deny[msg] {
-  input.kind == "Namespace"
-  not input.metadata.labels["cloud-platform.justice.gov.uk/environment-name"]
+  not has_cp_label("environment-name")
   msg := "Namespace must have environment-name label"
-}
-
-deny[msg] {
-  input.kind == "Namespace"
-  input.metadata.labels["cloud-platform.justice.gov.uk/environment-name"] == ""
-  msg := "Namespace environment-name label must not be empty string"
 }

--- a/policy/namespace.rego
+++ b/policy/namespace.rego
@@ -1,0 +1,50 @@
+package main
+
+# Policy definitions that all namespaces defined in this repository should comply with.
+
+# Annotations
+
+deny[msg] {
+  input.kind == "Namespace"
+  not input.metadata.annotations["cloud-platform.justice.gov.uk/business-unit"]
+  msg := "Namespace must have business-unit annotation"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
+  not input.metadata.annotations["cloud-platform.justice.gov.uk/application"]
+  msg := "Namespace must have application annotation"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
+  not input.metadata.annotations["cloud-platform.justice.gov.uk/owner"]
+  msg := "Namespace must have owner annotation"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
+  not input.metadata.annotations["cloud-platform.justice.gov.uk/source-code"]
+  msg := "Namespace must have source-code annotation"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
+  not input.metadata.annotations["cloud-platform.justice.gov.uk/slack-channel"]
+  msg := "Namespace must have slack-channel annotation"
+}
+
+# Labels
+
+deny[msg] {
+  input.kind == "Namespace"
+  not input.metadata.labels["cloud-platform.justice.gov.uk/is-production"]
+  msg := "Namespace must have is-production label"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
+  not input.metadata.labels["cloud-platform.justice.gov.uk/environment-name"]
+  msg := "Namespace must have environment-name label"
+}
+

--- a/policy/namespace.rego
+++ b/policy/namespace.rego
@@ -12,8 +12,20 @@ deny[msg] {
 
 deny[msg] {
   input.kind == "Namespace"
+  input.metadata.annotations["cloud-platform.justice.gov.uk/business-unit"] == ""
+  msg := "Namespace business-unit annotation must not be empty string"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
   not input.metadata.annotations["cloud-platform.justice.gov.uk/application"]
   msg := "Namespace must have application annotation"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
+  input.metadata.annotations["cloud-platform.justice.gov.uk/application"] == ""
+  msg := "Namespace application annotation must not be empty string"
 }
 
 deny[msg] {
@@ -24,14 +36,32 @@ deny[msg] {
 
 deny[msg] {
   input.kind == "Namespace"
+  input.metadata.annotations["cloud-platform.justice.gov.uk/owner"] == ""
+  msg := "Namespace owner annotation must not be empty string"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
   not input.metadata.annotations["cloud-platform.justice.gov.uk/source-code"]
   msg := "Namespace must have source-code annotation"
 }
 
 deny[msg] {
   input.kind == "Namespace"
+  input.metadata.annotations["cloud-platform.justice.gov.uk/source-code"] == ""
+  msg := "Namespace source-code annotation must not be empty string"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
   not input.metadata.annotations["cloud-platform.justice.gov.uk/slack-channel"]
   msg := "Namespace must have slack-channel annotation"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
+  input.metadata.annotations["cloud-platform.justice.gov.uk/slack-channel"] == ""
+  msg := "Namespace slack-channel annotation must not be empty string"
 }
 
 # Labels
@@ -44,7 +74,18 @@ deny[msg] {
 
 deny[msg] {
   input.kind == "Namespace"
+  input.metadata.labels["cloud-platform.justice.gov.uk/is-production"] == ""
+  msg := "Namespace is-production label must not be empty string"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
   not input.metadata.labels["cloud-platform.justice.gov.uk/environment-name"]
   msg := "Namespace must have environment-name label"
 }
 
+deny[msg] {
+  input.kind == "Namespace"
+  input.metadata.labels["cloud-platform.justice.gov.uk/environment-name"] == ""
+  msg := "Namespace environment-name label must not be empty string"
+}


### PR DESCRIPTION
This change adds a `policy` directory to hold
rego files defining rules all namespaces should
comply with, and a makefile target that tests all
the yaml files in the repo against all of the
policies in that directory.

Initially, this only covers required annotations
and labels for Namespace definitions.

Later changes should add more rules for more
objects, and a github action to apply our policies
to any PRs raised.