### PR TITLE
Add CORS rule to S3 dev to allow file upload progress in Drupal

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -10,6 +10,16 @@ module "drupal_content_storage" {
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
 
+  # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
+  cors_rule = [
+      {
+        allowed_headers = ["Accept", "Content-Type", "Origin"]
+        allowed_methods = ["GET", "PUT", "POST", "DELETE"]
+        allowed_origins = ["https://cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk"]
+        max_age_seconds = 3000
+      }
+    ]
+
   # Adds staging & production S3 resources to user-policy to allow one-way sync
   # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
   user_policy = <<EOF

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -12,13 +12,13 @@ module "drupal_content_storage" {
 
   # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
   cors_rule = [
-      {
-        allowed_headers = ["Accept", "Content-Type", "Origin"]
-        allowed_methods = ["GET", "PUT", "POST", "DELETE"]
-        allowed_origins = ["https://cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk"]
-        max_age_seconds = 3000
-      }
-    ]
+    {
+      allowed_headers = ["Accept", "Content-Type", "Origin"]
+      allowed_methods = ["GET", "PUT", "POST", "DELETE"]
+      allowed_origins = ["https://cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk"]
+      max_age_seconds = 3000
+    }
+  ]
 
   # Adds staging & production S3 resources to user-policy to allow one-way sync
   # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets


### PR DESCRIPTION
This PR adds a CORS rule to the S3 bucket on the dev environment.  This will allow us to upload files from Drupal directly to S3, and enable the file upload progress bar functionality.
