### PR TITLE
Prisoner content hub - elasticache set clusters to 1 - dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
@@ -10,6 +10,7 @@ module "drupal_redis" {
   is-production          = var.is-production
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
   node_type              = "cache.t3.small"
   engine_version         = "5.0.6"
   parameter_group_name   = "default.redis5.0"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
@@ -41,3 +41,8 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
+
+variable "number_cache_clusters" {
+  default = "2"
+}
+

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
@@ -43,6 +43,6 @@ variable "is-production" {
 }
 
 variable "number_cache_clusters" {
-  default = "2"
+  default = "1"
 }
 


### PR DESCRIPTION
This reverts https://github.com/ministryofjustice/cloud-platform-environments/pull/5708 and explicitly sets number of clusters to 1, to override the setting of 2 from https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/blob/main/variables.tf and therefore disabling cluster mode.