### PR TITLE
Set a maintenance window for hmpps-book-secure-move-frontend-preprod

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  maintenance_window     = "sat:23:00-sun:03:00"
 
   providers = {
     aws = aws.london
@@ -28,4 +29,3 @@ resource "kubernetes_secret" "redis-elasticache" {
     auth_token               = module.redis-elasticache.auth_token
   }
 }
-


### PR DESCRIPTION
This sets a maintenance window for all the Book a Secure Move databases. Recently we had an issue where our database was down for a couple of minutes during its maintenance window which was inadvertently set to a time when our site is usually highly trafficked.

We've decided to change the maintenance window and set it explicitly to the early hours of Sunday morning when our site is least used (as moves aren't booked for Sundays).

Depends on ministryofjustice/cloud-platform-terraform-rds-instance#108 and ministryofjustice/cloud-platform-terraform-elasticache-cluster#25.