### PR TITLE
Routing policies

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/05-hello-world-stack.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/05-hello-world-stack.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-app
+  template:
+    metadata:
+      labels:
+        app: hello-world-app
+    spec:
+      containers:
+      - name: nginx
+        image: mogaal/nginx-hello-world:0.1
+        ports:
+        - containerPort: 8080
+      securityContext:
+        runAsUser: 101
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: hello-world
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8080
+  selector:
+    app: hello-world-app
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: hello-wold
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: mogaal-test-live-1
+    external-dns.alpha.kubernetes.io/aws-weight: "50"
+spec:
+  tls:
+  - hosts:
+    - mogaal-test.live.cloud-platform.service.justice.gov.uk
+    secretName: helloworld-tls
+  rules:
+  - host: mogaal-test.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: hello-world
+          servicePort: 80
+---
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: certificate-helloworld
+spec:
+  secretName: helloworld-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - mogaal-test.live.cloud-platform.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mogaal-test
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "#cloud-platform"
+    cloud-platform.justice.gov.uk/application: "Test Nginx Ingress"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: platform@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller"
+    cloud-platform.justice.gov.uk/team-name: "webops"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mogaal-test-admin
+  namespace: mogaal-test
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: mogaal-test
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: mogaal-test
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: mogaal-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-traffic
+  namespace: mogaal-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/05-hello-world-stack.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/05-hello-world-stack.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-app
+  template:
+    metadata:
+      labels:
+        app: hello-world-app
+    spec:
+      containers:
+      - name: nginx
+        image: mogaal/nginx-hello-world:0.1
+        ports:
+        - containerPort: 8080
+      securityContext:
+        runAsUser: 101
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: hello-world
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8080
+  selector:
+    app: hello-world-app
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: hello-wold
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: mogaal-test-live
+    external-dns.alpha.kubernetes.io/aws-weight: "50"
+spec:
+  tls:
+  - hosts:
+    - mogaal-test.live.cloud-platform.service.justice.gov.uk
+    secretName: helloworld-tls
+  rules:
+  - host: mogaal-test.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: hello-world
+          servicePort: 80
+---
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: certificate-helloworld
+spec:
+  secretName: helloworld-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - mogaal-test.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
Tested routed policies between live-1 (kops) and live (eks). Target domain is https://mogaal-test.live.cloud-platform.service.justice.gov.uk/ and weight is 50/50