### PR TITLE
update serviceaccount

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/service-account-github-actions.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/service-account-github-actions.yaml
@@ -8,8 +8,8 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: "slackbot"
-  namespace: "laa-apply-bot-production"
+  name: github-actions
+  namespace: laa-apply-bot-production
 rules:
   - apiGroups:
       - ""
@@ -22,11 +22,11 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: github-actions-laa-apply-bot
+  name: github-actions
   namespace: laa-apply-bot-production
 subjects:
 - kind: ServiceAccount
-  name: github-actions-laa-apply-bot
+  name: github-actions
   namespace: laa-apply-bot-production
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Permissions were not granted

On review, I noticed the names didn't always match and that the new block used quotes around the new name and namespace

Hoping this resolves the issue