### PR TITLE
Output DB engine & version for each rds instance

### DIFF
--- a/bin/rds-instances-by-namespace.rb
+++ b/bin/rds-instances-by-namespace.rb
@@ -22,7 +22,7 @@ def main
         db[:namespace],
         db[:db_name],
         db[:engine],
-        db[:engine_version],
+        db[:engine_version]
       ].join(", ")
     end
   end
@@ -62,7 +62,7 @@ def instance_attributes(namespace, rds)
     namespace: namespace,
     db_name: db_name,
     engine: engine,
-    engine_version: engine_version,
+    engine_version: engine_version
   }
 end
 


### PR DESCRIPTION
This is useful when we need to tell teams to upgrade their database
versions, as AWS end-of-lifes older ones.
