### PR TITLE
check-financial-eligibility-uat: Increase the paranioa level on the modsecurity

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/05-ingress.yaml
@@ -6,7 +6,13 @@ metadata:
     kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleEngine On
+      SecAction \
+      "id:900000,\
+        phase:1,\
+        nolog,\
+        pass,\
+        t:none,\
+        setvar:tx.paranoia_level=2"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
Increase the paranioa level on the modsecurity for check-financial-eligibility-**uat**

This is because the default level wasn't enough to reduce the number of attempts we had and have
on our service.