### PR TITLE
Increase the default CPU/RAM limits in ppud-replacement-dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 1000Mi
+      cpu: 2000m
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
This is due to clamav having issues starting up.