### PR TITLE
Update ingress.yaml to include rules

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ingress-nginx-controller
-  namespace: check-financial-eligibility-uat
-data:
-  proxy-hide-headers: "Server"
-  server-tokens: "False"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
@@ -5,3 +5,10 @@ metadata:
   namespace: check-financial-eligibility-uat
   annotations:
     nginx.org/server-tokens: "False"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
@@ -1,14 +1,8 @@
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: nginx-configuration
+  name: ingress-nginx-controller
   namespace: check-financial-eligibility-uat
-  annotations:
-    nginx.org/server-tokens: "False"
-spec:
-  podSelector: {}
-  policyTypes:
-  - Ingress
-  ingress:
-  - from:
-    - podSelector: {}
+data:
+  proxy-hide-headers: "Server"
+  server-tokens: "False"


### PR DESCRIPTION
~~Fix issue with namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
after merging [pr](https://github.com/ministryofjustice/cloud-platform-environments/pull/3645#issue-506905524)~~

~~The error was:
The Ingress "nginx-configuration" is invalid: spec: Invalid value: []networking.IngressRule(nil): either `backend` or `rules` must be specified~~

EDIT:

Remove this file namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml

The attempt to update the config in the ingress controller here was in the wrong repo , it should have been updated in this repo  ministryofjustice/cloud-platform-terraform-ingress-controller 