### PR TITLE
Update github-repo.tf to remove branch protection

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/workforce-management/resources/github-repo.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/workforce-management/resources/github-repo.tf
@@ -40,13 +40,6 @@ resource "github_repository" "prototype" {
   }
 }
 
-resource "github_branch_protection" "default" {
-  repository_id          = github_repository.prototype.id
-  pattern                = "main"
-  enforce_admins         = true
-  require_signed_commits = true
-}
-
 resource "github_team_repository" "prototype" {
   for_each   = local.teams
   team_id    = each.value.id


### PR DESCRIPTION
Thanks, but we don't need branch protection for a prototyping repo