### PR TITLE
 Add service token cache permission to formbuilder saas

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/01-rbac.yaml
@@ -16,3 +16,19 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-saas-test-service-account
+  namespace: formbuilder-saas-test
+subjects:
+  # Service token cache can read the service tokens
+  # from formbuilder saas namespace
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-test-production
+    namespace: formbuilder-platform-test-production
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The formbuilder service token cache app needs permission to see the config maps from formbuilder-saas-* namespaces.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>