### PR TITLE
Prisoner content hub - Add ListBucketVersions permission - dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/resources/s3-messaging.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/poornima-staging/resources/s3-messaging.tf
@@ -17,10 +17,11 @@ module "cp_test_s3_bucket" {
 }
 
 module "cp_test_s3_object_created_topic" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=add-test"
 
   team_name          = var.team_name
   topic_display_name = "cp-test-s3-object-created-topic"
+  encrypt_sns_kms    = true
 
   providers = {
     aws = aws.london

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -50,6 +50,16 @@ module "drupal_content_storage" {
         "arn:aws:s3:::cloud-platform-c3b3fc90408e8f9501268e354d44f461/*",
         "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b/*"
       ]
+    },
+    {
+      "Sid": "AllowListBucketVersions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${aws_s3_bucket.bucket.id}"
+      ]
     }
   ]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -58,7 +58,7 @@ module "drupal_content_storage" {
         "s3:ListBucketVersions"
       ],
       "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}"
+        "$${bucket_arn}"
       ]
     }
   ]


### PR DESCRIPTION
We are currently unable to retrieve object versions.  When using the AWS api, the following error is returned:

```
An error occurred (AccessDenied) when calling the ListObjectVersions operation: Access Denied
```

This PR adds in the policy to allow the operation.  

Relevant slack conversation: https://mojdt.slack.com/archives/C57UPMZLY/p1629801520280700