### PR TITLE
Add verification TXT record for Prisoner Money’s domains

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/main.tf
@@ -39,3 +39,4 @@ variable "environment-name" {
 variable "is-production" {
   default = "true"
 }
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/route53.tf
@@ -37,7 +37,10 @@ resource "aws_route53_record" "app_domain_txt_root" {
   zone_id = aws_route53_zone.app_domain.zone_id
   type    = "TXT"
   ttl     = "300"
-  records = ["v=spf1 include:eu.mailgun.org ~all"]
+  records = [
+    "v=spf1 include:eu.mailgun.org ~all",
+    "google-site-verification=IUBR5QDuFJbCicN27PV70pqWQHtiRMCBHzYKgF_dWw0"
+  ]
 }
 
 resource "aws_route53_record" "app_domain_txt_smtp_domainkey" {
@@ -45,7 +48,9 @@ resource "aws_route53_record" "app_domain_txt_smtp_domainkey" {
   zone_id = aws_route53_zone.app_domain.zone_id
   type    = "TXT"
   ttl     = "300"
-  records = ["k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0rIehv2VfJOHCm7qxuEfTrDuQFftKUF75jmt7I3EgfCDo+Bf1oagrCLGIAdTpwc399kx4GSQ8Fg32tKA2mxR9+xYKTNp1c6yvAyeRUCzmZ6ZKSgA9vOjvbY/NifKVL3+iHQ+tWs7QWGa+zoxYd5Bi8uXS++NZdmFFSVRFDNdZxnp5q1A0SLoETjEd+rbS54pRdnyqeEzFY\"\"GUIBuNW18bRewvEQdrDz/vHlsCnlm5CEskO5srgxOd9EaLzT1Za1Db9pT+wiVBIn/d0wyulRDjsQFdMZI0O1il9EMnRpW1kC/ohx9IQmiqbd3+LRolknQzoCbtXyea7nxnKNUkk9BRXQIDAQAB"]
+  records = [
+    "k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0rIehv2VfJOHCm7qxuEfTrDuQFftKUF75jmt7I3EgfCDo+Bf1oagrCLGIAdTpwc399kx4GSQ8Fg32tKA2mxR9+xYKTNp1c6yvAyeRUCzmZ6ZKSgA9vOjvbY/NifKVL3+iHQ+tWs7QWGa+zoxYd5Bi8uXS++NZdmFFSVRFDNdZxnp5q1A0SLoETjEd+rbS54pRdnyqeEzFY\"\"GUIBuNW18bRewvEQdrDz/vHlsCnlm5CEskO5srgxOd9EaLzT1Za1Db9pT+wiVBIn/d0wyulRDjsQFdMZI0O1il9EMnRpW1kC/ohx9IQmiqbd3+LRolknQzoCbtXyea7nxnKNUkk9BRXQIDAQAB"
+  ]
 }
 
 resource "aws_route53_record" "app_domain_mx" {
@@ -94,7 +99,10 @@ resource "aws_route53_record" "send_money_txt_root" {
   zone_id = aws_route53_zone.send_money.zone_id
   type    = "TXT"
   ttl     = "300"
-  records = ["v=spf1 include:mailgun.org ~all"]
+  records = [
+    "v=spf1 include:mailgun.org ~all",
+    "google-site-verification=T2qg1AVVzK0DAQSY2SmnS-rRN-hsJFUMeBLiMoyrahY"
+  ]
 }
 
 resource "aws_route53_record" "send_money_txt_mailo_domainkey" {
@@ -102,7 +110,9 @@ resource "aws_route53_record" "send_money_txt_mailo_domainkey" {
   zone_id = aws_route53_zone.send_money.zone_id
   type    = "TXT"
   ttl     = "300"
-  records = ["k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCuOs26XfsArjkmoN/tAy9OzgZi/ohE8JDaTZFoow6O+ft3ilrkfoWT+duiOUggwO4lPzQ0kFD5yqZeDUGyPOwHFyMRkeAHEruBXAS4hefUR+ZiTVCsKYPQJZ/NuUCU2tkVQ7muKUnLT90ggNu6q0PaTnxxaYUjSfdeyxLUVTxiwwIDAQAB"]
+  records = [
+    "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCuOs26XfsArjkmoN/tAy9OzgZi/ohE8JDaTZFoow6O+ft3ilrkfoWT+duiOUggwO4lPzQ0kFD5yqZeDUGyPOwHFyMRkeAHEruBXAS4hefUR+ZiTVCsKYPQJZ/NuUCU2tkVQ7muKUnLT90ggNu6q0PaTnxxaYUjSfdeyxLUVTxiwwIDAQAB"
+  ]
 }
 
 resource "aws_route53_record" "send_money_mx" {


### PR DESCRIPTION
Completes #5170 by adding verification TXT records to remaining (and important) domains:
• prisoner-money.service.justice.gov.uk
• send-money-to-prisoner.service.gov.uk