### PR TITLE
AR-1354: Increase elasticsearch nodes from 3 (default) to 4 - in manage-intelligence.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -13,6 +13,7 @@ module "manage_intelligence_elasticsearch" {
   elasticsearch_version           = "7.10"
   aws-es-proxy-replica-count      = 2
   instance_type                   = "t3.medium.elasticsearch"
+  instance_count                  = 4
   encryption_at_rest              = true
   node_to_node_encryption_enabled = true
 }


### PR DESCRIPTION
This is to trigger a restart of the manage-intelligence cluster and will be reduced to 3 again shortly.