### PR TITLE
Add Form Builder service account permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/01-rbac.yaml
@@ -31,6 +31,9 @@ subjects:
   - kind: ServiceAccount
     name: formbuilder-service-token-cache-live-production
     namespace: formbuilder-platform-live-production
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-2-live-production
+    namespace: formbuilder-platform-live-production
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
We need the service account to have permissions to interact with the `formbuilder-services-live-production`.