### PR TITLE
Integration ID for Pingdom in CCCD (staging)

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/resources/pingdom.tf
@@ -15,6 +15,6 @@ resource "pingdom_check" "claim-crown-court-defence-staging" {
   port                     = 443
   tags                     = "businessunit_${var.business-unit},application_${var.application},component_ping,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_${var.application}"
   probefilters             = "region:EU"
-  integrationids           = [94703]
+  integrationids           = [116115]
 }
 


### PR DESCRIPTION
CCCD alerts need to be sent to the channel laa-cccd-alerts in Slack. The
relevant integration ID has been set here:

  ministryofjustice/cloud-platform#3136