### PR TITLE
Prisoner content hub - Fix missing S3 config - development

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -10,6 +10,8 @@ module "drupal_content_storage" {
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
   logging_enabled        = true
+  log_target_bucket      = module.drupal_content_storage.bucket_name
+  log_path               = "log/"
 
   # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
   cors_rule = [

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -10,8 +10,9 @@ module "drupal_content_storage" {
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
   logging_enabled        = true
-  log_target_bucket      = module.drupal_content_storage.bucket_name
+  log_target_bucket      = "cloud-platform-8f67b39c6e3bd0e7ca18f73b97b39938"
   log_path               = "log/"
+  acl                    = "log-delivery-write"
 
   # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
   cors_rule = [


### PR DESCRIPTION
Adding additional configuration required to enable logging.

This fixes issue introduced by previous PR: https://github.com/ministryofjustice/cloud-platform-environments/pull/5471