### PR TITLE
CFE UAT add serviceaccount back in

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/01-rbac.yaml
@@ -11,23 +11,4 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tiller
-  namespace: check-financial-eligibility-uat
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: tiller
-  namespace: check-financial-eligibility-uat
-subjects:
-- kind: ServiceAccount
-  name: tiller
-  namespace: check-financial-eligibility-uat
-roleRef:
-  kind: ClusterRole
-  name: admin
-  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/serviceaccount-circleci.yaml
@@ -19,7 +19,6 @@ rules:
       - "secrets"
       - "services"
       - "pods"
-      - "HorizontalPodAutoscaler"
     verbs:
       - "patch"
       - "get"
@@ -45,3 +44,17 @@ rules:
       - "patch"
       - "list"
 
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: check-financial-eligibility-uat
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: check-financial-eligibility-uat
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
While upgrading to helm3 I removed the circleci service account instead of the tiller serviceaccount. This PR is to reinstate the circle serviceaccount and remove the tiller serviceaccount from `rbac.yaml`

Question: Do we need the circle serviceaccount to be reinstated? The deployments all work without this serviceaccount and I assume having an unused serviceaccount is probably a security risk. If it is required why are deployments working without it?