### PR TITLE
Prisoner content hub - elasticache remove cluster support - dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
@@ -10,7 +10,6 @@ module "drupal_redis" {
   is-production          = var.is-production
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
-  number_cache_clusters  = var.number_cache_clusters
   node_type              = "cache.t3.small"
   engine_version         = "5.0.6"
   parameter_group_name   = "default.redis5.0"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
@@ -41,8 +41,3 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
-
-variable "number_cache_clusters" {
-  default = "2"
-}
-


### PR DESCRIPTION
This PR removes cluster support from elasticache (by removing the `number_cache_clusters` setting, cluster support should then be disabled).

As cluster support is not yet supported by Drupal. See https://www.drupal.org/project/redis/issues/2900947