### PR TITLE
Add live cluster name to serviceaccount interpolation

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-migration/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-migration/resources/serviceaccount.tf
@@ -6,4 +6,5 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["cloud-platform-reference-app"]
+  kubernetes_cluster  = "live.cloud-platform.service.justice.gov.uk"
 }


### PR DESCRIPTION
This commit connects to https://github.com/ministryofjustice/cloud-platform/issues/2956 and relates to the migration of an application from one cluster (live-1) to another (live).