### PR TITLE
Re-adds the interventions SNS topic to domain-events

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-intervention-events-topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-intervention-events-topic.tf
@@ -1,0 +1,23 @@
+module "intervention_events" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+
+  team_name          = var.team_name
+  topic_display_name = "intervention-events"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "intervention_events_sns" {
+  metadata {
+    name      = "intervention-events-topic"
+    namespace = "hmpps-interventions-dev"
+  }
+
+  data = {
+    access_key_id     = module.intervention_events.access_key_id
+    secret_access_key = module.intervention_events.secret_access_key
+    topic_arn         = module.intervention_events.topic_arn
+  }
+}


### PR DESCRIPTION
We're moving SNS topics to `hmpps-domain-events-{env}` namespaces so they are all discoverable in the same place.

This is part 2 of 2: adding the topic to its destination
Part 1 of 2 was #4254, 28b2ba1d340b347be652d2d349ba11e35db1524a

Related to the previous attempt of moving the topic in one go: #4252 and its revert: #4253.