### PR TITLE
Allow CircleCI to manage Jobs in interventions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-research/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-research/05-serviceaccount-circleci.yaml
@@ -19,7 +19,6 @@ rules:
       - "secrets"
       - "services"
       - "pods"
-      - "jobs"
     verbs:
       - "patch"
       - "get"
@@ -42,6 +41,19 @@ rules:
       - "create"
       - "patch"
       - "list"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
To address

`
Error from server (Forbidden): error when retrieving current configuration of:
Resource: "batch/v1, Resource=jobs", GroupVersionKind: "batch/v1, Kind=Job"
Name: "clean-and-migrate-user-research-env", Namespace: "hmpps-interventions-research"
from server for: "user_research/reset_env.yaml": jobs.batch "clean-and-migrate-user-research-env" is forbidden: User "system:serviceaccount:***********************:circleci" cannot get resource "jobs" in API group "batch" in the namespace "hmpps-interventions-research"
`