### PR TITLE
Update S3 bucket to latest module release + add aws tag var.namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/s3.tf
@@ -11,7 +11,7 @@ module "calculate-journey-variable-payments_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "calculate-journey-variable-payments_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "calculate-journey-variable-payments_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/s3.tf
@@ -11,7 +11,7 @@ module "calculate-journey-variable-payments_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "calculate-journey-variable-payments_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "calculate-journey-variable-payments_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/s3.tf
@@ -11,7 +11,7 @@ module "calculate-journey-variable-payments_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "calculate-journey-variable-payments_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "calculate-journey-variable-payments_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"
@@ -7,6 +7,7 @@ module "cccd_s3_bucket" {
   is-production          = "false"
   environment-name       = "api-sandbox"
   infrastructure-support = "crowncourtdefence@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"
@@ -7,6 +7,7 @@ module "cccd_s3_bucket" {
   is-production          = "false"
   environment-name       = "dev"
   infrastructure-support = "crowncourtdefence@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"
@@ -7,6 +7,7 @@ module "cccd_s3_bucket" {
   is-production          = "false"
   environment-name       = "dev"
   infrastructure-support = "crowncourtdefence@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/resources/s3.tf
@@ -6,7 +6,7 @@
  */
 
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = var.business-unit
@@ -14,6 +14,7 @@ module "cccd_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"
@@ -7,6 +7,7 @@ module "cccd_s3_bucket" {
   is-production          = "false"
   environment-name       = "staging"
   infrastructure-support = "crowncourtdefence@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/s3.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.cluster_name
   business-unit          = var.business-unit
@@ -13,6 +13,7 @@ module "example_team_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/s3.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.cluster_name
   business-unit          = var.business-unit
@@ -13,6 +13,7 @@ module "example_team_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/s3.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.cluster_name
   business-unit          = var.business-unit
@@ -13,6 +13,7 @@ module "example_team_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"
@@ -12,6 +12,7 @@ module "track_a_query_s3" {
   is-production          = "false"
   environment-name       = "development"
   infrastructure-support = "mohammed.seedat@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   acl                    = "private"
@@ -9,6 +9,7 @@ module "json-output-attachments-s3-bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   acl                    = "private"
@@ -12,6 +12,7 @@ module "user-filestore-s3-bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   acl                    = "private"
@@ -9,6 +9,7 @@ module "json-output-attachments-s3-bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   acl                    = "private"
@@ -12,6 +12,7 @@ module "user-filestore-s3-bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   acl                    = "private"
@@ -9,6 +9,7 @@ module "json-output-attachments-s3-bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   acl                    = "private"
@@ -12,6 +12,7 @@ module "user-filestore-s3-bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   acl                    = "private"
@@ -9,6 +9,7 @@ module "json-output-attachments-s3-bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   acl                    = "private"
@@ -12,6 +12,7 @@ module "user-filestore-s3-bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-documents.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-metrics.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-metrics.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_metrics_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_metrics_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-metrics.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-metrics.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_metrics_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_reporting_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-reporting.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_reporting_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-documents.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_reporting_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-reporting.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_reporting_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3-documents.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_reporting_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/s3-reporting.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_reporting_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-documents.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_reporting_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-reporting.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_reporting_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3.tf
@@ -11,7 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
-  namespace              = var.namespace
+  namespace        = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"
@@ -11,6 +11,7 @@ module "book_a_secure_move_documents_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "hmpps_pin_phone_monitor_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -8,6 +8,7 @@ module "hmpps_pin_phone_monitor_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "hmpps_submit_information_report_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = var.business-unit
@@ -8,6 +8,7 @@ module "hmpps_submit_information_report_s3_bucket" {
 
   is-production    = var.is-production
   environment-name = var.environment-name
+  namespace              = var.namespace
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"
@@ -8,6 +8,7 @@ module "authorized-keys" {
   is-production          = "true"
   environment-name       = "production"
   infrastructure-support = "apply@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"
@@ -8,6 +8,7 @@ module "authorized-keys" {
   is-production          = "false"
   environment-name       = "staging"
   infrastructure-support = "apply@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"
@@ -8,6 +8,7 @@ module "authorized-keys" {
   is-production          = "false"
   environment-name       = "uat"
   infrastructure-support = "apply@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_backend_private_reports_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl    = "private"
 
   team_name              = var.team_name
@@ -8,6 +8,7 @@ module "cla_backend_private_reports_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -49,7 +50,7 @@ EOF
 }
 
 module "cla_backend_deleted_objects_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl    = "private"
 
   team_name              = var.team_name
@@ -96,7 +97,7 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   acl                           = "public-read"
   enable_allow_block_pub_access = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_backend_private_reports_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl    = "private"
 
   team_name              = var.team_name
@@ -8,6 +8,7 @@ module "cla_backend_private_reports_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -49,7 +50,7 @@ EOF
 }
 
 module "cla_backend_deleted_objects_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl    = "private"
 
   team_name              = var.team_name
@@ -96,7 +97,7 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl                           = "public-read"
   enable_allow_block_pub_access = false
   team_name                     = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_backend_private_reports_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl    = "private"
 
   team_name              = var.team_name
@@ -8,6 +8,7 @@ module "cla_backend_private_reports_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -49,7 +50,7 @@ EOF
 }
 
 module "cla_backend_deleted_objects_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl    = "private"
 
   team_name              = var.team_name
@@ -96,7 +97,7 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl                           = "public-read"
   enable_allow_block_pub_access = false
   team_name                     = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_backend_private_reports_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl    = "private"
 
   team_name              = var.team_name
@@ -8,6 +8,7 @@ module "cla_backend_private_reports_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -49,7 +50,7 @@ EOF
 }
 
 module "cla_backend_deleted_objects_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl    = "private"
 
   team_name              = var.team_name
@@ -96,7 +97,7 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl                           = "public-read"
   enable_allow_block_pub_access = false
   team_name                     = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = var.business-unit
@@ -7,6 +7,7 @@ module "s3" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = var.business-unit
@@ -7,6 +7,7 @@ module "s3" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = var.business-unit
@@ -7,6 +7,7 @@ module "s3" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = var.business-unit
@@ -7,6 +7,7 @@ module "s3" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = var.business-unit
@@ -7,6 +7,7 @@ module "s3" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   business-unit          = var.business-unit
@@ -7,6 +7,7 @@ module "s3" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.email
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false
@@ -8,6 +8,7 @@ module "manage_intelligence_rds_to_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "manage_soc_cases_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -8,6 +8,7 @@ module "manage_soc_cases_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -64,7 +65,7 @@ EOF
 }
 
 module "manage_soc_cases_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "manage_soc_cases_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -8,6 +8,7 @@ module "manage_soc_cases_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -64,7 +65,7 @@ EOF
 }
 
 module "manage_soc_cases_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "manage_soc_cases_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -8,6 +8,7 @@ module "manage_soc_cases_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -64,7 +65,7 @@ EOF
 }
 
 module "manage_soc_cases_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "mps_storage_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false
@@ -8,6 +8,7 @@ module "mps_storage_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "mps_storage_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false
@@ -8,6 +8,7 @@ module "mps_storage_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moving-people-safely-prod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "mps_storage_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false
@@ -8,6 +8,7 @@ module "mps_storage_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false
@@ -8,6 +8,7 @@ module "risk_profiler_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false
@@ -8,7 +8,7 @@ module "risk_profiler_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
-
+  namespace              = var.namespace
   providers = {
     aws = aws.london
   }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false
@@ -8,7 +8,7 @@ module "risk_profiler_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
-
+  namespace              = var.namespace
   providers = {
     aws = aws.london
   }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "pathfinder_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -8,6 +8,7 @@ module "pathfinder_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -64,7 +65,7 @@ EOF
 }
 
 module "pathfinder_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "pathfinder_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -8,6 +8,7 @@ module "pathfinder_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -64,7 +65,7 @@ EOF
 }
 
 module "pathfinder_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "pathfinder_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -8,6 +8,7 @@ module "pathfinder_document_s3_bucket" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london
@@ -64,7 +65,7 @@ EOF
 }
 
 module "pathfinder_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"
@@ -28,6 +28,7 @@ module "peoplefinder_s3" {
       max_age_seconds = 3000
     },
   ]
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"
@@ -30,6 +30,7 @@ module "peoplefinder_s3" {
       max_age_seconds = 3000
     },
   ]
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"
@@ -28,6 +28,7 @@ module "peoplefinder_s3" {
       max_age_seconds = 3000
     },
   ]
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"
@@ -28,6 +28,7 @@ module "peoplefinder_s3" {
       max_age_seconds = 3000
     },
   ]
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -1,5 +1,5 @@
 module "drupal_content_storage" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   versioning             = true
@@ -8,6 +8,7 @@ module "drupal_content_storage" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 }
 
 resource "kubernetes_secret" "drupal_content_storage_secret" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -1,5 +1,5 @@
 module "drupal_content_storage" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   versioning             = true
@@ -11,10 +11,12 @@ module "drupal_content_storage" {
 
   # S3 was provisioned before we changed the default region to London
   # so if this isn't set we get a 301 error when it tries to rebuild it
+  namespace              = var.namespace
+
   providers = {
-    aws = aws.ireland
+      aws = aws.ireland
+    }
   }
-}
 
 resource "kubernetes_secret" "drupal_content_storage_secret" {
   metadata {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "drupal_content_storage" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = var.team_name
   versioning             = true
@@ -8,6 +8,7 @@ module "drupal_content_storage" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 }
 
 resource "kubernetes_secret" "drupal_content_storage_secret" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"
@@ -28,7 +28,7 @@ module "track_a_query_s3" {
       max_age_seconds = 3000
     },
   ]
-
+  namespace              = var.namespace
   providers = {
     aws = aws.london
   }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"
@@ -12,6 +12,7 @@ module "track_a_query_s3" {
   is-production          = "false"
   environment-name       = "development"
   infrastructure-support = "mohammed.seedat@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   cors_rule = [
     {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"
@@ -28,6 +28,7 @@ module "track_a_query_s3" {
       max_age_seconds = 3000
     },
   ]
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"
@@ -28,6 +28,7 @@ module "track_a_query_s3" {
       max_age_seconds = 3000
     },
   ]
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"
@@ -28,6 +28,7 @@ module "track_a_query_s3" {
       max_age_seconds = 3000
     },
   ]
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
Why: [Tag all AWS resources with namespace name#2348](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2348)