### PR TITLE
Form Builder - Remove old HMCTS adapter repo

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -377,54 +377,6 @@ resource "kubernetes_secret" "ecr-repo-fb-base-adapter" {
 
 ##################################################
 
-module "ecr-repo-fb-hmcts-complaints-adapter-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
-
-  team_name = "formbuilder"
-  repo_name = "ecr-repo-fb-hmcts-complaints-adapter-api"
-
-  providers = {
-    aws = aws.london
-  }
-}
-
-resource "kubernetes_secret" "ecr-repo-fb-hmcts-complaints-adapter-api" {
-  metadata {
-    name      = "ecr-repo-fb-hmcts-complaints-adapter-api"
-    namespace = "formbuilder-repos"
-  }
-
-  data = {
-    repo_url          = module.ecr-repo-fb-hmcts-complaints-adapter-api.repo_url
-    access_key_id     = module.ecr-repo-fb-hmcts-complaints-adapter-api.access_key_id
-    secret_access_key = module.ecr-repo-fb-hmcts-complaints-adapter-api.secret_access_key
-  }
-}
-
-module "ecr-repo-fb-hmcts-complaints-adapter-workers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
-
-  team_name = "formbuilder"
-  repo_name = "ecr-repo-fb-hmcts-complaints-adapter-workers"
-
-  providers = {
-    aws = aws.london
-  }
-}
-
-resource "kubernetes_secret" "ecr-repo-fb-hmcts-complaints-adapter-workers" {
-  metadata {
-    name      = "ecr-repo-fb-hmcts-complaints-adapter-workers"
-    namespace = "formbuilder-repos"
-  }
-
-  data = {
-    repo_url          = module.ecr-repo-fb-hmcts-complaints-adapter-workers.repo_url
-    access_key_id     = module.ecr-repo-fb-hmcts-complaints-adapter-workers.access_key_id
-    secret_access_key = module.ecr-repo-fb-hmcts-complaints-adapter-workers.secret_access_key
-  }
-}
-
 module "ecr-repo-hmcts-complaints-formbuilder-adapter-api" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
 


### PR DESCRIPTION
We have now migrated to using the new ECR repos so these can be deleted.

https://trello.com/c/TuaqBFCp/944-adjust-hmcts-complaints-adapter-deployment