### PR TITLE
court-probation-prod: add RDS client ID/secret to k8s secrets

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds.tf
@@ -37,6 +37,8 @@ resource "kubernetes_secret" "court_case_service_rds" {
     database_password     = module.court_case_service_rds.database_password
     rds_instance_address  = module.court_case_service_rds.rds_instance_address
     url                   = "postgres://${module.court_case_service_rds.database_username}:${module.court_case_service_rds.database_password}@${module.court_case_service_rds.rds_instance_endpoint}/${module.court_case_service_rds.database_name}"
+    access_key_id         = module.court_case_service_rds.access_key_id
+    secret_access_key     = module.court_case_service_rds.secret_access_key
   }
 }
 


### PR DESCRIPTION
This PR adds the AWS client ID/secret for RDS so we can configure manual snapshots of RDS databases for court-case-service in court-probation-prod namespace.