### PR TITLE
Remove hyphenated variables

### DIFF
--- a/namespace-resources-cli-template/resources/variables.tf
+++ b/namespace-resources-cli-template/resources/variables.tf
@@ -42,32 +42,3 @@ variable "slack_channel" {
   description = "Team slack channel to use if we need to contact your team"
   default     = "{{ .SlackChannel }}"
 }
-
-# DEPRECATED: snake-case variables are the default. The definitions below
-# have been left in place until all code has been updated to use snake-case
-# variable names.
-
-variable "business-unit" {
-  description = "Area of the MOJ responsible for the service."
-  default     = "{{ .BusinessUnit }}"
-}
-
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "{{ .GithubTeam }}"
-}
-
-variable "infrastructure-support" {
-  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "{{ .InfrastructureSupport }}"
-}
-
-variable "is-production" {
-  default = "{{ .IsProduction }}"
-}
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "{{ .SlackChannel }}"
-}
-


### PR DESCRIPTION
This change removes the hyphenated (`foo-bar` vs. `foo_bar`) versions of terraform variables in the namespace template.

This probably means that, for new namespaces, we will encounter problems where our modules are expecting hyphenated variables. Spotting these failures in new namespaces is probably the least disruptive way to ensure that we do actually get around to fixing our modules, as per the [ADR]

[ADR]: https://github.com/ministryofjustice/cloud-platform/blob/main/architecture-decision-record/017-Variable-Naming.md#variable-names-in-yaml--terraform-files-are-in-snake-case