### PR TITLE
Add Helm authentication in canary application

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/resources/main.tf
@@ -19,3 +19,9 @@ provider "aws" {
 
 provider "pingdom" {
 }
+
+provider "helm" {
+  kubernetes {
+    config_path = "/tmp/kubeconfig"
+  }
+}


### PR DESCRIPTION
Terraform requires an auth block so it knows where to look for a
kubeconfig file. This PR adds that block into the canary app namespace. 