### PR TITLE
Create formbuilder-saas namespace and Metadata API DB

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/00-namespace.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-saas-test
+  labels:
+    name: formbuilder-saas-test
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "test"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "formbuilder-saas"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: form-builder-developers@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"
+    cloud-platform.justice.gov.uk/slack-channel: "moj-online-devs"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/01-rbac.yaml
@@ -1,0 +1,18 @@
+---
+# Source: formbuilder-publisher/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-saas-test-admins
+  namespace: formbuilder-saas-test
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-publisher/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-saas-test
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-saas-test
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-publisher/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-saas-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-saas-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
@@ -1,0 +1,30 @@
+module "metadata-api-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.7"
+
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period
+  application                = "formbuilder-metadata-api"
+  environment-name           = var.environment_name
+  is-production              = var.is_production
+  namespace                  = var.namespace
+  infrastructure-support     = var.infrastructure_support
+  team_name                  = var.team_name
+  db_engine_version          = "12"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "metadata-api-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-metadata-api-${var.environment_name}"
+    namespace = "formbuilder-saas-${var.environment_name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.metadata-api-rds-instance.database_username}:${module.metadata-api-rds-instance.database_password}@${module.metadata-api-rds-instance.rds_instance_endpoint}/${module.metadata-api-rds-instance.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/variables.tf
@@ -1,0 +1,30 @@
+variable "environment_name" {
+  default = "test"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "is_production" {
+  default = "true"
+}
+
+variable "db_backup_retention_period" {
+  default = "2"
+}
+
+variable "infrastructure_support" {
+  default = "Form Builder form-builder-developers@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "namespace" {
+  default = "formbuilder-saas-test"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "0.12.17"
+}


### PR DESCRIPTION
We are creating a new Metadata API application that will be backed by a postgres database.

At the same time we need to create a new namespace `formbuilder-saas-test` which the api will live in along with some future apps.

https://trello.com/c/6s5j3gj7/972-cloud-platform-configuration-for-the-db