### PR TITLE
Migrate form builder base adapter to new live cluster

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/00-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-base-adapter-test
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "Form Builder Base Adapter API Endpoint"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: form-builder-developers@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/fb-base-adapter"
+    cloud-platform.justice.gov.uk/slack-channel: "form-builder-alerts"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-base-adapter-test-admin
+  namespace: formbuilder-base-adapter-test
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-base-adapter-test
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-base-adapter-test
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-base-adapter-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-base-adapter-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/circleci-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/circleci-service-account.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-base-adapter-test
+  namespace: formbuilder-base-adapter-test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-base-adapter-test
+  namespace: formbuilder-base-adapter-test
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-base-adapter-test
+  namespace: formbuilder-base-adapter-test
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/resources/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
## Context

On the MoJ forms team (a.k.a Formbuilder team) we decide to start the migration to the live cluster with a small app called "base adapter". This PR follow [this guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live-sa-github-actions.html#migrating-serviceaccount-module-for-github-actions-to-the-quot-live-quot-cluster)
