### PR TITLE
Enable dynamodb autoscaler for HOODAW

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/resources/dynamodb.tf
@@ -11,7 +11,7 @@ module "hoodaw_dynamodb" {
 
   hash_key          = "filename"
   enable_encryption = "false"
-  enable_autoscaler = "false"
+  enable_autoscaler = "true"
   aws_region        = "eu-west-2"
 }
 


### PR DESCRIPTION
The application isn't working right now, and the pod logs show this
error:

```
2020-10-23 11:24:36 -
Aws::DynamoDB::Errors::ProvisionedThroughputExceededException - The
level of configured provisioned throughput for the table was exceeded.
Consider increasing your provisioning level with the UpdateTable API.:
```

Enabling the dynamodb autoscaler should fix this.
