### PR TITLE
Upgrading the Live Production User Datastore instance and storage.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/03-resourcequota.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: formbuilder-platform-live-production
 spec:
   hard:
-    pods: "50"
+    pods: "100"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -10,6 +10,8 @@ module "user-datastore-rds-instance" {
   infrastructure-support     = var.infrastructure-support
   team_name                  = var.team_name
   db_engine_version          = "10"
+  db_instance_class          = "db.t3.large"
+  db_allocated_storage       = "100"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
The platform needs upgrading to cater for more traffic and ensuring
that service can cope with increased number of concurrent users.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>