### PR TITLE
Switch interventions team on prod

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-interventions-prod
 subjects:
   - kind: Group
-    name: "github:hmpps-interventions"
+    name: "github:interventions-ops"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
The current team has dozens of people who don't _actually_ need access
to production