### PR TITLE
Add "watch" permission to serviceaccount template

### DIFF
--- a/namespace-resources-cli-template/05-serviceaccount.yaml
+++ b/namespace-resources-cli-template/05-serviceaccount.yaml
@@ -25,6 +25,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -38,6 +39,7 @@ rules:
       - "delete"
       - "create"
       - "patch"
+      - "watch"
 
 ---
 kind: RoleBinding

--- a/namespace-resources-cli-template/05-serviceaccount.yaml
+++ b/namespace-resources-cli-template/05-serviceaccount.yaml
@@ -39,6 +39,7 @@ rules:
       - "delete"
       - "create"
       - "patch"
+      - "list"
       - "watch"
 
 ---


### PR DESCRIPTION
see #3424 

Adding this permission should allow users/pipelines to continually monitor status as they deploy their services.