### PR TITLE
Update pins bt s3 upload user

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/iam.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/iam.tf
@@ -1,17 +1,13 @@
-resource "random_id" "upload" {
-  byte_length = 8
-}
-
-resource "aws_iam_user" "upload_user" {
-  name = "hmpps-pin-phone-monitor-upload-user-${random_id.upload.hex}"
+resource "aws_iam_user" "bt_upload_user" {
+  name = "hmpps-pin-phone-monitor-qa-bt-upload-user"
   path = "/system/hmpps-pin-phone-monitor-qa-upload-users/"
 }
 
-resource "aws_iam_access_key" "upload_user" {
-  user = aws_iam_user.upload_user.name
+resource "aws_iam_access_key" "bt_upload_user_key" {
+  user = aws_iam_user.bt_upload_user.name
 }
 
-data "aws_iam_policy_document" "upload_policy" {
+data "aws_iam_policy_document" "bt_upload_policy" {
   statement {
     actions = ["s3:PutObject"]
 
@@ -42,22 +38,22 @@ data "aws_iam_policy_document" "upload_policy" {
   }
 }
 
-resource "aws_iam_user_policy" "upload_policy" {
-  name   = "hmpps-pin-phone-monitor-upload-policy"
-  policy = data.aws_iam_policy_document.upload_policy.json
-  user   = aws_iam_user.upload_user.name
+resource "aws_iam_user_policy" "bt_upload_policy" {
+  name   = "hmpps-pin-phone-monitor-bt-upload-policy-qa"
+  policy = data.aws_iam_policy_document.bt_upload_policy.json
+  user   = aws_iam_user.bt_upload_user.name
 }
 
-resource "kubernetes_secret" "hmpps_pin_phone_monitor_upload_user" {
+resource "kubernetes_secret" "hmpps_pin_phone_monitor_bt_upload_user" {
   metadata {
-    name      = "hmpps-pin-phone-monitor-upload-user"
+    name      = "hmpps-pin-phone-monitor-bt-upload-user-qa"
     namespace = var.namespace
   }
 
   data = {
-    hmpps_pin_phone_monitor_upload_user_arn               = aws_iam_user.upload_user.arn
-    hmpps_pin_phone_monitor_upload_user_access_key_id     = aws_iam_access_key.upload_user.id
-    hmpps_pin_phone_monitor_upload_user_secret_access_key = aws_iam_access_key.upload_user.secret
+    hmpps_pin_phone_monitor_upload_user_arn               = aws_iam_user.bt_upload_user.arn
+    hmpps_pin_phone_monitor_upload_user_access_key_id     = aws_iam_access_key.bt_upload_user_key.id
+    hmpps_pin_phone_monitor_upload_user_secret_access_key = aws_iam_access_key.bt_upload_user_key.secret
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/s3.tf
@@ -21,7 +21,7 @@ module "hmpps_pin_phone_monitor_document_s3_bucket" {
       prefix  = "recordings/"
       expiration = [
         {
-          days = 1
+          days = 10
         },
       ]
     },


### PR DESCRIPTION
The intention of this low privilege IAM user is that BT will use it to upload files to an MoJ S3 bucket. The ideal would be BT providing their own IAM user for S3 cross-account access. Unfortunately, the BT team don't have the means to create and manage an AWS Account. 

Discussed with AWS account team and agreed on a low privilege user whereby the creds don't rotate automatically as they do now due to the random number generated as part of the user name in the terraform.