### PR TITLE
Increase memory on peoplefinder dev env

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2000Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
We are having trouble running a report and think that it is related to
running out of RAM, upping the RAM here to test that hypothesis.