### PR TITLE
Upgrade dev namespace to Terraform 0.13 and bump resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/book-a-prison-visit-development/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/book-a-prison-visit-development/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/book-a-prison-visit-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/book-a-prison-visit-development/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-metabase/resources/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "calculate-journey-variable-payments_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
 
   team_name          = var.team_name
   topic_display_name = "cccd-claims-submitted"
@@ -10,7 +10,7 @@ module "cccd_claims_submitted" {
 }
 
 module "claims_for_ccr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -64,7 +64,7 @@ EOF
 }
 
 module "claims_for_cclf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -118,7 +118,7 @@ EOF
 }
 
 module "responses_for_cccd" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -143,7 +143,7 @@ EOF
 }
 
 module "ccr_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -160,7 +160,7 @@ module "ccr_dead_letter_queue" {
 }
 
 module "cclf_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -177,7 +177,7 @@ module "cclf_dead_letter_queue" {
 }
 
 module "cccd_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name                = var.cluster_name
   cluster_state_bucket        = var.cluster_state_bucket
   team_name                   = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
@@ -1,6 +1,6 @@
 
 module "cccd_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "cccd"
   team_name = "laa-get-paid"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
 
   team_name          = var.team_name
   topic_display_name = "cccd-claims-submitted"
@@ -10,7 +10,7 @@ module "cccd_claims_submitted" {
 }
 
 module "claims_for_ccr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -64,7 +64,7 @@ EOF
 }
 
 module "claims_for_cclf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -118,7 +118,7 @@ EOF
 }
 
 module "responses_for_cccd" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -143,7 +143,7 @@ EOF
 }
 
 module "ccr_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -160,7 +160,7 @@ module "ccr_dead_letter_queue" {
 }
 
 module "cclf_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -177,7 +177,7 @@ module "cclf_dead_letter_queue" {
 }
 
 module "cccd_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name                = var.cluster_name
   cluster_state_bucket        = var.cluster_state_bucket
   team_name                   = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "checkmydiary-service-dev" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "check-my-diary-dev"
   team_name = "check-my-diary"
 
@@ -23,7 +23,7 @@ resource "kubernetes_secret" "checkmydiary_ecr_credentials" {
 }
 
 module "checkmydiary-notification-service-dev" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "check-my-diary-notification-service-dev"
   team_name = "check-my-diary"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/rds.tf
@@ -10,7 +10,7 @@ variable "cluster_state_bucket" {
 }
 
 module "checkmydiary_dev_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = var.repo_name
   team_name = var.team_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-oas-basic-testing/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-bots/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-bots/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa_crime_apps_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "laa-common-platform-connector"
   team_name = "laa-crime-apps-team"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/common-platform-connector-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact_moj_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact-moj_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/crime-portal-gateway-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/crime-portal-gateway-queue.tf
@@ -1,5 +1,5 @@
 module "crime-portal-gateway-queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -22,7 +22,7 @@ module "crime-portal-gateway-queue" {
 }
 
 module "crime-portal-gateway-dead-letter-queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/crime_portal_gateway_s3_bucket.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/crime_portal_gateway_s3_bucket.tf
@@ -1,5 +1,5 @@
 module "crime-portal-gateway-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/ecr.tf
@@ -1,7 +1,7 @@
 
 
 module "court_probation_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "court-probation-service"
   team_name = "probation-services"
 
@@ -25,7 +25,7 @@ resource "kubernetes_secret" "court_probation_service_ecr_credentials" {
 }
 
 module "ps_cps_pack_parser_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "cps-pack-parser"
   team_name = "probation-services"
 
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "ps_cps_pack_parser_ecr_credentials" {
 }
 
 module "mock_cp_court_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "mock-cp-court-service"
   team_name = "probation-services"
 
@@ -73,7 +73,7 @@ resource "kubernetes_secret" "mock_cp_court_service_ecr_credentials" {
 }
 
 module "court_list_service_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "court-list-service"
   team_name = "probation-services"
 
@@ -97,7 +97,7 @@ resource "kubernetes_secret" "court_list_service_ecr_credentials" {
 }
 
 module "prepare_probation_courtcases_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "prepare-probation-courtcases"
   team_name = "probation-services"
 
@@ -121,7 +121,7 @@ resource "kubernetes_secret" "prepare_probation_courtcases_ecr_credentials" {
 }
 
 module "ndelius_new_tech_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "ndelius-new-tech"
   team_name = "probation-services"
 
@@ -145,7 +145,7 @@ resource "kubernetes_secret" "ndelius_new_tech_ecr_credentials" {
 }
 
 module "community_api_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "community-api"
   team_name = "probation-services"
 
@@ -169,7 +169,7 @@ resource "kubernetes_secret" "community_api_ecr_credentials" {
 }
 
 module "ukcloud_proxy_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "ukcloud-proxy"
   team_name = "probation-services"
 
@@ -193,7 +193,7 @@ resource "kubernetes_secret" "ukcloud_proxy_ecr_credentials" {
 }
 
 module "delius_oauth2_server_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "delius-oauth2-server"
   team_name = "probation-services"
 
@@ -217,7 +217,7 @@ resource "kubernetes_secret" "delius_oauth2_server_ecr_credentials" {
 }
 
 module "probation_court_prototype_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "probation-court-prototype"
   team_name = "probation-services"
 
@@ -241,7 +241,7 @@ resource "kubernetes_secret" "probation_court_prototype_ecr_credentials" {
 }
 
 module "court_list_mock_data_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "court-list-mock-data"
   team_name = "probation-services"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "court_case_service_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/resources/ecr.tf
@@ -2,7 +2,7 @@
 // This registry is used in the dev, preprod and prod namespaces which all deploy the same image from this ECR
 
 module "pict_cpmg_database_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "cpmg-database"
   team_name = "probation-in-court"
 
@@ -12,7 +12,7 @@ module "pict_cpmg_database_ecr_credentials" {
 }
 
 module "pict_cpmg_wildfly_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "cpmg-wildfly"
   team_name = "probation-in-court"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/resources/rds.tf
@@ -11,7 +11,7 @@ variable "cluster_state_bucket" {
 }
 
 module "crime_portal_mirror_gateway_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name                 = var.cluster_name
   cluster_state_bucket         = var.cluster_state_bucket
   team_name                    = "probation-in-court"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/data-eng-rds-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/data-eng-rds-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/data-eng-rds-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/data-eng-rds-dev/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/data-eng-rds-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/data-eng-rds-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/delius-updates-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/delius-updates-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-estatesdb-dev" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "estatesdb-dev"
   team_name = "programmeandperformance"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/resources/rds.tf
@@ -21,7 +21,7 @@ variable "cluster_state_bucket" {
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "programmeandperformance_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = "estatesprojects"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/estatesdb-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
@@ -1,5 +1,5 @@
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
@@ -1,5 +1,5 @@
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
@@ -1,5 +1,5 @@
 module "json-output-attachments-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
@@ -1,5 +1,5 @@
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
@@ -1,5 +1,5 @@
 module "submitter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
@@ -2,7 +2,7 @@
 ##################################################
 # User Filestore S3
 module "user-filestore-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
@@ -1,5 +1,5 @@
 module "publisher-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
@@ -34,7 +34,7 @@ resource "kubernetes_secret" "publisher-rds-instance" {
 ########################################################
 # Publisher Elasticache Redis (for resque + job logging)
 module "publisher-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
@@ -1,5 +1,5 @@
 module "editor-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
@@ -1,5 +1,5 @@
 module "metadata-api-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/versions.tf
@@ -1,3 +1,11 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }


### PR DESCRIPTION
All state in the cloud-platform-environments repository is upgrading to
Terraform 0.13. This commit changes the `versions.tf` file and bumps any
modules to allow for this upgrade. This should be a clean upgrade and
will return a "clean" plan, making no changes to resources.