### PR TITLE
Update ingress with external-dns annotation

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/ingress.yaml
@@ -3,6 +3,10 @@ kind: Ingress
 metadata:
   name: how-out-of-date-are-we-app-ingress
   namespace: how-out-of-date-are-we
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/set-identifier: how-out-of-date-are-we-app-ingress-how-out-of-date-are-we-blue
 spec:
   tls:
   - hosts:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/99-redirect_old_url_ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/licences-prod/99-redirect_old_url_ingress.yaml
@@ -5,6 +5,8 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
     nginx.ingress.kubernetes.io/rewrite-target: https://licences.prison.service.justice.gov.uk/$1
+    external-dns.alpha.kubernetes.io/set-identifier: licences-redirect-old-url-licences-prod-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
   labels:
     app: licences
   name: licences-redirect-old-url

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/ingress.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/maintenance-pages/ingress.yaml
@@ -3,6 +3,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: domains-ingress
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: domains-ingress-maintenance-pages-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/05-hello-world-stack.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/mogaal-test/05-hello-world-stack.yaml
@@ -37,7 +37,7 @@ kind: Ingress
 metadata:
   name: hello-wold
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: mogaal-test-live-1
+    external-dns.alpha.kubernetes.io/set-identifier: hello-wold-mogaal-test-blue
     external-dns.alpha.kubernetes.io/aws-weight: "50"
 spec:
   tls:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/kibana-dsd-oauth2-proxy.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/kibana-dsd-oauth2-proxy.yaml
@@ -99,6 +99,9 @@ metadata:
     release: kibana-dsd-proxy
   name: kibana-dsd-proxy-oauth2-proxy
   namespace: monitoring
+  annotations:
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: kibana-dsd-proxy-oauth2-proxy-monitoring-blue
 spec:
   tls:
   - hosts:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/ingress.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/how-out-of-date-are-we/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    external-dns.alpha.kubernetes.io/set-identifier: dns-hoodaw
+    external-dns.alpha.kubernetes.io/set-identifier: how-out-of-date-are-we-app-ingress-how-out-of-date-are-we-green
 spec:
   tls:
   - hosts:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/05-hello-world-stack.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mogaal-test/05-hello-world-stack.yaml
@@ -37,7 +37,7 @@ kind: Ingress
 metadata:
   name: hello-wold
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: mogaal-test-live
+    external-dns.alpha.kubernetes.io/set-identifier: hello-wold-mogaal-test-green
     external-dns.alpha.kubernetes.io/aws-weight: "50"
 spec:
   tls:


### PR DESCRIPTION
Now we have OPA policy to block ingress without this annotation.