### PR TITLE
Upgrade to v7.9 and add encryption to cluster.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.5.1-encryption-branch"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=add-es-domain-encryption-support"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   application                = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source                     = "github.com/ministryofjustice/https://github.com/ministryofjustice/cloud-platform-terraform-elasticsearch/tree/add-es-domain-encryption-support"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.5.1-encryption-branch"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   application                = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.5.1"
+  source                     = "github.com/ministryofjustice/https://github.com/ministryofjustice/cloud-platform-terraform-elasticsearch/tree/add-es-domain-encryption-support"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   application                = var.application
@@ -10,7 +10,7 @@ module "manage_intelligence_elasticsearch" {
   team_name                  = var.team_name
   elasticsearch-domain       = "manage-intelligence"
   namespace                  = var.namespace
-  elasticsearch_version      = "7.7"
+  elasticsearch_version      = "7.9"
   aws-es-proxy-replica-count = 2
   instance_type              = "t2.medium.elasticsearch"
 }


### PR DESCRIPTION
As per recommendation from cloud-platform team, attempting to use a branch of the elasticsearch terraform module to add encryption support to our dev cluster. The expectation is that the cluster will be rebuilt which is fine for the dev instance.