### PR TITLE
Add cloud-platform-demo prototype kit namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloud-platform-demo
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "cloud-platform"
+    cloud-platform.justice.gov.uk/application: "Gov.UK Prototype Kit"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-demo"
+    cloud-platform.justice.gov.uk/team-name: "webops" 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-platform-demo-admin
+  namespace: cloud-platform-demo
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: cloud-platform-demo
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: cloud-platform-demo
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: cloud-platform-demo
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: cloud-platform-demo
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/basic-auth.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/basic-auth.tf
@@ -1,0 +1,13 @@
+# Username and password for the prototype kit website's http basic
+# authentication
+resource "kubernetes_secret" "basic-auth" {
+  metadata {
+    name      = "basic-auth"
+    namespace = var.namespace
+  }
+
+  data = {
+    username = var.basic-auth-username
+    password = var.basic-auth-password
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/ecr.tf
@@ -1,0 +1,21 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  github_repositories = [var.namespace]
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/github-repo.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/github-repo.tf
@@ -40,13 +40,6 @@ resource "github_repository" "prototype" {
   }
 }
 
-resource "github_branch_protection" "default" {
-  repository_id          = github_repository.prototype.id
-  pattern                = "main"
-  enforce_admins         = true
-  require_signed_commits = true
-}
-
 resource "github_team_repository" "prototype" {
   for_each   = local.teams
   team_id    = each.value.id

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/github-repo.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/github-repo.tf
@@ -1,0 +1,61 @@
+data "github_team" "default" {
+  slug = "webops"
+}
+
+locals {
+  topics = ["gov-uk-prototype-kit", "moj-cloud-platform"]
+
+  # These teams will be granted admin access to the github repository
+  teams = {
+    "default" : { id = data.github_team.default.id },
+  }
+}
+
+# Repository basics
+resource "github_repository" "prototype" {
+  name                   = var.namespace
+  description            = "Gov.UK Prototype Kit. This repository is defined and managed in Terraform"
+  visibility             = "public"
+  has_issues             = false
+  has_projects           = false
+  has_wiki               = false
+  has_downloads          = false
+  is_template            = false
+  allow_merge_commit     = true
+  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  delete_branch_on_merge = true
+  auto_init              = false
+  archived               = false
+  vulnerability_alerts   = true
+  topics                 = local.topics
+
+  template {
+    owner      = "ministryofjustice"
+    repository = "moj-prototype-template"
+  }
+
+  lifecycle {
+    ignore_changes = [template]
+  }
+}
+
+resource "github_branch_protection" "default" {
+  repository_id          = github_repository.prototype.id
+  pattern                = "main"
+  enforce_admins         = true
+  require_signed_commits = true
+}
+
+resource "github_team_repository" "prototype" {
+  for_each   = local.teams
+  team_id    = each.value.id
+  repository = github_repository.prototype.name
+  permission = "admin"
+}
+
+resource "github_actions_secret" "prototype" {
+  repository      = github_repository.prototype.name
+  secret_name     = "PROTOTYPE_NAME"
+  plaintext_value = var.namespace
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/serviceaccount.tf
@@ -1,0 +1,7 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.3"
+
+  namespace = var.namespace
+
+  github_repositories = [var.namespace]
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/variables.tf
@@ -1,0 +1,66 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Gov.UK Prototype Kit"
+}
+
+variable "namespace" {
+  default = "cloud-platform-demo"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "webops"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "platforms@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "cloud-platform"
+}
+
+variable "github_owner" {
+  description = "Required by the github terraform provider"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the github terraform provider"
+  default     = ""
+}
+
+## Prototype kit variables
+
+variable "basic-auth-username" {
+  description = "Basic auth. username of the deployed prototype website"
+  default     = "cloud"
+}
+
+variable "basic-auth-password" {
+  description = "Basic auth. password of the deployed prototype website"
+  default     = "platform"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-demo/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is for an end of sprint demo on 2021-02-05, and should be deleted
after that date, along with the github repository:

https://github.com/ministryofjustice/cloud-platform-demo
