### PR TITLE
LAA-CLA-BACKEND-PRODUCTION Add round function to prometheus rules fix rounding errors

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/07-prometheus-k8.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/07-prometheus-k8.yaml
@@ -52,7 +52,7 @@ spec:
               matched the expected number of replicas for longer than an hour.
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
         - alert: KubePodCrashLooping
-          expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="laa-cla-backend-production"}[10m]) * 60 * 10 > 1
+          expr: round(rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="laa-cla-backend-production"}[10m]) * 60 * 10 > 1)
           for: 5m
           labels:
             severity: laa-get-access


### PR DESCRIPTION
We would get alerts of `KubePodCrashLooping` due to extrapolation done by the rate function in Prometheus. This would give us results like 1.02 which is > 1 and would trigger the alerts.

The round function will fix this issue and ensure we deal with restarts as integer values.