### PR TITLE
Set snapshot window for hmpps-book-secure-move-api-uat

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.3"
 
   cluster_name = var.cluster_name
 
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  snapshot_window        = var.backup_window
   maintenance_window     = var.maintenance_window
 
   providers = {


### PR DESCRIPTION
This sets a snapshot window for Redis to match the backup window for RDS. Previously we weren't setting this because the parameter wasn't supported by the module, but we've hit an issue where the chosen window by AWS conflicts with our desired maintenance window.