### PR TITLE
Revert "Remove privileged rules from metabase rbac"

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/01-rbac.yaml
@@ -11,3 +11,60 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:privileged:c100-application-metabase
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - privileged-c100-application-metabase
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: PrivilegedRoleBinding:c100-application-metabase
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:privileged:c100-application-metabase
+subjects:
+- kind: Group
+  name: system:serviceaccounts:c100-application-metabase
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged-c100-application-metabase
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  labels:
+    kubernetes.io/cluster-service: "true"
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - NET_BIND_SERVICE
+    - NET_ADMIN
+  requiredDropCapabilities:
+    - NET_RAW
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'


### PR DESCRIPTION
This reverts commit 1a632650ce8848b5bd0afa7d59f0f558955d0c30.

It turns out the necessary changes to run the container as non-root will be part of the next major version (v0.38) and not included in the current latest version (v0.37.3)

As we don't know when the version will be released we need to rollback the rbac so we can get metabase working again in the meantime 😞 