### PR TITLE
Add watch and list verb privileges for all cccd ns serviceaccounts

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/serviceaccount-circleci.yaml
@@ -26,6 +26,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -35,6 +36,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/serviceaccount-circleci.yaml
@@ -26,6 +26,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -35,6 +36,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/serviceaccount-circleci.yaml
@@ -26,6 +26,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -35,6 +36,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/serviceaccount-circleci.yaml
@@ -26,6 +26,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -35,6 +36,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"


### PR DESCRIPTION
Add watch and list verb privileges for all cccd namespace circleci serviceaccounts

To enable watching a deployment rollout and fail with timeout 
if pods not replaced.