### PR TITLE
[LAA Court Data Adaptor] Use one IAM user per SQS queue (dev)

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/messaging-queues.tf
@@ -138,76 +138,6 @@ module "unlink_queue_m_dead_letter_queue" {
   }
 }
 
-module "laa_status_update_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
-
-  environment-name          = var.environment_name
-  team_name                 = var.team_name
-  infrastructure-support    = var.infrastructure_support
-  application               = var.application
-  sqs_name                  = "laa-status-update-queue"
-  existing_user_name        = module.create_link_queue_m.user_name
-  encrypt_sqs_kms           = var.encrypt_sqs_kms
-  message_retention_seconds = var.message_retention_seconds
-  namespace                 = var.namespace
-
-  redrive_policy = <<EOF
-  {
-    "deadLetterTargetArn": "${module.laa_status_update_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
-  }
-  EOF
-
-  providers = {
-    aws = aws.london
-  }
-}
-
-resource "aws_sqs_queue_policy" "laa_status_update_queue_policy" {
-  queue_url = module.laa_status_update_queue.sqs_id
-
-  policy = <<EOF
-  {
-    "Version": "2012-10-17",
-    "Id": "${module.laa_status_update_queue.sqs_arn}/SQSDefaultPolicy",
-    "Statement":
-      [
-        {
-          "Sid": "PublishPolicy",
-          "Effect": "Allow",
-          "Principal": {"AWS": "*"},
-          "Resource": "${module.laa_status_update_queue.sqs_arn}",
-          "Action": "sqs:SendMessage"
-        },
-        {
-          "Sid": "ConsumePolicy",
-          "Effect": "Allow",
-          "Principal": {"AWS": "*"},
-          "Resource": "${module.laa_status_update_queue.sqs_arn}",
-          "Action": "sqs:ReceiveMessage"
-        }
-      ]
-  }
-   EOF
-}
-
-module "laa_status_update_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
-
-  environment-name       = var.environment_name
-  team_name              = var.team_name
-  infrastructure-support = var.infrastructure_support
-  application            = var.application
-  sqs_name               = "laa-status-update-queue-dl"
-  existing_user_name     = module.create_link_queue_m.user_name
-  encrypt_sqs_kms        = var.encrypt_sqs_kms
-  namespace              = var.namespace
-
-  providers = {
-    aws = aws.london
-  }
-}
-
-
 module "hearing_resulted_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
 
@@ -510,12 +440,6 @@ resource "kubernetes_secret" "create_link_queue_m" {
     sqs_url_d_unlink                     = module.unlink_queue_m_dead_letter_queue.sqs_id
     sqs_arn_d_unlink                     = module.unlink_queue_m_dead_letter_queue.sqs_arn
     sqs_name_d_unlink                    = module.unlink_queue_m_dead_letter_queue.sqs_name
-    sqs_url_laa_status                   = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status                   = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status                  = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status                 = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status                 = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status                = module.laa_status_update_dead_letter_queue.sqs_name
     sqs_url_hearing_resulted             = module.hearing_resulted_queue.sqs_id
     sqs_arn_hearing_resulted             = module.hearing_resulted_queue.sqs_arn
     sqs_name_hearing_resulted            = module.hearing_resulted_queue.sqs_name


### PR DESCRIPTION
Remove unused SQS queues, in an attempt to fix:

```
Error: Error putting IAM user policy crime-apps-dev-prosecution-concluded-queue: LimitExceeded: Maximum policy size of 2048 bytes exceeded for user cp-sqs-02f5ffc4ea89
```