### PR TITLE
Form Builder - New formbuilder-saas-live namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/00-namespace.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-saas-live
+  labels:
+    name: formbuilder-saas-live
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "live"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "formbuilder-saas"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: form-builder-developers@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/form-builder"
+    cloud-platform.justice.gov.uk/slack-channel: "moj-forms-devs"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/01-rbac.yaml
@@ -1,0 +1,34 @@
+---
+# Source: formbuilder-publisher/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-saas-live-admins
+  namespace: formbuilder-saas-live
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-saas-live-service-account
+  namespace: formbuilder-saas-live
+subjects:
+  # Service token cache can read the service tokens
+  # from formbuilder saas namespace
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-live-production
+    namespace: formbuilder-platform-live-production
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-publisher/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-saas-live
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-saas-live
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/04-networkpolicy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-publisher/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-saas-live
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-saas-live
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/05-circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/05-circleci-service-account.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "circleci-formbuilder-saas-live"
+  namespace: "formbuilder-saas-live"
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "circleci-formbuilder-saas-live"
+  namespace: "formbuilder-saas-live"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+      - "configmaps"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+      - "monitoring.coreos.com"
+    resources:
+      - "deployments"
+      - "ingresses"
+      - "networkpolicies"
+      - "servicemonitors"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+      - "watch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "circleci-formbuilder-saas-live"
+  namespace: "formbuilder-saas-live"
+subjects:
+- kind: ServiceAccount
+  name: "circleci-formbuilder-saas-live"
+  namespace: "formbuilder-saas-live"
+roleRef:
+  kind: Role
+  name: "circleci-formbuilder-saas-live"
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/editor-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/editor-service-account.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "formbuilder-editor-live"
+  namespace: "formbuilder-saas-live"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "formbuilder-editor-live"
+  namespace: "formbuilder-saas-live"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+      - "watch"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "formbuilder-editor-live"
+  namespace: "formbuilder-saas-live"
+subjects:
+- kind: ServiceAccount
+  name: "formbuilder-editor-live"
+  namespace: "formbuilder-saas-live"
+roleRef:
+  kind: Role
+  name: "formbuilder-editor-live"
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/editor-workers-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/editor-workers-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-editor/templates/editor-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the editor worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-live-(deploymentEnvironment)
+# namespaces so that they can deploy services there
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-editor-workers-live
+  namespace: formbuilder-saas-live

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/metadata-api-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/metadata-api-service-account.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "formbuilder-metadata-api-live"
+  namespace: "formbuilder-saas-live"
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "formbuilder-metadata-api-live"
+  namespace: "formbuilder-saas-live"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+      - "watch"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "formbuilder-metadata-api-live"
+  namespace: "formbuilder-saas-live"
+subjects:
+- kind: ServiceAccount
+  name: "formbuilder-metadata-api-live"
+  namespace: "formbuilder-saas-live"
+roleRef:
+  kind: Role
+  name: "formbuilder-metadata-api-live"
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/editor.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/editor.tf
@@ -1,0 +1,31 @@
+module "editor-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period
+  application                = "formbuilder-editor"
+  environment-name           = var.environment_name
+  is-production              = var.is_production
+  namespace                  = var.namespace
+  infrastructure-support     = var.infrastructure_support
+  team_name                  = var.team_name
+  db_engine_version          = "12"
+  rds_family                 = "postgres12"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "editor-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-editor-${var.environment_name}"
+    namespace = "formbuilder-saas-${var.environment_name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.editor-rds-instance.database_username}:${module.editor-rds-instance.database_password}@${module.editor-rds-instance.rds_instance_endpoint}/${module.editor-rds-instance.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
@@ -1,0 +1,31 @@
+module "metadata-api-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+
+  cluster_name               = var.cluster_name
+  cluster_state_bucket       = var.cluster_state_bucket
+  db_backup_retention_period = var.db_backup_retention_period
+  application                = "formbuilder-metadata-api"
+  environment-name           = var.environment_name
+  is-production              = var.is_production
+  namespace                  = var.namespace
+  infrastructure-support     = var.infrastructure_support
+  team_name                  = var.team_name
+  db_engine_version          = "12"
+  rds_family                 = "postgres12"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "metadata-api-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-metadata-api-${var.environment_name}"
+    namespace = "formbuilder-saas-${var.environment_name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.metadata-api-rds-instance.database_username}:${module.metadata-api-rds-instance.database_password}@${module.metadata-api-rds-instance.rds_instance_endpoint}/${module.metadata-api-rds-instance.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/variables.tf
@@ -1,0 +1,30 @@
+variable "environment_name" {
+  default = "live"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "is_production" {
+  default = "true"
+}
+
+variable "db_backup_retention_period" {
+  default = "7"
+}
+
+variable "infrastructure_support" {
+  default = "Form Builder form-builder-developers@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "namespace" {
+  default = "formbuilder-saas-live"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "0.12.17"
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "0.12.17"
+  required_version = ">= 0.12"
 }


### PR DESCRIPTION
This creates the required bits and pieces for the Live environment for
the upcoming Editor:

- formbuilder-saas-live namespace
- postgres db for the editor
- postgres db for the metadata api
- service account for the editor
- service account for the editor workers
- service account for the metadata api
- service account for circle ci
- usual network policies and rbac

Leaving out prometheus at this point. Will be added once we start to deploy the apps.