### PR TITLE
Update non-prod namespaces to ECR module 4.3

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/alexhaslehurst-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/alexhaslehurst-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/book-a-prison-visit-development/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/book-a-prison-visit-development/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
@@ -1,6 +1,6 @@
 
 module "cccd_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cccd"
   team_name = "laa-get-paid"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-check-financial-eligibility-service" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = "laa-apply-for-legal-aid"
   repo_name = "check-financial-eligibility-service"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "checkmydiary-service-dev" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "check-my-diary-dev"
   team_name = "check-my-diary"
 
@@ -23,7 +23,7 @@ resource "kubernetes_secret" "checkmydiary_ecr_credentials" {
 }
 
 module "checkmydiary-notification-service-dev" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "check-my-diary-notification-service-dev"
   team_name = "check-my-diary"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "checkmydiary-service-preprod" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "check-my-diary-preprod"
   team_name = "check-my-diary"
 }
@@ -19,7 +19,7 @@ resource "kubernetes_secret" "checkmydiary_ecr_credentials" {
 }
 
 module "checkmydiary-notification-service-preprod" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "check-my-diary-notification-service-preprod"
   team_name = "check-my-diary"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/chrisfaulkner-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/chrisfaulkner-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "chrisfaulkner-ruby-app"
   team_name = "probation-in-court"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cica-repo" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cica"
   team_name = "cica"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = var.repo_name
   team_name = var.team_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cica-repo-dev"
   team_name = "cica"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cica-repo-stg"
   team_name = "cica"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cica-repo-uat"
   team_name = "cica"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa_crime_apps_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "laa-common-platform-connector"
   team_name = "laa-crime-apps-team"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
@@ -1,7 +1,7 @@
 
 
 module "court_probation_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "court-probation-service"
   team_name = "probation-services"
 
@@ -25,7 +25,7 @@ resource "kubernetes_secret" "court_probation_service_ecr_credentials" {
 }
 
 module "ps_cps_pack_parser_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cps-pack-parser"
   team_name = "probation-services"
 
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "ps_cps_pack_parser_ecr_credentials" {
 }
 
 module "mock_cp_court_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "mock-cp-court-service"
   team_name = "probation-services"
 
@@ -73,7 +73,7 @@ resource "kubernetes_secret" "mock_cp_court_service_ecr_credentials" {
 }
 
 module "court_list_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "court-list-service"
   team_name = "probation-services"
 
@@ -97,7 +97,7 @@ resource "kubernetes_secret" "court_list_service_ecr_credentials" {
 }
 
 module "prepare_probation_courtcases_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "prepare-probation-courtcases"
   team_name = "probation-services"
 
@@ -121,7 +121,7 @@ resource "kubernetes_secret" "prepare_probation_courtcases_ecr_credentials" {
 }
 
 module "ndelius_new_tech_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "ndelius-new-tech"
   team_name = "probation-services"
 
@@ -145,7 +145,7 @@ resource "kubernetes_secret" "ndelius_new_tech_ecr_credentials" {
 }
 
 module "community_api_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "community-api"
   team_name = "probation-services"
 
@@ -169,7 +169,7 @@ resource "kubernetes_secret" "community_api_ecr_credentials" {
 }
 
 module "ukcloud_proxy_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "ukcloud-proxy"
   team_name = "probation-services"
 
@@ -193,7 +193,7 @@ resource "kubernetes_secret" "ukcloud_proxy_ecr_credentials" {
 }
 
 module "delius_oauth2_server_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "delius-oauth2-server"
   team_name = "probation-services"
 
@@ -217,7 +217,7 @@ resource "kubernetes_secret" "delius_oauth2_server_ecr_credentials" {
 }
 
 module "probation_court_prototype_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "probation-court-prototype"
   team_name = "probation-services"
 
@@ -241,7 +241,7 @@ resource "kubernetes_secret" "probation_court_prototype_ecr_credentials" {
 }
 
 module "court_list_mock_data_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "court-list-mock-data"
   team_name = "probation-services"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/resources/ecr.tf
@@ -2,7 +2,7 @@
 // This registry is used in the dev, preprod and prod namespaces which all deploy the same image from this ECR
 
 module "pict_cpmg_database_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cpmg-database"
   team_name = "probation-in-court"
 
@@ -12,7 +12,7 @@ module "pict_cpmg_database_ecr_credentials" {
 }
 
 module "pict_cpmg_wildfly_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cpmg-wildfly"
   team_name = "probation-in-court"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/data-eng-rds-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/data-eng-rds-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-estatesdb-dev" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "estatesdb-dev"
   team_name = "programmeandperformance"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 ####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "formbuilder_product_page_staging_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "formbuilder-product-page-staging"
   team_name = "formbuilder"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/helloworldapp-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/helloworldapp-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa_crime_apps_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "hmcts-common-platform-mock-api"
   team_name = "laa-crime-apps-team"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr-repo-datasette.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr-repo-datasette.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-datasette" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "ecr-repo-datasette"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jacob-hello-world-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jacob-hello-world-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "jacobbrowning-dev-repo"
   team_name = "jacobbrowning-dev-team"
   /*

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa_crime_apps_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "laa-court-data-adaptor"
   team_name = "laa-crime-apps-team"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "lcdui_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   team_name = var.team_name
   repo_name = var.repo_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa_fee_caclulator_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = var.repo_name
   team_name = var.team_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/learning-cloud-deployments-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/learning-cloud-deployments-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cloud-platform-environments"
   team_name = "hmpps-dev-test"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/markberridge-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/markberridge-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "markberridge-dev-ecr-credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "markberridge-dev-repo"
   team_name = "markberridge-dev-team"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-allocation-manager.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-allocation-manager.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-allocation-manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "offender-management-allocation-manager"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-nomis-delius-emulator.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-nomis-delius-emulator.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-nomis-delius-emulator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "nomis-delius-emulator"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/ecr.tf
@@ -4,7 +4,7 @@
 
 module "pq_ecr_credentials" {
   repo_name = var.repo_name
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   team_name = var.team_name
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cp_team_test_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "cp-poornima-dev-module"
   team_name = "cp-team"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-public.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-public.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-prison-visits-public" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "prison-visits-public"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-staff.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-staff.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-prison-visits-staff" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "prison-visits-staff"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-tests.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-tests.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-prison-visits-tests" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "prison-visits-integration-tests"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/proffeapp-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/proffeapp-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "proffe_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "proffe-repo"
   team_name = "hmpps-dev-test"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/rja-sandbox/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/rja-sandbox/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ryanforsyth-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ryanforsyth-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/support-labelling-webhook/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/support-labelling-webhook/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-support-labelling" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = "webops"
   repo_name = "support-labelling-webhooks"


### PR DESCRIPTION
depends on
https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/pull/39
