### PR TITLE
Add CORS rule to S3 to allow file upload progress in Drupal - staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -10,6 +10,16 @@ module "drupal_content_storage" {
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
 
+  # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
+  cors_rule = [
+    {
+      allowed_headers = ["Accept", "Content-Type", "Origin"]
+      allowed_methods = ["GET", "PUT", "POST", "DELETE"]
+      allowed_origins = ["https://cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk"]
+      max_age_seconds = 3000
+    }
+  ]
+
   bucket_policy = <<EOF
 {
   "Version": "2012-10-17",


### PR DESCRIPTION
This PR adds a CORS rule to the S3 bucket on the staging environment for prisoner-content-hub. This will allow us to upload files from Drupal directly to S3, and enable the file upload progress bar functionality.

PR for the dev environment has already been merged: https://github.com/ministryofjustice/cloud-platform-environments/pull/4854