### PR TITLE
Enable staging & development to read-only sync S3 from production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -10,7 +10,7 @@ module "drupal_content_storage" {
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
 
-  # Adds staging S3 resource to user-policy to allow one-way sync
+  # Adds staging & production S3 resources to user-policy to allow one-way sync
   # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
   user_policy = <<EOF
 {
@@ -25,7 +25,8 @@ module "drupal_content_storage" {
       ],
       "Resource": [
         "$${bucket_arn}",
-        "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461"
+        "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461",
+        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"
       ]
     },
     {
@@ -36,7 +37,8 @@ module "drupal_content_storage" {
       ],
       "Resource": [
         "$${bucket_arn}/*",
-        "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461/*"
+        "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461/*",
+        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*
       ]
     }
   ]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -38,7 +38,7 @@ module "drupal_content_storage" {
       "Resource": [
         "$${bucket_arn}/*",
         "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461/*",
-        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*
+        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*"
       ]
     }
   ]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -38,7 +38,7 @@ module "drupal_content_storage" {
       "Resource": [
         "$${bucket_arn}/*",
         "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461/*",
-        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*"
+        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b/*"
       ]
     }
   ]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -16,6 +16,44 @@ module "drupal_content_storage" {
   providers = {
     aws = aws.ireland
   }
+
+  bucket_policy = = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowHubDevelopmentS3Sync",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-8f67b39c6e3bd0e7ca18f73b97b39938"
+      },
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "$${bucket_arn}",
+        "$${bucket_arn}/*"
+      ]
+    },
+    {
+      "Sid": "AllowHubStagingS3Sync",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-c3b3fc90408e8f9501268e354d44f461"
+      },
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "$${bucket_arn}",
+        "$${bucket_arn}/*"
+      ]
+    }
+  ]
+}
+EOF
 }
 
 resource "kubernetes_secret" "drupal_content_storage_secret" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -17,7 +17,7 @@ module "drupal_content_storage" {
     aws = aws.ireland
   }
 
-  bucket_policy = = <<EOF
+  bucket_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -32,11 +32,10 @@ module "drupal_content_storage" {
   ]
 }
 EOF
-}
 
-# Adds production S3 resources to user-policy to allow one-way sync
-# https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
-user_policy = <<EOF
+  # Adds production S3 resources to user-policy to allow one-way sync
+  # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
+  user_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -66,6 +65,8 @@ user_policy = <<EOF
   ]
 }
 EOF
+
+}
 resource "kubernetes_secret" "drupal_content_storage_secret" {
   metadata {
     name      = "drupal-s3"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -62,7 +62,7 @@ user_policy = <<EOF
         "$${bucket_arn}/*",
         "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*"
       ]
-    },
+    }
   ]
 }
 EOF

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -60,7 +60,7 @@ EOF
       ],
       "Resource": [
         "$${bucket_arn}/*",
-        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*
+        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*"
       ]
     },
   ]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -60,7 +60,7 @@ user_policy = <<EOF
       ],
       "Resource": [
         "$${bucket_arn}/*",
-        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*"
+        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b/*"
       ]
     }
   ]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -34,6 +34,38 @@ module "drupal_content_storage" {
 EOF
 }
 
+  # Adds production S3 resources to user-policy to allow one-way sync
+  # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
+  user_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "$${bucket_arn}",
+        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"
+      ]
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "$${bucket_arn}/*",
+        "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"/*
+      ]
+    },
+  ]
+}
+EOF
 resource "kubernetes_secret" "drupal_content_storage_secret" {
   metadata {
     name      = "drupal-s3"


### PR DESCRIPTION
Following on from #4045, we've validated those changes enable us to sync data from one S3 bucket to another.

This PR introduces the same change, but for to enable sync from `production` S3 to `staging` and `development`.

The multi-namespace check will complain, but again, this is reaching between namespaces.