### PR TITLE
Increase the number of pods available within namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/03-resourcequota.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/03-resourcequota.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: formbuilder-services-live-production
 spec:
   hard:
-    pods: "50"
+    pods: "100"


### PR DESCRIPTION
Live services have 2 pods per services, we have reached 84% of pods in
the namespace. Increasing the number of pods will allow new services to be deployed.