### PR TITLE
Short Domains for HMPPS EMS AC Non Production Accounts

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/00-namespace.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/slack-channel: "hmpps-ems-platform-team"
-    cloud-platform.justice.gov.uk/application: "Electronic Monitoring Service"
+    cloud-platform.justice.gov.uk/application: "HMPPS EMS Platform"
     cloud-platform.justice.gov.uk/owner: "HMPPS EMS Platform Team: hmpps-ems-platform-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-electronic-monitoring-service-platform"
     cloud-platform.justice.gov.uk/team-name: "hmpps-ems-team"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/route53.tf
@@ -21,14 +21,14 @@ resource "aws_route53_zone" "route53_zone" {
 #   records = ["TBC", "TBC", "TBC", "TBC"]
 # }
 
-# # Acquisitive Crime Test
-# resource "aws_route53_record" "hmpps_ems_ac_test_zone" {
-#   zone_id = aws_route53_zone.route53_zone.zone_id
-#   name    = "ac.test.${var.domain}"
-#   type    = "NS"
-#   ttl     = "600"
-#   records = ["TBC", "TBC", "TBC", "TBC"]
-# }
+# Acquisitive Crime Test
+resource "aws_route53_record" "hmpps_ems_ac_test_zone" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "ac.test.${var.domain}"
+  type    = "NS"
+  ttl     = "600"
+  records = ["ns-1390.awsdns-45.org.", "ns-99.awsdns-12.com.", "ns-535.awsdns-02.net.", "ns-1979.awsdns-55.co.uk"]
+}
 
 # # Acquisitive Crime PreProd
 # resource "aws_route53_record" "hmpps_ems_ac_preprod_zone" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/route53.tf
@@ -1,0 +1,22 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = var.domain
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+# Acquisitive Crime Development
+resource "aws_route53_record" "hmpps_ems_ac_dev_zone" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "ac.dev.${var.domain}"
+  type    = "NS"
+  ttl     = "600"
+  records = ["TBC", "TBC", "TBC", "TBC"]
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/route53.tf
@@ -22,7 +22,7 @@ resource "aws_route53_zone" "route53_zone" {
 # }
 
 # # Acquisitive Crime Test
-# resource "aws_route53_record" "hmpps_ems_ac_dev_zone" {
+# resource "aws_route53_record" "hmpps_ems_ac_test_zone" {
 #   zone_id = aws_route53_zone.route53_zone.zone_id
 #   name    = "ac.test.${var.domain}"
 #   type    = "NS"
@@ -31,7 +31,7 @@ resource "aws_route53_zone" "route53_zone" {
 # }
 
 # # Acquisitive Crime PreProd
-# resource "aws_route53_record" "hmpps_ems_ac_dev_zone" {
+# resource "aws_route53_record" "hmpps_ems_ac_preprod_zone" {
 #   zone_id = aws_route53_zone.route53_zone.zone_id
 #   name    = "ac.preprod.${var.domain}"
 #   type    = "NS"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/route53.tf
@@ -12,11 +12,29 @@ resource "aws_route53_zone" "route53_zone" {
   }
 }
 
-# Acquisitive Crime Development
-resource "aws_route53_record" "hmpps_ems_ac_dev_zone" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
-  name    = "ac.dev.${var.domain}"
-  type    = "NS"
-  ttl     = "600"
-  records = ["TBC", "TBC", "TBC", "TBC"]
-}
+# # Acquisitive Crime Development
+# resource "aws_route53_record" "hmpps_ems_ac_dev_zone" {
+#   zone_id = aws_route53_zone.route53_zone.zone_id
+#   name    = "ac.dev.${var.domain}"
+#   type    = "NS"
+#   ttl     = "600"
+#   records = ["TBC", "TBC", "TBC", "TBC"]
+# }
+
+# # Acquisitive Crime Test
+# resource "aws_route53_record" "hmpps_ems_ac_dev_zone" {
+#   zone_id = aws_route53_zone.route53_zone.zone_id
+#   name    = "ac.test.${var.domain}"
+#   type    = "NS"
+#   ttl     = "600"
+#   records = ["TBC", "TBC", "TBC", "TBC"]
+# }
+
+# # Acquisitive Crime PreProd
+# resource "aws_route53_record" "hmpps_ems_ac_dev_zone" {
+#   zone_id = aws_route53_zone.route53_zone.zone_id
+#   name    = "ac.preprod.${var.domain}"
+#   type    = "NS"
+#   ttl     = "600"
+#   records = ["TBC", "TBC", "TBC", "TBC"]
+# }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-dev/resources/variables.tf
@@ -7,7 +7,11 @@ variable "cluster_state_bucket" {
 
 variable "application" {
   description = "Name of Application you are deploying"
-  default     = "Electronic Monitoring Service"
+  default     = "HMPPS EMS Platform"
+}
+
+variable "domain" {
+  default = "em.service.justice.gov.uk"
 }
 
 variable "namespace" {


### PR DESCRIPTION
The original non production domains of acquisitive-crime.(dev|test|preprod).electronic-monitoring.service.justice.gov.uk were too long for AWS ACM, see [AWS ACM Docs](https://docs.aws.amazon.com/acm/latest/APIReference/API_RequestCertificate.html#API_RequestCertificate_RequestParameters)

> DomainName
> 
> Fully qualified domain name (FQDN), such as www.example.com, that you want to secure with an ACM certificate. Use an asterisk (*) to create a wildcard certificate that protects several sites in the same domain. For example, *.example.com protects www.example.com, site.example.com, and images.example.com.
> 
> The first domain name you enter cannot exceed 64 octets, including periods. Each subsequent Subject Alternative Name (SAN), however, can be up to 253 octets in length.
> 
> Type: String
> 
> Length Constraints: Minimum length of 1. Maximum length of 253.
> 
> Pattern: ^(\*\.)?(((?!-)[A-Za-z0-9-]{0,62}[A-Za-z0-9])\.)+((?!-)[A-Za-z0-9-]{1,62}[A-Za-z0-9])$
> 
> Required: Yes

This PR is to switch to ac.(dev|test|preprod).em.service.justice.gov.uk.