### PR TITLE
Add serviceaccount for laa-apply-slack-bot

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-serviceaccount.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-serviceaccount.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+rules:
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "ingresses"
+    verbs:
+      - "get"
+      - "list"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+subjects:
+- kind: ServiceAccount
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+roleRef:
+  kind: Role
+  name: "slackbot"
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This, currently, only needs to rad the ingresses data from the UAT
namespace. so hopefully this set of permissions is restricted/
permissive enough!