### PR TITLE
add update to resources verbs uat cfe

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/serviceaccount-circleci.yaml
@@ -24,6 +24,7 @@ rules:
       - "patch"
       - "get"
       - "create"
+      - "update"
       - "delete"
       - "list"
   - apiGroups:


### PR DESCRIPTION
deployments are failing because serviceaccount doesnt have permission to update resources, added in permission