### PR TITLE
Comment out the S3 bucket resource

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/s3.tf
@@ -1,6 +1,10 @@
 /*
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
+
+/* COMMENTING OUT TO FIX THE APPLY PIPELINE
+https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-live-1/builds/1191
+
 module "calculate_journey_payments_s3_bucket" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
 
@@ -110,3 +114,6 @@ resource "kubernetes_secret" "calculate_journey_payments_s3_bucket" {
     bucket_name       = module.calculate_journey_payments_s3_bucket.bucket_name
   }
 }
+     
+*/
+


### PR DESCRIPTION
The apply pipeline is complaining about a  malformed policy.
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-live-1/builds/1191

I'm commenting this out to fix the pipeline.