### PR TITLE
Upgrade non-prod namespace to Terraform 0.13 and bump resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_intelligence_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -19,7 +19,7 @@ module "manage_intelligence_elasticsearch" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.manage_intelligence_elasticsearch.aws_iam_role_name]
   namespace           = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/rds.tf
@@ -3,7 +3,7 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_storage_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false
@@ -16,7 +16,7 @@ module "manage_intelligence_storage_bucket" {
 }
 
 module "manage_intelligence_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/elasticache.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/elasticache.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_soc_cases_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
@@ -9,7 +9,7 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "manage_soc_cases_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -65,7 +65,7 @@ EOF
 }
 
 module "manage_soc_cases_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_soc_cases_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/rds.tf
@@ -9,7 +9,7 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "manage_soc_cases_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -65,7 +65,7 @@ EOF
 }
 
 module "manage_soc_cases_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "oc_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_change" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -45,7 +45,7 @@ EOF
 }
 
 module "risk_profiler_change_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "oc_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_change" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -45,7 +45,7 @@ EOF
 }
 
 module "risk_profiler_change_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "risk_profiler_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/cfo-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/cfo-sub-queue.tf
@@ -1,5 +1,5 @@
 module "cfo_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "cfo_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/hmpps-tier-offender-events-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/hmpps-tier-offender-events-sub-queue.tf
@@ -1,5 +1,5 @@
 module "hmpps_tier_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "hmpps_tier_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/hmpps-tier-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/hmpps-tier-sub-queue.tf
@@ -1,5 +1,5 @@
 module "hmpps_tier_event_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "hmpps_tier_event_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/keyworker_api-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/keyworker_api-sub-queue.tf
@@ -1,5 +1,5 @@
 module "keyworker_api_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "keyworker_api_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/manage-soc-cases-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/manage-soc-cases-sub-queue.tf
@@ -1,5 +1,5 @@
 module "manage_soc_cases_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -22,7 +22,7 @@ module "manage_soc_cases_offender_events_queue" {
 }
 
 module "manage_soc_cases_probation_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -99,7 +99,7 @@ resource "aws_sqs_queue_policy" "manage_soc_cases_probation_offender_events_queu
 }
 
 module "manage_soc_cases_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -115,7 +115,7 @@ module "manage_soc_cases_offender_events_dead_letter_queue" {
 }
 
 module "manage_soc_cases_probation_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_case_notes-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_case_notes-sub-queue.tf
@@ -1,5 +1,5 @@
 module "offender_case_notes_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -49,7 +49,7 @@ resource "aws_sqs_queue_policy" "offender_case_notes_events_queue_policy" {
 }
 
 module "offender_case_notes_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_categorisation-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_categorisation-sub-queue.tf
@@ -1,5 +1,5 @@
 module "offender_categorisation_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -49,7 +49,7 @@ resource "aws_sqs_queue_policy" "offender_categorisation_events_queue_policy" {
 }
 
 module "offender_categorisation_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -106,7 +106,7 @@ resource "aws_sns_topic_subscription" "offender_categorisation_subscription" {
 
 
 module "offender_categorisation_ui_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -156,7 +156,7 @@ resource "aws_sqs_queue_policy" "offender_categorisation_ui_events_queue_policy"
 }
 
 module "offender_categorisation_ui_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_events_ui-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_events_ui-sub-queue.tf
@@ -1,5 +1,5 @@
 module "offender_events_ui_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "offender_events_ui_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/pathfinder-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/pathfinder-sub-queue.tf
@@ -1,7 +1,7 @@
 
 
 module "pathfinder_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -24,7 +24,7 @@ module "pathfinder_offender_events_queue" {
 }
 
 module "pathfinder_probation_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -101,7 +101,7 @@ resource "aws_sqs_queue_policy" "pathfinder_probation_offender_events_queue_poli
 }
 
 module "pathfinder_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -117,7 +117,7 @@ module "pathfinder_offender_events_dead_letter_queue" {
 }
 
 module "pathfinder_probation_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/poll-pusher-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/poll-pusher-sub-queue.tf
@@ -1,5 +1,5 @@
 module "case_note_poll_pusher_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "case_note_poll_pusher_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/prison_to_probation_update-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/prison_to_probation_update-sub-queue.tf
@@ -1,5 +1,5 @@
 module "prison_to_probation_update_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "prison_to_probation_update_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/prisoner-offender-search-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/prisoner-offender-search-sub-queue.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "prisoner_offender_search_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/probation-offender-search-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/probation-offender-search-sub-queue.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_event_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "probation_offender_search_event_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/topic.tf
@@ -1,5 +1,5 @@
 module "offender_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
 
   team_name          = var.team_name
   topic_display_name = "offender-events"
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "prison-data-compliance" {
 }
 
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
   team_name          = var.team_name
   topic_display_name = "probation-offender-events"
   providers = {
@@ -70,7 +70,7 @@ resource "kubernetes_secret" "probation_offender_events" {
 }
 
 module "offender_assessments_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
   team_name          = var.team_name
   topic_display_name = "offender-assessments-events"
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/whereabouts-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/whereabouts-sub-queue.tf
@@ -1,5 +1,5 @@
 module "whereabouts_api_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -49,7 +49,7 @@ resource "aws_sqs_queue_policy" "whereabouts_api_queue_policy" {
 }
 
 module "whereabouts_api_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/cfo-sub-queue-perf.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/cfo-sub-queue-perf.tf
@@ -1,5 +1,5 @@
 module "cfo_queue_perf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "cfo_dead_letter_queue_perf" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/cfo-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/cfo-sub-queue.tf
@@ -1,5 +1,5 @@
 module "cfo_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "cfo_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/hmpps-tier-offender-events-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/hmpps-tier-offender-events-sub-queue.tf
@@ -1,5 +1,5 @@
 module "hmpps_tier_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "hmpps_tier_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/hmpps-tier-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/hmpps-tier-sub-queue.tf
@@ -1,5 +1,5 @@
 module "hmpps_tier_event_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "hmpps_tier_event_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/keyworker_api-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/keyworker_api-sub-queue.tf
@@ -1,5 +1,5 @@
 module "keyworker_api_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "keyworker_api_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/manage-soc-cases-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/manage-soc-cases-sub-queue.tf
@@ -1,5 +1,5 @@
 module "manage_soc_cases_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -22,7 +22,7 @@ module "manage_soc_cases_offender_events_queue" {
 }
 
 module "manage_soc_cases_probation_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -99,7 +99,7 @@ resource "aws_sqs_queue_policy" "manage_soc_cases_probation_offender_events_queu
 }
 
 module "manage_soc_cases_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -115,7 +115,7 @@ module "manage_soc_cases_offender_events_dead_letter_queue" {
 }
 
 module "manage_soc_cases_probation_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/offender_case_notes-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/offender_case_notes-sub-queue.tf
@@ -1,5 +1,5 @@
 module "offender_case_notes_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -49,7 +49,7 @@ resource "aws_sqs_queue_policy" "offender_case_notes_events_queue_policy" {
 }
 
 module "offender_case_notes_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/offender_categorisation-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/offender_categorisation-sub-queue.tf
@@ -1,5 +1,5 @@
 module "offender_categorisation_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -49,7 +49,7 @@ resource "aws_sqs_queue_policy" "offender_categorisation_events_queue_policy" {
 }
 
 module "offender_categorisation_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -106,7 +106,7 @@ resource "aws_sns_topic_subscription" "offender_categorisation_subscription" {
 
 
 module "offender_categorisation_ui_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -156,7 +156,7 @@ resource "aws_sqs_queue_policy" "offender_categorisation_ui_events_queue_policy"
 }
 
 module "offender_categorisation_ui_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/pathfinder-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/pathfinder-sub-queue.tf
@@ -1,7 +1,7 @@
 
 
 module "pathfinder_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -24,7 +24,7 @@ module "pathfinder_offender_events_queue" {
 }
 
 module "pathfinder_probation_offender_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -101,7 +101,7 @@ resource "aws_sqs_queue_policy" "pathfinder_probation_offender_events_queue_poli
 }
 
 module "pathfinder_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name
@@ -117,7 +117,7 @@ module "pathfinder_offender_events_dead_letter_queue" {
 }
 
 module "pathfinder_probation_offender_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/poll-pusher-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/poll-pusher-sub-queue.tf
@@ -1,5 +1,5 @@
 module "case_note_poll_pusher_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "case_note_poll_pusher_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/prison_to_probation_update-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/prison_to_probation_update-sub-queue.tf
@@ -1,5 +1,5 @@
 module "prison_to_probation_update_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "prison_to_probation_update_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/prisoner-offender-search-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/prisoner-offender-search-sub-queue.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "prisoner_offender_search_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/probation-offender-search-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/probation-offender-search-sub-queue.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_event_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "probation_offender_search_event_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic-perf.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic-perf.tf
@@ -1,5 +1,5 @@
 module "probation_offender_events_perf" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
   team_name          = var.team_name
   topic_display_name = "probation-offender-events-perf"
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic.tf
@@ -1,5 +1,5 @@
 module "offender_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
 
   team_name          = var.team_name
   topic_display_name = "offender-events"
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "prison-data-compliance" {
 }
 
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
   team_name          = var.team_name
   topic_display_name = "probation-offender-events"
   providers = {
@@ -70,7 +70,7 @@ resource "kubernetes_secret" "probation_offender_events" {
 }
 
 module "offender_assessments_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
   team_name          = var.team_name
   topic_display_name = "offender-assessments-events"
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/whereabouts-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/whereabouts-sub-queue.tf
@@ -1,5 +1,5 @@
 module "whereabouts_api_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -49,7 +49,7 @@ resource "aws_sqs_queue_policy" "whereabouts_api_queue_policy" {
 }
 
 module "whereabouts_api_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-staging/resources/probation-offender-search-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-staging/resources/probation-offender-search-sub-queue.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_event_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -53,7 +53,7 @@ EOF
 }
 
 module "probation_offender_search_event_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-staging/resources/topic.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-staging/resources/topic.tf
@@ -1,5 +1,5 @@
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
   team_name          = var.team_name
   topic_display_name = "probation-offender-events"
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-staging/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-offender-management-allocation-manager" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/rds-allocations-api.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/rds-allocations-api.tf
@@ -17,7 +17,7 @@ variable "cluster_state_bucket" {
  *
  */
 module "allocation-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-allocation-manager.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-allocation-manager.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-allocation-manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "offender-management-allocation-manager"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-nomis-delius-emulator.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-nomis-delius-emulator.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-nomis-delius-emulator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = var.team_name
   repo_name = "nomis-delius-emulator"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-offender-management-allocation-manager" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   node_type              = "cache.m4.xlarge"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds-allocations-api.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds-allocations-api.tf
@@ -17,7 +17,7 @@ variable "cluster_state_bucket" {
  *
  */
 module "allocation-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds-nomis-delius-emulator.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds-nomis-delius-emulator.tf
@@ -5,7 +5,7 @@
  *
  */
 module "nomis-delius-emulator-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
 
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/ecr.tf
@@ -4,7 +4,7 @@
 
 module "pq_ecr_credentials" {
   repo_name = var.repo_name
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   team_name = var.team_name
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
@@ -16,7 +16,7 @@ module "rds_instance" {
   is-production               = var.is-production
   namespace                   = var.namespace
   rds_family                  = "postgres12"
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   team_name                   = var.team_name
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/versions.tf
@@ -1,3 +1,11 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds_instance" {
   is-production              = var.is-production
   namespace                  = var.namespace
   rds_family                 = "postgres12"
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   team_name                  = var.team_name
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pathfinder_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -9,7 +9,7 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/s3.tf
@@ -1,5 +1,5 @@
 module "pathfinder_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -65,7 +65,7 @@ EOF
 }
 
 module "pathfinder_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pathfinder_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
@@ -9,7 +9,7 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "pathfinder_document_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = true
@@ -65,7 +65,7 @@ EOF
 }
 
 module "pathfinder_rds_to_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
@@ -19,7 +19,7 @@ module "peoplefinder_es" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.peoplefinder_es.aws_iam_role_name]
   namespace           = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "peoplefinder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -19,7 +19,7 @@ module "peoplefinder_es" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.peoplefinder_es.aws_iam_role_name]
   namespace           = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "peoplefinder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -19,7 +19,7 @@ module "peoplefinder_es" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.peoplefinder_es.aws_iam_role_name]
   namespace           = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "peoplefinder"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "peoplefinder"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/data-compliance-request-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/data-compliance-request-queue.tf
@@ -1,5 +1,5 @@
 module "data_compliance_request_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name           = var.environment-name
   team_name                  = var.team_name
@@ -23,7 +23,7 @@ module "data_compliance_request_queue" {
 }
 
 module "data_compliance_request_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/data-compliance-response-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/data-compliance-response-queue.tf
@@ -1,5 +1,5 @@
 module "data_compliance_response_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name           = var.environment-name
   team_name                  = var.team_name
@@ -23,7 +23,7 @@ module "data_compliance_response_queue" {
 }
 
 module "data_compliance_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/data-compliance-request-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/data-compliance-request-queue.tf
@@ -1,5 +1,5 @@
 module "data_compliance_request_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name           = var.environment-name
   team_name                  = var.team_name
@@ -23,7 +23,7 @@ module "data_compliance_request_queue" {
 }
 
 module "data_compliance_request_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/data-compliance-response-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/data-compliance-response-queue.tf
@@ -1,5 +1,5 @@
 module "data_compliance_response_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name           = var.environment-name
   team_name                  = var.team_name
@@ -23,7 +23,7 @@ module "data_compliance_response_queue" {
 }
 
 module "data_compliance_response_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-data-compliance-preprod/resources/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-preprod/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-dev/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-dev/resources/dynamodb.tf
@@ -1,6 +1,6 @@
 
 module "message_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name                    = var.team_name
   application                  = var.application
@@ -31,7 +31,7 @@ resource "kubernetes_secret" "message_dynamodb" {
 }
 
 module "schedule_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name              = var.team_name
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-preprod/resources/dynamodb.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-preprod/resources/dynamodb.tf
@@ -1,6 +1,6 @@
 
 module "message_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name                    = var.team_name
   application                  = var.application
@@ -31,7 +31,7 @@ resource "kubernetes_secret" "message_dynamodb" {
 }
 
 module "schedule_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.1.4"
 
   team_name              = var.team_name
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prison-to-probation-update-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
@@ -14,7 +14,7 @@ module "content_hub_elasticsearch" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.content_hub_elasticsearch.aws_iam_role_name]
   namespace           = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -1,6 +1,6 @@
 module "drupal_rds" {
   # We need to use at least 5.4, which introduces support for MariaDB by making `custom_parameters` overridable.
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -1,5 +1,5 @@
 module "drupal_content_storage" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   versioning             = true

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
@@ -20,12 +20,12 @@ module "prisoner_offender_search_elasticsearch" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.prisoner_offender_search_elasticsearch.aws_iam_role_name]
   namespace           = var.namespace
 }
 module "es_snapshots_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/index-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/index-queue.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_index_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -23,7 +23,7 @@ EOF
 }
 
 module "prisoner_offender_index_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
@@ -20,7 +20,7 @@ module "prisoner_offender_search_elasticsearch" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.prisoner_offender_search_elasticsearch.aws_iam_role_name]
   namespace           = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/index-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/index-queue.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_index_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name          = var.environment-name
   team_name                 = var.team_name
@@ -23,7 +23,7 @@ EOF
 }
 
 module "prisoner_offender_index_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-case-sampler-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-case-sampler-dev/resources/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/es.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/es.tf
@@ -20,13 +20,13 @@ module "probation_offender_search_elasticsearch" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.probation_offender_search_elasticsearch.aws_iam_role_name]
   namespace           = var.namespace
 }
 
 module "es_snapshots_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
   team_name              = var.team_name
   acl                    = "private"
   versioning             = false

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/index-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/index-queue.tf
@@ -1,5 +1,5 @@
 module "probation_offender_index_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name           = var.environment-name
   team_name                  = var.team_name
@@ -25,7 +25,7 @@ EOF
 }
 
 module "probation_offender_index_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/es.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/es.tf
@@ -21,7 +21,7 @@ module "probation_offender_search_elasticsearch" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.probation_offender_search_elasticsearch.aws_iam_role_name]
   namespace           = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/index-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/index-queue.tf
@@ -1,5 +1,5 @@
 module "probation_offender_index_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name           = var.environment-name
   team_name                  = var.team_name
@@ -24,7 +24,7 @@ EOF
 }
 
 module "probation_offender_index_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/es.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/es.tf
@@ -21,7 +21,7 @@ module "probation_offender_search_elasticsearch" {
 }
 
 module "ns_annotation" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.2"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ns-annotation?ref=0.0.3"
   ns_annotation_roles = [module.probation_offender_search_elasticsearch.aws_iam_role_name]
   namespace           = var.namespace
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/index-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/index-queue.tf
@@ -1,5 +1,5 @@
 module "probation_offender_index_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name           = var.environment-name
   team_name                  = var.team_name
@@ -24,7 +24,7 @@ EOF
 }
 
 module "probation_offender_index_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
   environment-name       = var.environment-name
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/proffeapp-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/proffeapp-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "proffe_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
   repo_name = "proffe-repo"
   team_name = "hmpps-dev-test"
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/proffeapp-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/proffeapp-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "sentence-planning_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-development/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "sentence-planning_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/sentence-planning-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/support-labelling-webhook/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/support-labelling-webhook/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-support-labelling" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.4"
 
   team_name = "webops"
   repo_name = "support-labelling-webhooks"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/support-labelling-webhook/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/support-labelling-webhook/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "tva_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "tva_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "track_a_move_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/versions.tf
@@ -1,4 +1,18 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    http = {
+      source = "hashicorp/http"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/s3.tf
@@ -2,7 +2,7 @@
  Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
  */
 module "track_a_move_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = var.team_name
   business-unit          = "Digital and Technology"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/versions.tf
@@ -1,4 +1,18 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    http = {
+      source = "hashicorp/http"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name               = var.cluster_name
   cluster_state_bucket       = var.cluster_state_bucket
   team_name                  = "correspondence"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
 
   team_name              = "correspondence"
   business-unit          = "Central Digital"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "uof_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "uof_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.3"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   application            = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/rds.tf
@@ -5,7 +5,7 @@ variable "cluster_state_bucket" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13"
   cluster_name           = var.cluster_name
   cluster_state_bucket   = var.cluster_state_bucket
   team_name              = var.team_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }


### PR DESCRIPTION
We're upgrading all state in the cloud-platform-environments repository
to Terraform 0.13. This commit changes the versions.tf file and bumps
any
modules to allow for this upgrade. This should be a clean upgrade and
will return a "clean" plan, making no changes to resources.