### PR TITLE
Increase PQ Staging env memory allocation.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2000Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
The Parliamentary Questions app is having problems with pods being reset (OOMKilled) regularly in all environments.  Testing to see if increasing the available memory will stop the resets on Staging. 