### PR TITLE
Bump cp rds terraform module 5.14.1 --> 5.15

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "cccd_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.14.1"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.15"
   cluster_name                = var.cluster_name
   team_name                   = var.team_name
   business-unit               = var.business-unit


### PR DESCRIPTION
Bump cp rds terraform module 5.14.1 --> 5.15

Grants `rds:DescribeDBEngineVersions` privileges
which are useful for seeing upgrade paths for current
version using, for example:

```
aws rds describe-db-engine-versions \
  --engine postgres \
  --engine-version 9.6.20 \
  --region <> \
  --endpoint https://rds.<region>.amazonaws.com \
  --output text --query '*[].ValidUpgradeTarget[?IsMajorVersionUpgrade==`true`].{EngineVersion:EngineVersion}'
```