### PR TITLE
set hmpps-interventions-dev rds_family to 'postgres10' to fix deployment

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds.tf
@@ -1,35 +1,35 @@
-# module "hmpps_interventions_rds" {
-#   source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.10"
-#   cluster_name           = var.cluster_name
-#   cluster_state_bucket   = var.cluster_state_bucket
-#   team_name              = var.team_name
-#   business-unit          = var.business_unit
-#   application            = var.application
-#   is-production          = var.is_production
-#   namespace              = var.namespace
-#   environment-name       = var.environment
-#   infrastructure-support = var.infrastructure_support
-#   rds_family             = var.rds_family
-# 
-#   providers = {
-#     aws = aws.london
-#   }
-# }
-# 
-# resource "kubernetes_secret" "hmpps_interventions_rds" {
-#   metadata {
-#     name      = "postgres"
-#     namespace = var.namespace
-#   }
-# 
-#   data = {
-#     rds_instance_endpoint = module.hmpps_interventions_rds.rds_instance_endpoint
-#     database_name         = module.hmpps_interventions_rds.database_name
-#     database_username     = module.hmpps_interventions_rds.database_username
-#     database_password     = module.hmpps_interventions_rds.database_password
-#     rds_instance_address  = module.hmpps_interventions_rds.rds_instance_address
-#     access_key_id         = module.hmpps_interventions_rds.access_key_id
-#     secret_access_key     = module.hmpps_interventions_rds.secret_access_key
-#     url                   = "postgres://${module.hmpps_interventions_rds.database_username}:${module.hmpps_interventions_rds.database_password}@${module.hmpps_interventions_rds.rds_instance_endpoint}/${module.hmpps_interventions_rds.database_name}"
-#   }
-# }
+module "hmpps_interventions_rds" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.10"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  namespace              = var.namespace
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  rds_family             = var.rds_family
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "hmpps_interventions_rds" {
+  metadata {
+    name      = "postgres"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.hmpps_interventions_rds.rds_instance_endpoint
+    database_name         = module.hmpps_interventions_rds.database_name
+    database_username     = module.hmpps_interventions_rds.database_username
+    database_password     = module.hmpps_interventions_rds.database_password
+    rds_instance_address  = module.hmpps_interventions_rds.rds_instance_address
+    access_key_id         = module.hmpps_interventions_rds.access_key_id
+    secret_access_key     = module.hmpps_interventions_rds.secret_access_key
+    url                   = "postgres://${module.hmpps_interventions_rds.database_username}:${module.hmpps_interventions_rds.database_password}@${module.hmpps_interventions_rds.rds_instance_endpoint}/${module.hmpps_interventions_rds.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/variables.tf
@@ -48,5 +48,5 @@ variable "number_cache_clusters" {
 }
 
 variable "rds_family" {
-  default = "postgres11"
+  default = "postgres10"
 }


### PR DESCRIPTION
this is to address the following error when applying terraform

```
Error: Error creating DB Instance: InvalidParameterCombination: The Parameter Group cloud-platform-c6fbb5a155375227 with DBParameterGroupFamily postgres11 cannot be used for this instance. Please use a Parameter Group with DBParameterGroupFamily postgres10
    status code: 400, request id: 385d9afe-9161-42cc-94b3-520212767027
```