### PR TITLE
Add (slack) integration ID's for PPUD pingdom checks.

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/pingdom.tf
@@ -11,4 +11,5 @@ resource "pingdom_check" "manage-recalls" {
   port                     = 443
   tags                     = "hmpps,ppud-replacement,manage-recalls,dev,isproduction_false,cloudplatform-managed"
   probefilters             = "region:EU"
+  integrationids           = [116726]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/pingdom.tf
@@ -11,4 +11,5 @@ resource "pingdom_check" "manage-recalls" {
   port                     = 443
   tags                     = "hmpps,ppud-replacement,manage-recalls,preprod,isproduction_false,cloudplatform-managed"
   probefilters             = "region:EU"
+  integrationids           = [116726]
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/pingdom.tf
@@ -11,4 +11,5 @@ resource "pingdom_check" "manage-recalls" {
   port                     = 443
   tags                     = "hmpps,ppud-replacement,manage-recalls,prod,isproduction_true,cloudplatform-managed"
   probefilters             = "region:EU"
+  # integrationids           = [116724] # NOTE: disabled for now to prevent false alerts - we're not deployed in PROD yet.
 }


### PR DESCRIPTION
NOTE: PROD is currently commented out to stop alert noise - we've not
deployed the application(s) to PROD yet, so the pingdom check is
currently red.