### PR TITLE
Add a DynamoDB table for terraform state locking

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/state-lock-table.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/state-lock-table.tf
@@ -1,0 +1,30 @@
+module "opseng_tf_state_lock" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+
+  team_name              = var.team_name
+  application            = var.application
+  business-unit          = var.business_unit
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  is-production          = "true"
+  namespace              = var.namespace
+
+  hash_key          = "LockID"
+  enable_encryption = "false"
+  enable_autoscaler = "true"
+  aws_region        = "eu-west-2"
+}
+
+resource "kubernetes_secret" "opseng_tf_state_lock" {
+  metadata {
+    name      = "terraform-state-lock-table"
+    namespace = var.namespace
+  }
+
+  data = {
+    table_name        = module.opseng_tf_state_lock.table_name
+    table_arn         = module.opseng_tf_state_lock.table_arn
+    access_key_id     = module.opseng_tf_state_lock.access_key_id
+    secret_access_key = module.opseng_tf_state_lock.secret_access_key
+  }
+}


### PR DESCRIPTION
This table will be used to lock terraform states for Operations
Engineering projects (initially [this
one](https://github.com/ministryofjustice/github-collaborators).

A later change will add an AWS IAM user with permissions to access both
this dynamodb table, and the S3 bucket (also defined in this folder)
which stores the terraform state files.
