### PR TITLE
Removed secret and route53-zone-output for an old URL

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/certificates.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/certificates.yaml
@@ -1,19 +1,6 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: moj-online-product-page-prod-cert
-  namespace: formbuilder-product-page-prod
-spec:
-  secretName: moj-online-product-page-prod-secret
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
-  - moj-online.service.justice.gov.uk
----
-apiVersion: cert-manager.io/v1alpha3
-kind: Certificate
-metadata:
   name: moj-forms-product-page-prod-cert
   namespace: formbuilder-product-page-prod
 spec:

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/route53.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/route53.tf
@@ -1,16 +1,3 @@
-resource "aws_route53_zone" "moj_online_route53_zone" {
-  name = var.zone_name
-
-  tags = {
-    application            = var.application
-    is-production          = var.is_production
-    environment-name       = var.environment_name
-    owner                  = var.team_name
-    infrastructure-support = var.infrastructure_support
-    namespace              = var.namespace
-  }
-}
-
 resource "aws_route53_zone" "moj_forms_route53_zone" {
   name = var.zone_name_new
 
@@ -21,17 +8,6 @@ resource "aws_route53_zone" "moj_forms_route53_zone" {
     owner                  = var.team_name
     infrastructure-support = var.infrastructure_support
     namespace              = var.namespace
-  }
-}
-
-resource "kubernetes_secret" "moj_online_route53_zone_sec" {
-  metadata {
-    name      = "moj-online-route53-zone-output"
-    namespace = var.namespace
-  }
-
-  data = {
-    zone_id = aws_route53_zone.moj_online_route53_zone.zone_id
   }
 }
 

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/variables.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/variables.tf
@@ -16,10 +16,6 @@ variable "environment_name" {
   default     = "prod"
 }
 
-variable "zone_name" {
-  default = "moj-online.service.justice.gov.uk"
-}
-
 variable "zone_name_new" {
   default = "moj-forms.service.justice.gov.uk"
 }


### PR DESCRIPTION
The product site had 2 URLs and we have removed the old one. This
PR cleans up the secret and zone-output in the namespace.