### PR TITLE
Force HTTP1.1, posting namespace usage to HOODAW

### DIFF
--- a/bin/post_namespace_usage_data.sh
+++ b/bin/post_namespace_usage_data.sh
@@ -3,6 +3,7 @@
 bin/namespace-usage-reporter.rb -n '.*' -o json > namespace-usage.json
 
 curl \
+  --http1.1 \
   -H "Content-Type: application/json" \
   -H "X-API-KEY: ${HOODAW_API_KEY}" \
   -d @namespace-usage.json \


### PR DESCRIPTION
Occasionally (about 1 time in 10), we get this error in the concourse
pipeline job that posts namespace usage data to HOODAW:

```
curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err
1)
```

e.g.
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/hoodaw/jobs/hoodaw-namespace-usage/builds/52

This PR is an attempt to fix that.

I think the underlying problem is that *something* in the chain between
the script's invocation of `curl` and the HOODAW web application is not
handling http/2 correctly wrt. large POST requests.

I've checked the curl version on the tools image, and it seems up to
date. I suspect a tweak to increase the post buffer size of the ingress
controller might be a better solution to this intermittent problem, but
TBH it just doesn't seem worth the effort for this particular issue.

Downgrading the HTTP POST to use HTTP 1.1 *should* be a viable
workaround. If it doesn't work, we can investigate other options.
