### PR TITLE
Add namespace tag to replica database

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -66,6 +66,7 @@ module "cla_backend_replica" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
 
   # Settings from current setup


### PR DESCRIPTION
The replica RDS instance does not have a value for "namespace", so its
costs are not being allocated correctly.
