### PR TITLE
Revert laa-cla-backend-production RDS to 5.11

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -9,7 +9,7 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.11"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name
@@ -56,7 +56,7 @@ module "cla_backend_rds" {
 }
 
 module "cla_backend_replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.11"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket


### PR DESCRIPTION
The iops needs more testing. 
Concourse throws error
`Invalid iops to max storage (GB) ratio for engine name postgres and storage type io1: 0.3000`