### PR TITLE
Allow major version upgrade

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
@@ -22,7 +22,7 @@ module "rds" {
   rds_family = "postgres9.5"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
-  allow_major_version_upgrade = "false"
+  allow_major_version_upgrade = "true"
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Creating this RDS instance failed with:

```
Error: Error modifying DB Parameter Group: InvalidParameterCombination: cannot use immediate apply method for static parameter
```

I think allowing major version upgrade here might fix this, since that's the only significant difference I can see between this RDS instance and [this one](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf)