### PR TITLE
AR-1240- Revert RDS Aurora version upgrade 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/rds-aurora.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/rds-aurora.tf
@@ -9,7 +9,7 @@ module "rds_aurora" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
   engine                 = "aurora-postgresql"
-  engine_version         = "12.4"
+  engine_version         = "11.8"
   engine_mode            = "provisioned"
   replica_count          = 1
   instance_type          = "db.t3.medium"


### PR DESCRIPTION
The RDS Aurora modules doesn't currently support major upgrades so reverting the previous PR to upgrade from v11.8 to v12/4 