### PR TITLE
Rename ECR repo

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/elsa-relevant-search-staging/resources/ecr.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/elsa-relevant-search-staging/resources/ecr.tf
@@ -2,14 +2,14 @@ module "ecr-repo" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.5"
 
   team_name = var.team_name
-  repo_name = "${var.namespace}-ecr"
+  repo_name = var.github_repo_name
 
   github_repositories = [var.github_repo_name]
 }
 
 resource "kubernetes_secret" "ecr-repo" {
   metadata {
-    name      = "ecr-repo-${var.namespace}"
+    name      = "ecr-repo-${var.github_repo_name}"
     namespace = var.namespace
   }
 


### PR DESCRIPTION
For consistency with our other namespaces. Also because we only use 1 ecr repo for all environments (staging and production).