### PR TITLE
Add watch and list verb privileges for all VCD namespace circleci serviceaccounts

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/serviceaccount-circleci.yaml
@@ -25,6 +25,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -34,6 +35,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/serviceaccount-circleci.yaml
@@ -25,6 +25,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -34,6 +35,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/serviceaccount-circleci.yaml
@@ -25,6 +25,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -34,6 +35,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/serviceaccount-circleci.yaml
@@ -25,6 +25,7 @@ rules:
       - "create"
       - "delete"
       - "list"
+      - "watch"
   - apiGroups:
       - "extensions"
       - "apps"
@@ -34,6 +35,8 @@ rules:
       - "ingresses"
     verbs:
       - "get"
+      - "list"
+      - "watch"
       - "update"
       - "delete"
       - "create"


### PR DESCRIPTION
Add watch and list verb privileges for all VCD namespace circleci serviceaccounts

To enable watching a deployment rollout and fail with timeout
if pods not replaced.