### PR TITLE
Increase prisoner content hub Elasticsearch resources

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -11,7 +11,7 @@ module "content_hub_elasticsearch" {
   namespace              = var.namespace
   elasticsearch_version  = "7.1"
   ebs_volume_size        = 50
-  instance_type          = "t3.small.elasticsearch"
+  instance_type          = "t3.medium.elasticsearch"
 }
 
 module "ns_annotation" {


### PR DESCRIPTION
As part of debugging ElasticSearch red cluster status issues we think a larger instance type will help (https://mojdt.slack.com/archives/C57UPMZLY/p1623247521299600?thread_ts=1623246302.297800&cid=C57UPMZLY).
