### PR TITLE
Bumping minor RDS version to reflect live

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/rds.tf
@@ -13,7 +13,7 @@ module "peoplefinder_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12.5"
   db_backup_retention_period = "7"
   db_name                    = "peoplefinder_staging"
   environment-name           = "staging"


### PR DESCRIPTION
Our concourse pipeline fails with the error:
```
Error: Error modifying DB Instance cloud-platform-asdasdas: InvalidParameterCombination: Cannot upgrade postgres from 12.5 to 12.3

```
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-namespace-changes-live-1/builds/52.1