### PR TITLE
Add namespace & s3 bucket for OpsEng

### DIFF
--- a/.checksum
+++ b/.checksum
@@ -1,3 +1,3 @@
 #This file is used by the auto pr github action. Please commit
-helloworldapp-dev
-h1:WpNJVSdN05hXimTwfj6STOS3S5KpL+0Y1aMhj/lpCt8=
+operations-engineering
+h1:Ut8aWvGwy1g5Ax3eWVzRZNaOKM9g1oIS1MmXr91h7Ms=

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: operations-engineering
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "ask-operations-engineering"
+    cloud-platform.justice.gov.uk/application: "Operations Engineering"
+    cloud-platform.justice.gov.uk/owner: "Operations Engineering: operations-engineering@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/operations-engineering/"
+    cloud-platform.justice.gov.uk/team-name: "operations-engineering" 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: operations-engineering-admin
+  namespace: operations-engineering
+subjects:
+  - kind: Group
+    name: "github:operations-engineering"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: operations-engineering
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: operations-engineering
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: operations-engineering
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: operations-engineering
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/s3.tf
@@ -1,0 +1,35 @@
+module "s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  acl    = "private"
+
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+
+}
+
+resource "kubernetes_secret" "s3_bucket" {
+  metadata {
+    name      = "tfstate-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id               = module.s3_bucket.access_key_id
+    secret_access_key           = module.s3_bucket.secret_access_key
+    reports_bucket_arn          = module.s3_bucket.bucket_arn
+    reports_bucket_name         = module.s3_bucket.bucket_name
+    deleted_objects_bucket_arn  = module.s3_bucket.bucket_arn
+    deleted_objects_bucket_name = module.s3_bucket.bucket_name
+    static_files_bucket_name    = module.s3_bucket.bucket_name
+    static_files_bucket_arn     = module.s3_bucket.bucket_arn
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/variables.tf
@@ -1,0 +1,44 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Operations Engineering"
+}
+
+variable "namespace" {
+  default = "operations-engineering"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "operations-engineering"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "operations-engineering@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "true"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "ask-operations-engineering"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This S3 bucket will be used to store terraform
statefiles relating to operations-engineering
projects.