### PR TITLE
Restrict S3 object access to the live-1 cluster

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/s3.tf
@@ -18,6 +18,39 @@ module "manage_recalls_s3_bucket_prod" {
   versioning = false
 }
 
+# This policy restricts access to the bucket to applications running within the VPC.
+resource "aws_s3_bucket_policy" "manage_recalls_s3_bucket_policy_prod" {
+  bucket = module.manage_recalls_s3_bucket_prod.bucket_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "SourceIP"
+        Effect    = "Deny"
+        Principal = "*"
+        Action = [
+          "s3:GetObject*",
+          "s3:PutObject*",
+          "s3:DeleteObject*",
+        ]
+        Resource = [
+          module.manage_recalls_s3_bucket_prod.bucket_arn,
+          "${module.manage_recalls_s3_bucket_prod.bucket_arn}/*",
+        ]
+        Condition = {
+          "NotIpAddress" = {
+            # Live-1 IP addresses
+            "aws:SourceIp" = [
+              "35.178.209.113", "3.8.51.207", "35.177.252.54"
+            ]
+          }
+        }
+      },
+    ]
+  })
+}
+
 resource "kubernetes_secret" "manage_recalls_s3_bucket_prod" {
   metadata {
     name      = "manage-recalls-s3-bucket"


### PR DESCRIPTION
This is the prod change of https://github.com/ministryofjustice/cloud-platform-environments/pull/5135

This will restrict object access to applications running within the
live-1 cluster only.

ref PUD-255