### PR TITLE
Bumping minor RDS version to reflect live

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/rds.tf
@@ -13,7 +13,7 @@ module "peoplefinder_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12.5"
   db_backup_retention_period = "7"
   db_name                    = "peoplefinder_demo"
   environment-name           = "demo"


### PR DESCRIPTION
Our concourse pipeline fails with the error:
```
Error: Error modifying DB Instance cloud-platform-5dd2bf4aa0e9fe08: InvalidParameterCombination: Cannot upgrade postgres from 12.5 to 12.3
```
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-live-1/builds/83#L60368cf1:20257