### PR TITLE
[LAA Court Data Adaptor] Use separate IAM user for prosecution_concluded DL queue (dev)

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/messaging-queues.tf
@@ -375,7 +375,6 @@ module "prosecution_concluded_dl_queue" {
   infrastructure-support = var.infrastructure_support
   application            = var.application
   sqs_name               = "prosecution-concluded-queue-dl"
-  existing_user_name     = module.create_link_queue_m.user_name
   encrypt_sqs_kms        = var.encrypt_sqs_kms
   namespace              = var.namespace
 


### PR DESCRIPTION
Attempt to fix:

```
Error: Error putting IAM user policy crime-apps-dev-prosecution-concluded-queue: LimitExceeded: Maximum policy size of 2048 bytes exceeded for user cp-sqs-02f5ffc4ea89
```