### PR TITLE
Add formbuilder editor workers service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/editor-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/editor-workers-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-editor/templates/editor-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the editor worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-test-(deploymentEnvironment)
+# namespaces so that they can deploy services there
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-editor-workers-test
+  namespace: formbuilder-saas-test


### PR DESCRIPTION
## Context
We are building the new formbuilder editor in the test environment.

The editor will be publishing forms into the formbuilder-services-test-* namespaces and it needs a specific service account to provision new pods and applying k8s files.

## What this PR adds

This PR adds a service account that will be used to provisioning new forms into the formbuilder services namespace as we are starting to build the editor test environment.

## Next steps

Add the permission to this service account to this two namespaces:

- formbuilder-services-test-dev
- formbuilder-services-test-production
