### PR TITLE
Add "ReviewAfter" namespace annotation

### DIFF
--- a/namespace-resources-cli-template/00-namespace.yaml
+++ b/namespace-resources-cli-template/00-namespace.yaml
@@ -12,3 +12,4 @@ metadata:
     cloud-platform.justice.gov.uk/owner: "{{ .Owner }}: {{ .InfrastructureSupport }}"
     cloud-platform.justice.gov.uk/source-code: "{{ .SourceCode }}"
     cloud-platform.justice.gov.uk/team-name: "{{ .GithubTeam }}"
+    cloud-platform.justice.gov.uk/review-after: "{{ .ReviewAfter }}"


### PR DESCRIPTION
depends on https://github.com/ministryofjustice/cloud-platform-cli/pull/70

> Do not merge until the new version of the CLI has been released. Otherwise, people will not be able to create namespaces via the CLI.