### PR TITLE
[LAA Court Data Adaptor] Use separate IAM user for prosecution_concluded DL queue (test)

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
@@ -1,5 +1,5 @@
 module "create_link_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -56,7 +56,7 @@ resource "aws_sqs_queue_policy" "create_link_queue_policy" {
 
 
 module "create_link_queue_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -73,7 +73,7 @@ module "create_link_queue_dead_letter_queue" {
 }
 
 module "unlink_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -129,7 +129,7 @@ resource "aws_sqs_queue_policy" "unlink_queue_policy" {
 }
 
 module "unlink_queue_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -145,9 +145,8 @@ module "unlink_queue_dead_letter_queue" {
   }
 }
 
-
 module "hearing_resulted_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -203,7 +202,7 @@ resource "aws_sqs_queue_policy" "hearing_resulted_queue_policy" {
 }
 
 module "hearing_resulted_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -220,7 +219,7 @@ module "hearing_resulted_dead_letter_queue" {
 }
 
 module "cp_laa_status_job_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -272,7 +271,7 @@ resource "aws_sqs_queue_policy" "cp_laa_status_job_queue_policy" {
 }
 
 module "cp_laa_status_job_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
@@ -289,7 +288,7 @@ module "cp_laa_status_job_dead_letter_queue" {
 }
 
 module "prosecution_concluded_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name          = var.environment_name
   team_name                 = var.team_name
@@ -313,14 +312,13 @@ module "prosecution_concluded_queue" {
 }
 
 module "prosecution_concluded_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
   environment-name       = var.environment_name
   team_name              = var.team_name
   infrastructure-support = var.infrastructure_support
   application            = var.application
   sqs_name               = "prosecution-concluded-queue-dl"
-  existing_user_name     = module.create_link_queue.user_name
   encrypt_sqs_kms        = var.encrypt_sqs_kms
   namespace              = var.namespace
 


### PR DESCRIPTION
Attempt to fix:

```
Error: Error putting IAM user policy crime-apps-test-prosecution-concluded-queue: LimitExceeded: Maximum policy size of 2048 bytes exceeded for user cp-sqs-02f5ffc4ea89
```