### PR TITLE
PUD-815: pingdom checks for manage-recalls /health endpoints

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/pingdom.tf
@@ -1,12 +1,44 @@
 resource "pingdom_check" "manage-recalls" {
   type                     = "http"
-  name                     = "ppud-replacement - dev - manage-recalls - cloud-platform"
+  name                     = "manage-recalls - DEV"
   host                     = "manage-recalls-dev.hmpps.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
   url                      = "/"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,ppud-replacement,manage-recalls,dev,isproduction_false,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [116726]
+}
+
+resource "pingdom_check" "manage-recalls-ui-health" {
+  type                     = "http"
+  name                     = "manage-recalls-ui /health - DEV"
+  host                     = "manage-recalls-dev.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,ppud-replacement,manage-recalls,dev,isproduction_false,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [116726]
+}
+
+resource "pingdom_check" "manage-recalls-api-health" {
+  type                     = "http"
+  name                     = "manage-recalls-api /health - DEV"
+  host                     = "manage-recalls-api-dev.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
   encryption               = true
   port                     = 443
   tags                     = "hmpps,ppud-replacement,manage-recalls,dev,isproduction_false,cloudplatform-managed"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/pingdom.tf
@@ -1,12 +1,44 @@
 resource "pingdom_check" "manage-recalls" {
   type                     = "http"
-  name                     = "ppud-replacement - preprod - manage-recalls - cloud-platform"
+  name                     = "manage-recalls - PREPROD"
   host                     = "manage-recalls-preprod.hmpps.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
   url                      = "/"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,ppud-replacement,manage-recalls,preprod,isproduction_false,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [116726]
+}
+
+resource "pingdom_check" "manage-recalls-ui-health" {
+  type                     = "http"
+  name                     = "manage-recalls-ui /health - PREPROD"
+  host                     = "manage-recalls-preprod.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,ppud-replacement,manage-recalls,preprod,isproduction_false,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [116726]
+}
+
+resource "pingdom_check" "manage-recalls-api-health" {
+  type                     = "http"
+  name                     = "manage-recalls-api /health - PREPROD"
+  host                     = "manage-recalls-api-preprod.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
   encryption               = true
   port                     = 443
   tags                     = "hmpps,ppud-replacement,manage-recalls,preprod,isproduction_false,cloudplatform-managed"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/pingdom.tf
@@ -1,12 +1,44 @@
 resource "pingdom_check" "manage-recalls" {
   type                     = "http"
-  name                     = "ppud-replacement - prod - manage-recalls - cloud-platform"
+  name                     = "manage-recalls - PROD"
   host                     = "manage-recalls.hmpps.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
   url                      = "/"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,ppud-replacement,manage-recalls,prod,isproduction_true,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [116724]
+}
+
+resource "pingdom_check" "manage-recalls-ui-health" {
+  type                     = "http"
+  name                     = "manage-recalls-ui /health - PROD"
+  host                     = "manage-recalls.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,ppud-replacement,manage-recalls,prod,isproduction_true,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [116724]
+}
+
+resource "pingdom_check" "manage-recalls-api-health" {
+  type                     = "http"
+  name                     = "manage-recalls-api /health - PROD"
+  host                     = "manage-recalls-api.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
   encryption               = true
   port                     = 443
   tags                     = "hmpps,ppud-replacement,manage-recalls,prod,isproduction_true,cloudplatform-managed"


### PR DESCRIPTION
This adds pingdom checks for the `/health` endpoints on the
manage-recalls applications. This should give us an overview of any
issues with both our applications and our dependences.