### PR TITLE
Removing DELETE method from S3 CORS config - staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -14,7 +14,7 @@ module "drupal_content_storage" {
   cors_rule = [
     {
       allowed_headers = ["Accept", "Content-Type", "Origin"]
-      allowed_methods = ["GET", "PUT", "POST", "DELETE"]
+      allowed_methods = ["GET", "PUT", "POST"]
       allowed_origins = ["https://cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk"]
       max_age_seconds = 3000
     }


### PR DESCRIPTION
For the prisoner-content-hub staging environment.

Relevant Trello card: https://trello.com/c/ZVSfPcz6/225-fix-the-mysterious-missing-file-issue

We have seen unwanted file deletions occurring, and believe that the recent inclusion of this CORS config is the reason why (see https://github.com/ministryofjustice/cloud-platform-environments/pull/4863).

The DELETE method via CORS is not required, file deletions should always happen via a server side request. So this method can be safety removed.