### PR TITLE
PAT-2045 - restrict athena iam policy to the AWS data catalog. 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/athena-iam.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/athena-iam.tf
@@ -75,6 +75,7 @@ data "aws_iam_policy_document" "athena" {
     resources = [
       "${aws_athena_workgroup.queries.arn}",
       "${aws_athena_workgroup.queries.arn}/*",
+      "arn:aws:athena:eu-west-2:*:datacatalog/AwsDataCatalog",
       "arn:aws:glue:eu-west-2:*:catalog",
       "arn:aws:glue:eu-west-2:*:database/${aws_athena_database.database.id}",
       "arn:aws:glue:eu-west-2:*:table/${aws_athena_database.database.id}",


### PR DESCRIPTION
Required to get the database metadata. Any queries against the database are restricted by workgroup. The GetDatabase action returns just the database metadata from the Athena data catalog.