### PR TITLE
Prisoner content hub - enable S3 logging - development

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -9,6 +9,7 @@ module "drupal_content_storage" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
+  logging_enabled        = true
 
   # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
   cors_rule = [


### PR DESCRIPTION
Enabling logging on S3 bucket.

This should fix https://github.com/ministryofjustice/cloud-platform/issues/3126