### PR TITLE
Form Builder - Add delayed job alerting for saas Live namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/07-prometheus.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/07-prometheus.yaml
@@ -55,3 +55,12 @@ spec:
       for: 1m
       labels:
         severity: form-builder
+    - alert: FailedDelayedJobs
+      annotations:
+        message: A failed Delayed job has occured in live
+        runbook_url: https://ministryofjustice.github.io/fb-guide-and-runbook/troubleshooting/find-a-failed-submission/#delayed-job-failures
+      expr: |-
+        avg(delayed_jobs_failed{namespace="formbuilder-saas-live"}) > 0
+      for: 1m
+      labels:
+        severity: form-builder


### PR DESCRIPTION
This adds the alerting necessary for the Live namespace for our Editor app.

Co-authored by: Brendan Butler <brendan.butler@digital.justice.gov.uk>