### PR TITLE
Remove the requirement for change

### DIFF
--- a/.github/workflows/iam-role-policy-changes-check.yaml
+++ b/.github/workflows/iam-role-policy-changes-check.yaml
@@ -31,6 +31,5 @@ jobs:
         if: steps.review_pr.outputs.review_pr_iam_check == 'false'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN  }}"
-          event: REQUEST_CHANGES
           body: |
             There are potential IAM Role and/or policy Changes/additions. Reviewer - If satisfied with the changes/additions - dismiss this request


### PR DESCRIPTION
I don't think we need to completely halt a PR that has an IAM change, I think a comment is enough.