### PR TITLE
Enable skip namespaces for apply-namespace-changes

### DIFF
--- a/bin/apply-namespace-changes
+++ b/bin/apply-namespace-changes
@@ -11,7 +11,7 @@ def main(cluster)
     CpEnv::NamespaceDir.new(
       cluster: cluster,
       dir: dir,
-      enable_skip_namespaces: false, # Ignore APPLY_PIPELINE_SKIP_THIS_NAMESPACE files
+      enable_skip_namespaces: true, # Ignore APPLY_PIPELINE_SKIP_THIS_NAMESPACE files
     ).apply
   end
 


### PR DESCRIPTION
This is to skip "apply-namespace-changes" pipeline, when "APPLY_PIPELINE_SKIP_THIS_NAMESPACE" file is added.
As part of migrating LIVE-1 to LIVE cluster, this skip is needed to apply for both "apply" and "apply-namespace-changes" pipelines