### PR TITLE
Update dstest RDS to postgres9.6

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
@@ -8,7 +8,7 @@ module "rds" {
   is-production              = var.is_production
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "9.5"
+  db_engine_version          = "9.6"
   db_backup_retention_period = "7"
   db_name                    = "dstest_rds"
   environment-name           = var.environment
@@ -16,7 +16,7 @@ module "rds" {
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best
-  rds_family = "postgres9.5"
+  rds_family = "postgres9.6"
 
   # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".


### PR DESCRIPTION
I've already done this, so this change brings the code into alignment
with the RDS instance.
