### PR TITLE
enable performance_insights_enabled

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/rds.tf
@@ -11,6 +11,8 @@ module "rds-instance" {
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
 
+  performance_insights_enabled = true
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london


### PR DESCRIPTION
Enables RDS performance insights on the Book a Secure Move dev database