### PR TITLE
Add modsecurity ingress firewall for laa apply for legal aid Production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/06-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/06-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: laa-apply-for-legalaid-production-ingress
+  annotations:
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+spec:
+  tls:
+  - hosts:
+    - apply-for-legal-aid.service.justice.gov.uk
+  rules:
+  - host: apply-for-legal-aid.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: laa-apply-for-legalaid-production
+          servicePort: 8080


### PR DESCRIPTION
Add modsecurity to implement secure firewall on **production** environment for laa-apply


This is so that we can filter out malicious attacks on our service.

ModSecurity is an open source, cross platform web application firewall (WAF) developed by Trustwave’s SpiderLabs.

I followed the guide here https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall****