### PR TITLE
Add a route53 zone for prisonvisits.service.just..

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/route53.tf
@@ -23,3 +23,28 @@ resource "kubernetes_secret" "route53_zone_sec" {
   }
 }
 
+resource "aws_route53_zone" "route53_justice_zone" {
+  name = "prisonvisits.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = "HMPPS"
+    application            = "PVB"
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "route53_justice_zone_sec" {
+  metadata {
+    name      = "route53-justice-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.route53_justice_zone.zone_id
+  }
+}
+


### PR DESCRIPTION
There is a route53 hosted zone which has an A record for a production service:
```
http://staff.prisonvisits.service.justice.gov.uk/
```
...but it's not being managed in terraform.

This change adds a terraform resource for the zone. A manual `terraform
import` will import the existing AWS route53 hosted zone into the
terraform state.
