### PR TITLE
Prisoner content hub s3 live revert permissions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -60,16 +60,6 @@ module "drupal_content_storage" {
         "$${bucket_arn}",
         "$${bucket_arn}/*"
       ]
-    },
-    {
-      "Sid": "AllowListBucketVersions",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucketVersions"
-      ],
-      "Resource": [
-        "$${bucket_arn}"
-      ]
     }
   ]
 }


### PR DESCRIPTION
Reverting previous change to fix issue with S3 permissions on live.

https://github.com/ministryofjustice/cloud-platform-environments/pull/5418

This added in a new user policy, we have found this has caused an issue where it has overwritten a previous user policy.  Resulting in broken images on the live site.
