### PR TITLE
Increase timeout and rationalize alert messages for Manage POM cases prometheus alerts

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/prometheus-custom-alerts-moic-preprod.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-preprod/prometheus-custom-alerts-moic-preprod.yaml
@@ -165,16 +165,15 @@ spec:
     - alert: KubeCronJobRunning
       annotations:
         message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
-          than 30mins to complete.
+          than 2 hours to complete.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
-      expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="offender-management-preprod"} > 3600
+      expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="offender-management-preprod"} > 7200
       for: 30m
       labels:
         severity: moic
     - alert: KubeJobCompletion
       annotations:
-        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
-          than 30mins to complete.
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} seems to be failing.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
       expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics", namespace="offender-management-preprod"}  >
         0

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/prometheus-custom-alerts-moic-production.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-production/prometheus-custom-alerts-moic-production.yaml
@@ -164,17 +164,15 @@ spec:
         severity: moic
     - alert: KubeCronJobRunning
       annotations:
-        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
-          than 30mins to complete.
+        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 2 hours to complete.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
-      expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="offender-management-production"} > 3600
+      expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="offender-management-production"} > 7200
       for: 30m
       labels:
         severity: moic
     - alert: KubeJobCompletion
       annotations:
-        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
-          than 30mins to complete.
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} seems to be failing.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
       expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics", namespace="offender-management-production"}  >
         0

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/prometheus-custom-alerts-moic-staging.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-management-staging/prometheus-custom-alerts-moic-staging.yaml
@@ -164,17 +164,15 @@ spec:
         severity: moic
     - alert: KubeCronJobRunning
       annotations:
-        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
-          than 30mins to complete.
+        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 2 hours to complete.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
-      expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="offender-management-staging"} > 3600
+      expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="offender-management-staging"} > 7200
       for: 30m
       labels:
         severity: moic
     - alert: KubeJobCompletion
       annotations:
-        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
-          than 30mins to complete.
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} seems to be failing.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
       expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics", namespace="offender-management-staging"}  >
         0


### PR DESCRIPTION
We (Manage POM Cases) have been getting confusing messages in our alerts channel. This PR attempts to clean them and and rationalize them. Can't work out how to change the alert slack channel from #moic_alerts though...