### PR TITLE
WFP-322 add certificate for hmpps-workload-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/05-certificate.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: hmpps-workload-dev.hmpps.service.justice.gov.uk
+  namespace: hmpps-workload-dev
+spec:
+  secretName: hmpps-workload-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - hmpps-workload-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Will this create the certificate and put it into the named secret, or do we have to create the certificate ourselves. If so are there any instructions we can follow please?