### PR TITLE
Remove http error rate prometheus alert

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/c100-application-production/prometheus.yml
@@ -58,19 +58,3 @@ spec:
         severity: c100-application
       annotations:
         message: Pod `{{ $labels.pod }}` has been restarting in `{{ $labels.namespace }}` for the last 5 minutes.
-
-    # This alert is only for production namespaces, as staging envs will easily trigger it and cause noise
-    # Filter out errors 499 caused by client dropping the connection as these are normal, and 401 due to many
-    # namespaces having http auth credentials.
-    #
-    - alert: C100-IncreasedHTTPErrors
-      expr: >-
-        100
-        * sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="c100-application-production", status=~"400|40[2-9]|4[1-8][0-9]|49[0-8]|5.."}[5m]))
-        / sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="c100-application-production"}[5m]))
-        > 3
-      for: 10m
-      labels:
-        severity: c100-application
-      annotations:
-        message: '{{ printf "%0.0f" $value }}% HTTP error rate in `{{ $labels.exported_namespace }}` for the last 10 minutes.'

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/prometheus.yml
@@ -58,19 +58,3 @@ spec:
         severity: family-justice
       annotations:
         message: Pod `{{ $labels.pod }}` has been restarting in `{{ $labels.namespace }}` for the last 5 minutes.
-
-    # This alert is only for production namespaces, as staging envs will easily trigger it and cause noise
-    # Filter out errors 499 caused by client dropping the connection as these are normal, and 401 due to many
-    # namespaces having http auth credentials.
-    #
-    - alert: FJ-DC-IncreasedHTTPErrors
-      expr: >-
-        100
-        * sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="disclosure-checker-production", status=~"400|40[2-9]|4[1-8][0-9]|49[0-8]|5.."}[5m]))
-        / sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="disclosure-checker-production"}[5m]))
-        > 3
-      for: 10m
-      labels:
-        severity: family-justice
-      annotations:
-        message: '{{ printf "%0.0f" $value }}% HTTP error rate in `{{ $labels.exported_namespace }}` for the last 10 minutes.'

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/prometheus.yml
@@ -58,19 +58,3 @@ spec:
         severity: family-justice
       annotations:
         message: Pod `{{ $labels.pod }}` has been restarting in `{{ $labels.namespace }}` for the last 5 minutes.
-
-    # This alert is only for production namespaces, as staging envs will easily trigger it and cause noise
-    # Filter out errors 499 caused by client dropping the connection as these are normal, and 401 due to many
-    # namespaces having http auth credentials.
-    #
-    - alert: FJ-FMAPI-IncreasedHTTPErrors
-      expr: >-
-        100
-        * sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="family-mediators-api-production", status=~"400|40[2-9]|4[1-8][0-9]|49[0-8]|5.."}[5m]))
-        / sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="family-mediators-api-production"}[5m]))
-        > 3
-      for: 10m
-      labels:
-        severity: family-justice
-      annotations:
-        message: '{{ printf "%0.0f" $value }}% HTTP error rate in `{{ $labels.exported_namespace }}` for the last 10 minutes.'

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/prometheus.yml
@@ -58,19 +58,3 @@ spec:
         severity: family-justice
       annotations:
         message: Pod `{{ $labels.pod }}` has been restarting in `{{ $labels.namespace }}` for the last 5 minutes.
-
-    # This alert is only for production namespaces, as staging envs will easily trigger it and cause noise
-    # Filter out errors 499 caused by client dropping the connection as these are normal, and 401 due to many
-    # namespaces having http auth credentials.
-    #
-    - alert: FJ-CAIT-IncreasedHTTPErrors
-      expr: >-
-        100
-        * sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="fj-cait-production", status=~"400|40[2-9]|4[1-8][0-9]|49[0-8]|5.."}[5m]))
-        / sum by(exported_namespace) (increase(nginx_ingress_controller_requests{exported_namespace="fj-cait-production"}[5m]))
-        > 3
-      for: 10m
-      labels:
-        severity: family-justice
-      annotations:
-        message: '{{ printf "%0.0f" $value }}% HTTP error rate in `{{ $labels.exported_namespace }}` for the last 10 minutes.'


### PR DESCRIPTION
Note: this is a multi-namespace PR for simplicity, as I'm doing the same thing in 4 namespaces. Let me know if you prefer 4 separate PRs.

Remove the `IncreasedHTTPErrors` prometheus alert as it is becoming increasingly annoying with all the bots scans and probing lately.

We have other, service-side monitoring alerts with Sentry which are more accurate to detect real issues with "real" users (and not bots), so for the time being we are removing the prometheus one.