### PR TITLE
Remove old secret from interventions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-interventions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-interventions.tf
@@ -1,16 +1,3 @@
-resource "kubernetes_secret" "intervention_events_sns" {
-  metadata {
-    name      = "intervention-events-topic"
-    namespace = "hmpps-interventions-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps-domain-events.access_key_id
-    secret_access_key = module.hmpps-domain-events.secret_access_key
-    topic_arn         = module.hmpps-domain-events.topic_arn
-  }
-}
-
 resource "kubernetes_secret" "intervention_global_events_sns" {
   metadata {
     name      = "hmpps-domain-events-topic"


### PR DESCRIPTION
https://github.com/ministryofjustice/hmpps-interventions-service/pull/98 has switched to the new one, so we no longer need to maintain the fallback name

Cleans up #4284 