### PR TITLE
Add external-dns annotation to how-out-of-date-are-we

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/ingress.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/ingress.yaml
@@ -3,6 +3,10 @@ kind: Ingress
 metadata:
   name: how-out-of-date-are-we-app-ingress
   namespace: how-out-of-date-are-we
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: dns-hoodaw
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
With out external-dns annotation, opa policy will reject ingress