### PR TITLE
Add configmaps access for cccd-dev-lgfs circleci service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "configmaps"
     verbs:
       - "patch"
       - "get"


### PR DESCRIPTION
Add configmaps access for cccd-dev-lgfs circleci service account

Want to use configmaps as part of deploy to avoid
repetition between app and worker pods