### PR TITLE
Migrate ref app github action to live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloud-platform-reference-app-github-action
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "cloud-platform"
+    cloud-platform.justice.gov.uk/application: "cloud-platform"
+    cloud-platform.justice.gov.uk/owner: "cloud-platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-reference-app-github-action"
+    cloud-platform.justice.gov.uk/team-name: "webops"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-platform-reference-app-github-action-admin
+  namespace: cloud-platform-reference-app-github-action
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: cloud-platform-reference-app-github-action
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: cloud-platform-reference-app-github-action
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: cloud-platform-reference-app-github-action
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: cloud-platform-reference-app-github-action
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/ecr.tf
@@ -1,0 +1,26 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.5"
+
+  team_name    = var.team_name
+  repo_name    = "${var.namespace}-ecr"
+  scan_on_push = "false"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  github_repositories = ["cloud-platform-reference-app-github-action"]
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
+    repo_arn          = module.ecr-repo.repo_arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/serviceaccount.tf
@@ -1,0 +1,8 @@
+module "serviceaccount" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.5"
+  namespace = var.namespace
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["cloud-platform-reference-app-github-action"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/variables.tf
@@ -1,0 +1,52 @@
+
+variable "cluster_name" {
+}
+
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "cloud-platform"
+}
+
+variable "namespace" {
+  default = "cloud-platform-reference-app-github-action"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "webops"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "platforms@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "cloud-platform"
+}
+
+variable "github_owner" {
+  description = "Required by the github terraform provider"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the github terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}


### PR DESCRIPTION
Add skip for ref app github action namespace in live-1, this is to avoid conflict of github service account