### PR TITLE
Create SQS queue for prosecution concluded messages

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/messaging-queues.tf
@@ -415,6 +415,79 @@ module "create_link_cp_status_job_dead_letter_queue" {
   }
 }
 
+module "prosecution_concluded_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "prosecution-concluded-queue"
+  existing_user_name        = module.create_link_queue_m.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+  namespace                 = var.namespace
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.prosecution_concluded_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "prosecution_concluded_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "prosecution-concluded-queue-dl"
+  existing_user_name     = module.create_link_queue_m.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "prosecution_concluded_queue_policy" {
+  queue_url = module.prosecution_concluded_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.prosecution_concluded_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {
+          "AWS": [
+            "140455166311"
+              ]
+          },
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
 
 resource "kubernetes_secret" "create_link_queue_m" {
   metadata {
@@ -449,6 +522,12 @@ resource "kubernetes_secret" "create_link_queue_m" {
     sqs_url_d_hearing_resulted           = module.hearing_resulted_dead_letter_queue.sqs_id
     sqs_arn_d_hearing_resulted           = module.hearing_resulted_dead_letter_queue.sqs_arn
     sqs_name_d_hearing_resulted          = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_prosecution_concluded        = module.prosecution_concluded_queue.sqs_id
+    sqs_arn_prosecution_concluded        = module.prosecution_concluded_queue.sqs_arn
+    sqs_name_prosecution_concluded       = module.prosecution_concluded_queue.sqs_name
+    sqs_url_d_prosecution_concluded      = module.prosecution_concluded_dead_letter_queue.sqs_id
+    sqs_arn_d_prosecution_concluded      = module.prosecution_concluded_dead_letter_queue.sqs_arn
+    sqs_name_d_prosecution_concluded     = module.prosecution_concluded_dead_letter_queue.sqs_name
     sqs_url_cp_laa_status_job            = module.cp_laa_status_job_queue.sqs_id
     sqs_arn_cp_laa_status_job            = module.cp_laa_status_job_queue.sqs_arn
     sqs_name_cp_laa_status_job           = module.cp_laa_status_job_queue.sqs_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds.tf
@@ -15,13 +15,13 @@ variable "cluster_name" {
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
-  cluster_name         = var.cluster_name
-  team_name            = "laa-crime-apps-team"
-  business-unit        = "Crime Apps"
-  application          = "laa-court-data-adaptor"
-  is-production        = "false"
-  namespace            = var.namespace
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  cluster_name  = var.cluster_name
+  team_name     = "laa-crime-apps-team"
+  business-unit = "Crime Apps"
+  application   = "laa-court-data-adaptor"
+  is-production = "false"
+  namespace     = var.namespace
 
   # change the postgres version as you see fit.
   db_engine_version      = "11"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/versions.tf
@@ -9,7 +9,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     pingdom = {
-      source = "russellcardullo/pingdom"
+      source  = "russellcardullo/pingdom"
       version = "1.1.3"
     }
   }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
@@ -361,6 +361,79 @@ module "cp_laa_status_job_dead_letter_queue" {
   }
 }
 
+module "prosecution_concluded_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "prosecution-concluded-queue"
+  existing_user_name        = module.create_link_queue.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+  namespace                 = var.namespace
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.prosecution_concluded_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "prosecution_concluded_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "prosecution-concluded-queue-dl"
+  existing_user_name     = module.create_link_queue.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "prosecution_concluded_queue_policy" {
+  queue_url = module.prosecution_concluded_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.prosecution_concluded_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {
+          "AWS": [
+            "140455166311"
+              ]
+          },
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
 resource "kubernetes_secret" "create_link_queue" {
   metadata {
     name      = "cda-messaging-queues-output"
@@ -368,37 +441,43 @@ resource "kubernetes_secret" "create_link_queue" {
   }
 
   data = {
-    access_key_id                = module.create_link_queue.access_key_id
-    secret_access_key            = module.create_link_queue.secret_access_key
-    sqs_url_link                 = module.create_link_queue.sqs_id
-    sqs_arn_link                 = module.create_link_queue.sqs_arn
-    sqs_name_link                = module.create_link_queue.sqs_name
-    sqs_url_d_link               = module.create_link_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_link               = module.create_link_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_link              = module.create_link_queue_dead_letter_queue.sqs_name
-    sqs_url_unlink               = module.unlink_queue.sqs_id
-    sqs_arn_unlink               = module.unlink_queue.sqs_arn
-    sqs_name_unlink              = module.unlink_queue.sqs_name
-    sqs_url_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_name
-    sqs_url_laa_status           = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status           = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status          = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_name
-    sqs_url_hearing_resulted     = module.hearing_resulted_queue.sqs_id
-    sqs_arn_hearing_resulted     = module.hearing_resulted_queue.sqs_arn
-    sqs_name_hearing_resulted    = module.hearing_resulted_queue.sqs_name
-    sqs_url_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_id
-    sqs_arn_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_arn
-    sqs_name_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_name
-    sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
-    sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
-    sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name
-    sqs_url_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_id
-    sqs_arn_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_arn
-    sqs_name_d_cp_laa_status_job = module.cp_laa_status_job_dead_letter_queue.sqs_name
+    access_key_id                    = module.create_link_queue.access_key_id
+    secret_access_key                = module.create_link_queue.secret_access_key
+    sqs_url_link                     = module.create_link_queue.sqs_id
+    sqs_arn_link                     = module.create_link_queue.sqs_arn
+    sqs_name_link                    = module.create_link_queue.sqs_name
+    sqs_url_d_link                   = module.create_link_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_link                   = module.create_link_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_link                  = module.create_link_queue_dead_letter_queue.sqs_name
+    sqs_url_unlink                   = module.unlink_queue.sqs_id
+    sqs_arn_unlink                   = module.unlink_queue.sqs_arn
+    sqs_name_unlink                  = module.unlink_queue.sqs_name
+    sqs_url_d_unlink                 = module.unlink_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_unlink                 = module.unlink_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_unlink                = module.unlink_queue_dead_letter_queue.sqs_name
+    sqs_url_laa_status               = module.laa_status_update_queue.sqs_id
+    sqs_arn_laa_status               = module.laa_status_update_queue.sqs_arn
+    sqs_name_laa_status              = module.laa_status_update_queue.sqs_name
+    sqs_url_d_laa_status             = module.laa_status_update_dead_letter_queue.sqs_id
+    sqs_arn_d_laa_status             = module.laa_status_update_dead_letter_queue.sqs_arn
+    sqs_name_d_laa_status            = module.laa_status_update_dead_letter_queue.sqs_name
+    sqs_url_hearing_resulted         = module.hearing_resulted_queue.sqs_id
+    sqs_arn_hearing_resulted         = module.hearing_resulted_queue.sqs_arn
+    sqs_name_hearing_resulted        = module.hearing_resulted_queue.sqs_name
+    sqs_url_d_hearing_resulted       = module.hearing_resulted_dead_letter_queue.sqs_id
+    sqs_arn_d_hearing_resulted       = module.hearing_resulted_dead_letter_queue.sqs_arn
+    sqs_name_d_hearing_resulted      = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_prosecution_concluded    = module.prosecution_concluded_queue.sqs_id
+    sqs_arn_prosecution_concluded    = module.prosecution_concluded_queue.sqs_arn
+    sqs_name_prosecution_concluded   = module.prosecution_concluded_queue.sqs_name
+    sqs_url_d_prosecution_concluded  = module.prosecution_concluded_dead_letter_queue.sqs_id
+    sqs_arn_d_prosecution_concluded  = module.prosecution_concluded_dead_letter_queue.sqs_arn
+    sqs_name_d_prosecution_concluded = module.prosecution_concluded_dead_letter_queue.sqs_name
+    sqs_url_cp_laa_status_job        = module.cp_laa_status_job_queue.sqs_id
+    sqs_arn_cp_laa_status_job        = module.cp_laa_status_job_queue.sqs_arn
+    sqs_name_cp_laa_status_job       = module.cp_laa_status_job_queue.sqs_name
+    sqs_url_d_cp_laa_status_job      = module.cp_laa_status_job_dead_letter_queue.sqs_id
+    sqs_arn_d_cp_laa_status_job      = module.cp_laa_status_job_dead_letter_queue.sqs_arn
+    sqs_name_d_cp_laa_status_job     = module.cp_laa_status_job_dead_letter_queue.sqs_name
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds.tf
@@ -15,13 +15,13 @@ variable "cluster_name" {
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
-  cluster_name         = var.cluster_name
-  team_name            = "laa-crime-apps-team"
-  business-unit        = "Crime Apps"
-  application          = "laa-court-data-adaptor"
-  is-production        = "true"
-  namespace            = var.namespace
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  cluster_name  = var.cluster_name
+  team_name     = "laa-crime-apps-team"
+  business-unit = "Crime Apps"
+  application   = "laa-court-data-adaptor"
+  is-production = "true"
+  namespace     = var.namespace
 
   # change the postgres version as you see fit.
   db_engine_version      = "11"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/versions.tf
@@ -9,7 +9,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     pingdom = {
-      source = "russellcardullo/pingdom"
+      source  = "russellcardullo/pingdom"
       version = "1.1.3"
     }
   }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/messaging-queues.tf
@@ -361,6 +361,79 @@ module "cp_laa_status_job_dead_letter_queue" {
   }
 }
 
+module "prosecution_concluded_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "prosecution-concluded-queue"
+  existing_user_name        = module.create_link_queue.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+  namespace                 = var.namespace
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.prosecution_concluded_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "prosecution_concluded_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "prosecution-concluded-queue-dl"
+  existing_user_name     = module.create_link_queue.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "prosecution_concluded_queue_policy" {
+  queue_url = module.prosecution_concluded_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.prosecution_concluded_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {
+          "AWS": [
+            "140455166311"
+              ]
+          },
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
 resource "kubernetes_secret" "create_link_queue" {
   metadata {
     name      = "cda-messaging-queues-output"
@@ -368,37 +441,43 @@ resource "kubernetes_secret" "create_link_queue" {
   }
 
   data = {
-    access_key_id                = module.create_link_queue.access_key_id
-    secret_access_key            = module.create_link_queue.secret_access_key
-    sqs_url_link                 = module.create_link_queue.sqs_id
-    sqs_arn_link                 = module.create_link_queue.sqs_arn
-    sqs_name_link                = module.create_link_queue.sqs_name
-    sqs_url_d_link               = module.create_link_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_link               = module.create_link_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_link              = module.create_link_queue_dead_letter_queue.sqs_name
-    sqs_url_unlink               = module.unlink_queue.sqs_id
-    sqs_arn_unlink               = module.unlink_queue.sqs_arn
-    sqs_name_unlink              = module.unlink_queue.sqs_name
-    sqs_url_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_name
-    sqs_url_laa_status           = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status           = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status          = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_name
-    sqs_url_hearing_resulted     = module.hearing_resulted_queue.sqs_id
-    sqs_arn_hearing_resulted     = module.hearing_resulted_queue.sqs_arn
-    sqs_name_hearing_resulted    = module.hearing_resulted_queue.sqs_name
-    sqs_url_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_id
-    sqs_arn_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_arn
-    sqs_name_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_name
-    sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
-    sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
-    sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name
-    sqs_url_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_id
-    sqs_arn_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_arn
-    sqs_name_d_cp_laa_status_job = module.cp_laa_status_job_dead_letter_queue.sqs_name
+    access_key_id                    = module.create_link_queue.access_key_id
+    secret_access_key                = module.create_link_queue.secret_access_key
+    sqs_url_link                     = module.create_link_queue.sqs_id
+    sqs_arn_link                     = module.create_link_queue.sqs_arn
+    sqs_name_link                    = module.create_link_queue.sqs_name
+    sqs_url_d_link                   = module.create_link_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_link                   = module.create_link_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_link                  = module.create_link_queue_dead_letter_queue.sqs_name
+    sqs_url_unlink                   = module.unlink_queue.sqs_id
+    sqs_arn_unlink                   = module.unlink_queue.sqs_arn
+    sqs_name_unlink                  = module.unlink_queue.sqs_name
+    sqs_url_d_unlink                 = module.unlink_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_unlink                 = module.unlink_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_unlink                = module.unlink_queue_dead_letter_queue.sqs_name
+    sqs_url_laa_status               = module.laa_status_update_queue.sqs_id
+    sqs_arn_laa_status               = module.laa_status_update_queue.sqs_arn
+    sqs_name_laa_status              = module.laa_status_update_queue.sqs_name
+    sqs_url_d_laa_status             = module.laa_status_update_dead_letter_queue.sqs_id
+    sqs_arn_d_laa_status             = module.laa_status_update_dead_letter_queue.sqs_arn
+    sqs_name_d_laa_status            = module.laa_status_update_dead_letter_queue.sqs_name
+    sqs_url_hearing_resulted         = module.hearing_resulted_queue.sqs_id
+    sqs_arn_hearing_resulted         = module.hearing_resulted_queue.sqs_arn
+    sqs_name_hearing_resulted        = module.hearing_resulted_queue.sqs_name
+    sqs_url_d_hearing_resulted       = module.hearing_resulted_dead_letter_queue.sqs_id
+    sqs_arn_d_hearing_resulted       = module.hearing_resulted_dead_letter_queue.sqs_arn
+    sqs_name_d_hearing_resulted      = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_prosecution_concluded    = module.prosecution_concluded_queue.sqs_id
+    sqs_arn_prosecution_concluded    = module.prosecution_concluded_queue.sqs_arn
+    sqs_name_prosecution_concluded   = module.prosecution_concluded_queue.sqs_name
+    sqs_url_d_prosecution_concluded  = module.prosecution_concluded_dead_letter_queue.sqs_id
+    sqs_arn_d_prosecution_concluded  = module.prosecution_concluded_dead_letter_queue.sqs_arn
+    sqs_name_d_prosecution_concluded = module.prosecution_concluded_dead_letter_queue.sqs_name
+    sqs_url_cp_laa_status_job        = module.cp_laa_status_job_queue.sqs_id
+    sqs_arn_cp_laa_status_job        = module.cp_laa_status_job_queue.sqs_arn
+    sqs_name_cp_laa_status_job       = module.cp_laa_status_job_queue.sqs_name
+    sqs_url_d_cp_laa_status_job      = module.cp_laa_status_job_dead_letter_queue.sqs_id
+    sqs_arn_d_cp_laa_status_job      = module.cp_laa_status_job_dead_letter_queue.sqs_arn
+    sqs_name_d_cp_laa_status_job     = module.cp_laa_status_job_dead_letter_queue.sqs_name
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds.tf
@@ -15,13 +15,13 @@ variable "cluster_name" {
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
-  cluster_name         = var.cluster_name
-  team_name            = "laa-crime-apps-team"
-  business-unit        = "Crime Apps"
-  application          = "laa-court-data-adaptor"
-  is-production        = "false"
-  namespace            = var.namespace
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  cluster_name  = var.cluster_name
+  team_name     = "laa-crime-apps-team"
+  business-unit = "Crime Apps"
+  application   = "laa-court-data-adaptor"
+  is-production = "false"
+  namespace     = var.namespace
 
   # change the postgres version as you see fit.
   db_engine_version      = "11"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
@@ -361,6 +361,79 @@ module "cp_laa_status_job_dead_letter_queue" {
   }
 }
 
+module "prosecution_concluded_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "prosecution-concluded-queue"
+  existing_user_name        = module.create_link_queue.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+  namespace                 = var.namespace
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.prosecution_concluded_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "prosecution_concluded_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "prosecution-concluded-queue-dl"
+  existing_user_name     = module.create_link_queue.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "prosecution_concluded_queue_policy" {
+  queue_url = module.prosecution_concluded_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.prosecution_concluded_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {
+          "AWS": [
+            "140455166311"
+              ]
+          },
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
 resource "kubernetes_secret" "create_link_queue" {
   metadata {
     name      = "cda-messaging-queues-output"
@@ -368,37 +441,43 @@ resource "kubernetes_secret" "create_link_queue" {
   }
 
   data = {
-    access_key_id                = module.create_link_queue.access_key_id
-    secret_access_key            = module.create_link_queue.secret_access_key
-    sqs_url_link                 = module.create_link_queue.sqs_id
-    sqs_arn_link                 = module.create_link_queue.sqs_arn
-    sqs_name_link                = module.create_link_queue.sqs_name
-    sqs_url_d_link               = module.create_link_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_link               = module.create_link_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_link              = module.create_link_queue_dead_letter_queue.sqs_name
-    sqs_url_unlink               = module.unlink_queue.sqs_id
-    sqs_arn_unlink               = module.unlink_queue.sqs_arn
-    sqs_name_unlink              = module.unlink_queue.sqs_name
-    sqs_url_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_id
-    sqs_arn_d_unlink             = module.unlink_queue_dead_letter_queue.sqs_arn
-    sqs_name_d_unlink            = module.unlink_queue_dead_letter_queue.sqs_name
-    sqs_url_laa_status           = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status           = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status          = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status         = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status        = module.laa_status_update_dead_letter_queue.sqs_name
-    sqs_url_hearing_resulted     = module.hearing_resulted_queue.sqs_id
-    sqs_arn_hearing_resulted     = module.hearing_resulted_queue.sqs_arn
-    sqs_name_hearing_resulted    = module.hearing_resulted_queue.sqs_name
-    sqs_url_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_id
-    sqs_arn_d_hearing_resulted   = module.hearing_resulted_dead_letter_queue.sqs_arn
-    sqs_name_d_hearing_resulted  = module.hearing_resulted_dead_letter_queue.sqs_name
-    sqs_url_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_id
-    sqs_arn_cp_laa_status_job    = module.cp_laa_status_job_queue.sqs_arn
-    sqs_name_cp_laa_status_job   = module.cp_laa_status_job_queue.sqs_name
-    sqs_url_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_id
-    sqs_arn_d_cp_laa_status_job  = module.cp_laa_status_job_dead_letter_queue.sqs_arn
-    sqs_name_d_cp_laa_status_job = module.cp_laa_status_job_dead_letter_queue.sqs_name
+    access_key_id                    = module.create_link_queue.access_key_id
+    secret_access_key                = module.create_link_queue.secret_access_key
+    sqs_url_link                     = module.create_link_queue.sqs_id
+    sqs_arn_link                     = module.create_link_queue.sqs_arn
+    sqs_name_link                    = module.create_link_queue.sqs_name
+    sqs_url_d_link                   = module.create_link_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_link                   = module.create_link_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_link                  = module.create_link_queue_dead_letter_queue.sqs_name
+    sqs_url_unlink                   = module.unlink_queue.sqs_id
+    sqs_arn_unlink                   = module.unlink_queue.sqs_arn
+    sqs_name_unlink                  = module.unlink_queue.sqs_name
+    sqs_url_d_unlink                 = module.unlink_queue_dead_letter_queue.sqs_id
+    sqs_arn_d_unlink                 = module.unlink_queue_dead_letter_queue.sqs_arn
+    sqs_name_d_unlink                = module.unlink_queue_dead_letter_queue.sqs_name
+    sqs_url_laa_status               = module.laa_status_update_queue.sqs_id
+    sqs_arn_laa_status               = module.laa_status_update_queue.sqs_arn
+    sqs_name_laa_status              = module.laa_status_update_queue.sqs_name
+    sqs_url_d_laa_status             = module.laa_status_update_dead_letter_queue.sqs_id
+    sqs_arn_d_laa_status             = module.laa_status_update_dead_letter_queue.sqs_arn
+    sqs_name_d_laa_status            = module.laa_status_update_dead_letter_queue.sqs_name
+    sqs_url_hearing_resulted         = module.hearing_resulted_queue.sqs_id
+    sqs_arn_hearing_resulted         = module.hearing_resulted_queue.sqs_arn
+    sqs_name_hearing_resulted        = module.hearing_resulted_queue.sqs_name
+    sqs_url_d_hearing_resulted       = module.hearing_resulted_dead_letter_queue.sqs_id
+    sqs_arn_d_hearing_resulted       = module.hearing_resulted_dead_letter_queue.sqs_arn
+    sqs_name_d_hearing_resulted      = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_prosecution_concluded    = module.prosecution_concluded_queue.sqs_id
+    sqs_arn_prosecution_concluded    = module.prosecution_concluded_queue.sqs_arn
+    sqs_name_prosecution_concluded   = module.prosecution_concluded_queue.sqs_name
+    sqs_url_d_prosecution_concluded  = module.prosecution_concluded_dead_letter_queue.sqs_id
+    sqs_arn_d_prosecution_concluded  = module.prosecution_concluded_dead_letter_queue.sqs_arn
+    sqs_name_d_prosecution_concluded = module.prosecution_concluded_dead_letter_queue.sqs_name
+    sqs_url_cp_laa_status_job        = module.cp_laa_status_job_queue.sqs_id
+    sqs_arn_cp_laa_status_job        = module.cp_laa_status_job_queue.sqs_arn
+    sqs_name_cp_laa_status_job       = module.cp_laa_status_job_queue.sqs_name
+    sqs_url_d_cp_laa_status_job      = module.cp_laa_status_job_dead_letter_queue.sqs_id
+    sqs_arn_d_cp_laa_status_job      = module.cp_laa_status_job_dead_letter_queue.sqs_arn
+    sqs_name_d_cp_laa_status_job     = module.cp_laa_status_job_dead_letter_queue.sqs_name
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds.tf
@@ -15,13 +15,13 @@ variable "cluster_name" {
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
-  cluster_name         = var.cluster_name
-  team_name            = "laa-crime-apps-team"
-  business-unit        = "Crime Apps"
-  application          = "laa-court-data-adaptor"
-  is-production        = "false"
-  namespace            = var.namespace
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  cluster_name  = var.cluster_name
+  team_name     = "laa-crime-apps-team"
+  business-unit = "Crime Apps"
+  application   = "laa-court-data-adaptor"
+  is-production = "false"
+  namespace     = var.namespace
 
   # change the postgres version as you see fit.
   db_engine_version      = "11"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/messaging-queues.tf
@@ -430,6 +430,79 @@ module "cp_laa_status_job_dead_letter_queue" {
   }
 }
 
+module "prosecution_concluded_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name          = var.environment_name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "prosecution-concluded-queue"
+  existing_user_name        = module.create_link_queue.user_name
+  encrypt_sqs_kms           = var.encrypt_sqs_kms
+  message_retention_seconds = var.message_retention_seconds
+  namespace                 = var.namespace
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.prosecution_concluded_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "prosecution_concluded_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+
+  environment-name       = var.environment_name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "prosecution-concluded-queue-dl"
+  existing_user_name     = module.create_link_queue.user_name
+  encrypt_sqs_kms        = var.encrypt_sqs_kms
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "prosecution_concluded_queue_policy" {
+  queue_url = module.prosecution_concluded_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.prosecution_concluded_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Sid": "PublishPolicy",
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:SendMessage"
+        },
+        {
+          "Sid": "ConsumePolicy",
+          "Effect": "Allow",
+          "Principal": {
+          "AWS": [
+            "140455166311"
+              ]
+          },
+          "Resource": "${module.prosecution_concluded_queue.sqs_arn}",
+          "Action": "sqs:ReceiveMessage"
+        }
+      ]
+  }
+   EOF
+}
+
 resource "kubernetes_secret" "create_link_queue" {
   metadata {
     name      = "cda-messaging-queues-output"
@@ -463,6 +536,12 @@ resource "kubernetes_secret" "create_link_queue" {
     sqs_url_d_hearing_resulted           = module.hearing_resulted_dead_letter_queue.sqs_id
     sqs_arn_d_hearing_resulted           = module.hearing_resulted_dead_letter_queue.sqs_arn
     sqs_name_d_hearing_resulted          = module.hearing_resulted_dead_letter_queue.sqs_name
+    sqs_url_prosecution_concluded        = module.prosecution_concluded_queue.sqs_id
+    sqs_arn_prosecution_concluded        = module.prosecution_concluded_queue.sqs_arn
+    sqs_name_prosecution_concluded       = module.prosecution_concluded_queue.sqs_name
+    sqs_url_d_prosecution_concluded      = module.prosecution_concluded_dead_letter_queue.sqs_id
+    sqs_arn_d_prosecution_concluded      = module.prosecution_concluded_dead_letter_queue.sqs_arn
+    sqs_name_d_prosecution_concluded     = module.prosecution_concluded_dead_letter_queue.sqs_name
     sqs_url_cp_create_link_status_job    = module.create_link_cp_status_job_queue.sqs_id
     sqs_arn_cp_create_link_status_job    = module.create_link_cp_status_job_queue.sqs_arn
     sqs_name_cp_create_link_status_job   = module.create_link_cp_status_job_queue.sqs_name

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds.tf
@@ -15,13 +15,13 @@ variable "cluster_name" {
  *
  */
 module "laa_crime_apps_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
-  cluster_name         = var.cluster_name
-  team_name            = "laa-crime-apps-team"
-  business-unit        = "Crime Apps"
-  application          = "laa-court-data-adaptor"
-  is-production        = "false"
-  namespace            = var.namespace
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  cluster_name  = var.cluster_name
+  team_name     = "laa-crime-apps-team"
+  business-unit = "Crime Apps"
+  application   = "laa-court-data-adaptor"
+  is-production = "false"
+  namespace     = var.namespace
 
   # change the postgres version as you see fit.
   db_engine_version      = "11"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/versions.tf
@@ -9,7 +9,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     pingdom = {
-      source = "russellcardullo/pingdom"
+      source  = "russellcardullo/pingdom"
       version = "1.1.3"
     }
   }


### PR DESCRIPTION
Create a dedicated SQS queue for posting prosecution concluded messages to MAAT API.

Only 5 files should have been modified, but the linter/formatter edited another 8.