### PR TITLE
Comment out resources to unbreak apply pipeline

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/acm.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/acm.tf
@@ -13,6 +13,6 @@ resource "aws_acm_certificate" "apigw_custom_hostname" {
   }
 }
 
-resource "aws_acm_certificate_validation" "apigw_custom_hostname" {
-  certificate_arn = aws_acm_certificate.apigw_custom_hostname.arn
-}
+# resource "aws_acm_certificate_validation" "apigw_custom_hostname" {
+#   certificate_arn = aws_acm_certificate.apigw_custom_hostname.arn
+# }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/apigw.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/apigw.tf
@@ -35,29 +35,29 @@ resource "aws_iam_role" "apigw_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "api_gw_firehose_policy" {
-
-  count = length(aws_kinesis_firehose_delivery_stream.extended_s3_stream.*.arn)
-  name  = "apigw-firehose-${count.index}"
-
-  role = aws_iam_role.apigw_role.name
-
-  policy = <<EOF
-{
-  "Version" : "2012-10-17",
-  "Statement" : [
-    {
-      "Effect": "Allow",
-      "Action": "firehose:PutRecordBatch",
-
-      "Resource": [
-        "${element(aws_kinesis_firehose_delivery_stream.extended_s3_stream.*.arn, count.index)}"
-      ]
-    }
-  ]
-}
-EOF
-}
+# resource "aws_iam_role_policy" "api_gw_firehose_policy" {
+#
+#   count = length(aws_kinesis_firehose_delivery_stream.extended_s3_stream.*.arn)
+#   name  = "apigw-firehose-${count.index}"
+#
+#   role = aws_iam_role.apigw_role.name
+#
+#   policy = <<EOF
+# {
+#   "Version" : "2012-10-17",
+#   "Statement" : [
+#     {
+#       "Effect": "Allow",
+#       "Action": "firehose:PutRecordBatch",
+#
+#       "Resource": [
+#         "${element(aws_kinesis_firehose_delivery_stream.extended_s3_stream.*.arn, count.index)}"
+#       ]
+#     }
+#   ]
+# }
+# EOF
+# }
 
 
 # /tracks
@@ -197,19 +197,19 @@ resource "aws_api_gateway_usage_plan_key" "main" {
   usage_plan_id = aws_api_gateway_usage_plan.default.id
 }
 
-resource "aws_api_gateway_domain_name" "apigw_fqdn" {
-  domain_name              = aws_acm_certificate.apigw_custom_hostname.domain_name
-  regional_certificate_arn = aws_acm_certificate_validation.apigw_custom_hostname.certificate_arn
-
-  endpoint_configuration {
-    types = ["REGIONAL"]
-  }
-
-  depends_on = [aws_acm_certificate_validation.apigw_custom_hostname]
-}
-
-resource "aws_api_gateway_base_path_mapping" "mapping" {
-  api_id      = aws_api_gateway_rest_api.apigw.id
-  stage_name  = aws_api_gateway_deployment.live.stage_name
-  domain_name = aws_api_gateway_domain_name.apigw_fqdn.domain_name
-}
+# resource "aws_api_gateway_domain_name" "apigw_fqdn" {
+#   domain_name              = aws_acm_certificate.apigw_custom_hostname.domain_name
+#   regional_certificate_arn = aws_acm_certificate_validation.apigw_custom_hostname.certificate_arn
+#
+#   endpoint_configuration {
+#     types = ["REGIONAL"]
+#   }
+#
+#   depends_on = [aws_acm_certificate_validation.apigw_custom_hostname]
+# }
+#
+# resource "aws_api_gateway_base_path_mapping" "mapping" {
+#   api_id      = aws_api_gateway_rest_api.apigw.id
+#   stage_name  = aws_api_gateway_deployment.live.stage_name
+#   domain_name = aws_api_gateway_domain_name.apigw_fqdn.domain_name
+# }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/firehose.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/firehose.tf
@@ -1,27 +1,27 @@
-resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
-  count       = length(local.suppliers)
-  name        = local.suppliers[count.index]
-  destination = "extended_s3"
-
-  extended_s3_configuration {
-    role_arn            = aws_iam_role.firehose_role.arn
-    bucket_arn          = module.track_a_move_s3_bucket.bucket_arn
-    buffer_size         = 5
-    buffer_interval     = 300
-    prefix              = "${local.suppliers[count.index]}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/"
-    error_output_prefix = "error/"
-  }
-
-  tags = {
-    business-unit          = var.business_unit
-    application            = var.application
-    is-production          = var.is_production
-    environment-name       = var.environment_name
-    owner                  = var.team_name
-    infrastructure-support = var.infrastructure_support
-    namespace              = var.namespace
-  }
-}
+# resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
+#   count       = length(local.suppliers)
+#   name        = local.suppliers[count.index]
+#   destination = "extended_s3"
+#
+#   extended_s3_configuration {
+#     role_arn            = aws_iam_role.firehose_role.arn
+#     bucket_arn          = module.track_a_move_s3_bucket.bucket_arn
+#     buffer_size         = 5
+#     buffer_interval     = 300
+#     prefix              = "${local.suppliers[count.index]}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/"
+#     error_output_prefix = "error/"
+#   }
+#
+#   tags = {
+#     business-unit          = var.business_unit
+#     application            = var.application
+#     is-production          = var.is_production
+#     environment-name       = var.environment_name
+#     owner                  = var.team_name
+#     infrastructure-support = var.infrastructure_support
+#     namespace              = var.namespace
+#   }
+# }
 
 resource "aws_iam_role" "firehose_role" {
   name               = "${var.namespace}-firehose"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/route53.tf
@@ -7,14 +7,14 @@ data "kubernetes_secret" "zone_id" {
 
 # Example DNS record using Route53.
 # Route53 is not specifically required; any DNS host can be used.
-resource "aws_route53_record" "data" {
-  name    = aws_api_gateway_domain_name.apigw_fqdn.domain_name
-  type    = "A"
-  zone_id = data.kubernetes_secret.zone_id.data["zone_id"]
-
-  alias {
-    evaluate_target_health = true
-    name                   = aws_api_gateway_domain_name.apigw_fqdn.regional_domain_name
-    zone_id                = aws_api_gateway_domain_name.apigw_fqdn.regional_zone_id
-  }
-}
+# resource "aws_route53_record" "data" {
+#   name    = aws_api_gateway_domain_name.apigw_fqdn.domain_name
+#   type    = "A"
+#   zone_id = data.kubernetes_secret.zone_id.data["zone_id"]
+#
+#   alias {
+#     evaluate_target_health = true
+#     name                   = aws_api_gateway_domain_name.apigw_fqdn.regional_domain_name
+#     zone_id                = aws_api_gateway_domain_name.apigw_fqdn.regional_zone_id
+#   }
+# }


### PR DESCRIPTION
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-live-1/builds/266

The error is:
```
Command: cd namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources; terraform apply -auto-approve failed.

Error: error creating Kinesis Firehose Delivery Stream: ResourceInUseException: Firehose geoamey under accountId 754256621582 already exists

Error: Error describing created certificate: Expected certificate to be issued but was in state PENDING_VALIDATION

Error: error creating Kinesis Firehose Delivery Stream: ResourceInUseException: Firehose serco under accountId 754256621582 already exists
```

I think the prod environment resources need different names from the existing dev
resources.

In order to restore the apply pipeline to a working state, this change
comments out the firehose delivery stream as well as any other resources
which had not been successfully created.

This is the minimum set of changes I could make, in terms of leaving the
terraform state as close to its current state as possible.
