### PR TITLE
Remove minor version from RDS

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
@@ -13,7 +13,7 @@ module "contact-moj_rds" {
   is-production              = "true"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "contact_moj_production"
   environment-name           = "production"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/rds.tf
@@ -13,7 +13,7 @@ module "contact-moj_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "contact_moj_staging"
   environment-name           = "staging"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
@@ -9,7 +9,7 @@ module "rds_instance" {
   cluster_state_bucket        = var.cluster_state_bucket
   db_backup_retention_period  = var.db_backup_retention_period
   db_engine                   = "postgres"
-  db_engine_version           = "12.3"
+  db_engine_version           = "12"
   db_name                     = "parliamentary_questions_dev"
   environment-name            = var.environment-name
   infrastructure-support      = var.infrastructure-support

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-demo/resources/rds.tf
@@ -13,7 +13,7 @@ module "track_a_query_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_demo"
   environment-name           = "demo"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
@@ -13,7 +13,7 @@ module "track_a_query_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_development"
   environment-name           = "development"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/rds-new.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/rds-new.tf
@@ -13,7 +13,7 @@ module "track_a_query_rds_new" {
   is-production              = "true"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_production_new"
   environment-name           = "production"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
@@ -13,7 +13,7 @@ module "track_a_query_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_qa"
   environment-name           = "qa"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
@@ -13,7 +13,7 @@ module "track_a_query_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.3"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_staging"
   environment-name           = "staging"


### PR DESCRIPTION
The Terraform module for RDS instances sets the auto minor update to
true as default. This coupled with pinning the minor versions creates a
Terraform error:

```
Error: Error modifying DB Instance cloud-platform-assadasd:
InvalidParameterCombination: Cannot upgrade postgres from 12.5 to 12.3

```

To remedy this, we will have to remove the pinned minor version and give
users the ability to pin in the future. In module 5.13.1 onwards, you
can now set the `auto_minor_version_upgrade` to false and then pin your
version.

https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/compare/5.13...5.13.1