### PR TITLE
Add custom http errors annotation

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/values.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/values.yaml
@@ -103,6 +103,7 @@ ingress:
   enabled: true
   annotations: 
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/custom-http-errors: "404"
     # kubernetes.io/tls-acme: "true"
   path: /
   hosts: 


### PR DESCRIPTION
This will fail to /healthz endpoint when the pod fails to receive
traffic.