### PR TITLE
Give Form Builder Metadata API service account more permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
@@ -33,6 +33,9 @@ rules:
     resources:
       - "deployments"
       - "ingresses"
+      - "configmaps"
+      - "networkpolicies"
+      - "servicemonitors"
     verbs:
       - "get"
       - "update"


### PR DESCRIPTION
The Service Account used by Circle needs to have some additional permissions in order to work correctly.

https://trello.com/c/16na1z6k/979-deployment-pipeline-configuration

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>