### PR TITLE
Add s3 storage bucket for managing manage-intelligence

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/s3.tf
@@ -1,3 +1,20 @@
+module "manage_intelligence_storage_bucket" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  team_name              = var.team_name
+  acl                    = "private"
+  versioning             = false
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
 module "manage_intelligence_rds_to_s3_bucket" {
   source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   team_name              = var.team_name
@@ -15,6 +32,19 @@ module "manage_intelligence_rds_to_s3_bucket" {
   }
 }
 
+resource "kubernetes_secret" "manage_intelligence_storage_bucket" {
+  metadata {
+    name      = "manage-intelligence-storage-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.manage_intelligence_storage_bucket.access_key_id
+    secret_access_key = module.manage_intelligence_storage_bucket.secret_access_key
+    bucket_arn        = module.manage_intelligence_storage_bucket.bucket_arn
+    bucket_name       = module.manage_intelligence_storage_bucket.bucket_name
+  }
+}
 
 resource "kubernetes_secret" "manage_intelligence_rds_to_s3_bucket" {
   metadata {


### PR DESCRIPTION
S3 bucket to store help and guidance content for the HMPPS manage intelligence service.