### PR TITLE
Pin ns_annotation module to 0.0.2

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/elasticsearch.tf
@@ -40,7 +40,7 @@ module "test_es_2" {
 
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
   ns_annotation_roles = [module.test_es_1.aws_iam_role_name, module.test_es_2.aws_iam_role_name]
   namespace           = var.namespace
 }


### PR DESCRIPTION
If unpinned the module will pickup Terraform 0.13 upgrades.