### PR TITLE
Form Builder - Use correct severity level for test namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/06-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/06-prometheus.yaml
@@ -54,4 +54,4 @@ spec:
         avg(delayed_jobs_failed{namespace="formbuilder-saas-test"}) > 0
       for: 1m
       labels:
-        severity: form-builder
+        severity: form-builder-low-severity


### PR DESCRIPTION
This should be low severity