### PR TITLE
Prisoner Content Hub: increase ElasticSearch yellow cluster alarm threshold

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/09-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/09-prometheus.yaml
@@ -140,7 +140,7 @@ spec:
             message: "[{{ $labels.domain_name }}] At least one ElasticSearch replica shard is not allocated to a node"
             runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html#aes-handling-errors-yellow-cluster-status
           expr: aws_es_cluster_status_yellow_maximum{domain_name=~"pfs-production-hub-search"} >= 1
-          for: 1m
+          for: 6m
           labels:
             severity: pfs-hub
         - alert: ElasticSearchClusterFreeStorageSpace


### PR DESCRIPTION
This PR increases our ElasticSearch yellow cluster alarm to 6 minute threshold.

Following on from https://mojdt.slack.com/archives/C57UPMZLY/p1610615299003400, we increased the available disk space in #4059 and #4060. However, we're still seeing the same alarms. 

Given the struggle to find a cause, and that they always resolve themselves in exactly 5 minutes, this feels like a good trade-off between getting to the bottom of it and retaining the will to live 🤷‍♂️