### PR TITLE
LAA Apply UAT: seperate prometheus alert for document upload request

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
@@ -61,12 +61,19 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-uat"} > 2
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-uat", controller!="providers/statement_of_cases"} > 2
       for: 1m
       labels:
         severity: apply-for-legal-aid-uat
       annotations:
         message: Request is taking more than 2 seconds
+    - alert: "Long-Request: Statement of case"
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-uat", controller="providers/statement_of_cases"} > 10
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Statement of case request is taking more than 10 seconds
     - alert: Address lookup service
       expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-apply-for-legalaid-uat", controller="providers/address_selections"}[30m])) * 1800 > 1
       for: 1m


### PR DESCRIPTION
Update the UAT environment:

- Update the existing long request alert to exclude the statement of case requests because it often takes longer than 2 seconds. This reduces alerts/messages pollution.

- Add a new prometheus alert to alert when the statement of cases request is taking longer than 10 seconds