### PR TITLE
Allow replicasets to be managed by CircleCI in interventions-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/05-serviceaccount-circleci.yaml
@@ -33,12 +33,14 @@ rules:
     resources:
       - "deployments"
       - "ingresses"
+      - "replicasets"
     verbs:
       - "get"
       - "update"
       - "delete"
       - "create"
       - "patch"
+      - "list"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
We are getting

`Error: UPGRADE FAILED: replicasets.apps is forbidden: User "system:serviceaccount:***********************:circleci" cannot list resource "replicasets" in API group "apps" in the namespace "***********************"`

during deployment -- this change allows this.

🙋 Additionally, the name of the file now mentions `circleci`, a convention we noticed in other folders.