### PR TITLE
Enable ECR creds for my namespace

### DIFF
--- a/namespace-resources-cli-template/resources/variables.tf
+++ b/namespace-resources-cli-template/resources/variables.tf
@@ -44,11 +44,11 @@ variable "slack_channel" {
 }
 
 variable "github_owner" {
-  description = "Required by the github terraform provider"
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
   default     = "ministryofjustice"
 }
 
 variable "github_token" {
-  description = "Required by the github terraform provider"
+  description = "Required by the Github Terraform provider"
   default     = ""
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/ecr.tf
@@ -7,7 +7,7 @@ module "ecr-repo" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in
   # github actions CI/CD pipelines
-  # github_repositories = ["helloworld-ruby-app-davidread"]
+  github_repositories = ["helloworld-ruby-app-davidread"]
 }
 
 resource "kubernetes_secret" "ecr-repo" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/davidread-dev/resources/variables.tf
@@ -69,3 +69,7 @@ variable "slack-channel" {
   default     = "davidread"
 }
 
+variable "github_owner" {
+  description = "Required by the github terraform provider"
+  default     = "ministryofjustice"
+}


### PR DESCRIPTION
This should inject the ECR creds into Github secrets for my namespace.
It didn't work last time because I didn't have the github_owner variable.
I'm leaving out the github_token variable also mentioned, to see if it
is really necessary.