### PR TITLE
Add Pager Duty integration to Book a Secure Move production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/pingdom.tf
@@ -3,6 +3,7 @@ provider "pingdom" {
 
 # Integration IDs
 # 94314 = #pecs-alerts
+# 108715 = PECS Pager Duty
 
 resource "pingdom_check" "book-secure-move-api-check" {
   type                     = "http"
@@ -17,5 +18,5 @@ resource "pingdom_check" "book-secure-move-api-check" {
   port                     = 443
   tags                     = "hmpps,cloudplatform-managed"
   probefilters             = "region:EU"
-  integrationids           = [94314]
+  integrationids           = [94314, 108715]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/pingdom.tf
@@ -3,6 +3,7 @@ provider "pingdom" {
 
 # Integration IDs
 # 94314 = #pecs-alerts
+# 108715 = PECS Pager Duty
 
 resource "pingdom_check" "book-secure-move-frontend-check" {
   type                     = "http"
@@ -17,5 +18,5 @@ resource "pingdom_check" "book-secure-move-frontend-check" {
   port                     = 443
   tags                     = "hmpps,cloudplatform-managed"
   probefilters             = "region:EU"
-  integrationids           = [94314]
+  integrationids           = [94314, 108715]
 }


### PR DESCRIPTION
Adds the pingdom integration ID to Book a Secure Move API and frontend production environments.