### PR TITLE
tag aws resource with namespace names

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
@@ -7,6 +7,7 @@ resource "aws_route53_zone" "route53_zone_short" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 
@@ -19,6 +20,7 @@ resource "aws_route53_zone" "route53_zone_long" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "route53_zone_short" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 
@@ -20,7 +20,7 @@ resource "aws_route53_zone" "route53_zone_long" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "cccd_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "cccd_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "cccd_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "cccd_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/route53.tf
@@ -13,6 +13,7 @@ resource "aws_route53_zone" "contact-moj_route53_zone" {
     environment-name       = var.environment-name
     owner                  = "Staff Services"
     infrastructure-support = "staffservices@digital.justice.gov.uk"
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/route53.tf
@@ -13,7 +13,7 @@ resource "aws_route53_zone" "contact-moj_route53_zone" {
     environment-name       = var.environment-name
     owner                  = "Staff Services"
     infrastructure-support = "staffservices@digital.justice.gov.uk"
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-prod/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "pic_cpmgw_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-prod/resources/route53.tf
@@ -7,6 +7,7 @@ resource "aws_route53_zone" "pic_cpmgw_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/route53.tf
@@ -7,6 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 
@@ -19,6 +20,7 @@ resource "aws_route53_zone" "route53_zone_gds" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 
@@ -20,7 +20,7 @@ resource "aws_route53_zone" "route53_zone_gds" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/route53.tf
@@ -7,6 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/route53.tf
@@ -7,6 +7,7 @@ resource "aws_route53_zone" "moj_online_route53_zone" {
     environment-name       = var.environment_name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "moj_online_route53_zone" {
     environment-name       = var.environment_name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "hmpps_assessments_route53_zone" {
     environment-name       = var.environment_name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "hmpps_assessments_route53_zone" {
     environment-name       = var.environment_name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "cla_backend_fox_admin_route53_zone" {
     is-production          = var.is-production
     environment-name       = var.environment-name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "cla_backend_fox_admin_route53_zone" {
     is-production          = var.is-production
     environment-name       = var.environment-name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     is-production    = var.is-production
     environment-name = var.environment-name
     owner            = var.team_name
-    namespace = var.namespace
+    namespace        = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/resources/route53.tf
@@ -7,6 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     is-production    = var.is-production
     environment-name = var.environment-name
     owner            = var.team_name
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "laa_crime_apps_team_route53_zone" {
     environment-name       = var.environment_name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "laa_crime_apps_team_route53_zone" {
     environment-name       = var.environment_name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "lcdui_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "lcdui_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     is-production    = var.is-production
     environment-name = var.environment-name
     owner            = var.team_name
-    namespace = var.namespace
+    namespace        = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/route53.tf
@@ -7,6 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     is-production    = var.is-production
     environment-name = var.environment-name
     owner            = var.team_name
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "laa_fee_calculator_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "laa_fee_calculator_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "mogaal_test_route53_zone" {
     environment-name       = var.environment
     owner                  = var.team-name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "mogaal_test_route53_zone" {
     environment-name       = var.environment
     owner                  = var.team-name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "app_domain" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.email
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "app_domain" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.email
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/oasys-keycloak-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/resources/route53.tf
@@ -7,6 +7,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
@@ -9,7 +9,7 @@ resource "aws_route53_zone" "parliamentary_questions" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/route53.tf
@@ -9,6 +9,7 @@ resource "aws_route53_zone" "parliamentary_questions" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/route53.tf
@@ -13,7 +13,7 @@ resource "aws_route53_zone" "peoplefinder_route53_zone" {
     environment-name       = var.environment-name
     owner                  = "peoplefinder"
     infrastructure-support = "people-finder-support@digital.justice.gov.uk"
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/route53.tf
@@ -13,6 +13,7 @@ resource "aws_route53_zone" "peoplefinder_route53_zone" {
     environment-name       = var.environment-name
     owner                  = "peoplefinder"
     infrastructure-support = "people-finder-support@digital.justice.gov.uk"
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "content_hub_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "content_hub_route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
@@ -13,6 +13,7 @@ resource "aws_route53_zone" "track_a_query_route53_zone" {
     environment-name       = var.environment-name
     owner                  = "staff-services"
     infrastructure-support = "correspondence-support@digital.justice.gov.uk"
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/route53.tf
@@ -13,7 +13,7 @@ resource "aws_route53_zone" "track_a_query_route53_zone" {
     environment-name       = var.environment-name
     owner                  = "staff-services"
     infrastructure-support = "correspondence-support@digital.justice.gov.uk"
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/route53.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace = var.namespace
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/route53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "route53_zone" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
-    namespace = var.namespace
+    namespace              = var.namespace
   }
 }
 


### PR DESCRIPTION
Why:
[Tag all AWS resources with namespace name#2348](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2348)
Firstly all that have var.namespace already in resource