### PR TITLE
Add GitHub Action check for ingress annotation

### DIFF
--- a/.github/workflows/check-ingress-annotation.yml
+++ b/.github/workflows/check-ingress-annotation.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Does live-1 namespace have ingress weighting
         id: review_pr
-        uses: ministryofjustice/cloud-platform-environments/cmd/check-ingress@add-ingress-gh-action
+        uses: ministryofjustice/cloud-platform-environments/cmd/check-ingress@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-ingress-annotation.yml
+++ b/.github/workflows/check-ingress-annotation.yml
@@ -1,0 +1,41 @@
+# description: |
+#               This GitHub Action will check the ingress resources in a live-1 namespace
+#               and fail if an ingress resource doesn't have the required weighting annotations.
+name: Check ingress weighting annotation
+
+on:
+  pull_request:
+    paths:
+      - 'namespaces/live.cloud-platform.service.justice.gov.uk/**'
+
+env:
+  # GITHUB_OAUTH_TOKEN created manually by the cloud-platform-bot-user in last pass.
+  GITHUB_OAUTH_TOKEN: ${{ secrets.CHECK_GITHUB_TEAM }}
+
+jobs:
+  check-ingress-weighting:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@master
+
+      - name: Does live-1 namespace have ingress weighting
+        id: review_pr
+        uses: ministryofjustice/cloud-platform-environments/cmd/check-ingress@add-ingress-gh-action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # If the user isn't permitted to make the change, write a comment in the issue.
+      - name: Create comment in the PR
+        uses: peter-evans/create-or-update-comment@v1
+
+        if: failure()
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            The namespace in this PR contains a live-1 ingress resource that doesn't have the correct weighting annotation.

--- a/cmd/check-ingress/Dockerfile
+++ b/cmd/check-ingress/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.17
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+RUN go build .
+
+CMD ["check-ingress"]

--- a/cmd/check-ingress/check-ingress.go
+++ b/cmd/check-ingress/check-ingress.go
@@ -36,7 +36,7 @@ func main() {
 	for _, ingress := range data.WeightingIngress {
 		for _, namespace := range namespaces {
 			if ingress.Namespace == namespace {
-				log.Fatalln("Namespace:", namespace, "doesn't have the correct ingress annotation.")
+				log.Fatalln("Namespace:", namespace+"/"+ingress.Resource, "doesn't have the correct ingress annotation.")
 			}
 		}
 	}

--- a/cmd/check-ingress/check-ingress.go
+++ b/cmd/check-ingress/check-ingress.go
@@ -21,7 +21,7 @@ func main() {
 	flag.Parse()
 
 	// Get list of namespaces to check from a pull request.
-	namespaces, err := namespace.ChangedInPR(branch, token, repo, org)
+	namespaces, err := namespace.ChangedInPR(*branch, *token, *repo, *org)
 	if err != nil {
 		log.Fatalln("Error getting files changed in PR:", err)
 	}

--- a/cmd/check-ingress/check-ingress.go
+++ b/cmd/check-ingress/check-ingress.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+type IngressReport struct {
+	WeightingIngress []struct {
+		Namespace string
+	} `json:"weighting_ingress"`
+}
+
+var (
+	nsToCompare = flag.String("namespace", "", "The namespace name of the service to check.")
+	host        = flag.String("host", "https://reports.cloud-platform.service.justice.gov.uk/ingress_weighting", "hostname of hoodaw.")
+)
+
+func main() {
+	flag.Parse()
+
+	// Grab all namespaces that don't have the required annotation.
+	namespaces, err := checkAnnotation(host)
+	if err != nil {
+		log.Fatalln("Error checking hoodaw:", err)
+	}
+
+	// If the namespace passed as an argument is found in our datatype, fail.
+	for _, ingress := range namespaces.WeightingIngress {
+		if ingress.Namespace == *nsToCompare {
+			log.Println("Found: This namespace doesn't have the correct annotation.")
+		}
+	}
+}
+
+// checkAnnotation takes a http endpoint and generates an IngressReport
+// data type. IngressReport contains a collection of namespaces that contain
+// an ingress resource that don't have the required annoation.
+func checkAnnotation(host *string) (*IngressReport, error) {
+	client := &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest("GET", *host, nil)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	req.Header.Add("User-Agent", "ingress-annotation-check")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaces := &IngressReport{}
+
+	err = json.Unmarshal(body, &namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	return namespaces, nil
+}

--- a/cmd/check-ingress/check-ingress_test.go
+++ b/cmd/check-ingress/check-ingress_test.go
@@ -13,9 +13,8 @@ func Test_checkAnnotation(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		args args
-		// want    *IngressReport
+		name    string
+		args    args
 		wantErr bool
 	}{
 		{

--- a/cmd/check-ingress/check-ingress_test.go
+++ b/cmd/check-ingress/check-ingress_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test_checkAnnotation(t *testing.T) {
+	goodHost := "https://reports.cloud-platform.service.justice.gov.uk/ingress_weighting"
+	badHost := "obviouslyFakeName"
+
+	type args struct {
+		host *string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		// want    *IngressReport
+		wantErr bool
+	}{
+		{
+			name: "GET valid json data",
+			args: args{
+				host: &goodHost,
+			},
+			wantErr: false,
+		},
+		{
+			name: "GET invalid json data",
+			args: args{
+				host: &badHost,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := checkAnnotation(tt.args.host)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/cmd/check-ingress/go.mod
+++ b/cmd/check-ingress/go.mod
@@ -1,0 +1,5 @@
+module github.com/ministryofjustice/cloud-platform-environments/cmd/check-ingress
+
+go 1.17
+
+require github.com/google/go-cmp v0.5.6

--- a/cmd/check-ingress/go.sum
+++ b/cmd/check-ingress/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/ingress/go.mod
+++ b/pkg/ingress/go.mod
@@ -1,0 +1,3 @@
+module github.com/ministryofjustice/cloud-platform-environments/pkg/ingress
+
+go 1.17

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -13,6 +13,7 @@ import (
 type IngressReport struct {
 	WeightingIngress []struct {
 		Namespace string
+		Resource  string
 	} `json:"weighting_ingress"`
 }
 

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -1,0 +1,57 @@
+package ingress
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+// IngressReport allows us to unmarshal the json from the Hoodaw page into
+// a data type.
+type IngressReport struct {
+	WeightingIngress []struct {
+		Namespace string
+	} `json:"weighting_ingress"`
+}
+
+// CheckAnnotation takes a http endpoint and generates an IngressReport
+// data type. IngressReport contains a collection of namespaces that contain
+// an ingress resource that don't have the required annoation.
+func CheckAnnotation(host *string) (*IngressReport, error) {
+	client := &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest("GET", *host, nil)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	req.Header.Add("User-Agent", "ingress-annotation-check")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaces := &IngressReport{}
+
+	err = json.Unmarshal(body, &namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	return namespaces, nil
+}

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -1,10 +1,10 @@
-package main
+package ingress
 
 import (
 	"testing"
 )
 
-func Test_checkAnnotation(t *testing.T) {
+func Test_CheckAnnotation(t *testing.T) {
 	goodHost := "https://reports.cloud-platform.service.justice.gov.uk/ingress_weighting"
 	badHost := "obviouslyFakeName"
 
@@ -34,9 +34,9 @@ func Test_checkAnnotation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := checkAnnotation(tt.args.host)
+			_, err := CheckAnnotation(tt.args.host)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("checkAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("CheckAnnotation() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})


### PR DESCRIPTION
Overview
---

This PR connects https://github.com/ministryofjustice/cloud-platform/issues/3074 and relates to the requirement to check the required ingress annotation the in live-1 cluster.

What's in this PR?
---

This PR contains the following:
- An ingress package that generates a json list of namespaces that doesn't contain an ingress annotation.
- A GitHub Action that will perform the check and comment on a PR if it fails.
- A `cmd` directory and `check-ingress` command that performs the check if live-1 annotation is set. If not, it'll fail.
- A Dockerfile to allow the GitHub Action to pull it execute the ingress check.