### PR TITLE
Grant Helm 3 replicaset permissions in court-probation-preprod

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/05-serviceaccount-circleci.yaml
@@ -30,6 +30,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "replicasets
     verbs:
       - "patch"
       - "get"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/05-serviceaccount-circleci.yaml
@@ -30,7 +30,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
-      - "replicasets
+      - "replicasets"
     verbs:
       - "patch"
       - "get"


### PR DESCRIPTION
This should resolve the following error returned by Helm:

```
Error: replicasets.apps is forbidden: User "system:serviceaccount:***********************:circleci" cannot list resource "replicasets" in API group "apps" in the namespace "***********************"
```