### PR TITLE
Fix permission granted to wrong apiGroup

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/05-serviceaccount-circleci.yaml
@@ -37,6 +37,12 @@ rules:
       - "create"
       - "delete"
       - "list"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "replicasets"
+    verbs:
+      - "list"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/05-serviceaccount-circleci.yaml
@@ -30,7 +30,6 @@ rules:
       - "secrets"
       - "services"
       - "pods"
-      - "replicasets"
     verbs:
       - "patch"
       - "get"


### PR DESCRIPTION
Fix for:

```
Error: replicasets.apps is forbidden: User "system:serviceaccount:***********************:circleci" cannot list resource "replicasets" in API group "apps" in the namespace "***********************"
```