### PR TITLE
Change default request limit for canary app

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 1000Mi
     defaultRequest:
-      cpu: 10m
+      cpu: 1m
       memory: 100Mi
     type: Container


### PR DESCRIPTION
Following @poornima-krishnasamy's demo, it was recommended that we change this down to 1m to make full use of the hpa.