### PR TITLE
Revert #4432

### DIFF
--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -41,17 +41,7 @@ class CpEnv
       return unless FileTest.directory?(tf_dir)
 
       log("blue", "applying terraform resources for namespace #{namespace} in #{cluster}")
-
-      begin
-        retries ||= 0
-        puts "Retry ##{retries} to do terraform init"
-        tf_init
-      rescue
-        if (retries += 1) < 2
-          tf_state_replace
-          retry
-        end
-      end
+      tf_init
       tf_apply
     end
 
@@ -86,15 +76,6 @@ class CpEnv
       ].join(" ")
 
       execute("cd #{tf_dir}; #{cmd}")
-    end
-
-    # terraform state replace-provider registry.terraform.io/-/pingdom registry.terraform.io/russellcardullo/pingdom
-    def tf_state_replace
-      if terraform_executable.match(/terraform0.13/) && Dir.glob("#{tf_dir}/*pingdom*.tf").size > 0
-        cmd = "#{terraform_executable} state replace-provider -auto-approve registry.terraform.io/-/pingdom registry.terraform.io/russellcardullo/pingdom"
-        log("blue", "replacing pingdom provider for namespace #{namespace} in #{cluster}")
-        execute("cd #{tf_dir}; #{cmd}")
-      end
     end
 
     def tf_apply


### PR DESCRIPTION
Revert PR "Add tf_state_replace for namespaces which has pingdom  tf 0.13 (#4432)"

This reverts commit f46792b926262297589000c1062859a061d571c0.

This is a one time change and no longer needed.