### PR TITLE
Allow updating secrets for default API group in interventions-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/05-serviceaccount-circleci.yaml
@@ -23,6 +23,7 @@ rules:
     verbs:
       - "patch"
       - "get"
+      - "update"
       - "create"
       - "delete"
       - "list"


### PR DESCRIPTION
Addressing deployment error on CircleCI:

`Error: UPGRADE FAILED: update: failed to update: secrets
"sh.helm.release.v1.hmpps-interventions-service.v4" is forbidden: User
"system:serviceaccount:***********************:circleci" cannot update
resource "secrets" in API group "" in the namespace
"***********************"`