### PR TITLE
Pin the version of the "random" provider

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}


### PR DESCRIPTION
Hashicorp upgraded the random provider from 2.30
to 3.0.0 today. This change seems to remove the
`b64` function (there are no release notes, so we
can't confirm this, but stuff breaks).

This PR pins the random provider version to 2.3+
so that namespaces in which the `b64` function is
used continue to plan/apply correctly.