### PR TITLE
Prisoner content hub - disable logging - production

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -13,14 +13,6 @@ module "drupal_content_storage" {
   # so if this isn't set we get a 301 error when it tries to rebuild it
   namespace = var.namespace
 
-  # Enable S3 logging to investigate issue with missing files.
-  # See: https://trello.com/c/ZVSfPcz6/89-fix-the-mysterious-missing-file-issue
-  # TODO: Remove this and clear out logs as soon as it's no longer required.
-  logging_enabled   = true
-  log_target_bucket = "cloud-platform-5e5f7ac99afe21a0181cbf50a850627b"
-  log_path          = "log/production/"
-  acl               = "log-delivery-write"
-
   # Add CORS rule to allow direct s3 file uploading with progress bar (in Drupal CMS).
   cors_rule = [
     {


### PR DESCRIPTION
This reverts changes from https://github.com/ministryofjustice/cloud-platform-environments/pull/5497

Logging is no longer required and should be disabled to avoid taking up unnecessary storage space on S3.