### PR TITLE
Add verification TXT record for Prisoner Money’s sendmoneytoaprisoner.justice.gov.uk domain

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
@@ -8,7 +8,7 @@ module "rds" {
     aws = aws.london
   }
 
-  cluster_name         = var.cluster_name
+  cluster_name = var.cluster_name
 
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
@@ -151,7 +151,10 @@ resource "aws_route53_record" "start_page_txt_root" {
   zone_id = aws_route53_zone.start_page.zone_id
   type    = "TXT"
   ttl     = "300"
-  records = ["v=spf1 include:mailgun.org ~all"]
+  records = [
+    "v=spf1 include:mailgun.org ~all",
+    "google-site-verification=weAYdFuWe6PfocCiQ66wBE18XZP0vqC1_FRx5BLtr5o"
+  ]
 }
 
 resource "aws_route53_record" "start_page_txt_smtp_domainkey" {
@@ -159,7 +162,9 @@ resource "aws_route53_record" "start_page_txt_smtp_domainkey" {
   zone_id = aws_route53_zone.start_page.zone_id
   type    = "TXT"
   ttl     = "300"
-  records = ["k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCiKXT4bXJkdvmDtdogyzBSbT0r47xoUdAzKIGXWTpD4fcK73QZg1A/Mya3yOyatd1PQnS5qVCT15TYOBi446xHbGOaWwSrJJv0JfqcJF/oU4xoFVyb5RyEfDrtEVv3VAznjFDQwc8ji8AqKE3/Od0H86hmryF9zE7PfTne/T2uVQIDAQAB"]
+  records = [
+    "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCiKXT4bXJkdvmDtdogyzBSbT0r47xoUdAzKIGXWTpD4fcK73QZg1A/Mya3yOyatd1PQnS5qVCT15TYOBi446xHbGOaWwSrJJv0JfqcJF/oU4xoFVyb5RyEfDrtEVv3VAznjFDQwc8ji8AqKE3/Od0H86hmryF9zE7PfTne/T2uVQIDAQAB"
+  ]
 }
 
 resource "aws_route53_record" "start_page_mx" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
@@ -28,32 +28,32 @@ resource "aws_route53_record" "app_domain_cname_email" {
   name    = "email.prisoner-money.service.justice.gov.uk."
   zone_id = aws_route53_zone.app_domain.zone_id
   type    = "CNAME"
-  records = ["eu.mailgun.org"]
   ttl     = "300"
+  records = ["eu.mailgun.org"]
 }
 
 resource "aws_route53_record" "app_domain_txt_root" {
   name    = "prisoner-money.service.justice.gov.uk."
   zone_id = aws_route53_zone.app_domain.zone_id
   type    = "TXT"
-  records = ["v=spf1 include:eu.mailgun.org ~all"]
   ttl     = "300"
+  records = ["v=spf1 include:eu.mailgun.org ~all"]
 }
 
 resource "aws_route53_record" "app_domain_txt_smtp_domainkey" {
   name    = "smtp._domainkey.prisoner-money.service.justice.gov.uk."
   zone_id = aws_route53_zone.app_domain.zone_id
   type    = "TXT"
-  records = ["k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0rIehv2VfJOHCm7qxuEfTrDuQFftKUF75jmt7I3EgfCDo+Bf1oagrCLGIAdTpwc399kx4GSQ8Fg32tKA2mxR9+xYKTNp1c6yvAyeRUCzmZ6ZKSgA9vOjvbY/NifKVL3+iHQ+tWs7QWGa+zoxYd5Bi8uXS++NZdmFFSVRFDNdZxnp5q1A0SLoETjEd+rbS54pRdnyqeEzFY\"\"GUIBuNW18bRewvEQdrDz/vHlsCnlm5CEskO5srgxOd9EaLzT1Za1Db9pT+wiVBIn/d0wyulRDjsQFdMZI0O1il9EMnRpW1kC/ohx9IQmiqbd3+LRolknQzoCbtXyea7nxnKNUkk9BRXQIDAQAB"]
   ttl     = "300"
+  records = ["k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0rIehv2VfJOHCm7qxuEfTrDuQFftKUF75jmt7I3EgfCDo+Bf1oagrCLGIAdTpwc399kx4GSQ8Fg32tKA2mxR9+xYKTNp1c6yvAyeRUCzmZ6ZKSgA9vOjvbY/NifKVL3+iHQ+tWs7QWGa+zoxYd5Bi8uXS++NZdmFFSVRFDNdZxnp5q1A0SLoETjEd+rbS54pRdnyqeEzFY\"\"GUIBuNW18bRewvEQdrDz/vHlsCnlm5CEskO5srgxOd9EaLzT1Za1Db9pT+wiVBIn/d0wyulRDjsQFdMZI0O1il9EMnRpW1kC/ohx9IQmiqbd3+LRolknQzoCbtXyea7nxnKNUkk9BRXQIDAQAB"]
 }
 
 resource "aws_route53_record" "app_domain_mx" {
   name    = "prisoner-money.service.justice.gov.uk."
   zone_id = aws_route53_zone.app_domain.zone_id
   type    = "MX"
-  records = ["10 mxa.eu.mailgun.org", "10 mxb.eu.mailgun.org"]
   ttl     = "300"
+  records = ["10 mxa.eu.mailgun.org", "10 mxb.eu.mailgun.org"]
 }
 
 resource "aws_route53_zone" "send_money" {
@@ -85,32 +85,32 @@ resource "aws_route53_record" "send_money_cname_email" {
   name    = "email.send-money-to-prisoner.service.gov.uk."
   zone_id = aws_route53_zone.send_money.zone_id
   type    = "CNAME"
-  records = ["mailgun.org"]
   ttl     = "300"
+  records = ["mailgun.org"]
 }
 
 resource "aws_route53_record" "send_money_txt_root" {
   name    = "send-money-to-prisoner.service.gov.uk."
   zone_id = aws_route53_zone.send_money.zone_id
   type    = "TXT"
-  records = ["v=spf1 include:mailgun.org ~all"]
   ttl     = "300"
+  records = ["v=spf1 include:mailgun.org ~all"]
 }
 
 resource "aws_route53_record" "send_money_txt_mailo_domainkey" {
   name    = "mailo._domainkey.send-money-to-prisoner.service.gov.uk."
   zone_id = aws_route53_zone.send_money.zone_id
   type    = "TXT"
-  records = ["k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCuOs26XfsArjkmoN/tAy9OzgZi/ohE8JDaTZFoow6O+ft3ilrkfoWT+duiOUggwO4lPzQ0kFD5yqZeDUGyPOwHFyMRkeAHEruBXAS4hefUR+ZiTVCsKYPQJZ/NuUCU2tkVQ7muKUnLT90ggNu6q0PaTnxxaYUjSfdeyxLUVTxiwwIDAQAB"]
   ttl     = "300"
+  records = ["k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCuOs26XfsArjkmoN/tAy9OzgZi/ohE8JDaTZFoow6O+ft3ilrkfoWT+duiOUggwO4lPzQ0kFD5yqZeDUGyPOwHFyMRkeAHEruBXAS4hefUR+ZiTVCsKYPQJZ/NuUCU2tkVQ7muKUnLT90ggNu6q0PaTnxxaYUjSfdeyxLUVTxiwwIDAQAB"]
 }
 
 resource "aws_route53_record" "send_money_mx" {
   name    = "send-money-to-prisoner.service.gov.uk."
   zone_id = aws_route53_zone.send_money.zone_id
   type    = "MX"
-  records = ["10 mxa.mailgun.org", "10 mxb.mailgun.org"]
   ttl     = "300"
+  records = ["10 mxa.mailgun.org", "10 mxb.mailgun.org"]
 }
 
 resource "aws_route53_zone" "start_page" {
@@ -142,32 +142,32 @@ resource "aws_route53_record" "start_page_cname_email" {
   name    = "email.sendmoneytoaprisoner.justice.gov.uk."
   zone_id = aws_route53_zone.start_page.zone_id
   type    = "CNAME"
-  records = ["mailgun.org"]
   ttl     = "300"
+  records = ["mailgun.org"]
 }
 
 resource "aws_route53_record" "start_page_txt_root" {
   name    = "sendmoneytoaprisoner.justice.gov.uk."
   zone_id = aws_route53_zone.start_page.zone_id
   type    = "TXT"
-  records = ["v=spf1 include:mailgun.org ~all"]
   ttl     = "300"
+  records = ["v=spf1 include:mailgun.org ~all"]
 }
 
 resource "aws_route53_record" "start_page_txt_smtp_domainkey" {
   name    = "smtp._domainkey.sendmoneytoaprisoner.justice.gov.uk."
   zone_id = aws_route53_zone.start_page.zone_id
   type    = "TXT"
-  records = ["k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCiKXT4bXJkdvmDtdogyzBSbT0r47xoUdAzKIGXWTpD4fcK73QZg1A/Mya3yOyatd1PQnS5qVCT15TYOBi446xHbGOaWwSrJJv0JfqcJF/oU4xoFVyb5RyEfDrtEVv3VAznjFDQwc8ji8AqKE3/Od0H86hmryF9zE7PfTne/T2uVQIDAQAB"]
   ttl     = "300"
+  records = ["k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCiKXT4bXJkdvmDtdogyzBSbT0r47xoUdAzKIGXWTpD4fcK73QZg1A/Mya3yOyatd1PQnS5qVCT15TYOBi446xHbGOaWwSrJJv0JfqcJF/oU4xoFVyb5RyEfDrtEVv3VAznjFDQwc8ji8AqKE3/Od0H86hmryF9zE7PfTne/T2uVQIDAQAB"]
 }
 
 resource "aws_route53_record" "start_page_mx" {
   name    = "sendmoneytoaprisoner.justice.gov.uk."
   zone_id = aws_route53_zone.start_page.zone_id
   type    = "MX"
-  records = ["10 mxa.mailgun.org", "10 mxb.mailgun.org"]
   ttl     = "300"
+  records = ["10 mxa.mailgun.org", "10 mxb.mailgun.org"]
 }
 
 resource "aws_route53_zone" "start_page_alias" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/versions.tf
@@ -9,7 +9,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     pingdom = {
-      source = "russellcardullo/pingdom"
+      source  = "russellcardullo/pingdom"
       version = "1.1.3"
     }
   }


### PR DESCRIPTION
Trial of adding multiple TXT records to a little-used domain. Other changes are cosmetic to appease terraform indentation rules.

Replaces #5168 which was split into this and #5169