### PR TITLE
configmaps permissions were missing too :'(

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
@@ -17,6 +17,7 @@ module "serviceaccount" {
         "services",
         "pods",
         "serviceaccounts",
+        "configmaps",
       ]
       verbs = [
         "patch",


### PR DESCRIPTION
Apologies for this, I should've checked the helm chart in a bit more detail.

As far as I can tell, this should be it:

```
agoneygarcia-deniz@L0943 dso-monitoring-prod % helm upgrade --install prometheus-blackbox-exporter prometheus-community/prometheus-blackbox-exporter --set pspEnabled=false --dry-run
Release "prometheus-blackbox-exporter" does not exist. Installing it now.
NAME: prometheus-blackbox-exporter
LAST DEPLOYED: Fri Feb  5 16:13:52 2021
NAMESPACE: dso-monitoring-prod
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST:
---
# Source: prometheus-blackbox-exporter/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: prometheus-blackbox-exporter
  labels:
    app.kubernetes.io/name: prometheus-blackbox-exporter
    app.kubernetes.io/instance: prometheus-blackbox-exporter
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: prometheus-blackbox-exporter-4.10.2
  annotations:
    {}
---
# Source: prometheus-blackbox-exporter/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: prometheus-blackbox-exporter
  labels:
    app.kubernetes.io/name: prometheus-blackbox-exporter
    app.kubernetes.io/instance: prometheus-blackbox-exporter
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: prometheus-blackbox-exporter-4.10.2
data:
  blackbox.yaml: |
    modules:
      http_2xx:
        http:
          no_follow_redirects: false
          preferred_ip_protocol: ip4
          valid_http_versions:
          - HTTP/1.1
          - HTTP/2.0
        prober: http
        timeout: 5s
---
# Source: prometheus-blackbox-exporter/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: prometheus-blackbox-exporter
  labels:
    app.kubernetes.io/name: prometheus-blackbox-exporter
    app.kubernetes.io/instance: prometheus-blackbox-exporter
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: prometheus-blackbox-exporter-4.10.2
spec:
  type: ClusterIP
  ports:
    - name: http
      port: 9115
      targetPort: http
      protocol: TCP
  selector:
    app.kubernetes.io/name: prometheus-blackbox-exporter
    app.kubernetes.io/instance: prometheus-blackbox-exporter
---
# Source: prometheus-blackbox-exporter/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: prometheus-blackbox-exporter
  labels:
    app.kubernetes.io/name: prometheus-blackbox-exporter
    app.kubernetes.io/instance: prometheus-blackbox-exporter
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: prometheus-blackbox-exporter-4.10.2
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: prometheus-blackbox-exporter
      app.kubernetes.io/instance: prometheus-blackbox-exporter
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/name: prometheus-blackbox-exporter
        app.kubernetes.io/instance: prometheus-blackbox-exporter
        app.kubernetes.io/managed-by: Helm
        helm.sh/chart: prometheus-blackbox-exporter-4.10.2
      annotations:
        checksum/config: e5c83700a347545fd667af114cd693300d55ac121eaaa47c3d819c4bbd785624
    spec:
      serviceAccountName: prometheus-blackbox-exporter

      restartPolicy: Always
      containers:
        - name: blackbox-exporter
          image: "prom/blackbox-exporter:v0.18.0"
          imagePullPolicy: IfNotPresent
          securityContext:
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
          env:
          args:
            - "--config.file=/config/blackbox.yaml"
          resources:
            {}
          ports:
            - containerPort: 9115
              name: http
          livenessProbe:
            httpGet:
              path: /health
              port: http
          readinessProbe:
            httpGet:
              path: /health
              port: http
          volumeMounts:
            - mountPath: /config
              name: config
      volumes:
        - name: config
          configMap:
            name: prometheus-blackbox-exporter
```