### PR TITLE
Remove minor version number from RDS instances

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
@@ -11,7 +11,7 @@ module "submitter-rds-instance" {
   infrastructure-support     = var.infrastructure-support
   team_name                  = var.team_name
 
-  db_engine_version = "10.9"
+  db_engine_version = "10"
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
@@ -11,7 +11,7 @@ module "submitter-rds-instance" {
   infrastructure-support     = var.infrastructure-support
   team_name                  = var.team_name
 
-  db_engine_version = "10"
+  db_engine_version = "10.13"
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -11,7 +11,7 @@ module "user-datastore-rds-instance" {
   infrastructure-support     = var.infrastructure-support
   team_name                  = var.team_name
 
-  db_engine_version = "10.9"
+  db_engine_version = "10"
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -11,7 +11,7 @@ module "user-datastore-rds-instance" {
   infrastructure-support     = var.infrastructure-support
   team_name                  = var.team_name
 
-  db_engine_version = "10"
+  db_engine_version = "10.13"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
These RDS instances have "auto minor upgrade" enabled. This causes
problems when the minor version of the AWS instances is greater than the
minor version specified in the code.

If "auto minor upgrade" is enabled, we shouldn't specify the minor
version in the terraform code.
