### PR TITLE
IC-926: Apply interventions dev changes to preprod

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/05-serviceaccount-circleci.yaml
@@ -23,6 +23,7 @@ rules:
     verbs:
       - "patch"
       - "get"
+      - "update"
       - "create"
       - "delete"
       - "list"
@@ -33,12 +34,14 @@ rules:
     resources:
       - "deployments"
       - "ingresses"
+      - "replicasets"
     verbs:
       - "get"
       - "update"
       - "delete"
       - "create"
       - "patch"
+      - "list"
 
 ---
 kind: RoleBinding

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/elasticache.tf
@@ -1,0 +1,32 @@
+module "hmpps_interventions_elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  application            = var.application
+  environment-name       = var.environment
+  is-production          = var.is_production
+  infrastructure-support = var.infrastructure_support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = "cache.t2.small"
+  engine_version         = "6.x"
+  parameter_group_name   = "default.redis6.x"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "hmpps_interventions_elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.hmpps_interventions_elasticache_redis.primary_endpoint_address
+    auth_token               = module.hmpps_interventions_elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.hmpps_interventions_elasticache_redis.member_clusters)
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds.tf
@@ -1,0 +1,35 @@
+module "hmpps_interventions_rds" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  namespace              = var.namespace
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  rds_family             = var.rds_family
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "hmpps_interventions_rds" {
+  metadata {
+    name      = "postgres"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.hmpps_interventions_rds.rds_instance_endpoint
+    database_name         = module.hmpps_interventions_rds.database_name
+    database_username     = module.hmpps_interventions_rds.database_username
+    database_password     = module.hmpps_interventions_rds.database_password
+    rds_instance_address  = module.hmpps_interventions_rds.rds_instance_address
+    access_key_id         = module.hmpps_interventions_rds.access_key_id
+    secret_access_key     = module.hmpps_interventions_rds.secret_access_key
+    url                   = "postgres://${module.hmpps_interventions_rds.database_username}:${module.hmpps_interventions_rds.database_password}@${module.hmpps_interventions_rds.rds_instance_endpoint}/${module.hmpps_interventions_rds.database_name}"
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/variables.tf
@@ -42,3 +42,11 @@ variable "slack_channel" {
   description = "Team slack channel to use if we need to contact your team"
   default     = "interventions"
 }
+
+variable "number_cache_clusters" {
+  default = "2"
+}
+
+variable "rds_family" {
+  default = "postgres10"
+}


### PR DESCRIPTION
This gets the pre-prod environment inline with the current development
environment, with the exception of the `hmpps-domain-events` topic.

That change was already promoted to preprod in 3e4291e
