### PR TITLE
Increase metadata api db size in saas live

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
@@ -12,6 +12,7 @@ module "metadata-api-rds-instance" {
   team_name                  = var.team_name
   db_engine_version          = "12"
   rds_family                 = "postgres12"
+  db_allocated_storage       = "300"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
The metadata API app will save all forms metadata and store versioning
for them so let's increase to a high number and monitor (future PR).

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>