### PR TITLE
Create moj-prototype namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/00-namespace.yaml
@@ -10,5 +10,5 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "ask-operations-engineering"
     cloud-platform.justice.gov.uk/application: "MoJ Prototype Template"
     cloud-platform.justice.gov.uk/owner: "Operations Engineering: operations-engineering@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/digitalronin/moj-prototype-template"
-    cloud-platform.justice.gov.uk/team-name: "operations-engineering" 
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/moj-prototype-template"
+    cloud-platform.justice.gov.uk/team-name: "operations-engineering"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: moj-prototype
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "ask-operations-engineering"
+    cloud-platform.justice.gov.uk/application: "MoJ Prototype Template"
+    cloud-platform.justice.gov.uk/owner: "Operations Engineering: operations-engineering@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/digitalronin/moj-prototype-template"
+    cloud-platform.justice.gov.uk/team-name: "operations-engineering" 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: moj-prototype-admin
+  namespace: moj-prototype
+subjects:
+  - kind: Group
+    name: "github:operations-engineering"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: moj-prototype
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: moj-prototype
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: moj-prototype
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: moj-prototype
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/ecr.tf
@@ -4,10 +4,7 @@ module "ecr-repo" {
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 
-  # Uncomment and provide repository names to create github actions secrets
-  # containing the ECR name, AWS access key, and AWS secret key, for use in
-  # github actions CI/CD pipelines
-  # github_repositories = ["my-repo"]
+  github_repositories = ["moj-prototype-template"]
 }
 
 resource "kubernetes_secret" "ecr-repo" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/ecr.tf
@@ -1,0 +1,24 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/serviceaccount.tf
@@ -3,7 +3,5 @@ module "serviceaccount" {
 
   namespace = var.namespace
 
-  # Uncomment and provide repository names to create github actions secrets
-  # containing the ca.crt and token for use in github actions CI/CD pipelines
-  # github_repositories = ["my-repo"]
+  github_repositories = ["moj-prototype-template"]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/serviceaccount.tf
@@ -1,0 +1,9 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.3"
+
+  namespace = var.namespace
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/variables.tf
@@ -1,0 +1,54 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "MoJ Prototype Template"
+}
+
+variable "namespace" {
+  default = "moj-prototype"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "operations-engineering"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "operations-engineering@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "ask-operations-engineering"
+}
+
+variable "github_owner" {
+  description = "Required by the github terraform provider"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the github terraform provider"
+  default     = ""
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/moj-prototype/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This namespace will be used to develop a Cloud Platform MoJ Prototype
tool. i.e. a way to quickly create prototypes based on the Gov.UK
prototype kit, hosted on the MoJ Cloud Platform.
