### PR TITLE
Change annotation to CP till monitoring alarms changed

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/00-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
-    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/business-unit: "cloud-platform"
     cloud-platform.justice.gov.uk/application: "Monitoring"
     cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"


### PR DESCRIPTION
Change annotation back to CP till we ready to change alarms as alarms are still using the cp annotation 