### PR TITLE
Add scheme to cla-frontend-training cors

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/s3.tf
@@ -17,7 +17,7 @@ module "cla_frontend_static_files_bucket" {
     {
       allowed_headers = ["*"]
       allowed_methods = ["GET"]
-      allowed_origins = ["https://*.apps.live-1.cloud-platform.service.justice.gov.uk", "training.cases.civillegaladvice.service.gov.uk"]
+      allowed_origins = ["https://training.cases.civillegaladvice.service.gov.uk", "https://*.apps.live-1.cloud-platform.service.justice.gov.uk"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000
     }


### PR DESCRIPTION
Also reorders the two origins to be consistent with how we have it in
the staging namespace