### PR TITLE
Add RDS secret to ARN Dev without environment name

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/resources/rds.tf
@@ -35,3 +35,20 @@ resource "kubernetes_secret" "hmpps_assess_risks_and_needs_dev_rds" {
   }
 }
 
+resource "kubernetes_secret" "hmpps_assess_risks_and_needs_dev_rds_secret" {
+  metadata {
+    name      = "hmpps-assess-risks-and-needs-rds-instance"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.hmpps_assess_risks_and_needs_dev_rds.rds_instance_endpoint
+    database_name         = module.hmpps_assess_risks_and_needs_dev_rds.database_name
+    database_username     = module.hmpps_assess_risks_and_needs_dev_rds.database_username
+    database_password     = module.hmpps_assess_risks_and_needs_dev_rds.database_password
+    rds_instance_address  = module.hmpps_assess_risks_and_needs_dev_rds.rds_instance_address
+    access_key_id         = module.hmpps_assess_risks_and_needs_dev_rds.access_key_id
+    secret_access_key     = module.hmpps_assess_risks_and_needs_dev_rds.secret_access_key
+    url                   = "postgres://${module.hmpps_assess_risks_and_needs_dev_rds.database_username}:${module.hmpps_assess_risks_and_needs_dev_rds.database_password}@${module.hmpps_assess_risks_and_needs_dev_rds.rds_instance_endpoint}/${module.hmpps_assess_risks_and_needs_dev_rds.database_name}"
+  }
+}


### PR DESCRIPTION
## Intent

- Add `kubernetes_secret` `hmpps_assess_risks_and_needs_dev_rds_secret` to create secret with new name
- Remove the old secret in a follow-up PR