### PR TITLE
Grant Circle CI user access to networkpolicies resource

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/06-service-account.yaml
@@ -31,6 +31,7 @@ rules:
       - "deployments"
       - "ingresses"
       - "replicasets"
+      - "networkpolicies"
     verbs:
       - "patch"
       - "update"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/06-service-account.yaml
@@ -31,6 +31,7 @@ rules:
       - "deployments"
       - "ingresses"
       - "replicasets"
+      - "networkpolicies"
     verbs:
       - "patch"
       - "update"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/06-service-account.yaml
@@ -31,6 +31,7 @@ rules:
       - "deployments"
       - "ingresses"
       - "replicasets"
+      - "networkpolicies"
     verbs:
       - "patch"
       - "update"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/06-service-account.yaml
@@ -31,6 +31,7 @@ rules:
       - "deployments"
       - "ingresses"
       - "replicasets"
+      - "networkpolicies"
     verbs:
       - "patch"
       - "update"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/06-service-account.yaml
@@ -31,6 +31,7 @@ rules:
       - "deployments"
       - "ingresses"
       - "replicasets"
+      - "networkpolicies"
     verbs:
       - "patch"
       - "update"


### PR DESCRIPTION
The Crime Apps team would like to create a network policy (https://github.com/ministryofjustice/laa-court-data-adaptor/pull/411) but the circleci user doesn't have permission.

This PR grants circleci user permission to do so.