### PR TITLE
Prisoner content hub - Add ListBucketVersions permission - staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -71,6 +71,16 @@ EOF
         "$${bucket_arn}/*",
         "arn:aws:s3:::cloud-platform-5e5f7ac99afe21a0181cbf50a850627b/*"
       ]
+    },
+    {
+      "Sid": "AllowListBucketVersions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "$${bucket_arn}"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds in the ListBucketVersions permission to the S3 bucket on staging, allowing us to retrieve deleted files.

This has already been merged to dev and tested there, see: https://github.com/ministryofjustice/cloud-platform-environments/pull/5403