### PR TITLE
Apply UAT networkpolicies is in wrong resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
@@ -20,7 +20,6 @@ rules:
       - "services"
       - "pods"
       - "HorizontalPodAutoscaler"
-      - "networkpolicies"
     verbs:
       - "patch"
       - "get"
@@ -39,6 +38,7 @@ rules:
       - "ingresses"
       - "statefulsets"
       - "replicasets"
+      - "networkpolicies"
     verbs:
       - "get"
       - "update"


### PR DESCRIPTION
remove tiller service account no longer needed due to helm3 upgrade