### PR TITLE
Change annotation back to CP till we ready to change

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
     cloud-platform.justice.gov.uk/application: "Cloud Platform"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-infrastructure"


### PR DESCRIPTION
We need to annotation to be set to cloud-platform till we change all monitoring alarms to use a different annotation 