### PR TITLE
Enable apply pipeline to skip namespaces

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -10,7 +10,11 @@ def main(cluster)
   apply_cluster_level_resources(cluster)
 
   all_namespace_dirs(cluster).each do |dir|
-    CpEnv::NamespaceDir.new(cluster: cluster, dir: dir).apply
+    CpEnv::NamespaceDir.new(
+      cluster: cluster,
+      dir: dir,
+      enable_skip_namespaces: true, # Honour any APPLY_PIPELINE_SKIP_THIS_NAMESPACE files
+    ).apply
   end
 
   log("green", "Done.")

--- a/bin/apply-namespace-changes
+++ b/bin/apply-namespace-changes
@@ -8,7 +8,11 @@ def main(cluster)
   set_kube_context(cluster)
 
   changed_namespace_dirs(cluster).each do |dir|
-    CpEnv::NamespaceDir.new(cluster: cluster, dir: dir).apply
+    CpEnv::NamespaceDir.new(
+      cluster: cluster,
+      dir: dir,
+      enable_skip_namespaces: false, # Ignore APPLY_PIPELINE_SKIP_THIS_NAMESPACE files
+    ).apply
   end
 
   log("green", "Done.")

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -29,7 +29,7 @@ class CpEnv
     def ignore_this_namespace?
       return true unless FileTest.directory?(dir)
 
-      if (enable_skip_namespaces && FileTest.exists?("#{dir}/#{SKIP_FILE}"))
+      if enable_skip_namespaces && FileTest.exists?("#{dir}/#{SKIP_FILE}")
         log("red", "#{namespace}/#{SKIP_FILE} file exists. Skipping this namespace.")
         true
       else

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -1,24 +1,41 @@
 class CpEnv
   class NamespaceDir
-    attr_reader :cluster, :dir
+    attr_reader :cluster, :dir, :enable_skip_namespaces
     attr_reader :executor
 
     # Hardcoded context is required to switch to the manager cluster
     MANAGER_CLUSTER = "manager.cloud-platform.service.justice.gov.uk"
 
+    # If this file exists in a namespace folder, and enable_skip_namespaces is
+    # `true`, calling `apply` on the namespace will do nothing.
+    SKIP_FILE = "APPLY_PIPELINE_SKIP_THIS_NAMESPACE"
+
     def initialize(args)
       @dir = args.fetch(:dir)
       @cluster = args.fetch(:cluster)
       @executor = args.fetch(:executor) { Executor.new }
+      @enable_skip_namespaces = args.fetch(:enable_skip_namespaces) { true }
     end
 
     def apply
-      return unless FileTest.directory?(dir)
+      return if ignore_this_namespace?
+
       executor.execute("git pull") # In case any PRs were merged since the pipeline started
       apply_namespace_dir
     end
 
     private
+
+    def ignore_this_namespace?
+      return true unless FileTest.directory?(dir)
+
+      if (enable_skip_namespaces && FileTest.exists?("#{dir}/#{SKIP_FILE}"))
+        log("red", "#{namespace}/#{SKIP_FILE} file exists. Skipping this namespace.")
+        true
+      else
+        false
+      end
+    end
 
     def namespace
       File.basename(dir)

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -19,7 +19,7 @@ describe CpEnv::NamespaceDir do
       dir: dir,
       cluster: cluster,
       executor: executor,
-      enable_skip_namespaces: enable_skip_namespaces,
+      enable_skip_namespaces: enable_skip_namespaces
     }
   }
 

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -12,12 +12,14 @@ describe CpEnv::NamespaceDir do
   let(:terraform) { double(CpEnv::Terraform) }
   let(:kubectl_apply) { "kubectl -n #{namespace} apply -f #{dir}" }
   let(:yaml_files) { [] }
+  let(:enable_skip_namespaces) { true }
 
   let(:params) {
     {
       dir: dir,
       cluster: cluster,
       executor: executor,
+      enable_skip_namespaces: enable_skip_namespaces,
     }
   }
 
@@ -76,6 +78,54 @@ describe CpEnv::NamespaceDir do
       it "does not run kubectl apply" do
         expect(executor).to_not receive(:execute).with(kubectl_apply)
         namespace_dir.apply
+      end
+    end
+
+    context "when enable_skip_namespaces is set" do
+      let(:enable_skip_namespaces) { true }
+
+      context "and a skip file is present" do
+        let(:yaml_files) { [1, 2, 3] } # just has to be a non-empty array that responds to 'any?'
+
+        before do
+          allow(FileTest).to receive(:exists?)
+            .with("#{dir}/#{CpEnv::NamespaceDir::SKIP_FILE}")
+            .and_return(true)
+        end
+
+        it "does not run kubectl apply" do
+          expect(executor).to_not receive(:execute).with(kubectl_apply)
+          namespace_dir.apply
+        end
+
+        it "does not run terraform apply" do
+          expect(terraform).to_not receive(:apply)
+          namespace_dir.apply
+        end
+      end
+    end
+
+    context "when enable_skip_namespaces is not set" do
+      let(:enable_skip_namespaces) { false }
+
+      context "and a skip file is present" do
+        let(:yaml_files) { [1, 2, 3] } # just has to be a non-empty array that responds to 'any?'
+
+        before do
+          allow(FileTest).to receive(:exists?)
+            .with("#{dir}/#{CpEnv::NamespaceDir::SKIP_FILE}")
+            .and_return(true)
+        end
+
+        it "runs kubectl apply" do
+          expect(executor).to receive(:execute).with(kubectl_apply)
+          namespace_dir.apply
+        end
+
+        it "runs terraform apply" do
+          expect(terraform).to receive(:apply)
+          namespace_dir.apply
+        end
       end
     end
   end


### PR DESCRIPTION
For long-running operations, such as upgrading RDS
instances, we have to pause the apply pipeline for
**every** namespace, so that it doesn't alter the
namespace in which the long-running change is 
happening (which has unpredictable effects).

Repeatedly having to pause/unpause the apply 
pipeline is cumbersome, so this change creates a
mechanism by which individual namespaces can be
skipped.

The `CpEnv::NamespaceDir#apply` method is called
by both the `apply` and `apply-namespace-changes`
pipeline jobs, so the class needs a way to know if
the "skip namespaces" feature should be applied or
not.

This change adds an `enable_skip_namespaces` flag
for that purpose, and sets it to `true` in the 
`apply` script, and `false` in the 
`apply-namespace-changes` script.

With `enable_skip_namespaces` set to true, the
code looks for a file in the top-level namespace
folder called `APPLY_PIPELINE_SKIP_THIS_NAMESPACE`
If this file exists, the namespace is skipped.

fixes https://github.com/ministryofjustice/cloud-platform/issues/2692