### PR TITLE
Prisoner content hub - elasticache set cluster back to 2 - dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/variables.tf
@@ -43,6 +43,6 @@ variable "is-production" {
 }
 
 variable "number_cache_clusters" {
-  default = "1"
+  default = "2"
 }
 


### PR DESCRIPTION
This fixes issue in build: 
```module.drupal_redis.aws_elasticache_replication_group.ec_redis: Creating...

Error: Error creating ElastiCache Replication Group (cp-66508e899082f511): InvalidParameterCombination: When using automatic failover, there must be at least 2 cache clusters in the replication group.
        status code: 400, request id: 014cf333-a243-4dc3-9ae9-61cc2e4175ff

  on .terraform/modules/drupal_redis/main.tf line 59, in resource "aws_elasticache_replication_group" "ec_redis":
  59: resource "aws_elasticache```