### PR TITLE
Update laa-hmrc-interface-uat to latest rds module

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/rds.tf
@@ -1,12 +1,12 @@
 
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16"
-  cluster_name         = var.cluster_name
-  team_name            = var.team_name
-  business-unit        = var.business_unit
-  application          = var.application
-  is-production        = var.is_production
-  namespace            = var.namespace
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16"
+  cluster_name  = var.cluster_name
+  team_name     = var.team_name
+  business-unit = var.business_unit
+  application   = var.application
+  is-production = var.is_production
+  namespace     = var.namespace
 
   # enable performance insights
   performance_insights_enabled = true

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/rds.tf
@@ -1,8 +1,7 @@
 
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13.1"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16"
   cluster_name         = var.cluster_name
-  cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name
   business-unit        = var.business_unit
   application          = var.application

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/variables.tf
@@ -2,9 +2,6 @@
 variable "cluster_name" {
 }
 
-variable "cluster_state_bucket" {
-}
-
 variable "application" {
   description = "Name of Application you are deploying"
   default     = "LAA-HMRC Interface Service API"


### PR DESCRIPTION
This is to fix the "No stored state was found for the given workspace in the given backend." ,
updated to latest RDS module v5.16 which got a fix for it.