### PR TITLE
[cccd-dev-lgfs] Add RDS access keys to secret

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/rds.tf
@@ -35,6 +35,8 @@ resource "kubernetes_secret" "cccd_rds" {
   }
 
   data = {
+    access_key_id         = module.cccd_rds.access_key_id
+    secret_access_key     = module.cccd_rds.secret_access_key
     rds_instance_endpoint = module.cccd_rds.rds_instance_endpoint
     database_name         = module.cccd_rds.database_name
     database_username     = module.cccd_rds.database_username


### PR DESCRIPTION
Add RDS access keys to secret

Required for investigation and testing of
DB snapshotting, upgrade and/or migration.