### PR TITLE
Set a maintenance window for hmpps-book-secure-move-api-production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -11,6 +11,8 @@ module "rds-instance" {
   team_name              = var.team_name
   db_allocated_storage   = 50
   db_instance_class      = "db.t3.medium"
+  backup_window          = var.backup_window
+  maintenance_window     = var.maintenance_window
 
   # enable performance insights
   performance_insights_enabled = true

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = var.maintenance_window
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/variables.tf
@@ -42,8 +42,14 @@ variable "domain" {
   default = "bookasecuremove.service.justice.gov.uk"
 }
 
+variable "backup_window" {
+  default = "22:00-23:59"
+}
+
+variable "maintenance_window" {
+  default = "sun:00:00-sun:03:00"
+}
+
 // The following two variables are provided at runtime by the pipeline.
 variable "cluster_name" {
 }
-
-


### PR DESCRIPTION
This sets a maintenance window for all the Book a Secure Move databases. Recently we had an issue where our database was down for a couple of minutes during its maintenance window which was inadvertently set to a time when our site is usually highly trafficked.

We've decided to change the maintenance window and set it explicitly to the early hours of Sunday morning when our site is least used (as moves aren't booked for Sundays).

Depends on ministryofjustice/cloud-platform-terraform-rds-instance#108 and ministryofjustice/cloud-platform-terraform-elasticache-cluster#25.