### PR TITLE
laa-cla-frontend-staging service account update

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/05-serviceaccount-circleci.yaml
@@ -28,9 +28,19 @@ rules:
       - "delete"
       - "list"
   - apiGroups:
-      - "extensions"
+      - "apps"
     resources:
       - "deployments"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
       - "ingresses"
     verbs:
       - "get"
@@ -38,6 +48,7 @@ rules:
       - "delete"
       - "create"
       - "patch"
+      - "list"
   - apiGroups:
       - "batch"
     resources:


### PR DESCRIPTION
This amends the service account to put the resources 'developments' and 'ingresses' into more up to date apiGroups for laa-cla-frontend-staging.