### PR TITLE
Use HOODAW image 2.30

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: how-out-of-date-are-we
-          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.29
+          image: ministryofjustice/cloud-platform-how-out-of-date-are-we:2.30
           env:
             - name: RACK_ENV
               value: "production"


### PR DESCRIPTION
This version includes the namespace usage report.

depends on https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/pull/61 (plus creating a new release)