### PR TITLE
claim-criminal-injuries removed misfiring alert

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/prometheus-custom-alerts-ccic-dev.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/prometheus-custom-alerts-ccic-dev.yaml
@@ -43,14 +43,6 @@ spec:
         message: Kubelet {{ $labels.instance }} is running {{ $value }} Pods, close to the
           limit of 1 Test.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
-    - alert: cica-dev-Node-Disk-Space-Low
-      annotations:
-        message: A node is reporting low disk space below 10%. Action is required on a node.
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#node-disk-space-low
-      expr: ((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10
-      for: 30m
-      labels:
-        severity: cica-dev-team
     - alert: cica--KubeDeploymentReplicasMismatch--dev
       annotations:
        message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than an hour.

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/prometheus-custom-alerts-ccic-prod.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/prometheus-custom-alerts-ccic-prod.yaml
@@ -41,14 +41,6 @@ spec:
         message: Kubelet {{ $labels.instance }} is running {{ $value }} Pods, close to the
           limit of 1 Test.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
-    - alert: cica-prod-Node-Disk-Space-Low
-      annotations:
-        message: A node is reporting low disk space below 10%. Action is required on a node.
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#node-disk-space-low
-      expr: ((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10
-      for: 30m
-      labels:
-        severity: cica-dev-team
     - alert: cica--KubeDeploymentReplicasMismatch--prod
       annotations:
        message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than an hour.


### PR DESCRIPTION
Remove the "Node disk space low" alert from out environments. This alert is not useful and since the most recent CP deployment, is erroneously firing multiple times a day.