### PR TITLE
Prisoner Content Hub - live - fix build issue with S3

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -60,7 +60,15 @@ module "drupal_content_storage" {
         "$${bucket_arn}",
         "$${bucket_arn}/*"
       ]
-    },
+    }
+  ]
+}
+EOF
+
+  user_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
     {
       "Sid": "AllowListBucketVersions",
       "Effect": "Allow",
@@ -74,6 +82,7 @@ module "drupal_content_storage" {
   ]
 }
 EOF
+
 }
 
 resource "kubernetes_secret" "drupal_content_storage_secret" {


### PR DESCRIPTION
Fix issue with build https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-live-1/builds/32

Related to previous PR: https://github.com/ministryofjustice/cloud-platform-environments/pull/5407

The policy was added as a bucket policy, but it didn't contain the `Principal` field.
This PR moves it to a user (IAM) policy, which keeps it inline with [dev](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf) and [staging](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf) versions.