### PR TITLE
Prisoner content hub - fix unsupported elasticache node_type - dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
@@ -11,7 +11,7 @@ module "drupal_redis" {
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
   number_cache_clusters  = var.number_cache_clusters
-  node_type              = "cache.m3.medium"
+  node_type              = "cache.t3.small"
   engine_version         = "5.0.6"
   parameter_group_name   = "default.redis5.0"
   namespace              = var.namespace


### PR DESCRIPTION
This fixes build issue https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-namespace-changes-live-1/builds/245

Introduced by https://github.com/ministryofjustice/cloud-platform-environments/pull/5687