### PR TITLE
Prisoner content hub - elasticache fix redis version number - dev

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
@@ -12,7 +12,7 @@ module "drupal_redis" {
   team_name              = var.team_name
   number_cache_clusters  = var.number_cache_clusters
   node_type              = "cache.t3.small"
-  engine_version         = "4.0.13"
+  engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
 


### PR DESCRIPTION
Use version 4.0.10 as 4.0.13 is not supported.

See error on build https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-namespace-changes-live-1/builds/292
```
Error: Error creating ElastiCache Replication Group (cp-66508e899082f511): InvalidParameterCombination: Cannot find version 4.0.13 for redis
```