### PR TITLE
Disable performance insights

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
@@ -9,9 +9,6 @@ module "rds" {
   is-production        = var.is_production
   namespace            = var.namespace
 
-  # enable performance insights
-  performance_insights_enabled = true
-
   # change the postgres version as you see fit.
   db_engine_version      = "9.5"
   environment-name       = var.environment


### PR DESCRIPTION
This RDS is still not building correctly.

This is another difference between this RDS and other 9.5 RDS instances that have already been built.