### PR TITLE
Changes needed to run clamav in higher tiers

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 1000Mi
+      cpu: 2000m
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/05-serviceaccount-circleci.yaml
@@ -17,35 +17,5 @@ subjects:
     namespace: ppud-replacement-preprod
 roleRef:
   kind: ClusterRole
-  name: edit
-  apiGroup: rbac.authorization.k8s.io
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: circleci
-  namespace: ppud-replacement-preprod
-rules:
-  - apiGroups:
-      - "monitoring.coreos.com"
-    resources:
-      - "prometheusrules"
-      - "servicemonitors"
-    verbs:
-      - "*"
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: circleci-prometheus
-  namespace: ppud-replacement-preprod
-subjects:
-  - kind: ServiceAccount
-    name: circleci
-    namespace: ppud-replacement-preprod
-roleRef:
-  kind: Role
-  name: circleci
+  name: admin
   apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/02-limitrange.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 1000Mi
+      cpu: 2000m
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/05-serviceaccount-circleci.yaml
@@ -17,35 +17,5 @@ subjects:
     namespace: ppud-replacement-prod
 roleRef:
   kind: ClusterRole
-  name: edit
-  apiGroup: rbac.authorization.k8s.io
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: circleci
-  namespace: ppud-replacement-prod
-rules:
-  - apiGroups:
-      - "monitoring.coreos.com"
-    resources:
-      - "prometheusrules"
-      - "servicemonitors"
-    verbs:
-      - "*"
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: circleci-prometheus
-  namespace: ppud-replacement-prod
-subjects:
-  - kind: ServiceAccount
-    name: circleci
-    namespace: ppud-replacement-prod
-roleRef:
-  kind: Role
-  name: circleci
+  name: admin
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This pushes the changes made in order to run the clamav helm chart in
the `ppud-replacement-dev` namespace forward to the `preprod` and `prod`
tiers.