### PR TITLE
✨ PIC-1085: Add S3 bucket for cpmg performance test data

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/perf_test_data_s3_bucket.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/perf_test_data_s3_bucket.tf
@@ -1,0 +1,30 @@
+module "perf-test-data-s3-bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+
+  team_name              = var.team_name
+  business-unit          = var.business-unit
+  application            = "cpmg-gatling-performance-tests"
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "perf-test-data-s3-secret" {
+  metadata {
+    name      = "perf-test-data-s3-credentials"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.perf-test-data-s3-bucket.access_key_id
+    bucket_arn        = module.perf-test-data-s3-bucket.bucket_arn
+    bucket_name       = module.perf-test-data-s3-bucket.bucket_name
+    secret_access_key = module.perf-test-data-s3-bucket.secret_access_key
+  }
+}
+


### PR DESCRIPTION
This bucket is required to support performance testing in preprod only so there are no corresponding buckets in dev or prod