### PR TITLE
Upgrade non-prod namespace to Terraform 0.13 and bump resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
@@ -3,7 +3,7 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/redis.tf
@@ -3,7 +3,7 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "calculate-journey-variable-payments_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/case-notes-to-probation-preprod/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name                = var.cluster_name
   cluster_state_bucket        = var.cluster_state_bucket
   team_name                   = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cccd_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "laa-get-paid"
   business-unit          = "legal-aid-agency"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "check-financial-eligibility-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-check-financial-eligibility-service" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = "laa-apply-for-legal-aid"
   repo_name = "check-financial-eligibility-service"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "checkmydiary-service-preprod" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "check-my-diary-preprod"
   team_name = "check-my-diary"
 }
@@ -19,7 +19,7 @@ resource "kubernetes_secret" "checkmydiary_ecr_credentials" {
 }
 
 module "checkmydiary-notification-service-preprod" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "check-my-diary-notification-service-preprod"
   team_name = "check-my-diary"
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
@@ -10,7 +10,7 @@ variable "cluster_state_bucket" {
 }
 
 module "checkmydiary_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cica-repo" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "cica"
   team_name = "cica"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cica-apply-for-compensation-uat/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "cica_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "cica-repo-stg"
   team_name = "cica"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/dynamodb.tf
@@ -1,5 +1,5 @@
 module "cloud_platform_reports_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name              = var.team_name
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact_moj_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact-moj_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/rds.tf
@@ -11,7 +11,7 @@ variable "cluster_state_bucket" {
  *
  */
 module "rds-staging" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "Correspondence Staff"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/correspondence-staff-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/crime-portal-gateway-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/crime-portal-gateway-queue.tf
@@ -1,5 +1,5 @@
 module "crime-portal-gateway-queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -22,7 +22,7 @@ module "crime-portal-gateway-queue" {
 }
 
 module "crime-portal-gateway-dead-letter-queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/crime_portal_gateway_s3_bucket.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/crime_portal_gateway_s3_bucket.tf
@@ -1,5 +1,5 @@
 module "crime-portal-gateway-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/perf_test_data_s3_bucket.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/perf_test_data_s3_bucket.tf
@@ -1,5 +1,5 @@
 module "perf-test-data-s3-bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "court_case_service_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name                = var.cluster_name
   cluster_state_bucket        = var.cluster_state_bucket
   team_name                   = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-preprod/resources/rds.tf
@@ -11,7 +11,7 @@ variable "cluster_state_bucket" {
 }
 
 module "crime_portal_mirror_gateway_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name                 = var.cluster_name
   cluster_state_bucket         = var.cluster_state_bucket
   team_name                    = "probation-in-court"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/crime-portal-mirror-gateway-preprod/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/delius-updates-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/delius-updates-preprod/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/delius-updates-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/delius-updates-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/elasticache.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/elasticache.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 ####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "formbuilder_product_page_staging_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "formbuilder-product-page-staging"
   team_name = "formbuilder"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmcts-complaints-adapter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa_crime_apps_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "hmcts-common-platform-mock-api"
   team_name = "laa-crime-apps-team"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "hmcts_mock_api_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
@@ -39,7 +39,7 @@ resource "kubernetes_secret" "rds-instance" {
 }
 
 module "rds-read-replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-metrics.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-metrics.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_metrics_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
@@ -58,7 +58,7 @@ resource "kubernetes_secret" "rds-instance" {
 }
 
 module "rds-read-replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-metrics.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-metrics.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_metrics_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "HMPPS"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/versions.tf
@@ -1,4 +1,18 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    postgresql = {
+      source = "cyrilgdn/postgresql"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr-repo-datasette.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr-repo-datasette.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-datasette" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "ecr-repo-datasette"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
@@ -42,7 +42,7 @@ resource "kubernetes_secret" "rds-instance" {
 }
 
 module "rds-read-replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-documents.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-documents.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-metrics.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-metrics.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_metrics_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "HMPPS"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-reporting.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/s3-reporting.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_reporting_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3-metrics.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3-metrics.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
  */
 module "book_a_secure_move_metrics_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "HMPPS"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "book_a_secure_move_documents_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_book_video_link_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_book_video_link_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-complexity-of-need" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "hmpps-complexity-of-need"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
@@ -17,7 +17,7 @@ variable "cluster_state_bucket" {
  *
  */
 module "complexity-of-need-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-domain-events-topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-domain-events-topic.tf
@@ -1,5 +1,5 @@
 module "hmpps-domain-events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
 
   team_name          = var.team_name
   topic_display_name = "hmpps-domain-events"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-domain-events-topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-domain-events-topic.tf
@@ -1,5 +1,5 @@
 module "hmpps-domain-events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
 
   team_name          = var.team_name
   topic_display_name = "hmpps-domain-events"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "grafana_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_interventions_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_interventions_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_interventions_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_interventions_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_pin_phone_monitor_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "hmpps_pin_phone_monitor_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -68,7 +68,7 @@ EOF
 }
 
 module "hmpps_pin_phone_monitor_s3_event_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -91,7 +91,7 @@ module "hmpps_pin_phone_monitor_s3_event_queue" {
 }
 
 module "hmpps_pin_phone_monitor_s3_event_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_pin_phone_monitor_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/s3.tf
@@ -1,5 +1,5 @@
 module "hmpps_pin_phone_monitor_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -57,7 +57,7 @@ EOF
 }
 
 module "hmpps_pin_phone_monitor_s3_event_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -80,7 +80,7 @@ module "hmpps_pin_phone_monitor_s3_event_queue" {
 }
 
 module "hmpps_pin_phone_monitor_s3_event_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_registers_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.hmpps-registers-application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name
@@ -36,7 +36,7 @@ resource "kubernetes_secret" "dps_rds" {
 }
 
 module "prisons_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_registers_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.hmpps-registers-application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name
@@ -36,7 +36,7 @@ resource "kubernetes_secret" "dps_rds" {
 }
 
 module "prisons_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/dynamodb.tf
@@ -5,7 +5,7 @@
  *
  */
 module "submit_information_report_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name              = "digital-prison-services"
   application            = "HMPPS Submit Information Report"
@@ -33,7 +33,7 @@ resource "kubernetes_secret" "submit_information_report_dynamodb" {
 }
 
 module "submit_information_report_reports_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name              = "digital-prison-services"
   application            = "HMPPS Submit Information Report"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "submit_information_report_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/manage-intelligence-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/manage-intelligence-sub-queue.tf
@@ -1,5 +1,5 @@
 module "information_report_submissions_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -22,7 +22,7 @@ module "information_report_submissions_queue" {
 }
 
 module "information_report_submissions_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "hmpps_submit_information_report_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-submit-information-report-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-template-apps-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-template-apps-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_template_typescript_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = "hmpps-template-typescript"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-template-apps-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-template-apps-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "hmpps_user_preferences_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "hmpps_user_preferences_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "hmpps_user_preferences_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/iatest-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/iatest-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/delius-intervention-update-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/delius-intervention-update-queue.tf
@@ -1,5 +1,5 @@
 module "delius_intervention_update_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -49,7 +49,7 @@ resource "aws_sqs_queue_policy" "delius_intervention_update_queue_policy" {
 }
 
 module "delius_intervention_update_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "interventions_catalogue_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/topic.tf
@@ -1,5 +1,5 @@
 module "intervention_reference_data_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
 
   team_name          = var.team_name
   topic_display_name = "intervention-reference-data-events"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-service-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-ui-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/interventions-catalogue-ui-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "authorized-keys" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "apply-for-legal-aid"
   acl                    = "private"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-aws-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-aws-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/rds.tf
@@ -9,7 +9,7 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
@@ -1,5 +1,5 @@
 module "cla_backend_private_reports_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   acl    = "private"
 
   team_name              = var.team_name
@@ -50,7 +50,7 @@ EOF
 }
 
 module "cla_backend_deleted_objects_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   acl    = "private"
 
   team_name              = var.team_name
@@ -98,7 +98,7 @@ EOF
 
 
 module "cla_backend_static_files_bucket" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   acl                           = "public-read"
   enable_allow_block_pub_access = false
   team_name                     = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/sqs.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/sqs.tf
@@ -1,5 +1,5 @@
 module "laa_cla_backend_uat_sqs" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/messaging-queues.tf
@@ -1,5 +1,5 @@
 module "create_link_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -56,7 +56,7 @@ resource "aws_sqs_queue_policy" "create_link_queue_policy" {
 
 
 module "create_link_queue_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -73,7 +73,7 @@ module "create_link_queue_dead_letter_queue" {
 }
 
 module "unlink_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -129,7 +129,7 @@ resource "aws_sqs_queue_policy" "unlink_queue_policy" {
 }
 
 module "unlink_queue_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -146,7 +146,7 @@ module "unlink_queue_dead_letter_queue" {
 }
 
 module "laa_status_update_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -202,7 +202,7 @@ resource "aws_sqs_queue_policy" "laa_status_update_queue_policy" {
 }
 
 module "laa_status_update_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -220,7 +220,7 @@ module "laa_status_update_dead_letter_queue" {
 
 
 module "hearing_resulted_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -276,7 +276,7 @@ resource "aws_sqs_queue_policy" "hearing_resulted_queue_policy" {
 }
 
 module "hearing_resulted_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -293,7 +293,7 @@ module "hearing_resulted_dead_letter_queue" {
 }
 
 module "cp_laa_status_job_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -345,7 +345,7 @@ resource "aws_sqs_queue_policy" "cp_laa_status_job_queue_policy" {
 }
 
 module "cp_laa_status_job_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds.tf
@@ -17,7 +17,7 @@ variable "cluster_state_bucket" {
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = "laa-crime-apps-team"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   // The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   cluster_name           = var.cluster_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
@@ -1,5 +1,5 @@
 module "create_link_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -56,7 +56,7 @@ resource "aws_sqs_queue_policy" "create_link_queue_policy" {
 
 
 module "create_link_queue_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -73,7 +73,7 @@ module "create_link_queue_dead_letter_queue" {
 }
 
 module "unlink_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -129,7 +129,7 @@ resource "aws_sqs_queue_policy" "unlink_queue_policy" {
 }
 
 module "unlink_queue_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -146,7 +146,7 @@ module "unlink_queue_dead_letter_queue" {
 }
 
 module "laa_status_update_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -202,7 +202,7 @@ resource "aws_sqs_queue_policy" "laa_status_update_queue_policy" {
 }
 
 module "laa_status_update_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -220,7 +220,7 @@ module "laa_status_update_dead_letter_queue" {
 
 
 module "hearing_resulted_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -276,7 +276,7 @@ resource "aws_sqs_queue_policy" "hearing_resulted_queue_policy" {
 }
 
 module "hearing_resulted_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -293,7 +293,7 @@ module "hearing_resulted_dead_letter_queue" {
 }
 
 module "cp_laa_status_job_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -345,7 +345,7 @@ resource "aws_sqs_queue_policy" "cp_laa_status_job_queue_policy" {
 }
 
 module "cp_laa_status_job_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment_name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds.tf
@@ -17,7 +17,7 @@ variable "cluster_state_bucket" {
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = "laa-crime-apps-team"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   // The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   cluster_name           = var.cluster_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "lcdui_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   team_name = var.team_name
   repo_name = var.repo_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "lcdui_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "lcdui_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name                = var.cluster_name
   cluster_state_bucket        = var.cluster_state_bucket
   team_name                   = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
@@ -1,5 +1,5 @@
 module "s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/learning-cloud-deployments-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/learning-cloud-deployments-dev/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "cloud-platform-environments"
   team_name = "hmpps-dev-test"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/learning-cloud-deployments-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/learning-cloud-deployments-dev/resources/versions.tf
@@ -1,3 +1,11 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "licences_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "licences_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-preprod/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/elasticache.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }


### PR DESCRIPTION
We're upgrading all state in the cloud-platform-environments repository
to Terraform 0.13. This commit changes the versions.tf file and bumps
any
modules to allow for this upgrade. This should be a clean upgrade and
will return a "clean" plan, making no changes to resources.