### PR TITLE
Move interventions SNS topic to hmpps-domain-events-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-interventions-topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-interventions-topic.tf
@@ -12,7 +12,7 @@ module "intervention_events" {
 resource "kubernetes_secret" "intervention_events_sns" {
   metadata {
     name      = "intervention-events-topic"
-    namespace = var.namespace
+    namespace = "hmpps-interventions-dev"
   }
 
   data = {


### PR DESCRIPTION
The new namespace is intended as the shared place for all domain event topics