### PR TITLE
Fix the ppud-replacement-dev-rds terraform.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/rds.tf
@@ -14,7 +14,7 @@ module "ppud_replacement_dev_rds" {
   rds_family        = "postgres12"
   db_engine         = "postgres"
   db_engine_version = "13"
-  db_instance_class = "db.t2.small"
+  db_instance_class = "db.t3.small"
   db_name           = "manage-recalls"
 
   providers = {


### PR DESCRIPTION
It looks like t2 database instances are not supported by postgresql 13.