### PR TITLE
Complexity of Need (preprod) | Grant CircleCI access to "configmaps"

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/serviceaccount-circleci.tf
@@ -6,4 +6,53 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   # github_repositories = ["my-repo"]
+
+  # This is a copy-and-paste of the default serviceaccount_rules
+  # See: https://github.com/ministryofjustice/cloud-platform-terraform-serviceaccount/blob/main/variables.tf
+  # The only difference is that we've also granted access to "configmaps" resources
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "configmaps",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
 }


### PR DESCRIPTION
I believe this PR will fix an error that I've encountered whilst trying to get our CircleCI pipeline up and running.

It doesn't seem to be able to deploy to preprod or prod due to missing permissions on the Service Account.

### Error seen in CircleCI

```
User "system:serviceaccount:hmpps-complexity-of-need-preprod:cd-serviceaccount" cannot get resource "configmaps" in API group "" in the namespace "hmpps-complexity-of-need-preprod"
```

See output logs here: https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-complexity-of-need/191/workflows/57ac7eaa-a5e2-487f-8872-2f234dde080f/jobs/750/parallel-runs/0/steps/0-106