### PR TITLE
Move cloud-platform-reports-dev from live-1 to live cluster

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloud-platform-reports-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "cloud-platform"
+    cloud-platform.justice.gov.uk/application: "Cloud Platform Reports"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we"
+    cloud-platform.justice.gov.uk/team-name: "webops" 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-platform-reports-dev-admin
+  namespace: cloud-platform-reports-dev
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: cloud-platform-reports-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: cloud-platform-reports-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: cloud-platform-reports-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: cloud-platform-reports-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/dynamodb.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/dynamodb.tf
@@ -1,0 +1,30 @@
+module "cloud_platform_reports_dynamodb" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.2.0"
+
+  team_name              = var.team_name
+  application            = var.application
+  business-unit          = var.business_unit
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  is-production          = "false"
+  namespace              = var.namespace
+
+  hash_key          = "filename"
+  enable_encryption = "false"
+  enable_autoscaler = "true"
+  aws_region        = "eu-west-2"
+}
+
+resource "kubernetes_secret" "cloud_platform_reports_dynamodb" {
+  metadata {
+    name      = "cloud-platform-reports-dynamodb-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    table_name        = module.cloud_platform_reports_dynamodb.table_name
+    table_arn         = module.cloud_platform_reports_dynamodb.table_arn
+    access_key_id     = module.cloud_platform_reports_dynamodb.access_key_id
+    secret_access_key = module.cloud_platform_reports_dynamodb.secret_access_key
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/variables.tf
@@ -1,0 +1,42 @@
+
+variable "cluster_name" {
+}
+
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Cloud Platform Reports"
+}
+
+variable "namespace" {
+  default = "cloud-platform-reports-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "webops"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "platforms@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "cloud-platform"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
Overview
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2857 and relates to the migration of the reports frontend. It just performs a straight copy from the live-1 directory to live in the hopes that we can deploy there and perform a full migration. 