### PR TITLE
Update pingdom host for migrated namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-staging/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-staging/resources/pingdom.tf
@@ -5,7 +5,7 @@ provider "pingdom" {
 resource "pingdom_check" "elsa-relevant-search-staging-pingdom" {
   type                     = "http"
   name                     = "ELSA Relevant Search - Staging"
-  host                     = "elsa-relevant-search-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
+  host                     = "elsa-relevant-search-staging.apps.live.cloud-platform.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 4


### PR DESCRIPTION
As we are going to kill the `live-1` namespace, we don't need to have 2 pingdom checks with 2 hosts, we only need the `live` one.