### PR TITLE
✨ PIC-1494 add DPS-tech to RBAC admin

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/court-probation-dev/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:probation-in-court"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
Adding DPS-tech so they can run parts of the dps-project-bootstrap process without being in the probation-in-court team