### PR TITLE
Revert "Restrict access to the `manage-recalls` S3 bucket to the VPC."

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
@@ -1,23 +1,3 @@
-data "aws_vpc" "selected" {
-  filter {
-    name   = "tag:Name"
-    values = [var.cluster_name == "live" ? "live-1" : var.cluster_name]
-  }
-}
-
-data "aws_subnet_ids" "private" {
-  vpc_id = data.aws_vpc.selected.id
-
-  tags = {
-    SubnetType = "Private"
-  }
-}
-
-data "aws_subnet" "private" {
-  for_each = data.aws_subnet_ids.private.ids
-  id       = each.value
-}
-
 # Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
 module "manage_recalls_s3_bucket_preprod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
@@ -36,32 +16,6 @@ module "manage_recalls_s3_bucket_preprod" {
   }
 
   versioning = false
-}
-
-# This policy restricts access to the bucket to applications running within the VPC.
-resource "aws_s3_bucket_policy" "manage_recalls_s3_bucket_policy_preprod" {
-  bucket = module.manage_recalls_s3_bucket_preprod.bucket_name
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid       = "SourceIP"
-        Effect    = "Deny"
-        Principal = "*"
-        Action    = "s3:*"
-        Resource = [
-          module.manage_recalls_s3_bucket_preprod.bucket_arn,
-          "${module.manage_recalls_s3_bucket_preprod.bucket_arn}/*",
-        ]
-        Condition = {
-          "NotIpAddress" = {
-            "aws:SourceIp" = [for s in data.aws_subnet.private : s.cidr_block]
-          }
-        }
-      },
-    ]
-  })
 }
 
 resource "kubernetes_secret" "manage_recalls_s3_bucket_preprod" {


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-environments#5127

This stops the pipeline concourse-user from accessing the bucket and hence the pipeline fails with error 
```
Error: error reading S3 Bucket (cloud-platform-03a24ea5a50651e8e138d4cd7b3e626e): Forbidden: Forbidden
```
This also prevents any the webops team IAM user to checks it from AWS console. 

Need to discuss with @dazoakley about alternative approach.