### PR TITLE
update-eks-vpc-cluster-details-amq-broker

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vijay-namespace-dev/resources/amq.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vijay-namespace-dev/resources/amq.tf
@@ -1,5 +1,5 @@
 module "test_amq_broker_creation" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-amq-broker?ref=update-vpc-cluster-details"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-amq-broker?ref=3.4"
 
   cluster_name           = var.cluster_name
   team_name              = var.team_name


### PR DESCRIPTION
update-eks-vpc-cluster-details-amq-broker - latest module release:
Why:
[Test users terraform modules with EKS cluster - amq-broker#2892](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2892)