### PR TITLE
Bump playground Terraform state to 0.14

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/alexhaslehurst-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/alexhaslehurst-dev/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/dstest/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jacob-hello-world-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jacob-hello-world-dev/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-demo/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-demo/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/jason-lab/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mayowa-hello-world-test-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mayowa-hello-world-test-dev/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "test_es_1" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=fix-resource-expression"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.8.1"
   cluster_name              = var.cluster_name
   cluster_state_bucket      = var.cluster_state_bucket
   application               = "cloud-platform-esupg"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-dev/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-pt-kit/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-pt-kit/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/rja-sandbox/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/rja-sandbox/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ryanforsyth-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ryanforsyth-dev/resources/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
This commit informs Terraform to use the 0.14 binary in the
cloud-platform-environments pipeline. The result of this change should
be a clean init and apply.