### PR TITLE
Add `GetAllNamespaces` function to `namespace` package

### DIFF
--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -3,13 +3,70 @@ package namespace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ministryofjustice/cloud-platform-environments/pkg/authenticate"
 )
+
+// HoodawReport contains the json to go struct of the hosted_services endpoint.
+type HoodawReport struct {
+	NamespaceDetails []struct {
+		Namespace        string        `json:"namespace"`
+		Application      string        `json:"application"`
+		BusinessUnit     string        `json:"business_unit"`
+		TeamName         string        `json:"team_name"`
+		TeamSlackChannel string        `json:"team_slack_channel"`
+		GithubURL        string        `json:"github_url"`
+		DeploymentType   string        `json:"deployment_type"`
+		DomainNames      []interface{} `json:"domain_names"`
+	} `json:"namespace_details"`
+}
+
+// GetAllNamespaces takes the host endpoint for the how-out-of-date-are-we and
+// returns a report of namespace details in the cluster.
+func GetAllNamespaces(host *string) (*HoodawReport, error) {
+	client := &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest("GET", *host, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("User-Agent", "environments-namespace-pkg")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaces := &HoodawReport{}
+
+	err = json.Unmarshal(body, &namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	return namespaces, nil
+}
 
 // ChangedInPR takes a GitHub branch reference (usually provided by a GitHub Action), a
 // personal access token with Read org permissions, the name of a repository and the owner.

--- a/pkg/namespace/namespace_test.go
+++ b/pkg/namespace/namespace_test.go
@@ -44,3 +44,41 @@ func TestChangedInPR(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAllNamespaces(t *testing.T) {
+	badHost := "https://obviouslyFakeURL/hosted_services"
+	goodHost := "https://reports.cloud-platform.service.justice.gov.uk/hosted_services"
+
+	type args struct {
+		host *string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Pass faulty hostname",
+			args: args{
+				host: &badHost,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Pass correct hostname",
+			args: args{
+				host: &goodHost,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetAllNamespaces(tt.args.host)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAllNamespaces() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
By calling and passing the hoodaw host name to this function we can
return a listed of all namespaces in a cluster. In fact not just
namespaces, but namespace details and specifics that are outlined in our
https://reports.cloud-platform.service.justice.gov.uk/hosted_services
page.

To call this package you simply:

```go
import
github.com/ministryofjustice/cloud-platform-environments/pkg/namespace

host :=
"https://reports.cloud-platform.service.justice.gov.uk/hosted_services"

allNamespaces, err := namespace.GetAllNamespaces(&host)

```

That will return you the report, to which you can do things like:

```go
for _, namespace := range allNamespaces {
	fmt.Println(namespace.TeamName)
}
```