### PR TITLE
Migrate elsa-relevant-search-production to live cluster

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: elsa-relevant-search-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "xj-elsa"
+    cloud-platform.justice.gov.uk/application: "Search information about legal problems"
+    cloud-platform.justice.gov.uk/owner: "Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/elsa-relevant-search"
+    cloud-platform.justice.gov.uk/team-name: "family-justice"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elsa-relevant-search-production-admin
+  namespace: elsa-relevant-search-production
+subjects:
+  - kind: Group
+    name: "github:family-justice"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: elsa-relevant-search-production
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: elsa-relevant-search-production
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: elsa-relevant-search-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: elsa-relevant-search-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: elsa-relevant-search-certificate-production
+  namespace: elsa-relevant-search-production
+spec:
+  secretName: elsa-relevant-search-tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - search-information-about-legal-problems.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/pingdom.tf
@@ -1,0 +1,20 @@
+
+provider "pingdom" {
+}
+
+resource "pingdom_check" "elsa-relevant-search-production-pingdom" {
+  type                     = "http"
+  name                     = "ELSA Relevant Search - Production"
+  host                     = "search-information-about-legal-problems.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 4
+  notifyagainevery         = 60
+  url                      = "/ping"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_${var.business_unit},component_ping,isproduction_${var.is_production},environment_${var.environment_name},cloudplatform-managed,crossjustice"
+  probefilters             = "region:EU"
+  integrationids           = [87620]
+  teamids                  = [385932]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/rds.tf
@@ -1,0 +1,57 @@
+module "rds" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  cluster_name           = var.cluster_name
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  environment-name       = var.environment_name
+  infrastructure-support = var.infrastructure_support
+  namespace              = var.namespace
+
+  # enable performance insights
+  performance_insights_enabled = true
+
+  # instance class
+  db_instance_class = "db.t3.small"
+
+  # change the postgres version as you see fit.
+  db_engine_version = "13"
+
+  # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11, postgres12, postgres13
+  # Pick the one that defines the postgres version the best
+  rds_family = "postgres13"
+
+  # use "allow_major_version_upgrade" when upgrading the major version of an engine
+  allow_major_version_upgrade = "false"
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+  }
+}
+
+# Configmap to store non-sensitive data related to the RDS instance
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/route53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = "search-information-about-legal-problems.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment_name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/serviceaccount.tf
@@ -1,0 +1,16 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.6"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = [var.github_repo_name]
+
+  # This module is also used in the staging namespace, so we must change the
+  # secret names here in order to not overwrite the existing ones.
+
+  github_actions_secret_kube_cert      = "KUBE_PROD_CERT"
+  github_actions_secret_kube_token     = "KUBE_PROD_TOKEN"
+  github_actions_secret_kube_cluster   = "KUBE_PROD_CLUSTER"
+  github_actions_secret_kube_namespace = "KUBE_PROD_NAMESPACE"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/variables.tf
@@ -1,0 +1,61 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Search information about legal problems"
+}
+
+variable "namespace" {
+  default = "elsa-relevant-search-production"
+}
+
+variable "github_repo_name" {
+  default = "elsa-relevant-search"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HQ"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "family-justice"
+}
+
+variable "environment_name" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "crossjusticedelivery@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "true"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "xj-elsa"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/resources/versions.tf
@@ -1,0 +1,16 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+    pingdom = {
+      source  = "russellcardullo/pingdom"
+      version = "1.1.3"
+    }
+  }
+}


### PR DESCRIPTION
Note: despite this being a "production" namespace, it is not publicly available yet or in use, and is mostly a static website so we are willing to accept any risks.

Staging namespace already migrated and working fine so far.