### PR TITLE
PAT-1981 - upgrading using a db instance snapshot requires use of the…

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds-aurora.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds-aurora.tf
@@ -13,7 +13,7 @@ module "rds_aurora" {
   engine_mode                 = "provisioned"
   replica_count               = 1
   instance_type               = "db.t3.medium"
-  snapshot_identifier         = "hmpps-pin-phone-dev-pre-migration-20210723-1436"
+  snapshot_identifier         = "arn:aws:rds:eu-west-2:754256621582:snapshot:hmpps-pin-phone-dev-pre-migration-20210723-1436"
   storage_encrypted           = true
   apply_immediately           = true
   cluster_name                = var.cluster_name


### PR DESCRIPTION
When upgrading to an rds aurora cluster the snapshot identifier must be the fully qualified snapshot arn. See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-snapshotidentifier