### PR TITLE
IC-1505: Add AP bucket name to the secret

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/analytical-platform-access.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/analytical-platform-access.tf
@@ -53,8 +53,9 @@ resource "kubernetes_secret" "ap_aws_secret" {
   }
 
   data = {
-    user_arn          = aws_iam_user.user.arn
-    access_key_id     = aws_iam_access_key.user.id
-    secret_access_key = aws_iam_access_key.user.secret
+    destination_bucket = "s3://${var.namespace}-landing"
+    user_arn           = aws_iam_user.user.arn
+    access_key_id      = aws_iam_access_key.user.id
+    secret_access_key  = aws_iam_access_key.user.secret
   }
 }


### PR DESCRIPTION
So that the application codebase doesn't need to know how the analytical
platform bucket is configured. It can get all details from the secret

Follows up on #4604 