### PR TITLE
Change data.name in dashboard to avoid conflict

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/10-prometheus-k8s-dashboard.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/10-prometheus-k8s-dashboard.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     grafana_dashboard: "court-probation-pods"
 data:
-  my-dashboard.json: |
+  court-probation-prod.json: |
     {
       "annotations": {
         "list": [


### PR DESCRIPTION
@jhevans reported an issue whereby the court-probation for prod dashboard had gone missing. This was caused by a failure to load the following configmap into grafana. A change of data.name fixed the issue when applying locally (kubectl edit). This PR reflects that change.