### PR TITLE
Create pact broker namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pact-broker-prod
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "pact-broker"
+    cloud-platform.justice.gov.uk/application: "Pact broker"
+    cloud-platform.justice.gov.uk/owner: "Interventions: interventions-alpha-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/pact-foundation/pact-broker-docker"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-interventions"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pact-broker-prod-admin
+  namespace: pact-broker-prod
+subjects:
+  - kind: Group
+    name: "github:pact-broker-maintainers"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: pact-broker-prod
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: pact-broker-prod
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: pact-broker-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: pact-broker-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/rds.tf
@@ -1,0 +1,31 @@
+module "pact_broker_rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.10"
+
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  namespace              = var.namespace
+  application            = var.application
+  business-unit          = var.business_unit
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  is-production          = var.is_production
+  team_name              = var.team_name
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "pact_broker_rds_secrets" {
+  metadata {
+    name      = "database"
+    namespace = var.namespace
+  }
+
+  data = {
+    host     = module.pact_broker_rds.rds_instance_address
+    name     = module.pact_broker_rds.database_name
+    username = module.pact_broker_rds.database_username
+    password = module.pact_broker_rds.database_password
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/variables.tf
@@ -1,0 +1,43 @@
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Pact broker"
+}
+
+variable "namespace" {
+  default = "pact-broker-prod"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-interventions"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "interventions-alpha-team@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "true"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "pact-broker"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
The https://github.com/pact-foundation/pact_broker itself is a Ruby application that requires a database. We have configured this as PostgreSQL.