### PR TITLE
Remove minor version for postgres RDS module

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
@@ -12,7 +12,7 @@ module "contact-moj_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.5"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "contact_moj_development"
   environment-name           = "development"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cts-prototype-dev-poc/resources/rds.tf
@@ -12,7 +12,7 @@ module "track_a_query_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.5"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_poc"
   environment-name           = "development"


### PR DESCRIPTION
allow_minor_version_upgrade default set to true, the minor version upgrade occurs automatically during the maintenance window.

This is to fix the pipeline failure as a minor version upgrade has already been completed, as a user-specified minor version, the pipeline is trying to downgrade to a specified version.