### PR TITLE
Enable watch verb on cccd-dev-lgfs 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/serviceaccount-circleci.yaml
@@ -26,6 +26,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -35,6 +36,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"


### PR DESCRIPTION
Attempting to watch a rollout during deploy but receiving this
error:

```
Waiting for deployment "claim-for-crown-court-defence" rollout to finish: 2 old replicas are pending termination...
Error from server (Forbidden): unknown (get deployments.apps)
```

Hoping this resolves it?!