### PR TITLE
Reconfigure the bandiera db as a general utility db

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/main.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/main.tf
@@ -24,3 +24,6 @@ provider "github" {
 
 provider "pingdom" {
 }
+
+provider "random" {
+}

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/rds.tf
@@ -104,7 +104,7 @@ resource "kubernetes_secret" "ppud_replica_dev_rds_secrets" {
 ## PostgreSQL - Bandiera (Feature Flagging Server) Database
 ##
 
-module "ppud_replacement_bandiera_rds" {
+module "ppud_replacement_utility_rds" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
 
   cluster_name           = var.cluster_name
@@ -116,31 +116,77 @@ module "ppud_replacement_bandiera_rds" {
   is-production          = var.is_production
   team_name              = var.team_name
 
-  rds_name          = "ppud-replacement-bandiera-dev"
+  rds_name          = "ppud-replacement-utility-dev"
   rds_family        = "postgres13"
   db_engine         = "postgres"
   db_engine_version = "13"
   db_instance_class = "db.t3.small"
-  db_name           = "bandiera"
+  db_name           = "utility"
 
   providers = {
     aws = aws.london
   }
 }
 
-resource "kubernetes_secret" "ppud_replacement_bandiera_rds" {
+provider "postgresql" {
+  alias    = "utility"
+  host     = module.ppud_replacement_utility_rds.rds_instance_address
+  port     = module.ppud_replacement_utility_rds.rds_instance_port
+  username = module.ppud_replacement_utility_rds.database_username
+  password = module.ppud_replacement_utility_rds.database_password
+}
+
+resource "random_string" "bandiera_password" {
+  length  = 24
+  special = false
+}
+
+resource "postgresql_role" "bandiera" {
+  provider = postgresql.utility
+  name     = "bandiera"
+  login    = true
+  password = random_string.bandiera_password.result
+}
+
+resource "postgresql_database" "bandiera" {
+  provider   = postgresql.utility
+  name       = "bandiera"
+  owner      = "bandiera"
+  depends_on = [postgresql_role.bandiera]
+}
+
+resource "random_string" "dashboard_password" {
+  length  = 24
+  special = false
+}
+
+resource "postgresql_role" "dashboard" {
+  provider = postgresql.utility
+  name     = "dashboard"
+  login    = true
+  password = random_string.dashboard_password.result
+}
+
+resource "postgresql_database" "dashboard" {
+  provider   = postgresql.utility
+  name       = "dashboard"
+  owner      = "dashboard"
+  depends_on = [postgresql_role.dashboard]
+}
+
+resource "kubernetes_secret" "ppud_replacement_utility_rds" {
   metadata {
-    name      = "bandiera-database"
+    name      = "utility-database"
     namespace = var.namespace
   }
 
   data = {
-    host         = module.ppud_replacement_bandiera_rds.rds_instance_address
-    port         = module.ppud_replacement_bandiera_rds.rds_instance_port
-    endpoint     = module.ppud_replacement_bandiera_rds.rds_instance_endpoint
-    dbname       = module.ppud_replacement_bandiera_rds.database_name
-    username     = module.ppud_replacement_bandiera_rds.database_username
-    password     = module.ppud_replacement_bandiera_rds.database_password
-    DATABASE_URL = "postgres://${module.ppud_replacement_bandiera_rds.database_username}:${module.ppud_replacement_bandiera_rds.database_password}@${module.ppud_replacement_bandiera_rds.rds_instance_endpoint}/${module.ppud_replacement_bandiera_rds.database_name}"
+    host                   = module.ppud_replacement_utility_rds.rds_instance_address
+    port                   = module.ppud_replacement_utility_rds.rds_instance_port
+    endpoint               = module.ppud_replacement_utility_rds.rds_instance_endpoint
+    admin_username         = module.ppud_replacement_utility_rds.database_username
+    admin_password         = module.ppud_replacement_utility_rds.database_password
+    BANDIERA_DATABASE_URL  = "postgres://bandiera:${random_string.bandiera_password.result}@${module.ppud_replacement_utility_rds.rds_instance_endpoint}/bandiera"
+    DASHBOARD_DATABASE_URL = "postgres://dashboard:${random_string.dashboard_password.result}@${module.ppud_replacement_utility_rds.rds_instance_endpoint}/dashboard"
   }
 }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/versions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/versions.tf
@@ -11,5 +11,13 @@ terraform {
     pingdom = {
       source = "russellcardullo/pingdom"
     }
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "~> 1.14.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1.0"
+    }
   }
 }


### PR DESCRIPTION
As the db is likely to be quite underutilised on dev, push more than one
service into the instance, this makes the utility db work for both
bandiera (or other ff service) and our dashboard service.