### PR TITLE
Removing DELETE method from S3 CORS config - production 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -17,7 +17,7 @@ module "drupal_content_storage" {
   cors_rule = [
     {
       allowed_headers = ["Accept", "Content-Type", "Origin"]
-      allowed_methods = ["GET", "PUT", "POST", "DELETE"]
+      allowed_methods = ["GET", "PUT", "POST"]
       allowed_origins = ["https://manage.content-hub.prisoner.service.justice.gov.uk"]
       max_age_seconds = 3000
     }


### PR DESCRIPTION
For the prisoner-content-hub production environment.

Relevant Trello card: https://trello.com/c/ZVSfPcz6/225-fix-the-mysterious-missing-file-issue

We have seen unwanted file deletions occurring, and believe that the recent inclusion of this CORS config is the reason why (seehttps://github.com/ministryofjustice/cloud-platform-environments/pull/4867).

The DELETE method via CORS is not required, file deletions should always happen via a server side request. So this method can be safety removed.