### PR TITLE
Add prometheus rules for formbuilder saas test namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/06-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/06-prometheus.yaml
@@ -1,0 +1,40 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fb-alerting-saas-test
+  namespace: formbuilder-saas-test
+  labels:
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: formbuilder-saas-rules
+    rules:
+    - alert: KubePodNotReady
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+          state for longer than fifteen minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics",phase!~"Running|Succeeded", namespace="formbuilder-saas-test"}) > 0
+      for: 15m
+      labels:
+        severity: form-builder-low-severity
+    - alert: KubePodCrashLooping
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-saas-test"}[10m]) * 60 * 10 > 1
+      for: 5m
+      labels:
+        severity: form-builder-low-severity
+    - alert: KubeNamespaceQuotaNearing
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+      expr: |-
+        100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace="formbuilder-saas-test"}
+          / ignoring(instance, job, type)
+        (kube_resourcequota{job="kube-state-metrics", type="hard", namespace="formbuilder-saas-test"} > 0)
+          > 80
+      for: 5m
+      labels:
+        severity: form-builder-low-severity


### PR DESCRIPTION
## Context

Creating the Prometheus rules for the formbuilder saas test namespace.

Co-authored-by: Brendan Butler brendan.butler@digital.justice.gov.uk