### PR TITLE
Add Cert Manager API Group to HMPPS EMS Prod Service Account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/05-serviceaccount.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/05-serviceaccount.yaml
@@ -39,6 +39,16 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+    - "cert-manager.io"
+    resources:
+      - "certificates"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
Adds cert-manager.io API group to github-actions RBAC role 

#3384 