### PR TITLE
The ratio of IOPS to allocated storage should be atleast 0.5

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
@@ -34,8 +34,8 @@ module "cla_backend_rds" {
   # Allow testing of  rds module upgrade to 5.12 https://github.com/ministryofjustice/cloud-platform-environments/pull/3951
   # Should be reverted afterwards to due to impact on cost
   db_instance_class    = "db.m4.4xlarge"
-  db_allocated_storage = "1000"
-  db_iops              = "5000"
+  db_allocated_storage = "1500"
+  db_iops              = "3000"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
@@ -9,7 +9,7 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.11"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name
@@ -35,7 +35,7 @@ module "cla_backend_rds" {
   # Should be reverted afterwards to due to impact on cost
   db_instance_class    = "db.m4.4xlarge"
   db_allocated_storage = "1000"
-  db_iops              = "3000"
+  db_iops              = "5000"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
@@ -9,7 +9,7 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.11"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name


### PR DESCRIPTION
Increasing the allocated storage to 1500 to have minimum ratio of 0.5.

This is to fix the pipeline error: InvalidParameterCombination: Invalid iops to max storage (GB) ratio for engine name postgres and storage type io1: 0.3000

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#Concepts.Storage