### PR TITLE
Set Book a Secure Move maintenance windows

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/rds.tf
@@ -9,6 +9,7 @@ module "rds-instance" {
   namespace              = var.namespace
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
+  maintenance_window     = var.maintenance_window
 
   performance_insights_enabled = true
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/variables.tf
@@ -34,8 +34,10 @@ variable "domain" {
   default = "bookasecuremove.service.justice.gov.uk"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -11,6 +11,7 @@ module "rds-instance" {
   team_name              = var.team_name
   db_allocated_storage   = 20
   db_instance_class      = "db.t3.medium"
+  maintenance_window     = var.maintenance_window
 
   # enable performance insights
   performance_insights_enabled = true

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/variables.tf
@@ -34,8 +34,10 @@ variable "domain" {
   default = "bookasecuremove.service.justice.gov.uk"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -11,6 +11,7 @@ module "rds-instance" {
   team_name              = var.team_name
   db_allocated_storage   = 50
   db_instance_class      = "db.t3.medium"
+  maintenance_window     = var.maintenance_window
 
   # enable performance insights
   performance_insights_enabled = true

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
@@ -42,8 +42,10 @@ variable "domain" {
   default = "bookasecuremove.service.justice.gov.uk"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -9,6 +9,7 @@ module "rds-instance" {
   namespace              = var.namespace
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
+  maintenance_window     = var.maintenance_window
 
   # enable performance insights
   performance_insights_enabled = true

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/variables.tf
@@ -30,8 +30,10 @@ variable "repo_name" {
   default = "hmpps-book-secure-move-api"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
@@ -10,6 +10,7 @@ module "rds-instance" {
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
+  maintenance_window     = var.maintenance_window
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
@@ -29,4 +30,3 @@ resource "kubernetes_secret" "rds-instance" {
     url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
   }
 }
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/variables.tf
@@ -34,8 +34,10 @@ variable "domain" {
   default = "bookasecuremove.service.justice.gov.uk"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london
@@ -28,4 +29,3 @@ resource "kubernetes_secret" "redis-elasticache" {
     auth_token               = module.redis-elasticache.auth_token
   }
 }
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/variables.tf
@@ -26,8 +26,10 @@ variable "repo_name" {
   default = "hmpps-book-secure-move-frontend"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name         = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london
@@ -28,4 +29,3 @@ resource "kubernetes_secret" "redis-elasticache" {
     auth_token               = module.redis-elasticache.auth_token
   }
 }
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
@@ -1,7 +1,7 @@
 module "redis-elasticache" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
-  cluster_name         = var.cluster_name
+  cluster_name = var.cluster_name
 
   application            = var.application
   environment-name       = var.environment-name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/variables.tf
@@ -30,8 +30,10 @@ variable "repo_name" {
   default = "hmpps-book-secure-move-frontend"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/versions.tf
@@ -9,7 +9,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     pingdom = {
-      source = "russellcardullo/pingdom"
+      source  = "russellcardullo/pingdom"
       version = "1.1.3"
     }
   }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name         = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london
@@ -28,4 +29,3 @@ resource "kubernetes_secret" "redis-elasticache" {
     auth_token               = module.redis-elasticache.auth_token
   }
 }
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -1,7 +1,7 @@
 module "redis-elasticache" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
-  cluster_name         = var.cluster_name
+  cluster_name = var.cluster_name
 
   application            = var.application
   environment-name       = var.environment-name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/variables.tf
@@ -26,8 +26,10 @@ variable "repo_name" {
   default = "hmpps-book-secure-move-frontend"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
   cluster_name         = var.cluster_name
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london
@@ -28,4 +29,3 @@ resource "kubernetes_secret" "redis-elasticache" {
     auth_token               = module.redis-elasticache.auth_token
   }
 }
-

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
@@ -1,7 +1,7 @@
 module "redis-elasticache" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
 
-  cluster_name         = var.cluster_name
+  cluster_name = var.cluster_name
 
   application            = var.application
   environment-name       = var.environment-name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/variables.tf
@@ -26,8 +26,10 @@ variable "repo_name" {
   default = "hmpps-book-secure-move-frontend"
 }
 
+variable "maintenance_window" {
+  default = "sat:23:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-


### PR DESCRIPTION
This sets a maintenance window for all the Book a Secure Move databases. Recently we had an issue where our database was down for a couple of minutes during its maintenance window which was inadvertently set to a time when our site is usually highly trafficked.

We've decided to change the maintenance window and set it explicitly to the early hours of Sunday morning when our site is least used (as moves aren't booked for Sundays).

Depends on https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/pull/108 and https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/pull/25.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3024)