### PR TITLE
Add Pingdom to prisoner-content-hub-production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/pingdom.tf
@@ -1,0 +1,30 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "prisoner-content-hub-production-checks" {
+  for_each = {
+    drupal-cms  = "manage.content-hub.prisoner.service.justice.gov.uk",
+    berwyn      = "berwyn.content-hub.prisoner.service.justice.gov.uk",
+    cookhamwood = "cookhamwood.content-hub.prisoner.service.justice.gov.uk",
+    wayland     = "wayland.content-hub.prisoner.service.justice.gov.uk",
+  }
+
+  type                     = "http"
+  name                     = "Prisoner Content Hub Production ${each.key}"
+  host                     = "https://health-kick.prison.service.justice.gov.uk/https/${each.value}"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_${var.business-unit},application_${var.application},component_healthcheck,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_${var.infrastructure-support}"
+  probefilters             = "region:EU"
+  publicreport             = "true"
+
+  integrationids = [
+    106307 # #pfs_dev channel
+    # 106310, # #pfs_alerts channel
+  ]
+}


### PR DESCRIPTION
As far as I'm aware this should add the relevant check to each endpoint using health-kick to return the results.

We also have a previous integration id for #pfs_dev.