### PR TITLE
Stop pushing secrets to prison-to-nhs-update-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/prison_to_nhs_update-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/prison_to_nhs_update-sub-queue.tf
@@ -14,7 +14,7 @@ module "prison_to_nhs_update_queue" {
   {
     "deadLetterTargetArn": "${module.prison_to_nhs_update_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
   }
-  
+
 EOF
 
 
@@ -47,7 +47,7 @@ resource "aws_sqs_queue_policy" "prison_to_nhs_update_queue_policy" {
         }
       ]
   }
-   
+
 EOF
 
 }
@@ -68,35 +68,35 @@ module "prison_to_nhs_update_dead_letter_queue" {
   }
 }
 
-resource "kubernetes_secret" "prison_to_nhs_update_queue" {
-  metadata {
-    name      = "ptnhs-sqs-instance-output"
-    namespace = "prison-to-nhs-update-dev"
-  }
-
-  data = {
-    access_key_id     = module.prison_to_nhs_update_queue.access_key_id
-    secret_access_key = module.prison_to_nhs_update_queue.secret_access_key
-    sqs_ptnhs_url     = module.prison_to_nhs_update_queue.sqs_id
-    sqs_ptnhs_arn     = module.prison_to_nhs_update_queue.sqs_arn
-    sqs_ptnhs_name    = module.prison_to_nhs_update_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "prison_to_nhs_update_dead_letter_queue" {
-  metadata {
-    name      = "ptnhs-sqs-dl-instance-output"
-    namespace = "prison-to-nhs-update-dev"
-  }
-
-  data = {
-    access_key_id     = module.prison_to_nhs_update_dead_letter_queue.access_key_id
-    secret_access_key = module.prison_to_nhs_update_dead_letter_queue.secret_access_key
-    sqs_ptnhs_url     = module.prison_to_nhs_update_dead_letter_queue.sqs_id
-    sqs_ptnhs_arn     = module.prison_to_nhs_update_dead_letter_queue.sqs_arn
-    sqs_ptnhs_name    = module.prison_to_nhs_update_dead_letter_queue.sqs_name
-  }
-}
+# resource "kubernetes_secret" "prison_to_nhs_update_queue" {
+#   metadata {
+#     name      = "ptnhs-sqs-instance-output"
+#     namespace = "prison-to-nhs-update-dev"
+#   }
+#
+#   data = {
+#     access_key_id     = module.prison_to_nhs_update_queue.access_key_id
+#     secret_access_key = module.prison_to_nhs_update_queue.secret_access_key
+#     sqs_ptnhs_url     = module.prison_to_nhs_update_queue.sqs_id
+#     sqs_ptnhs_arn     = module.prison_to_nhs_update_queue.sqs_arn
+#     sqs_ptnhs_name    = module.prison_to_nhs_update_queue.sqs_name
+#   }
+# }
+#
+# resource "kubernetes_secret" "prison_to_nhs_update_dead_letter_queue" {
+#   metadata {
+#     name      = "ptnhs-sqs-dl-instance-output"
+#     namespace = "prison-to-nhs-update-dev"
+#   }
+#
+#   data = {
+#     access_key_id     = module.prison_to_nhs_update_dead_letter_queue.access_key_id
+#     secret_access_key = module.prison_to_nhs_update_dead_letter_queue.secret_access_key
+#     sqs_ptnhs_url     = module.prison_to_nhs_update_dead_letter_queue.sqs_id
+#     sqs_ptnhs_arn     = module.prison_to_nhs_update_dead_letter_queue.sqs_arn
+#     sqs_ptnhs_name    = module.prison_to_nhs_update_dead_letter_queue.sqs_name
+#   }
+# }
 
 resource "aws_sns_topic_subscription" "prison_to_nhs_update_subscription" {
   provider      = aws.london


### PR DESCRIPTION
The prison-to-nhs-update-dev namespace has been deleted, so these
secrets cannot be provisioned anymore. Trying to create them causes the
apply pipeline to fail.
