### PR TITLE
Form Builder - Batch cronjob permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
@@ -20,7 +20,6 @@ rules:
       - "services"
       - "pods"
       - "configmaps"
-      - "cronjobs"
     verbs:
       - "patch"
       - "get"
@@ -46,6 +45,19 @@ rules:
       - "patch"
       - "list"
       - "watch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
The previous PR added the cronjobs to the wrong api group. The "Batch" API group needs to have the cronjob permissions