### PR TITLE
Disable performance insights for postgres9.5 DB

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/rds.tf
@@ -9,7 +9,7 @@ module "rds" {
   namespace            = var.namespace
 
   # enable performance insights
-  performance_insights_enabled = true
+  performance_insights_enabled = false
 
   # change the postgres version as you see fit.
   db_engine_version      = "9.5"


### PR DESCRIPTION
It's not supported.
