### PR TITLE
Prisoner content hub - live - Adding GetObjectVersion permission

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -78,6 +78,16 @@ EOF
       "Resource": [
         "$${bucket_arn}"
       ]
+    },
+    {
+      "Sid": "AllowGetObjectVersion",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObjectVersion"
+      ],
+      "Resource": [
+        "$${bucket_arn}/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds `GetObjectVersion` to the prisoner content hub live S3 service.
This is required so that we can retrieve deleted files.

This relates to previous PR's: https://github.com/ministryofjustice/cloud-platform-environments/pull/5418 and https://github.com/ministryofjustice/cloud-platform-environments/pull/5407
Both of which have been deployed to live.

After testing the above changes, I ran into the following issue:
```
An error occurred (AccessDenied) when calling the GetObject operation: Access Denied
```

This isn't an issue on dev or staging, due to existing permissions `s3:*`.  See https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf#L64-L74
Rather than adding this broad permission to live, we just need to add the specific `GetObjectVersion` permission.