### PR TITLE
[LAA Court Data Adaptor - test] Point service monitor to metrics endpoint

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/07-service-monitor.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/07-service-monitor.yaml
@@ -11,5 +11,5 @@ spec:
     matchNames:
       - laa-court-data-adaptor-test
   endpoints:
-    - port: http
+    - port: metrics
       interval: 15s


### PR DESCRIPTION
Point service monitor to metrics endpoint on LAA Court Data Adaptor's `laa-court-data-adaptor-test` namespace.