### PR TITLE
Delete ingress.tf

### DIFF
--- a/namespace-resources-cli-template/resources/ingress.tf
+++ b/namespace-resources-cli-template/resources/ingress.tf
@@ -1,6 +1,0 @@
-module "ingress_controller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
-
-  namespace     = var.namespace
-  is_production = var.is_production
-}


### PR DESCRIPTION
because we decided to use a shared ingress controller, after all - see: https://github.com/ministryofjustice/cloud-platform/blob/main/architecture-decision-record/019-Shared-Ingress-Controllers.md