### PR TITLE
Add pingdom resource for laa-cla-frontend-training namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/pingdom.tf
@@ -1,0 +1,18 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "laa-cla-frontend-pingdom" {
+  type                     = "http"
+  name                     = "cla-frontend - training - cloud-platform"
+  host                     = "training.cases.civillegaladvice.service.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/status/ready"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_${var.business-unit},application_cla-frontend,component_ping,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_cla-frontend"
+  probefilters             = "region:EU"
+  integrationids           = []
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/pingdom.tf
@@ -14,5 +14,5 @@ resource "pingdom_check" "laa-cla-frontend-pingdom" {
   port                     = 443
   tags                     = "businessunit_${var.business-unit},application_cla-frontend,component_ping,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_cla-frontend"
   probefilters             = "region:EU"
-  integrationids           = []
+  integrationids           = [107761]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/versions.tf
@@ -8,5 +8,9 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    pingdom = {
+      source  = "russellcardullo/pingdom"
+      version = "1.1.3"
+    }
   }
 }


### PR DESCRIPTION
Requires https://github.com/ministryofjustice/cloud-platform/issues/2953 to be resolved first