### PR TITLE
Set a consistent snapshot window

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  snapshot_window        = var.backup_window
   maintenance_window     = var.maintenance_window
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  snapshot_window        = var.backup_window
   maintenance_window     = var.maintenance_window
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  snapshot_window        = var.backup_window
   maintenance_window     = var.maintenance_window
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
@@ -11,6 +11,7 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
+  snapshot_window        = var.backup_window
   maintenance_window     = var.maintenance_window
 
   providers = {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
@@ -11,7 +11,8 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
-  maintenance_window     = "sat:23:00-sun:03:00"
+  snapshot_window        = "22:00-23:59"
+  maintenance_window     = "sun:00:00-sun:03:00"
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
@@ -11,7 +11,8 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
-  maintenance_window     = "sat:23:00-sun:03:00"
+  snapshot_window        = "22:00-23:59"
+  maintenance_window     = "sun:00:00-sun:03:00"
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -11,7 +11,8 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
-  maintenance_window     = "sat:23:00-sun:03:00"
+  snapshot_window        = "22:00-23:59"
+  maintenance_window     = "sun:00:00-sun:03:00"
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
@@ -11,7 +11,8 @@ module "redis-elasticache" {
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
-  maintenance_window     = "sat:23:00-sun:03:00"
+  snapshot_window        = "22:00-23:59"
+  maintenance_window     = "sun:00:00-sun:03:00"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
This sets the same snapshot window for all Redis databases for Book a Secure Move. This follows on from https://github.com/ministryofjustice/cloud-platform-environments/pull/5252 where we had an issue that the maintenance window conflicted with the snapshot window, and therefore had to be set explicitly.