### PR TITLE
Add tf_state_replace for namespaces which has pingdom  tf 0.13

### DIFF
--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -49,7 +49,7 @@ class CpEnv
       rescue
         if (retries += 1) < 2
           tf_state_replace
-          retry 
+          retry
         end
       end
       tf_apply
@@ -88,11 +88,11 @@ class CpEnv
       execute("cd #{tf_dir}; #{cmd}")
     end
 
-    #terraform state replace-provider registry.terraform.io/-/pingdom registry.terraform.io/russellcardullo/pingdom
+    # terraform state replace-provider registry.terraform.io/-/pingdom registry.terraform.io/russellcardullo/pingdom
     def tf_state_replace
-      if terraform_executable.match(/terraform0.13/) &&  Dir.glob("#{tf_dir}/*pingdom*.tf").size>0
+      if terraform_executable.match(/terraform0.13/) && Dir.glob("#{tf_dir}/*pingdom*.tf").size > 0
         cmd = "#{terraform_executable} state replace-provider -auto-approve registry.terraform.io/-/pingdom registry.terraform.io/russellcardullo/pingdom"
-        log("blue", "replacing pingdom provider for namespace #{namespace} in #{cluster}") 
+        log("blue", "replacing pingdom provider for namespace #{namespace} in #{cluster}")
         execute("cd #{tf_dir}; #{cmd}")
       end
     end

--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -41,7 +41,17 @@ class CpEnv
       return unless FileTest.directory?(tf_dir)
 
       log("blue", "applying terraform resources for namespace #{namespace} in #{cluster}")
-      tf_init
+
+      begin
+        retries ||= 0
+        puts "Retry ##{retries} to do terraform init"
+        tf_init
+      rescue
+        if (retries += 1) < 2
+          tf_state_replace
+          retry 
+        end
+      end
       tf_apply
     end
 
@@ -76,6 +86,15 @@ class CpEnv
       ].join(" ")
 
       execute("cd #{tf_dir}; #{cmd}")
+    end
+
+    #terraform state replace-provider registry.terraform.io/-/pingdom registry.terraform.io/russellcardullo/pingdom
+    def tf_state_replace
+      if terraform_executable.match(/terraform0.13/) &&  Dir.glob("#{tf_dir}/*pingdom*.tf").size>0
+        cmd = "#{terraform_executable} state replace-provider -auto-approve registry.terraform.io/-/pingdom registry.terraform.io/russellcardullo/pingdom"
+        log("blue", "replacing pingdom provider for namespace #{namespace} in #{cluster}") 
+        execute("cd #{tf_dir}; #{cmd}")
+      end
     end
 
     def tf_apply


### PR DESCRIPTION
The pingdom provider is now available in the registry and hence we no longer need to store it locally in the tools-image. But the terraform init fails with below:
```Error: Failed to install legacy providers required by state

Found unresolvable legacy provider references in state. It looks like these
refer to in-house providers. You can update the resources in state with the
following command:

    terraform state replace-provider registry.terraform.io/-/pingdom registry.terraform.io/russellcardullo/pingdom
```

This script checks if the init fails, update the terraform state and retry the terraform init.

This has to be reverted once the pingdom upgrade to 3.1 is completed.