### PR TITLE
increased visibility timeout to 120 seconds to avoid the message 

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
@@ -1,14 +1,14 @@
 module "create_link_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
-  environment-name          = var.environment_name
-  team_name                 = var.team_name
-  infrastructure-support    = var.infrastructure_support
-  application               = var.application
-  sqs_name                  = "create-link-queue"
-  encrypt_sqs_kms           = var.encrypt_sqs_kms
-  message_retention_seconds = var.message_retention_seconds
-  namespace                 = var.namespace
+  environment-name           = var.environment_name
+  team_name                  = var.team_name
+  infrastructure-support     = var.infrastructure_support
+  application                = var.application
+  sqs_name                   = "create-link-queue"
+  encrypt_sqs_kms            = var.encrypt_sqs_kms
+  message_retention_seconds  = var.message_retention_seconds
+  namespace                  = var.namespace
   visibility_timeout_seconds = var.visibility_timeout_seconds
 
   redrive_policy = <<EOF
@@ -76,15 +76,15 @@ module "create_link_queue_dead_letter_queue" {
 module "unlink_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
-  environment-name          = var.environment_name
-  team_name                 = var.team_name
-  infrastructure-support    = var.infrastructure_support
-  application               = var.application
-  sqs_name                  = "unlink-queue"
-  existing_user_name        = module.create_link_queue.user_name
-  encrypt_sqs_kms           = var.encrypt_sqs_kms
-  message_retention_seconds = var.message_retention_seconds
-  namespace                 = var.namespace
+  environment-name           = var.environment_name
+  team_name                  = var.team_name
+  infrastructure-support     = var.infrastructure_support
+  application                = var.application
+  sqs_name                   = "unlink-queue"
+  existing_user_name         = module.create_link_queue.user_name
+  encrypt_sqs_kms            = var.encrypt_sqs_kms
+  message_retention_seconds  = var.message_retention_seconds
+  namespace                  = var.namespace
   visibility_timeout_seconds = var.visibility_timeout_seconds
 
   redrive_policy = <<EOF
@@ -150,15 +150,15 @@ module "unlink_queue_dead_letter_queue" {
 module "hearing_resulted_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.3"
 
-  environment-name          = var.environment_name
-  team_name                 = var.team_name
-  infrastructure-support    = var.infrastructure_support
-  application               = var.application
-  sqs_name                  = "hearing-resulted-queue"
-  existing_user_name        = module.create_link_queue.user_name
-  encrypt_sqs_kms           = var.encrypt_sqs_kms
-  message_retention_seconds = var.message_retention_seconds
-  namespace                 = var.namespace
+  environment-name           = var.environment_name
+  team_name                  = var.team_name
+  infrastructure-support     = var.infrastructure_support
+  application                = var.application
+  sqs_name                   = "hearing-resulted-queue"
+  existing_user_name         = module.create_link_queue.user_name
+  encrypt_sqs_kms            = var.encrypt_sqs_kms
+  message_retention_seconds  = var.message_retention_seconds
+  namespace                  = var.namespace
   visibility_timeout_seconds = var.visibility_timeout_seconds
 
   redrive_policy = <<EOF

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
@@ -9,6 +9,7 @@ module "create_link_queue" {
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
   namespace                 = var.namespace
+  visibility_timeout_seconds = var.visibility_timeout_seconds
 
   redrive_policy = <<EOF
   {
@@ -84,6 +85,7 @@ module "unlink_queue" {
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
   namespace                 = var.namespace
+  visibility_timeout_seconds = var.visibility_timeout_seconds
 
   redrive_policy = <<EOF
   {
@@ -157,6 +159,7 @@ module "hearing_resulted_queue" {
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
   namespace                 = var.namespace
+  visibility_timeout_seconds = var.visibility_timeout_seconds
 
   redrive_policy = <<EOF
   {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/variables.tf
@@ -45,3 +45,7 @@ variable "message_retention_seconds" {
 variable "domain" {
   default = "court-data-adaptor.service.justice.gov.uk"
 }
+variable "visibility_timeout_seconds" {
+  description = "Sets the length of time (seconds) that a message received from a queue will not be visible to the other message consumers."
+  default     = "120"
+}


### PR DESCRIPTION
Increased the visibility timeout for the 3 SQS. This is to avoid message duplications so that consumers don't pick the same message if this is being processed. 

more information on the user story:  https://dsdmoj.atlassian.net/browse/LASB-640 