### PR TITLE
Add formbuilder editor workers service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/editor-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/editor-workers-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-editor/templates/editor-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the editor worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-test-(deploymentEnvironment)
+# namespaces so that they can deploy services there
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-editor-workers-test
+  namespace: formbuilder-saas-test

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/01-rbac.yaml
@@ -14,8 +14,9 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
-  
-# Bind admin role for namespace to team group & publisher ServiceAccount
+
+# Bind admin role for namespace to team group & publisher ServiceAccount &
+# editor ServiceAccount
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,6 +28,10 @@ subjects:
   - kind: ServiceAccount
     name: formbuilder-publisher-workers-test
     namespace: formbuilder-publisher-test
+  # allow platformenv Editor to deploy to this deploymentenv
+  - kind: ServiceAccount
+    name: formbuilder-editor-workers-test
+    namespace: formbuilder-saas-test
   # ...but only the dev service token cache can read the dev
   # service tokens
   - kind: ServiceAccount

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/01-rbac.yaml
@@ -14,8 +14,9 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
-  
+
 # Bind admin role for namespace to team group & publisher ServiceAccount
+# & editor ServiceAccount
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,6 +28,10 @@ subjects:
   - kind: ServiceAccount
     name: formbuilder-publisher-workers-test
     namespace: formbuilder-publisher-test
+  # allow platformenv Editor to deploy to this deploymentenv
+  - kind: ServiceAccount
+    name: formbuilder-editor-workers-test
+    namespace: formbuilder-saas-test
   # ...but only the dev service token cache can read the dev
   # service tokens
   - kind: ServiceAccount


### PR DESCRIPTION
## Context

We are building the new formbuilder editor in the test environment. 

The editor will be publishing forms into the formbuilder-services-test-* namespaces and it needs a specific service account to provision new pods and applying k8s files. 

## What this PR adds

This PR adds a service account that will be used to provisioning new forms into the services namespace as we are starting to build the editor test environment.

The editor-workers for the test environment can provisioning forms for draft forms and published forms in the services test environment (formbuilder-services-test-dev and formbuilder-service-test-production respectively)