### PR TITLE
Fix: Remove minor version declaration

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
@@ -12,7 +12,7 @@ module "peoplefinder_rds" {
   is-production              = "false"
   namespace                  = var.namespace
   db_engine                  = "postgres"
-  db_engine_version          = "12.5"
+  db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "peoplefinder_development"
   environment-name           = "development"


### PR DESCRIPTION
This solves the error:

```
Error: Error modifying DB Instance cloud-platform-xxxx: InvalidParameterCombination: Cannot upgrade postgres from 12.7 to 12.5
```

As the [minor version variable](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/blob/main/main.tf#L127) isn't set this will cause an error if Terraform tries to set it to its declared version in this file. You can't downgrade an RDS instance so this causes the above error.