### PR TITLE
Remove minor version from pathfinder RDS instances

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -17,7 +17,7 @@ module "dps_rds" {
   application            = var.application
   is-production          = var.is-production
   namespace              = var.namespace
-  db_engine_version      = "11.4"
+  db_engine_version      = "11"
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
@@ -17,7 +17,7 @@ module "dps_rds" {
   application            = var.application
   is-production          = var.is-production
   namespace              = var.namespace
-  db_engine_version      = "11.4"
+  db_engine_version      = "11"
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
@@ -17,7 +17,7 @@ module "dps_rds" {
   application            = var.application
   is-production          = var.is-production
   namespace              = var.namespace
-  db_engine_version      = "11.4"
+  db_engine_version      = "11"
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
 


### PR DESCRIPTION
This avoids conflicts with "auto upgrade minor"
