### PR TITLE
Update annotations in all UCPD namespaces

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Apply to court about child arrangements - Metabase"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/c100-application"
-    cloud-platform.justice.gov.uk/slack-channel: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
-    cloud-platform.justice.gov.uk/application: "Apply to court about child arrangements"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "Apply to court about child arrangements (C100)"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/c100-application"
-    cloud-platform.justice.gov.uk/slack-channel: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
-    cloud-platform.justice.gov.uk/application: "Apply to court about child arrangements"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "Apply to court about child arrangements (C100)"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/c100-application"
-    cloud-platform.justice.gov.uk/slack-channel: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
-    cloud-platform.justice.gov.uk/application: "Check if you need to disclose your criminal record"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "Check when to disclose cautions or convictions"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/disclosure-checker"
-    cloud-platform.justice.gov.uk/slack-channel: "disclosure-checker"
+    cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
-    cloud-platform.justice.gov.uk/application: "Check if you need to disclose your criminal record"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "Check when to disclose cautions or convictions"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/disclosure-checker"
-    cloud-platform.justice.gov.uk/slack-channel: "disclosure-checker"
+    cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Family Mediators API"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/family-mediators-api"
     cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Family Mediators API"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/family-mediators-api"
     cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Get help with child arrangements"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pflr-cait"
     cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/00-namespace.yaml
@@ -6,8 +6,9 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Get help with child arrangements"
-    cloud-platform.justice.gov.uk/owner: "Family Justice: family-justice-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "UCPD Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pflr-cait"
     cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"


### PR DESCRIPTION
As per conversation in:
https://mojdt.slack.com/archives/C57UPMZLY/p1601638362184400

This PR reassign the business-unit to "HQ" and updates some other outdated or incorrect annotations. Also add the missing `team-name` annotation to all namespaces.

We are aware our team name (from github) is the old one and should be updated too, but that will have to wait as it involves changing a lot more files and re-authenticate to the cluster.