### PR TITLE
Update Form Builder Metadata API service account permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "configmaps"
     verbs:
       - "patch"
       - "get"
@@ -30,10 +31,10 @@ rules:
       - "extensions"
       - "apps"
       - "networking.k8s.io"
+      - "monitoring.coreos.com"
     resources:
       - "deployments"
       - "ingresses"
-      - "configmaps"
       - "networkpolicies"
       - "servicemonitors"
     verbs:


### PR DESCRIPTION
The core API group is in fact the one that requires the permission to get resources for configmaps.

We also need to add the ability to get servicemonitors for the monitoring.coreos.com API group.