### PR TITLE
Removed unnecessary tag

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/pingdom.tf
@@ -12,7 +12,7 @@ resource "pingdom_check" "prepare-a-case-production-check" {
   url                      = "/"
   encryption               = true
   port                     = 443
-  tags                     = "hmpps, prepare-a-case, pic, cloudplatform-managed"
+  tags                     = "hmpps, prepare-a-case, cloudplatform-managed"
   probefilters             = "region:EU"
   integrationids           = [110432]
 }


### PR DESCRIPTION
This PR is to remove `pic` tag from `pingdom.tf` as it's not required.