### PR TITLE
Add configuration to ingress to turn server-tokens off

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: nginx-configuration
+  namespace: check-financial-eligibility-uat
+  annotations:
+    nginx.org/server-tokens: "False"


### PR DESCRIPTION
Add configuration to ingress to turn server-tokens off in order to resolve a security issue that reveals the server and version e.g. nginx/v1... This is after curl-ing the url

curl https://.... which returns a http response with the server info in it.