### PR TITLE
Inject pre-prod DB credentials for refresh process

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds.tf
@@ -33,3 +33,22 @@ resource "kubernetes_secret" "hmpps_interventions_rds" {
     url                   = "postgres://${module.hmpps_interventions_rds.database_username}:${module.hmpps_interventions_rds.database_password}@${module.hmpps_interventions_rds.rds_instance_endpoint}/${module.hmpps_interventions_rds.database_name}"
   }
 }
+
+# Inject pre-prod DB credentials for refresh job running on production
+resource "kubernetes_secret" "hmpps_interventions_refresh_secret" {
+  metadata {
+    name      = "postgres-preprod"
+    namespace = "hmpps-interventions-prod"
+  }
+
+  data = {
+    rds_instance_endpoint = module.hmpps_interventions_rds.rds_instance_endpoint
+    database_name         = module.hmpps_interventions_rds.database_name
+    database_username     = module.hmpps_interventions_rds.database_username
+    database_password     = module.hmpps_interventions_rds.database_password
+    rds_instance_address  = module.hmpps_interventions_rds.rds_instance_address
+    access_key_id         = module.hmpps_interventions_rds.access_key_id
+    secret_access_key     = module.hmpps_interventions_rds.secret_access_key
+    url                   = "postgres://${module.hmpps_interventions_rds.database_username}:${module.hmpps_interventions_rds.database_password}@${module.hmpps_interventions_rds.rds_instance_endpoint}/${module.hmpps_interventions_rds.database_name}"
+  }
+}


### PR DESCRIPTION
Then a cronjob will take both the production and pre-production
credentials and pg_dump/pg_restore

Replaces a custom script in https://github.com/ministryofjustice/hmpps-interventions-ops/commit/4803fcd01bf77748d3659860057d06d2da293409