### PR TITLE
Apply Staging - add prometheusrules to resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
@@ -41,6 +41,7 @@ rules:
       - "replicasets"
       - "networkpolicies"
       - "servicemonitors"
+      - "prometheusrules"
     verbs:
       - "get"
       - "update"


### PR DESCRIPTION
Prometheus reporting appears broken at present, possibly because the serviceaccount doesn't have `prometheusrules` as an available resource. 