### PR TITLE
Use ES module v3.2

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.1"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.2"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = "peoplefinder"


### PR DESCRIPTION
This version adds the "namespace" tag to AWS resources.

This is an initial test, in a single non-prod namespace. If this doesn't
cause any problems, I'll raise other PRs for all the other instances of
this module in the environments repo.
