### PR TITLE
Add modsecurity to our UAT environment on apply for legal aid

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/06-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/06-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: laa-apply-for-legalaid-uat-ingress
+  annotations:
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+spec:
+  tls:
+  - hosts:
+    - master-applyforlegalaid-uat.apps.live-1.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: master-applyforlegalaid-uat.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: laa-apply-for-legalaid-uat
+          servicePort: 8080


### PR DESCRIPTION
Add modsecurity to implement secure firewall on **UAT** environment for laa-apply

This is so that we can filter out malicious attacks on our service.

ModSecurity is an open source, cross platform web application firewall (WAF) developed by Trustwave’s SpiderLabs.

I followed the guide here https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall