### PR TITLE
Add podinfo Helm Terraform resource and Pingdom check

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/application.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/application.tf
@@ -1,0 +1,11 @@
+resource "helm_release" "cloud_platform_canary" {
+  name       = "cloud-platform-canary-application"
+  namespace  = "cloud-platform-canary-app"
+  repository = "https://stefanprodan.github.io/podinfo"
+  chart      = "podinfo"
+  version    = "5.1.2"
+
+  values = [
+    "${file("values.yaml")}"
+  ]
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/main.tf
@@ -17,3 +17,5 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "pingdom" {
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/pingdom.tf
@@ -1,0 +1,17 @@
+resource "pingdom_check" "cloud-platform-canary" {
+  type                     = "http"
+  name                     = "cloud-platform monitoring canary"
+  host                     = "canary.apps.live-1.cloud-platform.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/healthz"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_false,environment_dev,infrastructuresupport_platforms"
+  probefilters             = "region:EU"
+  publicreport             = "true"
+  integrationids           = [90339]
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/psp.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/psp.tf
@@ -1,0 +1,15 @@
+resource "kubernetes_cluster_role_binding" "cloud_platform_canary" {
+  metadata {
+    name = "cloud-platform-canary"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "psp:privileged"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:serviceaccounts:cloud-platform-canary-app"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/values.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/values.yaml
@@ -1,0 +1,127 @@
+# Default values for podinfo.
+
+replicaCount: 3
+logLevel: info
+backend: #http://backend-podinfo:9898/echo
+backends: []
+
+ui:
+  color: "#34577c"
+  message: ""
+  logo: ""
+
+faults:
+  delay: false
+  error: false
+  unhealthy: false
+  unready: false
+  testFail: false
+  testTimeout: false
+
+h2c:
+  enabled: false
+
+image:
+  repository: ghcr.io/stefanprodan/podinfo
+  tag: 5.1.2
+  pullPolicy: IfNotPresent
+
+service:
+  enabled: true
+  type: ClusterIP
+  metricsPort: 9797
+  httpPort: 9898
+  externalPort: 9898
+  grpcPort: 9999
+  grpcService: podinfo
+  nodePort: 31198
+  # the port used to bind the http port to the host
+  # NOTE: requires privileged container with NET_BIND_SERVICE capability -- this is useful for testing
+  # in local clusters such as kind without port forwarding
+  hostPort:
+
+# enable tls on the podinfo service
+tls:
+  enabled: false
+  # the name of the secret used to mount the certificate key pair
+  secretName:
+  # the path where the certificate key pair will be mounted
+  certPath: /
+  # the port used to host the tls endpoint on the service
+  port: 9899
+  # the port used to bind the tls port to the host
+  # NOTE: requires privileged container with NET_BIND_SERVICE capability -- this is useful for testing
+  # in local clusters such as kind without port forwarding
+  hostPort:
+
+# create a certificate manager certificate
+certificate:
+  create: false
+  # the issuer used to issue the certificate
+  issuerRef:
+    kind: ClusterIssuer
+    name: self-signed
+  # the hostname / subject alternative names for the certificate
+  dnsNames:
+    - podinfo
+
+# metrics-server add-on required
+hpa:
+  enabled: true
+  maxReplicas: 10
+  # average total CPU usage per pod (1-100)
+  cpu:
+  # average memory usage per pod (100Mi-1Gi)
+  memory:
+  # average http requests per second per pod (k8s-prometheus-adapter)
+  requests:
+
+# Redis address in the format <host>:<port>
+cache: ""
+# Redis deployment
+redis:
+  enabled: false
+  repository: redis
+  tag: 6.0.8
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  enabled: false
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+linkerd:
+  profile:
+    enabled: false
+
+serviceMonitor:
+  enabled: false
+  interval: 15s
+
+ingress:
+  enabled: true
+  annotations: 
+    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts: 
+    - canary.apps.live-1.cloud-platform.service.justice.gov.uk
+  tls:
+    - secretName:
+      hosts:
+        - canary.apps.live-1.cloud-platform.service.justice.gov.uk
+
+resources:
+  limits:
+  requests:
+    cpu: 1m
+    memory: 16Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations: {}


### PR DESCRIPTION
Overview
---

This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2380 and relates to the creation of a canary application in the cluster. This application uses the helpful [podinfo](https://github.com/stefanprodan/podinfo) container that sends metrics to Prometheus, structured logging and graceful shutdowns. 

Clusterrolebinding
---

As the container runs as root, I'm required to bind all serviceaccounts in the `cloud-platform-canary-app` namespace to the privileged pod security policy. 

Pingdom
---

The purpose of creating this deployment is to monitor using blackbox tooling such as Pingdom. This PR also contains a Terraform resource that creates a check that will send a trigger alarm to the #low-priority-alarms channel.