### PR TITLE
Add prometheus rules to fj-cait namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/prometheus.yml
@@ -1,0 +1,76 @@
+# Prometheus Alerts
+#
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html
+#
+# Note: we are using a regex in the namespace to filter and trigger alerts
+# in both, staging and production environments.
+#
+# To see the current alerts in this namespace:
+#   kubectl describe prometheusrule -n fj-cait-production
+#
+# Alerts will be sent to the slack channel: #cross_justice_team
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fj-cait-prometheus-production
+  namespace: fj-cait-production
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: FJ-CAIT-DeploymentReplicasMismatch
+      expr: >-
+        kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"^fj-cait.*"}
+        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+      for: 30m
+      labels:
+        severity: family-justice
+      annotations:
+        message: Deployment `{{ $labels.deployment }}` has not matched the expected number of replicas for more than 30 mins.
+
+    - alert: FJ-CAIT-JobFailed
+      expr: >-
+        kube_job_status_failed{job="kube-state-metrics", namespace=~"^fj-cait.*"} > 0
+      for: 1h
+      labels:
+        severity: family-justice
+      annotations:
+        message: Job `{{ $labels.job_name }}` failed to complete.
+
+    - alert: FJ-CAIT-NamespaceMissing
+      expr: >-
+        absent(kube_namespace_created{namespace=~"^fj-cait.*"})
+      for: 1m
+      labels:
+        severity: family-justice
+      annotations:
+        message: Namespace `{{ $labels.namespace }}` is missing.
+
+    - alert: FJ-CAIT-ContainerRestarting
+      expr: >-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"^fj-cait.*"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: family-justice
+      annotations:
+        message: Pod `{{ $labels.pod }}` has been restarting in `{{ $labels.namespace }}` for the last 5 minutes.
+
+    # This alert is only for production namespaces, as staging envs will easily trigger it and cause noise
+    # Filter out errors 499 caused by client dropping the connection as these are normal, and 401 due to many
+    # namespaces having http auth credentials.
+    #
+    - alert: FJ-CAIT-IncreasedHTTPErrors
+      expr: >-
+        100
+        * sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="fj-cait-production", status=~"400|40[2-9]|4[1-8][0-9]|49[0-8]|5.."}[5m]))
+        / sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="fj-cait-production"}[5m]))
+        > 3
+      for: 10m
+      labels:
+        severity: family-justice
+      annotations:
+        message: '{{ printf "%0.0f" $value }}% HTTP error rate in `{{ $labels.exported_namespace }}` for the last 10 minutes.'


### PR DESCRIPTION
We are going to split the generic prometheus rules we have in the c100-application-production namespace, into their own namespaces.

More PRs will be raised for the other namespaces.