### PR TITLE
Extend service account permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
@@ -16,7 +16,7 @@ module "serviceaccount" {
         "secrets",
         "services",
         "pods",
-        "serviceaccounts"
+        "serviceaccounts",
       ]
       verbs = [
         "patch",
@@ -32,10 +32,12 @@ module "serviceaccount" {
         "extensions",
         "apps",
         "networking.k8s.io",
+        "monitoring.coreos.com",
       ]
       resources = [
         "deployments",
         "ingresses",
+        "servicemonitors",
       ]
       verbs = [
         "get",

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
@@ -6,7 +6,7 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["dso-monitoring"]
-  
+
   serviceaccount_rules = [
     {
       api_groups = [""]

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
@@ -6,4 +6,47 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["dso-monitoring"]
+  
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "serviceaccounts"
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "networking.k8s.io",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
+
 }


### PR DESCRIPTION
Installing the helm chart for Prometheus Blackbox exporter is failing with this error:

`Error: UPGRADE FAILED: could not get information about the resource: serviceaccounts "blackbox-exporter-prometheus-blackbox-exporter" is forbidden: User "system:serviceaccount:***:cd-serviceaccount" cannot get resource "serviceaccounts" in API group "" in the namespace "***"`

Furthermore, we are deploying servicemonitors to monitor certain endpoints, thus needing servicemonitors permissions

Note that all of this works fine using my credentials