### PR TITLE
Add cronjob and jobs permission to formbuilder saas live

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/05-circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/05-circleci-service-account.yaml
@@ -45,6 +45,19 @@ rules:
       - "patch"
       - "list"
       - "watch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
## Context

The form builder saas live will setup a cronjob and the service account circleci should have the necessary permissions to do this.

The error that is raising at the moment when deploying to the namespace: ` cannot get resource "cronjobs" in API group "batch" in the namespace "formbuilder-saas-live"`

This PR will solve the build error above.