### PR TITLE
Create new Form Builder service token cache service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/01-rbac.yaml
@@ -15,6 +15,9 @@ subjects:
   - kind: ServiceAccount
     name: formbuilder-service-token-cache-live-production
     namespace: formbuilder-platform-live-production
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-2-live-production
+    namespace: formbuilder-platform-live-production
 roleRef:
   kind: ClusterRole
   name: admin

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/service-token-cache-service-account-2.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/service-token-cache-service-account-2.yaml
@@ -1,0 +1,11 @@
+---
+# Source: formbuilder-platform/templates/service-token-cache-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the user datastore as a distinct service account
+# so that it can be granted access to read the service token secrets
+# from the formbuilder-services-live-production namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-service-token-cache-2-live-production
+  namespace: formbuilder-platform-live-production


### PR DESCRIPTION
Unfortunately we need to rotate the token used by the old service account for the service-token-cache app. The way the app utilises it makes it not possible to simply delete and let K8S regenerate it as that would mean potential downtime for some users.

We need to create another service account from scratch and move to use the token generated for that before deleting the old service account.

https://trello.com/c/LfLkccvb/963-redact-kubernetes-token-in-service-token-cache