### PR TITLE
increase BASM pre-prod rds db size

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -10,6 +10,7 @@ module "rds-instance" {
   namespace              = var.namespace
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
+  db_allocated_storage   = 20
 
   providers = {
     aws = aws.london
@@ -63,6 +64,7 @@ module "rds-read-replica" {
   is-production          = var.is-production
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
+  db_allocated_storage   = 20
 
   db_name             = module.rds-instance.database_name
   replicate_source_db = module.rds-instance.db_identifier


### PR DESCRIPTION
Increases Book A Secure Move rds size to 20gb, in order to apply a production snapshot to pre-prod.