### PR TITLE
Create intervention prod namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-interventions-prod
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "interventions"
+    cloud-platform.justice.gov.uk/application: "Providing rehabilitation services to service users"
+    cloud-platform.justice.gov.uk/owner: "Interventions: interventions-alpha-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-interventions-service"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-interventions"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-interventions-prod-admin
+  namespace: hmpps-interventions-prod
+subjects:
+  - kind: Group
+    name: "github:hmpps-interventions"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-interventions-prod
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-interventions-prod
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-interventions-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-interventions-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/variables.tf
@@ -1,0 +1,44 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Providing rehabilitation services to service users"
+}
+
+variable "namespace" {
+  default = "hmpps-interventions-prod"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-interventions"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "interventions-alpha-team@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "true"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "interventions"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Intervention teams are moving into the beta phase, so we need namespaces
to deploy the applications.

The namespace is "empty" as we will be adding modules later.

Split from #3795.