### PR TITLE
AR-301: Add certificate and DNS entry for manage-intelligence-api-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/07-certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/07-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: manage-intelligence-api-dev.hmpps.service.justice.gov.uk
+  namespace: manage-intelligence-dev
+spec:
+  secretName: manage-intelligence-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - manage-intelligence-api-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
An API service will share the same namespace as the manage-intelligence service.
This creates a certificate file and DNS entry for the API.