### PR TITLE
Add permissions to circleci serviceaccount

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "HorizontalPodAutoscaler"
     verbs:
       - "patch"
       - "get"
@@ -29,15 +30,20 @@ rules:
       - "extensions"
       - "apps"
       - "networking.k8s.io"
+      - "batch"
     resources:
       - "deployments"
+      - "cronjobs"
       - "ingresses"
+      - "statefulsets"
+      - "replicasets"
     verbs:
       - "get"
       - "update"
       - "delete"
       - "create"
       - "patch"
+      - "list"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
This will allow the circleci serviceaccount to deploy to the application
to the UAT environment. As discussed with @willc-work 