### PR TITLE
Complexity of Need (production) | Grant CircleCI access to "configmaps"

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/serviceaccount-circleci.tf
@@ -6,4 +6,53 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   # github_repositories = ["my-repo"]
+
+  # This is a copy-and-paste of the default serviceaccount_rules
+  # See: https://github.com/ministryofjustice/cloud-platform-terraform-serviceaccount/blob/main/variables.tf
+  # The only difference is that we've also granted access to "configmaps" resources
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "configmaps",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
 }


### PR DESCRIPTION
This PR performs the same change in `production` as #4554 did in `preprod`.

It adds "configmaps" permission to the Service Account used by CircleCI for deployments. We need this to deploy.