### PR TITLE
Switch interventions team on pre-prod

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-interventions-preprod
 subjects:
   - kind: Group
-    name: "github:hmpps-interventions"
+    name: "github:interventions-ops"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
The current team has dozens of people who don't _actually_ need access
to pre-prod. This wouldn't worry me, but unfortunately, this environment
will have live data on it