### PR TITLE
LAA-CLA-BACKEND-TRAINING Amend query so it rounds before the boolean (> 1) check

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/07-prometheus-k8.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/07-prometheus-k8.yaml
@@ -52,7 +52,7 @@ spec:
               matched the expected number of replicas for longer than an hour.
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
         - alert: KubePodCrashLooping
-          expr: round(rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="laa-cla-backend-training"}[10m]) * 60 * 10 > 1)
+          expr: round(rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="laa-cla-backend-training"}[10m]) * 60 * 10) > 1
           for: 5m
           labels:
             severity: laa-get-access


### PR DESCRIPTION
Previously the round function was being applied too late. 

It was being applied after we had checked if the avg no. of restarts is > 1. At this point, the round function basically isn't doing anything since the calculation/> 1 check is already done