### PR TITLE
Restrict s3 bucket from object access outside of live-1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
@@ -52,7 +52,11 @@ resource "aws_s3_bucket_policy" "manage_recalls_s3_bucket_policy_preprod" {
         Action = [
           "s3:GetObject*",
           "s3:PutObject*",
-          "s3:DeleteObject",
+          "s3:DeleteObject*",
+          "s3:ListObject*",
+          "s3:CopyObject*",
+          "s3:HeadObject*",
+          "s3:RestoreObject*",
         ]
         Resource = [
           module.manage_recalls_s3_bucket_preprod.bucket_arn,

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
@@ -53,10 +53,6 @@ resource "aws_s3_bucket_policy" "manage_recalls_s3_bucket_policy_preprod" {
           "s3:GetObject*",
           "s3:PutObject*",
           "s3:DeleteObject*",
-          "s3:ListObject*",
-          "s3:CopyObject*",
-          "s3:HeadObject*",
-          "s3:RestoreObject*",
         ]
         Resource = [
           module.manage_recalls_s3_bucket_preprod.bucket_arn,
@@ -64,7 +60,10 @@ resource "aws_s3_bucket_policy" "manage_recalls_s3_bucket_policy_preprod" {
         ]
         Condition = {
           "NotIpAddress" = {
-            "aws:SourceIp" = [for s in data.aws_subnet.private : s.cidr_block]
+            # Live-1 IP addresses
+            "aws:SourceIp" = [
+              "35.178.209.113", "3.8.51.207", "35.177.252.54"
+            ]
           }
         }
       },

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
@@ -1,3 +1,23 @@
+data "aws_vpc" "selected" {
+  filter {
+    name   = "tag:Name"
+    values = [var.cluster_name == "live" ? "live-1" : var.cluster_name]
+  }
+}
+
+data "aws_subnet_ids" "private" {
+  vpc_id = data.aws_vpc.selected.id
+
+  tags = {
+    SubnetType = "Private"
+  }
+}
+
+data "aws_subnet" "private" {
+  for_each = data.aws_subnet_ids.private.ids
+  id       = each.value
+}
+
 # Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
 module "manage_recalls_s3_bucket_preprod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
@@ -16,6 +36,32 @@ module "manage_recalls_s3_bucket_preprod" {
   }
 
   versioning = false
+}
+
+# This policy restricts access to the bucket to applications running within the VPC.
+resource "aws_s3_bucket_policy" "manage_recalls_s3_bucket_policy_preprod" {
+  bucket = module.manage_recalls_s3_bucket_preprod.bucket_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "SourceIP"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          module.manage_recalls_s3_bucket_preprod.bucket_arn,
+          "${module.manage_recalls_s3_bucket_preprod.bucket_arn}/*",
+        ]
+        Condition = {
+          "NotIpAddress" = {
+            "aws:SourceIp" = [for s in data.aws_subnet.private : s.cidr_block]
+          }
+        }
+      },
+    ]
+  })
 }
 
 resource "kubernetes_secret" "manage_recalls_s3_bucket_preprod" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
@@ -1,23 +1,3 @@
-data "aws_vpc" "selected" {
-  filter {
-    name   = "tag:Name"
-    values = [var.cluster_name == "live" ? "live-1" : var.cluster_name]
-  }
-}
-
-data "aws_subnet_ids" "private" {
-  vpc_id = data.aws_vpc.selected.id
-
-  tags = {
-    SubnetType = "Private"
-  }
-}
-
-data "aws_subnet" "private" {
-  for_each = data.aws_subnet_ids.private.ids
-  id       = each.value
-}
-
 # Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
 module "manage_recalls_s3_bucket_preprod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
@@ -49,7 +49,11 @@ resource "aws_s3_bucket_policy" "manage_recalls_s3_bucket_policy_preprod" {
         Sid       = "SourceIP"
         Effect    = "Deny"
         Principal = "*"
-        Action    = "s3:*"
+        Action = [
+          "s3:GetObject*",
+          "s3:PutObject*",
+          "s3:DeleteObject",
+        ]
         Resource = [
           module.manage_recalls_s3_bucket_preprod.bucket_arn,
           "${module.manage_recalls_s3_bucket_preprod.bucket_arn}/*",


### PR DESCRIPTION
Overview
---
Restrict S3 bucket access from Live-1 cluster. This PR connects to a conversation in [slack](https://mojdt.slack.com/archives/C57UPMZLY/p1626337226078500) that requires the s3 bucket access to be restricted to the app only. After deliberation, it was decided this can be achieved with live-1 IP restrictions. We considered VPC restriction to include all clusters, but this was unsuccessful.