### PR TITLE
Update claim-criminal-injuries-compensation-staging, RDS db version.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/rds.tf
@@ -18,7 +18,7 @@ module "rds" {
   infrastructure-support = var.email
 
   db_engine                  = "postgres"
-  db_engine_version          = "10.6"
+  db_engine_version          = "10"
   db_instance_class          = "db.t2.small"
   db_allocated_storage       = "5"
   db_name                    = "datacaptureservice"


### PR DESCRIPTION
To fix Error modifying DB Instance cloud-platform-13fde479e240250b:
InvalidParameterCombination: Cannot upgrade postgres from 10.13 to 10.6