### PR TITLE
Add a postgres9.5 RDS to dstest namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
@@ -1,0 +1,74 @@
+module "rds" {
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=add-modify-instance"
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
+  team_name            = var.team_name
+  business-unit        = var.business_unit
+  application          = var.application
+  is-production        = var.is_production
+  namespace            = var.namespace
+
+  # enable performance insights
+  performance_insights_enabled = true
+
+  # change the postgres version as you see fit.
+  db_engine_version      = "9.5"
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure-support
+
+  # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
+  # Pick the one that defines the postgres version the best
+  rds_family = "postgres9.5"
+
+  # use "allow_major_version_upgrade" when upgrading the major version of an engine
+  allow_major_version_upgrade = "true"
+
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    access_key_id         = module.rds.access_key_id
+    secret_access_key     = module.rds.secret_access_key
+  }
+  /* You can replace all of the above with the following, if you prefer to
+     * use a single database URL value in your application code:
+     *
+     * url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+     *
+     */
+}
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+
+  }
+}


### PR DESCRIPTION
This uses a branch of the RDS module which adds more permissions to the
IAM user which is created with the RDS instance. This should allow teams
to manage their own DB engine upgrades, which is what I'll test once
this RDS is created.
