### PR TITLE
Prisoner content hub - elasticache redis downgrade - dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
@@ -12,8 +12,8 @@ module "drupal_redis" {
   team_name              = var.team_name
   number_cache_clusters  = var.number_cache_clusters
   node_type              = "cache.t3.small"
-  engine_version         = "5.0.6"
-  parameter_group_name   = "default.redis5.0"
+  engine_version         = "4.0.13"
+  parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
 
   providers = {


### PR DESCRIPTION
This PR switches Redis version from 5 to 4.  This is to avoid an issue reported in the Drupal Redis integration with using version 5 on elasticache:  https://www.drupal.org/project/redis/issues/3151976