### PR TITLE
Restrict business unit

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Apply to court about child arrangements - Metabase"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/c100-application"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Apply to court about child arrangements"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/c100-application"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Apply to court about child arrangements"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/c100-application"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "api-sandbox"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa-get-paid"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "cccd"
     cloud-platform.justice.gov.uk/owner: "Joel Sugarman: joel.sugarman@digital.justice.gov.uk: crowncourtdefence@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev-lgfs"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa-get-paid"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "cccd"
     cloud-platform.justice.gov.uk/owner: "laa-get-paid: crowncourtdefence@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa-get-paid"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "cccd"
     cloud-platform.justice.gov.uk/owner: "laa-get-paid: crowncourtdefence@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "legal-aid-agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "cccd"
     cloud-platform.justice.gov.uk/owner: "LAA get paid team: crowncourtdefence@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa-get-paid"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "cccd"
     cloud-platform.justice.gov.uk/owner: "laa-get-paid: crowncourtdefence@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "check-financial-eligibility"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk: apply@digital.justice.gov.uk: apply@digtal.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/check-financial-eligibility"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "check-financial-eligibility"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk: apply@digital.justice.gov.uk: apply@digtal.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/check-financial-eligibility"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "uat"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "check-financial-eligibility"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk: apply@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/check-financial-eligibility"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "testing"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "cica"
+    cloud-platform.justice.gov.uk/business-unit: "CICA"
     cloud-platform.justice.gov.uk/application: "cica-oas-datacapture-test"
     cloud-platform.justice.gov.uk/owner: "Daniel Thornton: daniel.thornton@informed.com"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service.git"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "cica"
+    cloud-platform.justice.gov.uk/business-unit: "CICA"
     cloud-platform.justice.gov.uk/application: "data-capture-service"
     cloud-platform.justice.gov.uk/owner: "cica: infrastructure@cica.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/pkpaulk/claim-criminal-injuries-compensation-staging"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-bots/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-bots/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "Cloud Platform bots"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-slack-answerbot"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "HMCTS Common Platform Connector"
     cloud-platform.justice.gov.uk/owner: "Crime Apps: laa@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-common-platform-connector"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Contact MOJ"
     cloud-platform.justice.gov.uk/owner: "Staff Tools and Services: staffservices@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/correspondence_tool_public"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Contact MOJ"
     cloud-platform.justice.gov.uk/owner: "Staff Tools and Services: staffservices@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/correspondence_tool_public"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Contact MOJ"
     cloud-platform.justice.gov.uk/owner: "Staff Tools and Services: staffservices@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/correspondence_tool_public"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "correspondence-staff"
     cloud-platform.justice.gov.uk/owner: "Correspondence Team: mohammed.seedat@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/correspondence_tool_staff"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cp-terraform-module-testing/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "Development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "MOJ Digital"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "cloud-platform-terraform-aws-module"
     cloud-platform.justice.gov.uk/owner: "Cloud platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "cts-prototype-dev"
     cloud-platform.justice.gov.uk/owner: "Development: mohammed.seedat@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/correspondence_tool_staff/"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Check if you need to disclose your criminal record"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/disclosure-checker"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Check if you need to disclose your criminal record"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/disclosure-checker"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Estates"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Estates Database"
     cloud-platform.justice.gov.uk/owner: "Programmes and Portfolios: matthew.stainsby@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/estatesprojects.git"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Family Mediators API"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/family-mediators-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Family Mediators API"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/family-mediators-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Get help with child arrangements"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pflr-cait"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Family Justice"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "Get help with child arrangements"
     cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pflr-cait"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Form Builder Base Adapter API Endpoint"
     cloud-platform.justice.gov.uk/owner: "Form Builder: form-builder-developers@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/fb-base-adapter"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
     cloud-platform.justice.gov.uk/application: "formbuilder-monitoring"
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/contact_email: "formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/environment: "dev"
     cloud-platform.justice.gov.uk/github_team: "formbuilder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "live-dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-platform"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "live-production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-platform"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "test-dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-platform"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "test-production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-platform"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "prod"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Formbuilder Product Page"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/formBuilder-product-page"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Formbuilder Product Page"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/formBuilder-product-page"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "live"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-publisher"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/fb-publisher"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "test"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-publisher"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/fb-publisher"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/00-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "repos"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "live-dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-services"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "live-production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-services"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "test-dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-services"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/00-namespace.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "test-production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "formbuilder-services"
     cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-submit-product-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-submit-product-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "transformed-department"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "submit-product"
     cloud-platform.justice.gov.uk/owner: "Form Builder: form-builder-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/moj-form-builder-product-prototype"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Crime Apps"
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
     cloud-platform.justice.gov.uk/application: "HMCTS Mock API"
     cloud-platform.justice.gov.uk/owner: "Crime Apps: laa@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmcts-common-platform-mock-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "preprod"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "uat"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-api"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-api"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "preprod"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-frontend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-frontend"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-frontend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-frontend"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-frontend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-frontend"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "uat"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "hmpps-book-secure-move-frontend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-secure-move-frontend"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "Cloud Platform How Out Of Date Are We"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "Development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "MOJ DIGITAL"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "Jason-lab"
     cloud-platform.justice.gov.uk/owner: "Cloud-Platforms: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/jasonBirchall/ruby-reference-app"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "Cloud Platform"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-infrastructure"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "LAA Apply slack bot"
     cloud-platform.justice.gov.uk/owner: "Apply: apply@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "uat"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
     cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-aws-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-aws-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "LAA Development Environment"
     cloud-platform.justice.gov.uk/owner: "LAA AWS Development: laa-role-sre@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/orgs/ministryofjustice/teams/laa-aws-infrastructure"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "laa-court-data-adaptor"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "Crime Apps Team: laa-crime-apps@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "LAA Court Data Adaptor"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "LAA Crime Apps Team: laa-crime-apps@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "LAA Court Data Adaptor"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "LAA Crime Apps Team: laa-crime-apps@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "test"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "LAA Court Data Adaptor"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "LAA Crime Apps Team: laa-crime-apps@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "uat"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "LAA Court Data Adaptor"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "LAA Crime Apps Team: laa-crime-apps@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "legal-aid-agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "View court data"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "legal-aid-agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "View court data"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "legal-aid-agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "View court data"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "uat"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "legal-aid-agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "View court data"
     cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
     cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa-get-paid"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "LAA Fee Calculator"
     cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-fee-calculator"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "legal-aid-agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "LAA Fee Calculator"
     cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-fee-calculator"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "laa-get-paid"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "LAA Fee Calculator"
     cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-fee-calculator"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-get-access-service-improvement/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "team"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Legal Aid Agency"
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "laa-get-access-service-improvement"
     cloud-platform.justice.gov.uk/owner: "LAA Get Access Service Improvement: get-access-service-improvement@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "none"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/markberridge-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/markberridge-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "markberridge-dev-bu"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "markberridge-dev-app"
     cloud-platform.justice.gov.uk/owner: "Mark Berridge: mark.berridge@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "git@github.com:ministryofjustice/cloud-platform-reference-app.git"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/matttei-wordpress-av-demo/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/matttei-wordpress-av-demo/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "CentralDigital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Wordpress Antivirus Microservice Demo"
     cloud-platform.justice.gov.uk/owner: "Justice on the Web: matt.tei@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/mattempty/wp-av"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/00-namespace.yaml
@@ -6,9 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/slack-channel: "#cloud-platform"
     cloud-platform.justice.gov.uk/application: "Test Nginx Ingress"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platform@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller"
-    cloud-platform.justice.gov.uk/team-name: "webops" 
+    cloud-platform.justice.gov.uk/team-name: "webops"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/00-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "Monitoring"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Parliamentary Branch"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Parliamentary Questions Tracker"
     cloud-platform.justice.gov.uk/owner: "Tactical Products Team: pqsupport@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/parliamentary-questions"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Parliamentary Branch"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Parliamentary Questions Tracker"
     cloud-platform.justice.gov.uk/owner: "Tactical Products Team: pqsupport@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/parliamentary-questions"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Parliamentary Branch"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Parliamentary Questions Tracker"
     cloud-platform.justice.gov.uk/owner: "Tactical Products Team: pqsupport@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/parliamentary-questions"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pecs-move-platform-backend-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Digital and Technology"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "pecs-move-platform-backend"
     cloud-platform.justice.gov.uk/owner: "bookasecuremove@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pecs-move-platform-backend"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "demo"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "PeopleFinder"
     cloud-platform.justice.gov.uk/owner: "Staff Tools and Services: people-finder-support@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/peoplefinder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "PeopleFinder"
     cloud-platform.justice.gov.uk/owner: "Staff Tools and Services: people-finder-support@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/peoplefinder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "People Finder"
     cloud-platform.justice.gov.uk/owner: "Staff Tools and Services: people-finder-support@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/peoplefinder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "PeopleFinder"
     cloud-platform.justice.gov.uk/owner: "Staff Tools and Services: people-finder-support@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/peoplefinder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Cloud Platform"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "poornima-test-application"
     cloud-platform.justice.gov.uk/owner: "Poornima Krishnasamy: poornima.krishnasamy@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-multi-container-demo-app"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Cloud Platform"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "poornima-test-application"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/poornima-moj/wordpressapp"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-prod/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Cloud Platform"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "probation route53"
     cloud-platform.justice.gov.uk/owner: "webops: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "n/a"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/shared-test-zone/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/shared-test-zone/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "webops"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/slack-channel: "${slack-channel}"
     cloud-platform.justice.gov.uk/application: "test cluster"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sheffield-demo/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sheffield-demo/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "dev"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "sheffield-demo"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "dummy"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/support-labelling-webhook/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/support-labelling-webhook/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "prod"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "MOJ Digital"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/application: "support-labelling-webhook"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-support-labelling-webhook/"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "demo"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/slack-channel: "staff-services-tech"
     cloud-platform.justice.gov.uk/application: "Track a Query"
     cloud-platform.justice.gov.uk/owner: "Staff Services: correspondence-support@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/slack-channel: "staff-services-tech"
     cloud-platform.justice.gov.uk/application: "Track a Query"
     cloud-platform.justice.gov.uk/owner: "Staff Services: correspondence-support@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/slack-channel: "staff-services-tech"
     cloud-platform.justice.gov.uk/application: "Track a Query"
     cloud-platform.justice.gov.uk/owner: "Staff Services: correspondence-support@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "qa"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/slack-channel: "staff-services-tech"
     cloud-platform.justice.gov.uk/application: "Track a Query"
     cloud-platform.justice.gov.uk/owner: "Staff Services: correspondence-support@digital.justice.gov.uk"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Central Digital"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/slack-channel: "staff-services-tech"
     cloud-platform.justice.gov.uk/application: "Track a Query"
     cloud-platform.justice.gov.uk/owner: "Staff Services: correspondence-support@digital.justice.gov.uk"

--- a/policy/namespace.rego
+++ b/policy/namespace.rego
@@ -2,6 +2,16 @@ package main
 
 # Policy definitions that all namespaces defined in this repository should comply with.
 
+allowed_business_units := [
+  "CICA",
+  "HMCTS",
+  "HMPPS",
+  "HQ",
+  "LAA",
+  "OPG",
+  "Platforms"
+]
+
 # Annotations
 
 has_cp_annotation(annotation) {
@@ -20,6 +30,13 @@ deny[msg] {
   input.kind == "Namespace"
   not has_cp_annotation("business-unit")
   msg := "Namespace must have business-unit annotation"
+}
+
+deny[msg] {
+  input.kind == "Namespace"
+  annotation := input.metadata.annotations["cloud-platform.justice.gov.uk/business-unit"]
+  not array_contains(allowed_business_units, annotation)
+  msg := sprintf("Invalid business-unit annotation: %s", [annotation])
 }
 
 deny[msg] {

--- a/policy/namespace_test.rego
+++ b/policy/namespace_test.rego
@@ -1,0 +1,16 @@
+package main
+
+test_deny_invalid_busines_unit {
+  msg := "Invalid business-unit annotation: invalid-business-unit"
+
+  bad_business_unit := {
+    "kind": "Namespace",
+    "metadata": {
+      "annotations": {
+        "cloud-platform.justice.gov.uk/business-unit": "invalid-business-unit",
+      }
+    }
+  }
+
+  deny[msg] with input as bad_business_unit
+}

--- a/policy/utils.rego
+++ b/policy/utils.rego
@@ -1,0 +1,5 @@
+package main
+
+array_contains(arr, elem) {
+  arr[_] = elem
+}


### PR DESCRIPTION
* Set the `business-unit` annotation to the correct value in all namespaces which have a value that is not in the [approved list]
* Add a rego policy which will reject any namespace definitions where the `business-unit` annotation does not have a value from the [approved list]

[approved list]: https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tags-you-should-use