### PR TITLE
[LAA Court Data Adaptor] Add alert rules for new metrics endpoint

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/08-prometheus-rule.yaml
@@ -55,13 +55,6 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: http_server_request_duration_seconds_bucket{namespace="laa-court-data-adaptor-dev", path=~"/api/.*"} > 30
-      for: 1m
-      labels:
-        severity: Crime-Apps-Team
-      annotations:
-        message: API request is taking more than 30 seconds
-    - alert: Long-Request
       expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-dev", path=~"/api/.*"} > 30
       for: 1m
       labels:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/08-prometheus-rule.yaml
@@ -31,6 +31,14 @@ spec:
       annotations:
         message: More than one hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-dev,type:phrase),type:phrase,value:laa-court-data-adaptor-dev),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-dev,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-adaptor-dev"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: More than one hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-dev,type:phrase),type:phrase,value:laa-court-data-adaptor-dev),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-dev,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-adaptor-dev", status=~"5.."}[5m]))*270 > 0
       for: 1m
@@ -53,6 +61,13 @@ spec:
         severity: Crime-Apps-Team
       annotations:
         message: API request is taking more than 30 seconds
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-dev", path=~"/api/.*"} > 30
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: API request is taking more than 30 seconds
     - alert: Internal requests failing
       expr: sum(rate(http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-dev", path=~"/api/internal/.*"}[30m])) * 1800 > 1
       for: 1m
@@ -60,8 +75,22 @@ spec:
         severity: Crime-Apps-Team
       annotations:
         message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: Internal requests failing
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-dev", path=~"/api/internal/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
     - alert: External requests failing
       expr: sum(rate(http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-dev", path=~"/api/external/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA external interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: External requests failing
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-dev", path=~"/api/external/.*"}[30m])) * 1800 > 1
       for: 1m
       labels:
         severity: Crime-Apps-Team

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/08-prometheus-rule.yaml
@@ -31,6 +31,14 @@ spec:
       annotations:
         message: More than one hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-prod,type:phrase),type:phrase,value:laa-court-data-adaptor-prod),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-prod,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-adaptor-prod"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: More than one hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-prod,type:phrase),type:phrase,value:laa-court-data-adaptor-prod),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-prod,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-adaptor-prod", status=~"5.."}[5m]))*270 > 0
       for: 1m
@@ -47,7 +55,14 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: http_server_request_duration_seconds_bucket{namespace="laa-court-data-adaptor-prod", path=~"/api/.*"} > 30
+      expr: http_request_duration_seconds_bucket{namespace="laa-court-data-adaptor-prod", path=~"/api/.*"} > 30
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: API request is taking more than 30 seconds
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-prod", path=~"/api/.*"} > 30
       for: 1m
       labels:
         severity: Crime-Apps-Team
@@ -60,8 +75,22 @@ spec:
         severity: Crime-Apps-Team
       annotations:
         message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: Internal requests failing
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-prod", path=~"/api/internal/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
     - alert: External requests failing
       expr: sum(rate(http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-prod", path=~"/api/external/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA external interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: External requests failing
+      expr: sum(rate(ruby_http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-prod", path=~"/api/external/.*"}[30m])) * 1800 > 1
       for: 1m
       labels:
         severity: Crime-Apps-Team

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/08-prometheus-rule.yaml
@@ -55,13 +55,6 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: http_request_duration_seconds_bucket{namespace="laa-court-data-adaptor-prod", path=~"/api/.*"} > 30
-      for: 1m
-      labels:
-        severity: Crime-Apps-Team
-      annotations:
-        message: API request is taking more than 30 seconds
-    - alert: Long-Request
       expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-prod", path=~"/api/.*"} > 30
       for: 1m
       labels:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/08-prometheus-rule.yaml
@@ -31,6 +31,14 @@ spec:
       annotations:
         message: More than one hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-stage,type:phrase),type:phrase,value:laa-court-data-adaptor-stage),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-stage,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-adaptor-stage"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: More than one hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-stage,type:phrase),type:phrase,value:laa-court-data-adaptor-stage),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-stage,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-adaptor-stage", status=~"5.."}[5m]))*270 > 0
       for: 1m
@@ -53,8 +61,22 @@ spec:
         severity: Crime-Apps-Team
       annotations:
         message: API request is taking more than 30 seconds
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-stage", path=~"/api/.*"} > 30
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: API request is taking more than 30 seconds
     - alert: Internal requests failing
       expr: sum(rate(http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-stage", path=~"/api/internal/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: Internal requests failing
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-stage", path=~"/api/internal/.*"}[30m])) * 1800 > 1
       for: 1m
       labels:
         severity: Crime-Apps-Team

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/08-prometheus-rule.yaml
@@ -55,13 +55,6 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: http_server_request_duration_seconds_bucket{namespace="laa-court-data-adaptor-stage", path=~"/api/.*"} > 30
-      for: 1m
-      labels:
-        severity: Crime-Apps-Team
-      annotations:
-        message: API request is taking more than 30 seconds
-    - alert: Long-Request
       expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-stage", path=~"/api/.*"} > 30
       for: 1m
       labels:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/08-prometheus-rule.yaml
@@ -31,6 +31,14 @@ spec:
       annotations:
         message: More than one hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-test,type:phrase),type:phrase,value:laa-court-data-adaptor-test),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-test,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-adaptor-test"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: More than one hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-test,type:phrase),type:phrase,value:laa-court-data-adaptor-test),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-test,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-adaptor-test", status=~"5.."}[5m]))*270 > 0
       for: 1m
@@ -53,6 +61,13 @@ spec:
         severity: Crime-Apps-Team
       annotations:
         message: API request is taking more than 30 seconds
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-test", path=~"/api/.*"} > 30
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: API request is taking more than 30 seconds
     - alert: Internal requests failing
       expr: sum(rate(http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-test", path=~"/api/internal/.*"}[30m])) * 1800 > 1
       for: 1m
@@ -60,8 +75,22 @@ spec:
         severity: Crime-Apps-Team
       annotations:
         message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: Internal requests failing
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-test", path=~"/api/internal/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
     - alert: External requests failing
       expr: sum(rate(http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-test", path=~"/api/external/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA external interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: External requests failing
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-test", path=~"/api/external/.*"}[30m])) * 1800 > 1
       for: 1m
       labels:
         severity: Crime-Apps-Team

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/08-prometheus-rule.yaml
@@ -55,13 +55,6 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: http_server_request_duration_seconds_bucket{namespace="laa-court-data-adaptor-test", path=~"/api/.*"} > 30
-      for: 1m
-      labels:
-        severity: Crime-Apps-Team
-      annotations:
-        message: API request is taking more than 30 seconds
-    - alert: Long-Request
       expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-test", path=~"/api/.*"} > 30
       for: 1m
       labels:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/08-prometheus-rule.yaml
@@ -31,6 +31,14 @@ spec:
       annotations:
         message: More than one hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-uat,type:phrase),type:phrase,value:laa-court-data-adaptor-uat),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-uat,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-adaptor-uat"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: More than one hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-adaptor-uat,type:phrase),type:phrase,value:laa-court-data-adaptor-uat),query:(match:(kubernetes.namespace_name:(query:laa-court-data-adaptor-uat,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-adaptor-uat", status=~"5.."}[5m]))*270 > 0
       for: 1m
@@ -53,6 +61,13 @@ spec:
         severity: Crime-Apps-Team
       annotations:
         message: API request is taking more than 30 seconds
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-uat", path=~"/api/.*"} > 30
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: API request is taking more than 30 seconds
     - alert: Internal requests failing
       expr: sum(rate(http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-uat", path=~"/api/internal/.*"}[30m])) * 1800 > 1
       for: 1m
@@ -60,8 +75,22 @@ spec:
         severity: Crime-Apps-Team
       annotations:
         message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: Internal requests failing
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-uat", path=~"/api/internal/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA internal interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
     - alert: External requests failing
       expr: sum(rate(http_server_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-uat", path=~"/api/external/.*"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: Crime-Apps-Team
+      annotations:
+        message: Requests to CDA external interface has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: External requests failing
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-court-data-adaptor-uat", path=~"/api/external/.*"}[30m])) * 1800 > 1
       for: 1m
       labels:
         severity: Crime-Apps-Team

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/08-prometheus-rule.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/08-prometheus-rule.yaml
@@ -55,13 +55,6 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: http_server_request_duration_seconds_bucket{namespace="laa-court-data-adaptor-uat", path=~"/api/.*"} > 30
-      for: 1m
-      labels:
-        severity: Crime-Apps-Team
-      annotations:
-        message: API request is taking more than 30 seconds
-    - alert: Long-Request
       expr: ruby_http_duration_seconds{namespace="laa-court-data-adaptor-uat", path=~"/api/.*"} > 30
       for: 1m
       labels:


### PR DESCRIPTION
* Add alert rules for new metrics endpoint
* Remove erroneous long request alerts (they were not alerting us about the expected thing)

Must be merged before https://github.com/ministryofjustice/cloud-platform-environments/pull/5069 for zero downtime for alerting.