### PR TITLE
Upadted ingresses, certs and R53 zones for maintenance pages

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/certificate.yaml
@@ -1,25 +1,31 @@
-apiVersion: cert-manager.io/v1alpha3
-kind: Certificate
-metadata:
-  name: maintenance-pages-cert
-  namespace: maintenance-pages
-spec:
-  secretName: maintenance-pages-cert-secret
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
-  - maintenance-pages-demo.apps.live-1.cloud-platform.service.justice.gov.uk
 ---
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: administrativeappeals-cert
+  name: domains-cert
   namespace: maintenance-pages
 spec:
-  secretName: administrativeappeals-secret
+  secretName: domains-secret
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+  - adminappeals.reports.tribunals.gov.uk
   - administrativeappeals.decisions.tribunals.gov.uk
+  - carestandards.decisions.tribunals.gov.uk
+  - charity.decisions.tribunals.gov.uk
+  - cicap.decisions.tribunals.gov.uk
+  - claimsmanagement.decisions.tribunals.gov.uk
+  - consumercreditappeals.decisions.tribunals.gov.uk
+  - employmentappeals.decisions.tribunals.gov.uk
+  - estateagentappeals.decisions.tribunals.gov.uk
+  - financeandtax.decisions.tribunals.gov.uk
+  - immigrationservices.decisions.tribunals.gov.uk
+  - informationrights.decisions.tribunals.gov.uk
+  - landregistrationdivision.decisions.tribunals.gov.uk
+  - landschamber.decisions.tribunals.gov.uk
+  - phl.decisions.tribunals.gov.uk
+  - siac.decisions.tribunals.gov.uk
+  - sscs.venues.tribunals.gov.uk
+  - tax.decisions.tribunals.gov.uk
+  - transportappeals.decisions.tribunals.gov.uk

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/ingress.yaml
@@ -1,31 +1,23 @@
+---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: maintenance-pages-ingress
+  name: domains-ingress
 spec:
   tls:
   - hosts:
-    - maintenance-pages-demo.apps.live-1.cloud-platform.service.justice.gov.uk
-    secretName: maintenance-pages-cert-secret
+    - "*.decisions.tribunals.gov.uk"
+    - "*.reports.tribunals.gov.uk"
+    - "*.venues.tribunals.gov.uk"
+    secretName: domains-secret
   rules:
-  - host: maintenance-pages-demo.apps.live-1.cloud-platform.service.justice.gov.uk
+  - host: adminappeals.reports.tribunals.gov.uk
     http:
       paths:
       - path: /
         backend:
           serviceName: maintenance-pages-service
           servicePort: 4567
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: administrativeappeals-ingress
-spec:
-  tls:
-  - hosts:
-    - administrativeappeals.decisions.tribunals.gov.uk
-    secretName: administrativeappeals-secret
-  rules:
   - host: administrativeappeals.decisions.tribunals.gov.uk
     http:
       paths:
@@ -33,4 +25,129 @@ spec:
         backend:
           serviceName: maintenance-pages-service
           servicePort: 4567
- 
+  - host: carestandards.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: charity.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: cicap.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: claimsmanagement.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: consumercreditappeals.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: employmentappeals.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: estateagentappeals.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: financeandtax.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: immigrationservices.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: informationrights.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: landregistrationdivision.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: landschamber.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: maintenance-pages-demo.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: phl.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: siac.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: sscs.venues.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: tax.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567
+  - host: transportappeals.decisions.tribunals.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: maintenance-pages-service
+          servicePort: 4567

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/route53.tf
@@ -1,17 +1,3 @@
-resource "aws_route53_zone" "tribunals" {
-
-  name = "tribunals.gov.uk"
-
-  tags = {
-    business-unit          = "webops"
-    application            = "maintenance-pages"
-    is-production          = "true"
-    environment-name       = "production"
-    owner                  = "webops"
-    infrastructure-support = "platforms@digital.service.justice.gov.uk"
-  }
-}
-
 resource "aws_route53_zone" "legacy" {
   count = length(var.domains)
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/route53.tf
@@ -12,16 +12,3 @@ resource "aws_route53_zone" "legacy" {
     infrastructure-support = "platforms@digital.service.justice.gov.uk"
   }
 }
-
-
-resource "kubernetes_secret" "tribunals_zone_sec" {
-  metadata {
-    name      = "route53"
-    namespace = "maintenance-pages"
-  }
-
-  data = {
-    zone_id = aws_route53_zone.tribunals.zone_id
-  }
-}
-


### PR DESCRIPTION
The formula that worked : 

- One route53 zone per domain ( it seems we can't skip a parent when delegating) + 1:1 delegation

- No wildcard cert for domain whose parent we don't control. ( *.decisions)

- One broken or unresolvable domain prevents the whole cert from being  validated, that domain was skipped.

