### PR TITLE
Add Manage POM Cases to HMPPS Domain events

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/manage-pom-cases.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/manage-pom-cases.tf
@@ -1,0 +1,12 @@
+resource "kubernetes_secret" "manage-pom-cases" {
+  metadata {
+    name      = "hmpps-domain-events-topic"
+    namespace = "offender-management-staging"
+  }
+
+  data = {
+    access_key_id     = module.hmpps-domain-events.access_key_id
+    secret_access_key = module.hmpps-domain-events.secret_access_key
+    topic_arn         = module.hmpps-domain-events.topic_arn
+  }
+}


### PR DESCRIPTION
Environment: staging

Grants permission for the Manage POM Cases service (`offender-management-*` namespaces) to publish events to the HMPPS Domain Events SNS topic.