### PR TITLE
Form Builder - Remove old submit product ECR repo

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -333,28 +333,6 @@ resource "kubernetes_secret" "ecr-repo-fb-pdf-generator" {
 
 ##################################################
 
-module "ecr-repo-fb-submit-product" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
-
-  team_name = "formbuilder"
-  repo_name = "fb-submit-product"
-}
-
-resource "kubernetes_secret" "ecr-repo-fb-submit-product" {
-  metadata {
-    name      = "ecr-repo-fb-submit-product"
-    namespace = "formbuilder-repos"
-  }
-
-  data = {
-    repo_url          = module.ecr-repo-fb-submit-product.repo_url
-    access_key_id     = module.ecr-repo-fb-submit-product.access_key_id
-    secret_access_key = module.ecr-repo-fb-submit-product.secret_access_key
-  }
-}
-
-##################################################
-
 module "ecr-repo-fb-base-adapter" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
 


### PR DESCRIPTION
Carrying on from [this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/3990)

We also no longer require this ECR repo.

https://trello.com/c/hcr5vlD5/1132-remove-unused-namespace-and-document-the-other-namespaces-we-have