### PR TITLE
Prisoner content hub - Add ListBucketVersions permission - live

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -60,6 +60,16 @@ module "drupal_content_storage" {
         "$${bucket_arn}",
         "$${bucket_arn}/*"
       ]
+    },
+    {
+      "Sid": "AllowListBucketVersions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "$${bucket_arn}"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds in the ListBucketVersions permission to the S3 bucket on staging, allowing us to retrieve deleted files.

This has already been merged to dev and tested there, see: https://github.com/ministryofjustice/cloud-platform-environments/pull/5403