### PR TITLE
Add S3 bucket for LAA-HMRC interface UAT

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/s3.tf
@@ -1,0 +1,48 @@
+module "s3-bucket" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  namespace              = var.namespace
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  acl                    = "private"
+
+  providers = {
+    aws = aws.london
+  }
+
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "retire submission results after 7 days"
+      prefix  = "submission/result"
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+    }
+  ]
+}
+
+resource "kubernetes_secret" "s3-bucket" {
+  metadata {
+    name      = "s3"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_name       = module.s3-bucket.bucket_name
+    access_key_id     = module.s3-bucket.access_key_id
+    bucket_arn        = module.s3-bucket.bucket_arn
+    secret_access_key = module.s3-bucket.secret_access_key
+  }
+}


### PR DESCRIPTION
This will not store real PII so does not need encryption at rest
the production environment will require it, see
[this issue](https://github.com/ministryofjustice/cloud-platform/issues/3150)