### PR TITLE
IC-1505: Add job/cronjob permissions to CircleCI @ hmpps-interventions-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/05-serviceaccount-circleci.yaml
@@ -19,7 +19,6 @@ rules:
       - "secrets"
       - "services"
       - "pods"
-      - "jobs"
     verbs:
       - "patch"
       - "get"
@@ -42,6 +41,19 @@ rules:
       - "create"
       - "patch"
       - "list"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
To fix

https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/1742/workflows/36ace87f-7c00-4b63-9fa4-62805b8602ac/jobs/5824

`Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with update: could not get information about the resource: cronjobs.batch "data-extractor" is forbidden: User "system:serviceaccount:***********************:circleci" cannot get resource "cronjobs" in API group "batch" in the namespace "***********************"`

Effectively copies #4518 to dev env