### PR TITLE
LAA CLA Frontend Staging S3 Bucket

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_frontend_static_files_bucket" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
   acl                           = "public-read"
   enable_allow_block_pub_access = false
   team_name                     = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_frontend_static_files_bucket" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   acl                           = "public-read"
   enable_allow_block_pub_access = false
   team_name                     = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/s3.tf
@@ -1,0 +1,40 @@
+module "cla_frontend_static_files_bucket" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  acl                           = "public-read"
+  enable_allow_block_pub_access = false
+  team_name                     = var.team_name
+  business-unit                 = var.business-unit
+  application                   = var.application
+  is-production                 = var.is-production
+  environment-name              = var.environment-name
+  infrastructure-support        = var.infrastructure-support
+  namespace                     = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+  cors_rule = [
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET"]
+      allowed_origins = ["https://*.apps.live-1.cloud-platform.service.justice.gov.uk"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    }
+  ]
+}
+
+
+resource "kubernetes_secret" "cla_frontend_s3" {
+  metadata {
+    name      = "s3"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id               = module.cla_frontend_static_files_bucket.access_key_id
+    secret_access_key           = module.cla_frontend_static_files_bucket.secret_access_key
+    static_files_bucket_name    = module.cla_frontend_static_files_bucket.bucket_name
+    static_files_bucket_arn     = module.cla_frontend_static_files_bucket.bucket_arn
+  }
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/s3.tf
@@ -32,9 +32,9 @@ resource "kubernetes_secret" "cla_frontend_s3" {
   }
 
   data = {
-    access_key_id               = module.cla_frontend_static_files_bucket.access_key_id
-    secret_access_key           = module.cla_frontend_static_files_bucket.secret_access_key
-    static_files_bucket_name    = module.cla_frontend_static_files_bucket.bucket_name
-    static_files_bucket_arn     = module.cla_frontend_static_files_bucket.bucket_arn
+    access_key_id            = module.cla_frontend_static_files_bucket.access_key_id
+    secret_access_key        = module.cla_frontend_static_files_bucket.secret_access_key
+    static_files_bucket_name = module.cla_frontend_static_files_bucket.bucket_name
+    static_files_bucket_arn  = module.cla_frontend_static_files_bucket.bucket_arn
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/variable.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/variable.tf
@@ -29,3 +29,8 @@ variable "environment-name" {
 variable "is-production" {
   default = "false"
 }
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "civil-legal-advice@digital.justice.gov.uk"
+}


### PR DESCRIPTION
Intentionally created for public access. I heard there were cron jobs running weekly which turn the access to buckets from public to private. What do we need to do in order to be exempted from this just like how laa-cla-backend is exempted.