### PR TITLE
Remove the NamespaceMissing prometheus alert

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/disclosure-checker-production/prometheus.yml
@@ -41,15 +41,6 @@ spec:
       annotations:
         message: Job `{{ $labels.job_name }}` failed to complete.
 
-    - alert: FJ-DC-NamespaceMissing
-      expr: >-
-        absent(kube_namespace_created{namespace=~"^disclosure-checker.*"})
-      for: 1m
-      labels:
-        severity: family-justice
-      annotations:
-        message: Namespace `{{ $labels.namespace }}` is missing.
-
     - alert: FJ-DC-ContainerRestarting
       expr: >-
         rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"^disclosure-checker.*"}[5m]) > 0

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/family-mediators-api-production/prometheus.yml
@@ -41,15 +41,6 @@ spec:
       annotations:
         message: Job `{{ $labels.job_name }}` failed to complete.
 
-    - alert: FJ-FMAPI-NamespaceMissing
-      expr: >-
-        absent(kube_namespace_created{namespace=~"^family-mediators-api.*"})
-      for: 1m
-      labels:
-        severity: family-justice
-      annotations:
-        message: Namespace `{{ $labels.namespace }}` is missing.
-
     - alert: FJ-FMAPI-ContainerRestarting
       expr: >-
         rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"^family-mediators-api.*"}[5m]) > 0

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/prometheus.yml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/fj-cait-production/prometheus.yml
@@ -41,15 +41,6 @@ spec:
       annotations:
         message: Job `{{ $labels.job_name }}` failed to complete.
 
-    - alert: FJ-CAIT-NamespaceMissing
-      expr: >-
-        absent(kube_namespace_created{namespace=~"^fj-cait.*"})
-      for: 1m
-      labels:
-        severity: family-justice
-      annotations:
-        message: Namespace `{{ $labels.namespace }}` is missing.
-
     - alert: FJ-CAIT-ContainerRestarting
       expr: >-
         rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"^fj-cait.*"}[5m]) > 0


### PR DESCRIPTION
We are removing this alert from 3 of our namespaces.

This alert is misleading, and lately has been triggering without apparent reason.