### PR TITLE
Prisoner Content Hub: Add user/bucket policies to allow development S3 user to pull staging S3 content

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -38,7 +38,7 @@ module "drupal_content_storage" {
         "$${bucket_arn}/*",
         "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461/*"
       ]
-    },
+    }
   ]
 }
 EOF

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -35,7 +35,7 @@ module "drupal_content_storage" {
         "s3:*"
       ],
       "Resource": [
-        "$${bucket_arn}/*"
+        "$${bucket_arn}/*",
         "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461/*"
       ]
     },

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -9,6 +9,40 @@ module "drupal_content_storage" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
+
+  # Adds staging S3 resource to user-policy to allow one-way sync
+  # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
+  user_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "$${bucket_arn}",
+        "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461"
+      ]
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "$${bucket_arn}/*"
+        "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461/*"
+      ]
+    },
+  ]
+}
+EOF
+
 }
 
 resource "kubernetes_secret" "drupal_content_storage_secret" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -9,6 +9,29 @@ module "drupal_content_storage" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
+
+  bucket_policy = = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowHubDevelopmentS3Sync",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-8f67b39c6e3bd0e7ca18f73b97b39938"
+      },
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "$${bucket_arn}",
+        "$${bucket_arn}/*"
+      ]
+    }
+  ]
+}
+EOF
 }
 
 resource "kubernetes_secret" "drupal_content_storage_secret" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -10,7 +10,7 @@ module "drupal_content_storage" {
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
 
-  bucket_policy = = <<EOF
+  bucket_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [


### PR DESCRIPTION
This PR enables the S3 user in the `prisoner-content-hub-development` namespace to read from the S3 bucket in `prisoner-content-hub-staging`, following the [guidance for migrating S3 buckets](https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets).

I've hard-coded the IAM user and bucket ARNs because they're reaching across into different namespaces. If there's a way to reference it in Terraform rather than using absolute values I'd love a push in the right direction. I'll happily update this PR.