### PR TITLE
Adding ListBucketVersions to bucket policy - prisoner content hub - production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -60,6 +60,19 @@ module "drupal_content_storage" {
         "$${bucket_arn}",
         "$${bucket_arn}/*"
       ]
+    },
+    {
+      "Sid": "AllowListBucketVersions",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-5e5f7ac99afe21a0181cbf50a850627b"
+      },
+      "Action": [
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "$${bucket_arn}"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds the `ListBucketVersions` permission to the production S3 bucket.

This was previously added as user policy.  But was reverted (https://github.com/ministryofjustice/cloud-platform-environments/pull/5420) after we discovered setting `user_policy` in our s3.tf was overriding the one set in [main.tf](https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/blob/main/main.tf)

This PR adds back in the permission, but using the `bucket_policy` instead of `user_policy`.  As `bucket_policy` isn't set in main.tf, and is also already being set in this file.  So safe to assume we are not overwriting any permissions set externally with this change.

We have already updated [dev](https://github.com/ministryofjustice/cloud-platform-environments/pull/5423) and [staging](https://github.com/ministryofjustice/cloud-platform-environments/pull/5424) to match this.