### PR TITLE
Add CORS rule to S3 to allow file upload progress in Drupal - production 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -13,6 +13,16 @@ module "drupal_content_storage" {
   # so if this isn't set we get a 301 error when it tries to rebuild it
   namespace = var.namespace
 
+  # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
+  cors_rule = [
+    {
+      allowed_headers = ["Accept", "Content-Type", "Origin"]
+      allowed_methods = ["GET", "PUT", "POST", "DELETE"]
+      allowed_origins = ["https://manage.content-hub.prisoner.service.justice.gov.uk"]
+      max_age_seconds = 3000
+    }
+  ]
+
   providers = {
     aws = aws.ireland
   }


### PR DESCRIPTION
This PR adds a CORS rule to the S3 bucket on the production environment for prisoner-content-hub. This will allow us to upload files from Drupal directly to S3, and enable the file upload progress bar functionality. 

Related PRs:
Dev: https://github.com/ministryofjustice/cloud-platform-environments/pull/4854
Staging: https://github.com/ministryofjustice/cloud-platform-environments/pull/4863