### PR TITLE
Change certs to use prison.service.justice.gov.uk

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/06-certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/06-certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: manage-intelligence-dev.hmpps.service.justice.gov.uk
+  name: manage-intelligence-dev.prison.service.justice.gov.uk
   namespace: manage-intelligence-dev
 spec:
   secretName: manage-intelligence-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-  - manage-intelligence-dev.hmpps.service.justice.gov.uk
+  - manage-intelligence-dev.prison.service.justice.gov.uk

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/07-certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/07-certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: manage-intelligence-api-dev.hmpps.service.justice.gov.uk
+  name: manage-intelligence-api-dev.prison.service.justice.gov.uk
   namespace: manage-intelligence-dev
 spec:
   secretName: manage-intelligence-api-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-  - manage-intelligence-api-dev.hmpps.service.justice.gov.uk
+  - manage-intelligence-api-dev.prison.service.justice.gov.uk


### PR DESCRIPTION
Due to issues with DXC proxies, changing the certificates for the dev instance of the node app and api