### PR TITLE
Fix broken Prometheus rule, causing Prometheus to crashloop

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/07-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/07-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         severity: form-builder
     - alert: RDSLowStorage
       annotations:
-        message: "[{{ environment|upper }}] RDS free storage space is less than 100GB"
+        message: "RDS free storage space is less than 100GB"
       expr:
         aws_rds_free_storage_space_average{dbinstance_identifier="cloud-platform-0f2486b54a8e2c97"} offset 10m < 100000000000 # Alarm if metadata api db size is near to 80% used space
       for: 5m


### PR DESCRIPTION
Fix broken Prometheus rule, causing Prometheus to crashloop

Out of hours change is required, responding to a broken configuration of Prometheus caused by the 'environment|upper' statement in this message. Rather than remove the rule, I changed the message output and confirmed Prometheus validation.

Some work around Prometheus rule validation should following this commit.

The error message seen in config was as follows:
```
level=error ts=2021-03-07T13:49:27.831Z caller=manager.go:946
component="rule manager" msg="loading groups failed"
err="/etc/prometheus/rules/prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0/formbuilder-saas-live-fb-alerting-saas-live.yaml:
group \"formbuilder-saas-rules\", rule 4, \"RDSLowStorage\": annotation
\"message\": template: __alert_RDSLowStorage:1: function \"environment\"
not defined"
```

I'll inform the commit owner. For more information about the incident
response, please see this thread (requires slack authentication)
https://mojdt.slack.com/archives/C514ETYJX/p1615125028480400