### PR TITLE
Remove trailing forward slash on application url

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/06-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/06-ingress.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - staging.apply-for-legal-aid.service.justice.gov.uk/
+    - staging.apply-for-legal-aid.service.justice.gov.uk
   rules:
-  - host: staging.apply-for-legal-aid.service.justice.gov.uk/
+  - host: staging.apply-for-legal-aid.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
Related to https://github.com/ministryofjustice/cloud-platform-environments/pull/4535

Remove the trailing / on the domain name as requested by cloud platform.