### PR TITLE
Added new URL to certificates.yaml.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/certificates.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/certificates.yaml
@@ -10,3 +10,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
   - moj-online.service.justice.gov.uk
+  - moj-forms.service.justice.gov.uk


### PR DESCRIPTION
A second domain has been added to the namespace and the certificate
needs adding for the URL - moj-forms.service.justice.gov.uk