### PR TITLE
Setup an S3 bucket and SQL Server DB to house transferred Lumen data.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/rds.tf
@@ -1,3 +1,7 @@
+##
+## PostgreSQL - Application Database
+##
+
 module "ppud_replacement_preprod_rds" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.3"
 
@@ -33,5 +37,48 @@ resource "kubernetes_secret" "ppud_replacement_preprod_rds_secrets" {
     name     = module.ppud_replacement_preprod_rds.database_name
     username = module.ppud_replacement_preprod_rds.database_username
     password = module.ppud_replacement_preprod_rds.database_password
+  }
+}
+
+##
+## SQL Server - Lumen/PPUD Copy
+##
+
+module "ppud_replica_preprod_rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.3"
+
+  cluster_name           = var.cluster_name
+  namespace              = var.namespace
+  application            = var.application
+  business-unit          = var.business_unit
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  is-production          = var.is_production
+  team_name              = var.team_name
+
+  rds_name             = "ppud-replica-preprod"
+  rds_family           = "sqlserver-web-11.0"
+  db_engine            = "sqlserver-web"
+  db_engine_version    = "11.00"
+  db_instance_class    = "db.t3.small"
+  db_allocated_storage = "20"
+  license_model        = "license-included"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "ppud_replica_preprod_rds_secrets" {
+  metadata {
+    name      = "ppud-replica-database"
+    namespace = var.namespace
+  }
+
+  data = {
+    host     = module.ppud_replica_preprod_rds.rds_instance_address
+    name     = module.ppud_replica_preprod_rds.database_name
+    username = module.ppud_replica_preprod_rds.database_username
+    password = module.ppud_replica_preprod_rds.database_password
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/s3.tf
@@ -1,3 +1,7 @@
+##
+## Manage Recalls Document Storage
+##
+
 # Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/master/example
 module "manage_recalls_s3_bucket_preprod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
@@ -62,5 +66,42 @@ resource "kubernetes_secret" "manage_recalls_s3_bucket_preprod" {
     secret_access_key = module.manage_recalls_s3_bucket_preprod.secret_access_key
     bucket_arn        = module.manage_recalls_s3_bucket_preprod.bucket_arn
     bucket_name       = module.manage_recalls_s3_bucket_preprod.bucket_name
+  }
+}
+
+##
+## Lumen Data Transfer
+##
+
+module "lumen_transfer_s3_bucket_preprod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
+
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  infrastructure-support = var.infrastructure_support
+
+  is-production    = var.is_production
+  environment-name = var.environment
+  namespace        = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+
+  versioning = false
+}
+
+resource "kubernetes_secret" "lumen_transfer_s3_bucket_preprod" {
+  metadata {
+    name      = "lumen-transfer-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.lumen_transfer_s3_bucket_preprod.access_key_id
+    secret_access_key = module.lumen_transfer_s3_bucket_preprod.secret_access_key
+    bucket_arn        = module.lumen_transfer_s3_bucket_preprod.bucket_arn
+    bucket_name       = module.lumen_transfer_s3_bucket_preprod.bucket_name
   }
 }


### PR DESCRIPTION
This sets up an S3 bucket for the data import from Lumen, and a SQL
Server instance to house the transferred database content.

refs PUD-278, PUD-279