### PR TITLE
add new maintenance page release

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: sinatra-app
-        image: ministryofjustice/cloud-platform-maintenance-pages:1.2
+        image: ministryofjustice/cloud-platform-maintenance-pages:1.3
         ports:
         - containerPort: 4567


### PR DESCRIPTION
Why:
https://github.com/ministryofjustice/cloud-platform-maintenance-pages/pull/7