### PR TITLE
Update the namespace deleter script

### DIFF
--- a/bin/auto-delete-namespace.rb
+++ b/bin/auto-delete-namespace.rb
@@ -16,11 +16,14 @@
 #   export TF_VAR_cluster_name=live-1.cloud-platform.service.justice.gov.uk
 #   export TF_VAR_cluster_state_bucket=cloud-platform-terraform-state
 #   export TF_VAR_cluster_state_key=cloud-platform/live-1/terraform.tfstate
+#   export TF_VAR_github_owner="ministryofjustice"
+#   export TF_VAR_github_token=[redacted]
 #
 #   # Env vars to enable kubectl to operate on the cluster by grabbing the kubeconfig
 #   # file from S3
 #   export KUBECONFIG_S3_BUCKET=cloud-platform-concourse-kubeconfig
 #   export KUBECONFIG_S3_KEY=kubeconfig
+#   export KUBE_CONFIG_PATH=/tmp/kubeconfig
 #   export KUBE_CONFIG=/tmp/kubeconfig
 #   export KUBE_CTX=live-1.cloud-platform.service.justice.gov.uk
 
@@ -34,9 +37,9 @@ def main(cluster)
   if namespaces.any?
     msg = <<~EOF
       Deleting following namespaces which have been removed from the environments repository:
-  
+
         - #{namespaces.join("\n  - ")}
-  
+
     EOF
 
     puts msg

--- a/lib/cp_env/namespace_deleter.rb
+++ b/lib/cp_env/namespace_deleter.rb
@@ -19,7 +19,7 @@ class CpEnv
     NAMEPACES_DIR = "namespaces/#{CLUSTER}"
     PRODUCTION_LABEL = "cloud-platform.justice.gov.uk/is-production"
     LABEL_TRUE = "true"
-    EMPTY_MAIN_TF_URL = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template/resources/main.tf"
+    EMPTY_TF_DIR_URL = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template/resources"
 
     def initialize(args)
       @namespace = args.fetch(:namespace)
@@ -79,7 +79,7 @@ class CpEnv
     end
 
     def destroy_aws_resources
-      create_empty_main_tf
+      create_terraform_files_for_empty_namespace
       log("green", "Destroying AWS resources for namespace #{namespace}...")
       NamespaceDir.new(cluster: CLUSTER, dir: namespace_dir).apply
     end
@@ -120,12 +120,14 @@ class CpEnv
       )
     end
 
-    def create_empty_main_tf
+    def create_terraform_files_for_empty_namespace
       dir = File.join(namespace_dir, "resources")
       execute("mkdir -p #{dir}")
-      content = URI.open(EMPTY_MAIN_TF_URL).read
-      file = File.join(dir, "main.tf")
-      File.open(file, "w") { |f| f.puts(content) }
+      ["main.tf", "variables.tf", "versions.tf"].each do |tf_file|
+        content = URI.open(EMPTY_TF_DIR_URL + "/" + tf_file).read
+        file = File.join(dir, tf_file)
+        File.open(file, "w") { |f| f.puts(content) }
+      end
     end
 
     # Remove the empty main.tf we created, along

--- a/spec/namespace_deleter_spec.rb
+++ b/spec/namespace_deleter_spec.rb
@@ -103,7 +103,9 @@ describe CpEnv::NamespaceDeleter do
       allow(Open3).to receive(:capture3).at_least(:once).and_return(["", "", success])
       expect(Open3).to receive(:capture3).with("mkdir -p namespaces/live-1.cloud-platform.service.justice.gov.uk/nonprod/resources").and_return(["", "", success])
       allow(FileTest).to receive(:directory?).with("namespaces/live-1.cloud-platform.service.justice.gov.uk/#{namespace}").and_return(false, true)
-      expect(File).to receive(:open).with("namespaces/live-1.cloud-platform.service.justice.gov.uk/nonprod/resources/main.tf", "w").at_least(:once)
+      ["main.tf", "variables.tf", "versions.tf"].each do |tf_file|
+        expect(File).to receive(:open).with("namespaces/live-1.cloud-platform.service.justice.gov.uk/nonprod/resources/#{tf_file}", "w").at_least(:once)
+      end
     end
 
     it "deletes AWS resources" do


### PR DESCRIPTION
We now have resources which require the github
terraform provider. Initialising this provider
requires a "token" and "owner" terraform variable.

This change amends the namespace deleter so that
as well as creating a `main.tf`, it also creates a
`variables.tf` and `versions.tf` file from the
templates in the 
`namespace-resources-cli-template/resources`
directory. 

This ensures that all required terraform variables
are declared when the deleter script runs
`terraform apply`.