### PR TITLE
Prisoner Content Hub: Bring ElasticSearch Yellow/Red alerts in line with prisoner/probration offender search

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/09-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/09-prometheus.yaml
@@ -131,7 +131,7 @@ spec:
           annotations:
             message: "[{{ $labels.domain_name }}] At least one primary ElasticSearch shard and its replicas are not allocated to a node."
             runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html#aes-handling-errors-red-cluster-status
-          expr: aws_es_cluster_status_red_average{domain_name="pfs-production-hub-search"} >= 1
+          expr: aws_es_cluster_status_red_maximum{domain_name="pfs-production-hub-search"} >= 1
           for: 1m
           labels:
             severity: pfs-hub
@@ -139,7 +139,7 @@ spec:
           annotations:
             message: "[{{ $labels.domain_name }}] At least one ElasticSearch replica shard is not allocated to a node"
             runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html#aes-handling-errors-yellow-cluster-status
-          expr: aws_es_cluster_status_yellow_average{domain_name="pfs-production-hub-search"} >= 1
+          expr: aws_es_cluster_status_yellow_maximum{domain_name=~"pfs-production-hub-search"} >= 1
           for: 1m
           labels:
             severity: pfs-hub


### PR DESCRIPTION
This PR updates prisoner content hub's yellow/red ElasticSearch alerts to make them consistent with other ES monitoring on Cloud Platform.