### PR TITLE
Add second service account for formbuilder saas live namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/01-rbac.yaml
@@ -28,6 +28,9 @@ subjects:
   - kind: ServiceAccount
     name: formbuilder-service-token-cache-live-production
     namespace: formbuilder-platform-live-production
+  - kind: ServiceAccount
+    name: formbuilder-service-token-cache-2-live-production
+    namespace: formbuilder-platform-live-production
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
The service token cache is using the second service account so
we need to add the necessary permission for the service token cache
app to get config maps from the saas live namespace