### PR TITLE
Increase memory for Book a Secure Move production pods

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 2000m
-      memory: 1000Mi
+      cpu: 1000m
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
We discovered pods were sitting at the current memory limit pretty much constantly, which we suspect results in some timeouts.