### PR TITLE
Grant configmap resource access to all cccd circleci service accounts

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "configmaps"
     verbs:
       - "patch"
       - "get"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "configmaps"
     verbs:
       - "patch"
       - "get"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "configmaps"
     verbs:
       - "patch"
       - "get"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "configmaps"
     verbs:
       - "patch"
       - "get"


### PR DESCRIPTION
Grant configmap resource access to all cccd circleci service accounts

To enable sharing of common config between app
and worker pods
