### PR TITLE
Add policy to access Analytical Platform S3 bucket

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/analytical-platform-access.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/analytical-platform-access.tf
@@ -1,0 +1,60 @@
+data "aws_iam_policy_document" "ap_access" {
+  statement {
+    sid = "AllowRdsExportUserToListS3Buckets"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+
+    resources = [
+      "arn:aws:s3:::*"
+    ]
+  }
+
+  statement {
+    sid = "AllowRdsExportUserWriteToS3"
+    actions = [
+      "s3:PutObject*",
+      "s3:PutObjectAcl",
+      "s3:GetObject*",
+      "s3:DeleteObject*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.namespace}-landing/*",
+      "arn:aws:s3:::${var.namespace}-landing/"
+    ]
+  }
+}
+
+resource "random_id" "id" {
+  byte_length = 16
+}
+
+resource "aws_iam_user" "user" {
+  name = "ap-s3-bucket-user-${random_id.id.hex}"
+  path = "/system/ap-s3-bucket-user/"
+}
+
+resource "aws_iam_access_key" "user" {
+  user = aws_iam_user.user.name
+}
+
+resource "aws_iam_user_policy" "policy" {
+  name   = "${var.namespace}-ap-s3-snapshots"
+  policy = data.aws_iam_policy_document.ap_access.json
+  user   = aws_iam_user.user.name
+}
+
+resource "kubernetes_secret" "ap_aws_secret" {
+  metadata {
+    name      = "analytical-platform-reporting-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    user_arn          = aws_iam_user.user.arn
+    access_key_id     = aws_iam_access_key.user.id
+    secret_access_key = aws_iam_access_key.user.secret
+  }
+}


### PR DESCRIPTION
Our daily data extraction needs to push files to an S3 bucket that is
currently provisioned and managed by the Analytical Platform

This change adds a policy so that our apps can access those buckets and
pushes the related secrets into the namespace