### PR TITLE
Add a certificate for custom hostname

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: complexity-of-need-staging.hmpps.service.justice.gov.uk
+  namespace: hmpps-complexity-of-need-staging
+spec:
+  secretName: staging-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - complexity-of-need-staging.hmpps.service.justice.gov.uk


### PR DESCRIPTION
The Complexity of Need microservice will use the staging hostname:
complexity-of-need-staging.hmpps.service.justice.gov.uk

This commit adds a certificate which can be used by the ingress.