### PR TITLE
Pin "random" provider to 2.3+

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-dev/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-preprod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-preprod/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-nhs-update-prod/resources/main.tf
@@ -19,3 +19,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "random" {
+  version = ">= 2.3.0, < 3.0.0"
+}


### PR DESCRIPTION
The apply pipeline is breaking because `.b64` is no longer a valid
function. This fixes that.
