### PR TITLE
Fix broken GitHub Action

### DIFF
--- a/.github/workflows/auto-approve-pr.yaml
+++ b/.github/workflows/auto-approve-pr.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: ministryofjustice/cloud-platform-directory-hash@main
 
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@master
+        uses: vinodsai-a/actions-comment-pull-request@master
 
         if: steps.dir_hash.outputs.checksum_match == 'true'
         with:


### PR DESCRIPTION
An issue has caused a failure to pull down a Dockerfile. This has been rectified in a fork of the project. Will temporarily move there.