### PR TITLE
manage hmpps auth accounts prod fix service account perms

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-dev/05-serviceaccount-circleci.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: circleci
   namespace: check-my-diary-dev
+
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -11,10 +12,39 @@ metadata:
   name: circleci
   namespace: check-my-diary-dev
 subjects:
-- kind: ServiceAccount
-  name: circleci
-  namespace: check-my-diary-dev
+  - kind: ServiceAccount
+    name: circleci
+    namespace: check-my-diary-dev
 roleRef:
   kind: ClusterRole
   name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: check-my-diary-dev
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: check-my-diary-dev
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: check-my-diary-dev
+roleRef:
+  kind: Role
+  name: circleci
   apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/05-serviceaccount-circleci.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: circleci
   namespace: check-my-diary-preprod
+
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -11,10 +12,39 @@ metadata:
   name: circleci
   namespace: check-my-diary-preprod
 subjects:
-- kind: ServiceAccount
-  name: circleci
-  namespace: check-my-diary-preprod
+  - kind: ServiceAccount
+    name: circleci
+    namespace: check-my-diary-preprod
 roleRef:
   kind: ClusterRole
   name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: check-my-diary-preprod
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: check-my-diary-preprod
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: check-my-diary-preprod
+roleRef:
+  kind: Role
+  name: circleci
   apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/check-my-diary-prod/05-serviceaccount-circleci.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: circleci
   namespace: check-my-diary-prod
+
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -11,10 +12,39 @@ metadata:
   name: circleci
   namespace: check-my-diary-prod
 subjects:
-- kind: ServiceAccount
-  name: circleci
-  namespace: check-my-diary-prod
+  - kind: ServiceAccount
+    name: circleci
+    namespace: check-my-diary-prod
 roleRef:
   kind: ClusterRole
   name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: check-my-diary-prod
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: check-my-diary-prod
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: check-my-diary-prod
+roleRef:
+  kind: Role
+  name: circleci
   apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-dev/05-serviceaccount-circleci.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,10 +12,39 @@ metadata:
   name: circleci
   namespace: hmpps-manage-supervisions-dev
 subjects:
-- kind: ServiceAccount
-  name: circleci
-  namespace: hmpps-manage-supervisions-dev
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-manage-supervisions-dev
 roleRef:
   kind: ClusterRole
   name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: hmpps-manage-supervisions-dev
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: hmpps-manage-supervisions-dev
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-manage-supervisions-dev
+roleRef:
+  kind: Role
+  name: circleci
   apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-dev/05-serviceaccount-circleci.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,10 +12,39 @@ metadata:
   name: circleci
   namespace: manage-hmpps-auth-accounts-dev
 subjects:
-- kind: ServiceAccount
-  name: circleci
-  namespace: manage-hmpps-auth-accounts-dev
+  - kind: ServiceAccount
+    name: circleci
+    namespace: manage-hmpps-auth-accounts-dev
 roleRef:
   kind: ClusterRole
   name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: manage-hmpps-auth-accounts-dev
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: manage-hmpps-auth-accounts-dev
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: manage-hmpps-auth-accounts-dev
+roleRef:
+  kind: Role
+  name: circleci
   apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/05-serviceaccount-circleci.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,10 +12,39 @@ metadata:
   name: circleci
   namespace: manage-hmpps-auth-accounts-preprod
 subjects:
-- kind: ServiceAccount
-  name: circleci
-  namespace: manage-hmpps-auth-accounts-preprod
+  - kind: ServiceAccount
+    name: circleci
+    namespace: manage-hmpps-auth-accounts-preprod
 roleRef:
   kind: ClusterRole
   name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: manage-hmpps-auth-accounts-preprod
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: manage-hmpps-auth-accounts-preprod
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: manage-hmpps-auth-accounts-preprod
+roleRef:
+  kind: Role
+  name: circleci
   apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-prod/05-serviceaccount-circleci.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,10 +12,39 @@ metadata:
   name: circleci
   namespace: manage-hmpps-auth-accounts-prod
 subjects:
-- kind: ServiceAccount
-  name: circleci
-  namespace: manage-hmpps-auth-accounts-prod
+  - kind: ServiceAccount
+    name: circleci
+    namespace: manage-hmpps-auth-accounts-prod
 roleRef:
   kind: ClusterRole
   name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: manage-hmpps-auth-accounts-prod
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: manage-hmpps-auth-accounts-prod
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: manage-hmpps-auth-accounts-prod
+roleRef:
+  kind: Role
+  name: circleci
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- check-my-diary-dev - update circleci service account, allow prometheusrules
- check-my-diary-preprod - update circleci service account, allow prometheusrules
- check-my-diary-prod - update circleci service account, allow prometheusrules
- hmpps-manage-supervisions-dev - update circleci service account, allow prometheusrules
- manage-hmpps-auth-accounts-dev - update circleci service account, allow prometheusrules
- manage-hmpps-auth-accounts-preprod - update circleci service account, allow prometheusrules
- manage-hmpps-auth-accounts-prod - update circleci service account, allow prometheusrules
