### PR TITLE
Add template files for gov.uk prototype kits

### DIFF
--- a/namespace-resources-cli-template/resources/prototype/basic-auth.tf
+++ b/namespace-resources-cli-template/resources/prototype/basic-auth.tf
@@ -1,0 +1,13 @@
+# Username and password for the prototype kit website's http basic
+# authentication
+resource "kubernetes_secret" "basic-auth" {
+  metadata {
+    name      = "basic-auth"
+    namespace = var.namespace
+  }
+
+  data = {
+    username = var.basic-auth-username
+    password = var.basic-auth-password
+  }
+}

--- a/namespace-resources-cli-template/resources/prototype/ecr.tf
+++ b/namespace-resources-cli-template/resources/prototype/ecr.tf
@@ -1,0 +1,21 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  github_repositories = [var.namespace]
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
+  }
+}

--- a/namespace-resources-cli-template/resources/prototype/github-repo.tf
+++ b/namespace-resources-cli-template/resources/prototype/github-repo.tf
@@ -1,0 +1,61 @@
+data "github_team" "default" {
+  slug = "{{ .GithubTeam }}"
+}
+
+locals {
+  topics = ["gov-uk-prototype-kit", "moj-cloud-platform"]
+
+  # These teams will be granted admin access to the github repository
+  teams = {
+    "default" : { id = data.github_team.default.id },
+  }
+}
+
+# Repository basics
+resource "github_repository" "prototype" {
+  name                   = var.namespace
+  description            = "Gov.UK Prototype Kit. This repository is defined and managed in Terraform"
+  visibility             = "public"
+  has_issues             = false
+  has_projects           = false
+  has_wiki               = false
+  has_downloads          = false
+  is_template            = false
+  allow_merge_commit     = true
+  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  delete_branch_on_merge = true
+  auto_init              = false
+  archived               = false
+  vulnerability_alerts   = true
+  topics                 = local.topics
+
+  template {
+    owner      = "ministryofjustice"
+    repository = "moj-prototype-template"
+  }
+
+  lifecycle {
+    ignore_changes = [template]
+  }
+}
+
+resource "github_branch_protection" "default" {
+  repository_id          = github_repository.prototype.id
+  pattern                = "main"
+  enforce_admins         = true
+  require_signed_commits = true
+}
+
+resource "github_team_repository" "prototype" {
+  for_each   = local.teams
+  team_id    = each.value.id
+  repository = github_repository.prototype.name
+  permission = "admin"
+}
+
+resource "github_actions_secret" "prototype" {
+  repository      = github_repository.prototype.name
+  secret_name     = "PROTOTYPE_NAME"
+  plaintext_value = var.namespace
+}

--- a/namespace-resources-cli-template/resources/prototype/serviceaccount.tf
+++ b/namespace-resources-cli-template/resources/prototype/serviceaccount.tf
@@ -1,0 +1,7 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.3"
+
+  namespace = var.namespace
+
+  github_repositories = [var.namespace]
+}


### PR DESCRIPTION
These files will be used by the cli tool when a user runs:

```
cloud-platform environment prototype create
```

These files represent (most of) the difference between a "vanilla"
namespace, and a namespace plus github repository with continuous
deployment of a gov.uk prototype kit site.
