### PR TITLE
Set max_allocated_storage to 1000

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -9,7 +9,7 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.11"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name
@@ -23,6 +23,7 @@ module "cla_backend_rds" {
   db_instance_class    = "db.m4.4xlarge"
   db_allocated_storage = "1000"
   db_iops              = "3000"
+  db_max_allocated_storage = "1000"
 
   # change the postgres version as you see fit.
   db_engine_version      = "9.6"
@@ -56,7 +57,7 @@ module "cla_backend_rds" {
 }
 
 module "cla_backend_replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.11"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
@@ -73,6 +74,7 @@ module "cla_backend_replica" {
   db_instance_class    = "db.m4.4xlarge"
   db_allocated_storage = "1000"
   db_iops              = "3000"
+  db_max_allocated_storage = "1000"
 
   # change the postgres version as you see fit.
   db_engine_version = "9.6"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -20,9 +20,9 @@ module "cla_backend_rds" {
 
   db_name = "cla_backend"
   # Settings from current setup
-  db_instance_class    = "db.m4.4xlarge"
-  db_allocated_storage = "1000"
-  db_iops              = "3000"
+  db_instance_class        = "db.m4.4xlarge"
+  db_allocated_storage     = "1000"
+  db_iops                  = "3000"
   db_max_allocated_storage = "1000"
 
   # change the postgres version as you see fit.
@@ -71,9 +71,9 @@ module "cla_backend_replica" {
 
 
   # Settings from current setup
-  db_instance_class    = "db.m4.4xlarge"
-  db_allocated_storage = "1000"
-  db_iops              = "3000"
+  db_instance_class        = "db.m4.4xlarge"
+  db_allocated_storage     = "1000"
+  db_iops                  = "3000"
   db_max_allocated_storage = "1000"
 
   # change the postgres version as you see fit.


### PR DESCRIPTION
 the ratio of iops to max storage should be at-least 0.5. This is to adjust the auto-scaling capability enabled on the module.

More details here: https://github.com/ministryofjustice/cloud-platform-environments/pull/3978