### PR TITLE
Create Form Builder service accounts for formbuilder-saas-test namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "circleci-formbuilder-saas-test"
+  namespace: "formbuilder-saas-test"
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "circleci-formbuilder-saas-test"
+  namespace: "formbuilder-saas-test"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+      - "watch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "circleci-formbuilder-saas-test"
+  namespace: "formbuilder-saas-test"
+subjects:
+- kind: ServiceAccount
+  name: "circleci-formbuilder-saas-test"
+  namespace: "formbuilder-saas-test"
+roleRef:
+  kind: Role
+  name: "circleci-formbuilder-saas-test"
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/metadata-api-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/metadata-api-service-account.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "formbuilder-metadata-api-test"
+  namespace: "formbuilder-saas-test"
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "formbuilder-metadata-api-test"
+  namespace: "formbuilder-saas-test"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+      - "watch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "formbuilder-metadata-api-test"
+  namespace: "formbuilder-saas-test"
+subjects:
+- kind: ServiceAccount
+  name: "formbuilder-metadata-api-test"
+  namespace: "formbuilder-saas-test"
+roleRef:
+  kind: Role
+  name: "formbuilder-metadata-api-test"
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This creates the CircleCI service account and also the Metadata API app service account. This was done using the cloud-platform CLI.

Also create the ECR repo required for the Metadata API app.

https://trello.com/c/CXiolpPz/973-cloud-platform-configuration-for-the-app