### PR TITLE
[LAA Court Data Adaptor] - Change endpoint name to metrics

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/07-service-monitor.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/07-service-monitor.yaml
@@ -11,5 +11,5 @@ spec:
     matchNames:
       - laa-court-data-adaptor-dev
   endpoints:
-    - port: http
+    - port: metrics
       interval: 15s

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/07-service-monitor.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/07-service-monitor.yaml
@@ -11,5 +11,5 @@ spec:
     matchNames:
       - laa-court-data-adaptor-prod
   endpoints:
-    - port: http
+    - port: metrics
       interval: 15s

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/07-service-monitor.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/07-service-monitor.yaml
@@ -11,5 +11,5 @@ spec:
     matchNames:
       - laa-court-data-adaptor-stage
   endpoints:
-    - port: http
+    - port: metrics
       interval: 15s

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/07-service-monitor.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/07-service-monitor.yaml
@@ -11,5 +11,5 @@ spec:
     matchNames:
       - laa-court-data-adaptor-test
   endpoints:
-    - port: http
+    - port: metrics
       interval: 15s

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/07-service-monitor.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/07-service-monitor.yaml
@@ -11,5 +11,5 @@ spec:
     matchNames:
       - laa-court-data-adaptor-uat
   endpoints:
-    - port: http
+    - port: metrics
       interval: 15s


### PR DESCRIPTION
We're creating a new dedicated service for Prometheus to expose data in https://github.com/ministryofjustice/laa-court-data-adaptor/pull/581. The endpoint name is no longer `http` but `metrics`.

Dependent on https://github.com/ministryofjustice/cloud-platform-environments/pull/5078.