### PR TITLE
Force ssl for aurora

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/aurora.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/aurora.tf
@@ -16,15 +16,16 @@ module "mojforms_rds_aurora" {
   apply_immediately      = true
   replica_scale_enabled  = false
   replica_count          = 0
-  scaling_configuration = {
+  force_ssl              = true
+  scaling_configuration  = {
     auto_pause               = true
     min_capacity             = 2
     max_capacity             = 16
     seconds_until_auto_pause = 300
     timeout_action           = "ForceApplyCapacityChange"
   }
-  cluster_name         = var.cluster_name
-  cluster_state_bucket = var.cluster_state_bucket
+  cluster_name           = var.cluster_name
+  cluster_state_bucket   = var.cluster_state_bucket
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/aurora.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/aurora.tf
@@ -17,15 +17,15 @@ module "mojforms_rds_aurora" {
   replica_scale_enabled  = false
   replica_count          = 0
   force_ssl              = true
-  scaling_configuration  = {
+  scaling_configuration = {
     auto_pause               = true
     min_capacity             = 2
     max_capacity             = 16
     seconds_until_auto_pause = 300
     timeout_action           = "ForceApplyCapacityChange"
   }
-  cluster_name           = var.cluster_name
-  cluster_state_bucket   = var.cluster_state_bucket
+  cluster_name         = var.cluster_name
+  cluster_state_bucket = var.cluster_state_bucket
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
We are currently receiving the following a 'SSL error: certificate verify failed' error when trying to run the terraform.
We hope forcing ssl will fix this error.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>