### PR TITLE
Add S3 bucket to apply-for-legal-aid UAT namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,8 +1,8 @@
-module "authorized-keys" {
+module "s3_bucket" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
+  acl    = "private"
 
   team_name              = "apply-for-legal-aid"
-  acl                    = "private"
   business-unit          = "laa"
   application            = "laa-apply-for-legal-aid"
   is-production          = "false"
@@ -13,6 +13,7 @@ module "authorized-keys" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
@@ -22,9 +23,8 @@ resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
   }
 
   data = {
-    bucket_name       = module.authorized-keys.bucket_name
-    access_key_id     = module.authorized-keys.access_key_id
-    secret_access_key = module.authorized-keys.secret_access_key
+    bucket_name       = module.s3_bucket.bucket_name
+    access_key_id     = module.s3_bucket.access_key_id
+    secret_access_key = module.s3_bucket.secret_access_key
   }
 }
-


### PR DESCRIPTION
### Add S3 bucket / resource to UAT environment for apply for legal aid namespace

This is to allow testing of uploading documents on s3 before pushing code to live.