### PR TITLE
Update SES IAM Policy

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/iam.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/iam.tf
@@ -15,6 +15,14 @@ data "aws_iam_policy_document" "grafana_platform" {
 resource "aws_iam_user" "grafana_platform" {
   name = "hmpps-ems-prod-grafana-platform"
   path = "/cloud-platform/hmpps-ems-prod/"
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
 }
 
 resource "aws_iam_user_policy" "grafana_platform" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/iam.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/iam.tf
@@ -3,7 +3,7 @@ data "aws_iam_policy_document" "grafana_platform" {
     sid       = "AWSSESSendEmail"
     effect    = "Allow"
     actions   = ["ses:SendEmail", "ses:SendRawEmail"]
-    resources = [aws_ses_domain_identity.grafana_platform.arn]
+    resources = ["*"]
     condition {
       test     = "StringEquals"
       variable = "ses:FromAddress"


### PR DESCRIPTION
To fix
```
t=2020-10-01T15:16:03+0000 lvl=eror msg="Failed to send alert notification email" logger=alerting.notifier.email error="Failed to send notification to email addresses: jacob.woffenden@digital.justice.gov.uk: gomail: could not send email 1: 554 Access denied: User `arn:aws:iam::754256621582:user/cloud-platform/hmpps-ems-prod/hmpps-ems-prod-grafana-platform' is not authorized to perform `ses:SendRawEmail' on resource `arn:aws:ses:eu-west-2:754256621582:identity/jacob.woffenden@digital.justice.gov.uk'"
```