### PR TITLE
Shorten IAM user name for `manage-my-prison-dev` Athena user

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-my-prison-dev/resources/athena-iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-my-prison-dev/resources/athena-iam.tf
@@ -1,9 +1,5 @@
-resource "random_id" "athena-id" {
-  byte_length = 16
-}
-
 resource "aws_iam_user" "athena-user" {
-  name = "${var.namespace}-athena-user-${random_id.athena-id.hex}"
+  name = "${var.namespace}-athena-user"
   path = "/system/${var.namespace}/athena-user/"
 }
 
@@ -89,7 +85,7 @@ data "aws_iam_policy_document" "athena" {
 }
 
 resource "aws_iam_user_policy" "athena-policy" {
-  name   = "${var.namespace}-athena"
+  name   = "${var.namespace}-athena-policy"
   user   = aws_iam_user.athena-user.name
   policy = data.aws_iam_policy_document.athena.json
 }


### PR DESCRIPTION
…because 16 bytes of (needless) randomness made it exceed the 64 character limit! As the namespace is part of the user name, this name would be unique anyway: "manage-my-prison-dev-athena-user".

Concourse had failed with:

    Error creating IAM User manage-my-prison-dev-athena-user-b892e617d30a1200f4ca329c5bf99182: ValidationError: 1 validation error detected: Value 'manage-my-prison-dev-athena-user-b892e617d30a1200f4ca329c5bf99182' at 'userName' failed to satisfy constraint: Member must have length less than or equal to 64