### PR TITLE
Add modsecurity to ingress on check financial eligibility - UAT

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: check-financial-eligibility-uat-ingress
+  annotations:
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+spec:
+  tls:
+  - hosts:
+    - master-check-financial-uat.apps.live-1.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: master-check-financial-uat.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: check-financial-eligibility-uat
+          servicePort: 8080


### PR DESCRIPTION
This is to add security and prevent malicious attacks on the service for the UAT environment