### PR TITLE
Use hoodaw package to query the reports API

### DIFF
--- a/cmd/check-ingress/check-ingress.go
+++ b/cmd/check-ingress/check-ingress.go
@@ -10,11 +10,11 @@ import (
 )
 
 var (
-	branch = flag.String("branch", os.Getenv("GITHUB_REF"), "GitHub branch reference.")
-	host   = flag.String("host", "https://reports.cloud-platform.service.justice.gov.uk/ingress_weighting", "hostname of hoodaw.")
-	org    = flag.String("org", "ministryofjustice", "GitHub user or organisation.")
-	repo   = flag.String("repo", "cloud-platform-environments", "Repository to check the PR of.")
-	token  = flag.String("token", os.Getenv("GITHUB_OAUTH_TOKEN"), "Personal access token for GitHub API.")
+	branch   = flag.String("branch", os.Getenv("GITHUB_REF"), "GitHub branch reference.")
+	endpoint = flag.String("endpoint", "ingress_weighting", "Endpoint of hoodaw.")
+	org      = flag.String("org", "ministryofjustice", "GitHub user or organisation.")
+	repo     = flag.String("repo", "cloud-platform-environments", "Repository to check the PR of.")
+	token    = flag.String("token", os.Getenv("GITHUB_OAUTH_TOKEN"), "Personal access token for GitHub API.")
 )
 
 func main() {
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	// Get a list of namespaces in live-1 that don't have an annotation
-	data, err := ingress.CheckAnnotation(host)
+	data, err := ingress.CheckAnnotation(endpoint)
 	if err != nil {
 		log.Fatalln("Error checking hoodaw API:", err)
 	}

--- a/pkg/ingress/document.go
+++ b/pkg/ingress/document.go
@@ -1,0 +1,6 @@
+/*
+Package ingress implements a library for MoJ Cloud Platform ingress resources.
+
+An ingress resource is just a Kubernetes ingress with annotations specific to the Cloud Platform.
+*/
+package ingress // import "github.com/ministryofjustice/cloud-platform-environments/pkg/ingress"

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -2,10 +2,8 @@ package ingress
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"time"
+
+	"github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/reports/pkg/hoodaw"
 )
 
 // IngressReport allows us to unmarshal the json from the Hoodaw page into
@@ -20,29 +18,8 @@ type IngressReport struct {
 // CheckAnnotation takes a http endpoint and generates an IngressReport
 // data type. IngressReport contains a collection of namespaces that contain
 // an ingress resource that don't have the required annoation.
-func CheckAnnotation(host *string) (*IngressReport, error) {
-	client := &http.Client{
-		Timeout: time.Second * 2,
-	}
-
-	req, err := http.NewRequest("GET", *host, nil)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	req.Header.Add("User-Agent", "ingress-annotation-check")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
+func CheckAnnotation(endPoint string) (*IngressReport, error) {
+	body, err := hoodaw.QueryApi(endPoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -4,37 +4,33 @@ import (
 	"testing"
 )
 
-func Test_CheckAnnotation(t *testing.T) {
-	goodHost := "https://reports.cloud-platform.service.justice.gov.uk/ingress_weighting"
-	badHost := "obviouslyFakeName"
-
+func TestCheckAnnotation(t *testing.T) {
 	type args struct {
-		host *string
+		endPoint string
 	}
-
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
 		{
-			name: "GET valid json data",
+			name: "Fetch all annotations",
 			args: args{
-				host: &goodHost,
+				endPoint: "ingress_weighting",
 			},
 			wantErr: false,
 		},
 		{
-			name: "GET invalid json data",
+			name: "Fail to check annotations",
 			args: args{
-				host: &badHost,
+				endPoint: "%",
 			},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := CheckAnnotation(tt.args.host)
+			_, err := CheckAnnotation(tt.args.endPoint)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CheckAnnotation() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Overview
---

This PR removes a large part of the `CheckAnnotation` function and replaces it with the shared `hoodaw` package call, passing the endpoint instead of the whole host path.

By doing this, it means we have to change the checkIngress command to pass the endpoint and refactor the tests.