### PR TITLE
Upgrading the HMCTS Adapter rds instance and storage.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
@@ -10,10 +10,10 @@ module "hmcts-complaints-adapter-rds-instance" {
   infrastructure-support     = var.infrastructure-support
   team_name                  = var.team_name
 
-  db_engine_version          = "11"
-  rds_family                 = "postgres11"
-  db_instance_class          = "db.t3.medium"
-  db_allocated_storage       = "100"
+  db_engine_version    = "11"
+  rds_family           = "postgres11"
+  db_instance_class    = "db.t3.medium"
+  db_allocated_storage = "100"
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
@@ -10,8 +10,10 @@ module "hmcts-complaints-adapter-rds-instance" {
   infrastructure-support     = var.infrastructure-support
   team_name                  = var.team_name
 
-  db_engine_version = "11"
-  rds_family        = "postgres11"
+  db_engine_version          = "11"
+  rds_family                 = "postgres11"
+  db_instance_class          = "db.t3.medium"
+  db_allocated_storage       = "100"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
The platform needs upgrading to cater for more traffic and ensuring
that service can cope with increased number of concurrent users.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>