### PR TITLE
Form Builder - Editor service account permission to formbuilder-services-live-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/01-rbac.yaml
@@ -14,7 +14,7 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
-# Bind admin role for namespace to team group & publisher ServiceAccount
+# Bind admin role for namespace to team group & publisher ServiceAccount & editor SerivceAccount
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26,6 +26,10 @@ subjects:
   - kind: ServiceAccount
     name: formbuilder-publisher-workers-live
     namespace: formbuilder-publisher-live
+  # allow platformenv Editor to deploy to this deploymentenv
+  - kind: ServiceAccount
+    name: formbuilder-editor-workers-live
+    namespace: formbuilder-saas-live
   # ...but only the dev service token cache can read the dev
   # service tokens
   - kind: ServiceAccount


### PR DESCRIPTION
This adds the necessary permissions for the future Editor worker service account to interact with the formbuilder-services-live-dev namespace