### PR TITLE
Update ServiceAccount permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/service-account-github-actions.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/service-account-github-actions.yaml
@@ -5,6 +5,19 @@ metadata:
   name: github-actions
   namespace: laa-apply-bot-production
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/service-account-github-actions.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/service-account-github-actions.yaml
@@ -9,7 +9,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: "slackbot"
-  namespace: "laa-apply-for-legalaid-uat"
+  namespace: "laa-apply-bot-production"
 rules:
   - apiGroups:
       - ""
@@ -17,6 +17,7 @@ rules:
       - "secrets"
     verbs:
       - "get"
+      - "list"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
It needs access to decode the ECR secrets to
prevent them being stored outside of the
cluster