### PR TITLE
Formbuilder - Upgrading user datastore to handle more concurrent connections.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/03-resourcequota.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: formbuilder-platform-test-dev
 spec:
   hard:
-    pods: "50"
+    pods: "100"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -10,6 +10,7 @@ module "user-datastore-rds-instance" {
   infrastructure-support     = var.infrastructure-support
   team_name                  = var.team_name
   db_engine_version          = "10"
+  db_instance_class          = "db.t3.medium"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION

1. Increase instance of Postgres database from small to medium
2. Increase pod limit from 50 to 100, to scale sideways for pods.