### PR TITLE
Remove form from pingdom

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
@@ -7,7 +7,6 @@ locals {
     cica                     = "same-roof-rule.form.service.justice.gov.uk",
     complain-about-a-court   = "complain-about-a-court-or-tribunal.form.service.justice.gov.uk",
     fix-my-court             = "fix-my-court.form.service.justice.gov.uk",
-    hmcts-complaints         = "hmcts-complaints.form.service.justice.gov.uk",
     leavers-form             = "leavers.form.service.justice.gov.uk",
     let-us-know              = "let-us-know.form.service.justice.gov.uk",
     miscarriages-of-justice  = "miscarriages-of-justice.form.service.justice.gov.uk",


### PR DESCRIPTION
The form was used for user testing and now needs to be unpublished,
    hence the reason to remove from pingdom