### PR TITLE
Change principal of queue policy to s3

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
@@ -94,7 +94,9 @@ resource "aws_sqs_queue_policy" "hmpps_pin_phone_monitor_s3_event_queue_policy" 
     "Statement": [
       {
         "Effect": "Allow",
-        "Principal": "*",
+         "Principal": {
+            "Service": "s3.amazonaws.com"
+         },
         "Action": "sqs:SendMessage",
         "Resource": "${module.hmpps_pin_phone_monitor_s3_event_queue.sqs_arn}",
         "Condition": {


### PR DESCRIPTION
Following this example to create s3 notifications that are pushed to SQS:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification

Have been encountering this error: "Unable to validate the following destination configurations" which indicates the SQS policy needs to exist that grants S3 permissions to push messages to the queue. I believe there is a dependency on the policy existing before the bucket notification resources.