### PR TITLE
Create Prometheus Rules for training namespace

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/07-prometheus-k8.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/07-prometheus-k8.yaml
@@ -1,0 +1,61 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-cla-backend-training
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-laa-cla-backend-training
+spec:
+  groups:
+    - name: laa-cla-backend-training-k8s-rules
+      rules:
+        - alert: KubeQuotaExceeded
+          expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-cla-backend-training"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-cla-backend-training"} > 0) > 90
+          for: 5m
+          labels:
+            severity: laa-get-access
+          annotations:
+            message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+        - alert: KubePodNotReady
+          expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics",phase!~"Running|Succeeded", namespace="laa-cla-backend-training"}) > 0
+          for: 15m
+          labels:
+            severity: laa-get-access
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-readystate for longer than fifteen minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+        - alert: KubeDeploymentGenerationMismatch
+          expr: |-
+            kube_deployment_status_observed_generation{namespace="laa-cla-backend-training", job="kube-state-metrics"}
+              !=
+            kube_deployment_metadata_generation{namespace="laa-cla-backend-training", job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: laa-get-access
+          annotations:
+            message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+              }} does not match, this indicates that the Deployment has failed but has
+              not been rolled back.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
+        - alert: KubeDeploymentReplicasMismatch
+          expr: |-
+            kube_deployment_spec_replicas{namespace="laa-cla-backend-training", job="kube-state-metrics"}
+              !=
+            kube_deployment_status_replicas_available{namespace="laa-cla-backend-training", job="kube-state-metrics"}
+          for: 1h
+          labels:
+            severity: laa-get-access
+          annotations:
+            message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+              matched the expected number of replicas for longer than an hour.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
+        - alert: KubePodCrashLooping
+          expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="laa-cla-backend-training"}[10m]) * 60 * 10 > 1
+          for: 5m
+          labels:
+            severity: laa-get-access
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping


### PR DESCRIPTION
- Creates a PromethusRule as part of following the [creating your own custom alerts guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#create-a-prometheusrule). 
- Rules used are from already set prometheus rules from other repos in namespace repo. Thus these rules are what other people/teams are using.
- Use rules from other repos instead of in favour of what the ticket suggested
