### PR TITLE
Use forked version of `get-changed-files` to fix error

### DIFF
--- a/.github/workflows/check-permissions.yaml
+++ b/.github/workflows/check-permissions.yaml
@@ -28,9 +28,10 @@ jobs:
       # Grabs all files changed and displays them in csv format.
       - name: Get all files changed in PR
         id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v1.2
         with:
           format: 'csv'
+          filter: '*live*'
 
       # Loop over all files changed:
       # If the file path contains "live" then we assume it's a namespace change and requires an 


### PR DESCRIPTION
An example of this error can be found here:
https://github.com/ministryofjustice/cloud-platform-environments/pull/5205/checks?check_run_id=3162240748
and is fixed in the fork defined in this commit.