### PR TITLE
Set up the github provider in terraform template

### DIFF
--- a/namespace-resources-cli-template/resources/main.tf
+++ b/namespace-resources-cli-template/resources/main.tf
@@ -17,3 +17,7 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespace-resources-cli-template/resources/variables.tf
+++ b/namespace-resources-cli-template/resources/variables.tf
@@ -42,3 +42,13 @@ variable "slack_channel" {
   description = "Team slack channel to use if we need to contact your team"
   default     = "{{ .SlackChannel }}"
 }
+
+variable "github_owner" {
+  description = "Required by the github terraform provider"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the github terraform provider"
+  default     = ""
+}


### PR DESCRIPTION
This ensures that all namespaces created by the
cloud platform CLI will correctly initialise the
github provider.

This is required for the ECR and serviceaccount
modules, so that they can create github actions
secrets containing their credentials.