### PR TITLE
Add correct value in github action call

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-migration/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-migration/resources/ecr.tf
@@ -7,7 +7,7 @@ module "ecr-repo" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in
   # github actions CI/CD pipelines
-  github_repositories = ["cloud-platform-reference-app"]
+  github_repositories = ["cloud-platform-migration"]
 }
 
 resource "kubernetes_secret" "ecr-repo" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-migration/resources/serviceaccount.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cloud-platform-migration/resources/serviceaccount.tf
@@ -5,5 +5,5 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  github_repositories = ["cloud-platform-reference-app"]
+  github_repositories = ["cloud-platform-migration"]
 }


### PR DESCRIPTION
I was unaware that the `githubRepository` value had to match the namespace. As the namespace name and the repository name are different in this case, the deployment GH action fails. This change should fix that.