### PR TITLE
Prisoner content hub - Enable S3 logging - staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -9,6 +9,10 @@ module "drupal_content_storage" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
   namespace              = var.namespace
+  logging_enabled        = true
+  log_target_bucket      = "cloud-platform-c3b3fc90408e8f9501268e354d44f461"
+  log_path               = "log/staging/"
+  acl                    = "log-delivery-write"
 
   # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
   cors_rule = [


### PR DESCRIPTION
This will allow us to investigate the file deletion issue:
https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue
and https://github.com/ministryofjustice/cloud-platform/issues/3126

Note that we should remove this and clear out the logs as soon as it is no longer required.