### PR TITLE
Add a path to the opseng terraform IAM user

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/terraform-iam-user.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/terraform-iam-user.tf
@@ -10,6 +10,7 @@ resource "random_id" "id" {
 
 resource "aws_iam_user" "terraform_user" {
   name = "terraform-user-${random_id.id.hex}"
+  path = "/system/opsend-terraform-user"
 }
 
 resource "aws_iam_access_key" "terraform_user" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/terraform-iam-user.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/terraform-iam-user.tf
@@ -10,7 +10,7 @@ resource "random_id" "id" {
 
 resource "aws_iam_user" "terraform_user" {
   name = "terraform-user-${random_id.id.hex}"
-  path = "/system/opsend-terraform-user"
+  path = "/system/opseng-terraform-user"
 }
 
 resource "aws_iam_access_key" "terraform_user" {


### PR DESCRIPTION
The previous PR failed to create this user.

```
Error: Error creating IAM User terraform-user-bbddf46750d979fbbcec4e6bf067d4c4: AccessDenied: User: arn:aws:iam::754256621582:user/cloud-platform/manager-concourse is not authorized to perform: iam:CreateUser on resource: arn:aws:iam::754256621582:user/terraform-user-bbddf46750d979fbbcec4e6bf067d4c4
	status code: 403, request id: 0e2e65d7-7271-4bc7-bcfe-e210ad17fbc6
```

However, other IAM users have been created 
successfully.

Looking at others, I can see that they have a 
`path` defined, so this change adds a path to 
this IAM user, to see if that fixes the problem.