### PR TITLE
Upgrade namespace to Terraform 0.13 and bump resources to allow upgrade

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/alexhaslehurst-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/alexhaslehurst-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/alexhaslehurst-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/alexhaslehurst-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/chrisfaulkner-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/chrisfaulkner-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "chrisfaulkner-ruby-app"
   team_name = "probation-in-court"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/chrisfaulkner-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/chrisfaulkner-dev/resources/versions.tf
@@ -1,3 +1,11 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/dynamodb.tf
@@ -1,5 +1,5 @@
 module "cloud_platform_reports_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name              = var.team_name
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.4"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.5"
   namespace           = var.namespace
   github_repositories = ["cloud-platform-how-out-of-date-are-we"]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/versions.tf
@@ -1,3 +1,14 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/helloworldapp-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/helloworldapp-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/helloworldapp-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/helloworldapp-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jacob-hello-world-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jacob-hello-world-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "jacobbrowning-dev-repo"
   team_name = "jacobbrowning-dev-team"
   /*

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jacob-hello-world-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jacob-hello-world-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-demo/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-demo/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.5"
 
   namespace = var.namespace
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-demo/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-demo/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/javidtest-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/javidtest-development/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/markberridge-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/markberridge-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "markberridge-dev-ecr-credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "markberridge-dev-repo"
   team_name = "markberridge-dev-team"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/markberridge-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/markberridge-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mayowa-hello-world-test-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mayowa-hello-world-test-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mryall-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mryall-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/dynamodb.tf
@@ -1,5 +1,5 @@
 module "opseng_reports" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name              = var.team_name
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   acl    = "private"
 
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.5"
 
   namespace = var.namespace
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/state-lock-table.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/state-lock-table.tf
@@ -1,5 +1,5 @@
 module "opseng_tf_state_lock" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name              = var.team_name
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/versions.tf
@@ -1,4 +1,18 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/rja-sandbox/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/rja-sandbox/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/rja-sandbox/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/rja-sandbox/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ryanforsyth-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ryanforsyth-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ryanforsyth-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ryanforsyth-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/shared-test-zone/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/shared-test-zone/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }


### PR DESCRIPTION
All state in the cloud-platform-environments repository is upgrading to
Terraform 0.13. This commit changes the `versions.tf` file and bumps any
modules to allow for this upgrade. This should be a clean upgrade and
will return a "clean" plan, making no changes to resources.