### PR TITLE
Update service account

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-serviceaccount.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-serviceaccount.yaml
@@ -28,7 +28,6 @@ rules:
     verbs:
       - "get"
       - "list"
-      - "delete"
   - apiGroups:
       - ""
     resources:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-serviceaccount.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-serviceaccount.yaml
@@ -13,6 +13,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - "pods/exec"
+    verbs:
+      - "create"
+  - apiGroups:
+      - ""
+    resources:
       - "secrets"
       - "pods"
     verbs:


### PR DESCRIPTION
Add a pod/exec permission line - this will be used by the bot to issue hardcoded DB instructions
*not* passed through from the bot user

We have an issue with uat pod DB's not initializing correctly, this will allow the bot to respond to
`uat-reset-db ap1234` and issue a `kubectl exec <snip> -- rake db:migrate && rake db:seed` 
command to the pod in question