### PR TITLE
Prisoner Content Hub: Increase ElasticSearch disk (production)

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -12,4 +12,5 @@ module "content_hub_elasticsearch" {
   namespace              = var.namespace
   elasticsearch_version  = "7.1"
   ebs_volume_size        = 50
+  instance_type          = "t3.small.elasticsearch"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -11,4 +11,5 @@ module "content_hub_elasticsearch" {
   elasticsearch-domain   = "hub-search"
   namespace              = var.namespace
   elasticsearch_version  = "7.1"
+  ebs_volume_size        = 50
 }


### PR DESCRIPTION
This applies the ElasticSearch disk increase to the prisoner content hub production namespace. Follows on from the previous PR testing this in staging https://github.com/ministryofjustice/cloud-platform-environments/pull/4059.

We believe the yellow cluster alerts we've been receiving for prisoner content hub are caused by momentary dips in available disk space (talked about [here](https://mojdt.slack.com/archives/C57UPMZLY/p1610615299003400)).

This PR hopes to resolve these alarms by increasing the disk from 10Gb to 50Gb.