### PR TITLE
Terraform plan and  apply to check the contents of versions.tf and select respective binary

### DIFF
--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -48,7 +48,7 @@ class CpEnv
     private
 
     def terraform_executable
-      tf_versions = ["12", "13", "14"]
+      tf_versions = ["0.12", "0.13", "0.14"]
 
       # check for the version number in  the versions.tf and choose the binary accordingly
       if FileTest.exists?("#{tf_dir}/versions.tf")

--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -46,24 +46,25 @@ class CpEnv
     end
 
     private
-
+    
     def terraform_executable
       tf_versions = ["0.12", "0.13", "0.14"]
+  
       # check for the version number in  the versions.tf and choose the binary accordingly
       if FileTest.exists?("#{tf_dir}/versions.tf") 
         File.readlines("#{tf_dir}/versions.tf").each do |line|
           if line.match(/required_version/)
-            tf_versions.each do |tf_version|
-              if line.match?tf_version
-                return "terraform#{tf_version}"
-              end
-            end
+              tf_versions.each_with_index{ |e,i| 
+                  if line.match?(e)
+                    return"terraform#{e}"
+                  end
+                }
           end
         end
       end
-    
     end
     
+
     def tf_init
       key = "#{key_prefix}#{cluster}/#{namespace}/terraform.tfstate"
 

--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -46,24 +46,23 @@ class CpEnv
     end
 
     private
-    
+
     def terraform_executable
       tf_versions = ["12", "13", "14"]
-  
+
       # check for the version number in  the versions.tf and choose the binary accordingly
-      if FileTest.exists?("#{tf_dir}/versions.tf") 
+      if FileTest.exists?("#{tf_dir}/versions.tf")
         File.readlines("#{tf_dir}/versions.tf").each do |line|
-          if line.match(/required_version/)
-              tf_versions.each_with_index{ |e,i| 
-                  if line.match?(e)
-                    return"terraform#{e}"
-                  end
-                }
+          if /required_version/.match?(line)
+            tf_versions.each_with_index do |e, i|
+              if line.match?(e)
+                return "terraform#{e}"
+              end
+            end
           end
         end
       end
     end
-    
 
     def tf_init
       key = "#{key_prefix}#{cluster}/#{namespace}/terraform.tfstate"

--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -48,7 +48,7 @@ class CpEnv
     private
     
     def terraform_executable
-      tf_versions = ["0.12", "0.13", "0.14"]
+      tf_versions = ["12", "13", "14"]
   
       # check for the version number in  the versions.tf and choose the binary accordingly
       if FileTest.exists?("#{tf_dir}/versions.tf") 

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -27,11 +27,8 @@ describe CpEnv::Terraform do
     }
   }
 
-  
-
   subject(:tf) { described_class.new(params) }
   context "terraform 0.12" do
-
     let(:version_file) { "#{dir}/resources/versions.tf" }
     let(:content) {
       'terraform {
@@ -44,7 +41,6 @@ describe CpEnv::Terraform do
     end
 
     describe "plan" do
-
       it "runs terraform plan" do
         env_vars.each do |key, val|
           expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
@@ -63,82 +59,77 @@ describe CpEnv::Terraform do
         expect($stdout).to receive(:puts).at_least(:once)
         tf.plan
       end
+    end
+    describe "apply" do
+      it "applies terraform files" do
+        env_vars.each do |key, val|
+          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+        end
+        allow(FileTest).to receive(:directory?).and_return(true)
+        tf_dir = "#{dir}/resources"
+        tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-  end
-  describe "apply" do
+        tf_apply = "cd #{tf_dir}; terraform12 apply -auto-approve"
 
-    it "applies terraform files" do
-      env_vars.each do |key, val|
-        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+        expect_execute(tf_init, "", success)
+        expect_execute(tf_apply, "", success)
+        expect($stdout).to receive(:puts).at_least(:once)
+
+        tf.apply
       end
-      allow(FileTest).to receive(:directory?).and_return(true)
-      tf_dir = "#{dir}/resources"
-      tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-      tf_apply = "cd #{tf_dir}; terraform12 apply -auto-approve"
-
-      expect_execute(tf_init, "", success)
-      expect_execute(tf_apply, "", success)
-      expect($stdout).to receive(:puts).at_least(:once)
-
-      tf.apply
     end
   end
-end
 
-context "terraform 0.13" do
-
-  let(:version_file) { "#{dir}/resources/versions.tf" }
-  let(:content) {
-    'terraform {
+  context "terraform 0.13" do
+    let(:version_file) { "#{dir}/resources/versions.tf" }
+    let(:content) {
+      'terraform {
       required_version = ">= 0.13"
     }'
-  }
-  before do
-    allow(FileTest).to receive(:exists?).with(version_file).and_return(true)
-    allow(File).to receive(:readlines).with(version_file).and_return([content])
-  end
+    }
+    before do
+      allow(FileTest).to receive(:exists?).with(version_file).and_return(true)
+      allow(File).to receive(:readlines).with(version_file).and_return([content])
+    end
 
-  describe "plan" do
+    describe "plan" do
+      it "runs terraform plan" do
+        env_vars.each do |key, val|
+          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+        end
+        allow(FileTest).to receive(:directory?).and_return(true)
 
-    it "runs terraform plan" do
-      env_vars.each do |key, val|
-        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+        tf_dir = "#{dir}/resources"
+
+        tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+        tf_plan = "cd #{tf_dir}; terraform13 plan  "
+
+        expect_execute(tf_init, "", success)
+        expect_execute(tf_plan, "", success)
+        expect($stdout).to receive(:puts).at_least(:once)
+
+        tf.plan
       end
-      allow(FileTest).to receive(:directory?).and_return(true)
+    end
 
-      tf_dir = "#{dir}/resources"
+    describe "apply" do
+      it "applies terraform files" do
+        env_vars.each do |key, val|
+          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+        end
+        allow(FileTest).to receive(:directory?).and_return(true)
+        tf_dir = "#{dir}/resources"
+        tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-      tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+        tf_apply = "cd #{tf_dir}; terraform13 apply -auto-approve"
 
-      tf_plan = "cd #{tf_dir}; terraform13 plan  "
+        expect_execute(tf_init, "", success)
+        expect_execute(tf_apply, "", success)
+        expect($stdout).to receive(:puts).at_least(:once)
 
-      expect_execute(tf_init, "", success)
-      expect_execute(tf_plan, "", success)
-      expect($stdout).to receive(:puts).at_least(:once)
-
-      tf.plan
+        tf.apply
+      end
     end
   end
-
-  describe "apply" do
-    it "applies terraform files" do
-      env_vars.each do |key, val|
-        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-      end
-      allow(FileTest).to receive(:directory?).and_return(true)
-      tf_dir = "#{dir}/resources"
-      tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-      tf_apply = "cd #{tf_dir}; terraform13 apply -auto-approve"
-
-      expect_execute(tf_init, "", success)
-      expect_execute(tf_apply, "", success)
-      expect($stdout).to receive(:puts).at_least(:once)
-
-      tf.apply
-    end
-  end
-
-end
 end

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -49,10 +49,9 @@ describe CpEnv::Terraform do
 
         tf_dir = "#{dir}/resources"
 
-        # terraform_executable = "terraform12"
-        tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+        tf_init = "cd #{tf_dir}; terraform0.12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-        tf_plan = "cd #{tf_dir}; terraform12 plan  "
+        tf_plan = "cd #{tf_dir}; terraform0.12 plan  "
 
         expect_execute(tf_init, "", success)
         expect_execute(tf_plan, "", success)
@@ -67,9 +66,9 @@ describe CpEnv::Terraform do
         end
         allow(FileTest).to receive(:directory?).and_return(true)
         tf_dir = "#{dir}/resources"
-        tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+        tf_init = "cd #{tf_dir}; terraform0.12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-        tf_apply = "cd #{tf_dir}; terraform12 apply -auto-approve"
+        tf_apply = "cd #{tf_dir}; terraform0.12 apply -auto-approve"
 
         expect_execute(tf_init, "", success)
         expect_execute(tf_apply, "", success)
@@ -101,9 +100,9 @@ describe CpEnv::Terraform do
 
         tf_dir = "#{dir}/resources"
 
-        tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+        tf_init = "cd #{tf_dir}; terraform0.13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-        tf_plan = "cd #{tf_dir}; terraform13 plan  "
+        tf_plan = "cd #{tf_dir}; terraform0.13 plan  "
 
         expect_execute(tf_init, "", success)
         expect_execute(tf_plan, "", success)
@@ -120,9 +119,9 @@ describe CpEnv::Terraform do
         end
         allow(FileTest).to receive(:directory?).and_return(true)
         tf_dir = "#{dir}/resources"
-        tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+        tf_init = "cd #{tf_dir}; terraform0.13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-        tf_apply = "cd #{tf_dir}; terraform13 apply -auto-approve"
+        tf_apply = "cd #{tf_dir}; terraform0.13 apply -auto-approve"
 
         expect_execute(tf_init, "", success)
         expect_execute(tf_apply, "", success)

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'tempfile'
 
 describe CpEnv::Terraform do
   let(:cluster) { "live-1.cloud-platform.service.justice.gov.uk" }

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'tempfile'
 
 describe CpEnv::Terraform do
   let(:cluster) { "live-1.cloud-platform.service.justice.gov.uk" }
@@ -27,39 +28,55 @@ describe CpEnv::Terraform do
     }
   }
 
-  subject(:tf) { described_class.new(params) }
+  
 
-  describe "plan" do
+  subject(:tf) { described_class.new(params) }
+  context "terraform 0.12" do
+    let(:version_file) { "#{dir}/resources/versions.tf" }
+    let(:content) {
+      "terraform {
+        required_version = \">= 0.12\"
+      }"
+    }
+
+    def set_tfbinary(exists, status)
+      allow(File).to receive(:exists?).and_return(exists)
+      allow(File).to receive(:read).and_return(content)
+      allow_any_instance_of(version_file).to receive(:status).and_return(status)
+    end
+
     it "runs terraform plan" do
       env_vars.each do |key, val|
         expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
       end
       allow(FileTest).to receive(:directory?).and_return(true)
+      set_tfbinary(true,"terraform0.12")
 
       tf_dir = "#{dir}/resources"
 
-      tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+      terraform_executable = "terraform12"
+      tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-      tf_plan = "cd #{tf_dir}; terraform plan  "
+      tf_plan = "cd #{tf_dir}; terraform12 plan  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
 
+
+      expect_execute(terraform_executable, "", success)
       expect_execute(tf_init, "", success)
       expect_execute(tf_plan, "", success)
       expect($stdout).to receive(:puts).at_least(:once)
 
       tf.plan
     end
-  end
 
-  describe "apply" do
     it "applies terraform files" do
       env_vars.each do |key, val|
         expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
       end
       allow(FileTest).to receive(:directory?).and_return(true)
       tf_dir = "#{dir}/resources"
-      tf_init = "cd #{tf_dir}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+      tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-      tf_apply = "cd #{tf_dir}; terraform apply -auto-approve"
+      tf_apply = "cd #{tf_dir}; terraform12 apply -auto-approve"
 
       expect_execute(tf_init, "", success)
       expect_execute(tf_apply, "", success)
@@ -67,5 +84,62 @@ describe CpEnv::Terraform do
 
       tf.apply
     end
-  end
+
+end
+
+# context "terraform 0.13" do
+#   before do
+#     allow(FileTest).to receive(:exists?).with("#{dir}/resources/versions.tf").and_return(true)
+#     allow(FileTest).to receive(:write).with("required_version = \">= 0.13\"").and_return(true)
+#   end
+
+#   describe "plan" do
+#     # it "should create 'filename' and put 'required_version  in it" do
+#     #   FilTest.should_receive(:open).with("versions.tf", "w").and_yield(file)
+#     #   FileTest.should_receive(:write).with("required_version = \">= 0.12\"")
+#     #   tf_executable = terraform0.13
+#     #   expect_execute(tf_executable, "", success)
+#     #   tf.terraform_executable
+#     # end
+
+#     it "runs terraform plan" do
+#       env_vars.each do |key, val|
+#         expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+#       end
+#       allow(FileTest).to receive(:directory?).and_return(true)
+
+#       tf_dir = "#{dir}/resources"
+
+#       tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+#       tf_plan = "cd #{tf_dir}; terraform13 plan  "
+
+#       expect_execute(tf_init, "", success)
+#       expect_execute(tf_plan, "", success)
+#       expect($stdout).to receive(:puts).at_least(:once)
+
+#       tf.plan
+#     end
+#   end
+
+#   describe "apply" do
+#     it "applies terraform files" do
+#       env_vars.each do |key, val|
+#         expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+#       end
+#       allow(FileTest).to receive(:directory?).and_return(true)
+#       tf_dir = "#{dir}/resources"
+#       tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+#       tf_apply = "cd #{tf_dir}; terraform13 apply -auto-approve"
+
+#       expect_execute(tf_init, "", success)
+#       expect_execute(tf_apply, "", success)
+#       expect($stdout).to receive(:puts).at_least(:once)
+
+#       tf.apply
+#     end
+#   end
+
+# end
 end

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -32,41 +32,41 @@ describe CpEnv::Terraform do
 
   subject(:tf) { described_class.new(params) }
   context "terraform 0.12" do
+
     let(:version_file) { "#{dir}/resources/versions.tf" }
     let(:content) {
-      "terraform {
-        required_version = \">= 0.12\"
-      }"
+      'terraform {
+        required_version = ">= 0.12"
+      }'
     }
-
-    def set_tfbinary(exists, status)
-      allow(File).to receive(:exists?).and_return(exists)
-      allow(File).to receive(:read).and_return(content)
-      allow_any_instance_of(version_file).to receive(:status).and_return(status)
+    before do
+      allow(FileTest).to receive(:exists?).with(version_file).and_return(true)
+      allow(File).to receive(:readlines).with(version_file).and_return([content])
     end
 
-    it "runs terraform plan" do
-      env_vars.each do |key, val|
-        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+    describe "plan" do
+
+      it "runs terraform plan" do
+        env_vars.each do |key, val|
+          expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+        end
+        allow(FileTest).to receive(:directory?).and_return(true)
+
+        tf_dir = "#{dir}/resources"
+
+        # terraform_executable = "terraform12"
+        tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+
+        tf_plan = "cd #{tf_dir}; terraform12 plan  "
+
+        expect_execute(tf_init, "", success)
+        expect_execute(tf_plan, "", success)
+        expect($stdout).to receive(:puts).at_least(:once)
+        tf.plan
       end
-      allow(FileTest).to receive(:directory?).and_return(true)
-      set_tfbinary(true,"terraform0.12")
 
-      tf_dir = "#{dir}/resources"
-
-      terraform_executable = "terraform12"
-      tf_init = "cd #{tf_dir}; terraform12 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
-
-      tf_plan = "cd #{tf_dir}; terraform12 plan  | grep -vE '^(\\x1b\\[0m)?\\s{3,}'"
-
-
-      expect_execute(terraform_executable, "", success)
-      expect_execute(tf_init, "", success)
-      expect_execute(tf_plan, "", success)
-      expect($stdout).to receive(:puts).at_least(:once)
-
-      tf.plan
-    end
+  end
+  describe "apply" do
 
     it "applies terraform files" do
       env_vars.each do |key, val|
@@ -84,62 +84,62 @@ describe CpEnv::Terraform do
 
       tf.apply
     end
-
+  end
 end
 
-# context "terraform 0.13" do
-#   before do
-#     allow(FileTest).to receive(:exists?).with("#{dir}/resources/versions.tf").and_return(true)
-#     allow(FileTest).to receive(:write).with("required_version = \">= 0.13\"").and_return(true)
-#   end
+context "terraform 0.13" do
 
-#   describe "plan" do
-#     # it "should create 'filename' and put 'required_version  in it" do
-#     #   FilTest.should_receive(:open).with("versions.tf", "w").and_yield(file)
-#     #   FileTest.should_receive(:write).with("required_version = \">= 0.12\"")
-#     #   tf_executable = terraform0.13
-#     #   expect_execute(tf_executable, "", success)
-#     #   tf.terraform_executable
-#     # end
+  let(:version_file) { "#{dir}/resources/versions.tf" }
+  let(:content) {
+    'terraform {
+      required_version = ">= 0.13"
+    }'
+  }
+  before do
+    allow(FileTest).to receive(:exists?).with(version_file).and_return(true)
+    allow(File).to receive(:readlines).with(version_file).and_return([content])
+  end
 
-#     it "runs terraform plan" do
-#       env_vars.each do |key, val|
-#         expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-#       end
-#       allow(FileTest).to receive(:directory?).and_return(true)
+  describe "plan" do
 
-#       tf_dir = "#{dir}/resources"
+    it "runs terraform plan" do
+      env_vars.each do |key, val|
+        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+      end
+      allow(FileTest).to receive(:directory?).and_return(true)
 
-#       tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+      tf_dir = "#{dir}/resources"
 
-#       tf_plan = "cd #{tf_dir}; terraform13 plan  "
+      tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-#       expect_execute(tf_init, "", success)
-#       expect_execute(tf_plan, "", success)
-#       expect($stdout).to receive(:puts).at_least(:once)
+      tf_plan = "cd #{tf_dir}; terraform13 plan  "
 
-#       tf.plan
-#     end
-#   end
+      expect_execute(tf_init, "", success)
+      expect_execute(tf_plan, "", success)
+      expect($stdout).to receive(:puts).at_least(:once)
 
-#   describe "apply" do
-#     it "applies terraform files" do
-#       env_vars.each do |key, val|
-#         expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
-#       end
-#       allow(FileTest).to receive(:directory?).and_return(true)
-#       tf_dir = "#{dir}/resources"
-#       tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
+      tf.plan
+    end
+  end
 
-#       tf_apply = "cd #{tf_dir}; terraform13 apply -auto-approve"
+  describe "apply" do
+    it "applies terraform files" do
+      env_vars.each do |key, val|
+        expect(ENV).to receive(:fetch).with(key).at_least(:once).and_return(val)
+      end
+      allow(FileTest).to receive(:directory?).and_return(true)
+      tf_dir = "#{dir}/resources"
+      tf_init = "cd #{tf_dir}; terraform13 init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-#       expect_execute(tf_init, "", success)
-#       expect_execute(tf_apply, "", success)
-#       expect($stdout).to receive(:puts).at_least(:once)
+      tf_apply = "cd #{tf_dir}; terraform13 apply -auto-approve"
 
-#       tf.apply
-#     end
-#   end
+      expect_execute(tf_init, "", success)
+      expect_execute(tf_apply, "", success)
+      expect($stdout).to receive(:puts).at_least(:once)
 
-# end
+      tf.apply
+    end
+  end
+
+end
 end


### PR DESCRIPTION
This change allows us to run Terraform 0.12, 0.13 and 0.14 in the pipeline at the same time.