### PR TITLE
Grant permission to circleci user to servicemonitors resource

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/06-service-account.yaml
@@ -26,12 +26,17 @@ rules:
       - "create"
       - "delete"
       - "list"
-  - apiGroups: [extensions, apps, networking.k8s.io]
+  - apiGroups:
+    - "extensions"
+    - "apps"
+    - "networking.k8s.io"
+    - "monitoring.coreos.com"
     resources:
       - "deployments"
       - "ingresses"
       - "replicasets"
       - "networkpolicies"
+      - "servicemonitors"
     verbs:
       - "patch"
       - "update"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/06-service-account.yaml
@@ -26,12 +26,17 @@ rules:
       - "create"
       - "delete"
       - "list"
-  - apiGroups: [extensions, apps, networking.k8s.io]
+  - apiGroups:
+    - "extensions"
+    - "apps"
+    - "networking.k8s.io"
+    - "monitoring.coreos.com"
     resources:
       - "deployments"
       - "ingresses"
       - "replicasets"
       - "networkpolicies"
+      - "servicemonitors"
     verbs:
       - "patch"
       - "update"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/06-service-account.yaml
@@ -26,12 +26,17 @@ rules:
       - "create"
       - "delete"
       - "list"
-  - apiGroups: [extensions, apps, networking.k8s.io]
+  - apiGroups:
+    - "extensions"
+    - "apps"
+    - "networking.k8s.io"
+    - "monitoring.coreos.com"
     resources:
       - "deployments"
       - "ingresses"
       - "replicasets"
       - "networkpolicies"
+      - "servicemonitors"
     verbs:
       - "patch"
       - "update"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/06-service-account.yaml
@@ -26,12 +26,17 @@ rules:
       - "create"
       - "delete"
       - "list"
-  - apiGroups: [extensions, apps, networking.k8s.io]
+  - apiGroups:
+    - "extensions"
+    - "apps"
+    - "networking.k8s.io"
+    - "monitoring.coreos.com"
     resources:
       - "deployments"
       - "ingresses"
       - "replicasets"
       - "networkpolicies"
+      - "servicemonitors"
     verbs:
       - "patch"
       - "update"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/06-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/06-service-account.yaml
@@ -26,12 +26,17 @@ rules:
       - "create"
       - "delete"
       - "list"
-  - apiGroups: [extensions, apps, networking.k8s.io]
+  - apiGroups:
+    - "extensions"
+    - "apps"
+    - "networking.k8s.io"
+    - "monitoring.coreos.com"
     resources:
       - "deployments"
       - "ingresses"
       - "replicasets"
       - "networkpolicies"
+      - "servicemonitors"
     verbs:
       - "patch"
       - "update"


### PR DESCRIPTION
Grants permission to laa-court-data-adaptor circleci user to `servicemonitors` resource on
the apiGroup `monitoring.coreos.com`.

Fixes error:

```
Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with update: could not get information about the resource: servicemonitors.monitoring.coreos.com "laa-court-data-adaptor-monitor" is forbidden: User "system:serviceaccount:laa-court-data-adaptor-dev:circleci" cannot get resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "laa-court-data-adaptor-dev"
```

for all namespaces.