### PR TITLE
Update athena-iam.tf

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/athena-iam.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/athena-iam.tf
@@ -17,10 +17,12 @@ data "aws_iam_policy_document" "athena" {
     actions = [
       "athena:StartQueryExecution",
       "athena:GetQueryResults",
+      "s3:ListBucketMultipartUploads",
       "s3:ListMultipartUploadParts",
       "athena:GetWorkGroup",
       "s3:PutObject",
       "s3:GetObject",
+      "s3:GetBucketLocation",
       "s3:ListBucket",
       "s3:DescribeJob",
       "s3:AbortMultipartUpload",


### PR DESCRIPTION
Adds permissions `s3:ListBucketMultipartUploads` and `s3:GetBucketLocation` to track-a-move `athena-user` account, to (hopefully!) fix a permissions issue preventing querying of the data.