### PR TITLE
Temporary remove cross reference namespace secrets during migration

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/hmpps-tier-offender-events-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/hmpps-tier-offender-events-sub-queue.tf
@@ -68,64 +68,6 @@ module "hmpps_tier_offender_events_dead_letter_queue" {
   }
 }
 
-resource "kubernetes_secret" "hmpps_tier_offender_events_queue" {
-  metadata {
-    name      = "hmpps-tier-offender-events-sqs-instance-output"
-    namespace = "hmpps-tier-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_tier_offender_events_queue.access_key_id
-    secret_access_key = module.hmpps_tier_offender_events_queue.secret_access_key
-    sqs_ptpu_url      = module.hmpps_tier_offender_events_queue.sqs_id
-    sqs_ptpu_arn      = module.hmpps_tier_offender_events_queue.sqs_arn
-    sqs_ptpu_name     = module.hmpps_tier_offender_events_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "hmpps_tier_offender_events_dead_letter_queue" {
-  metadata {
-    name      = "hmpps-tier-offender-events-sqs-dl-instance-output"
-    namespace = "hmpps-tier-dev"
-  }
-  data = {
-    access_key_id     = module.hmpps_tier_offender_events_dead_letter_queue.access_key_id
-    secret_access_key = module.hmpps_tier_offender_events_dead_letter_queue.secret_access_key
-    sqs_ptpu_url      = module.hmpps_tier_offender_events_dead_letter_queue.sqs_id
-    sqs_ptpu_arn      = module.hmpps_tier_offender_events_dead_letter_queue.sqs_arn
-    sqs_ptpu_name     = module.hmpps_tier_offender_events_dead_letter_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "hmpps_tier_sqs_tool_main_queue" {
-  metadata {
-    name      = "hmpps-tier-sqs-tool-main-queue"
-    namespace = "hmpps-tier-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_tier_offender_events_queue.access_key_id
-    secret_access_key = module.hmpps_tier_offender_events_queue.secret_access_key
-    sqs_queue_url     = module.hmpps_tier_offender_events_queue.sqs_id
-    sqs_queue_arn     = module.hmpps_tier_offender_events_queue.sqs_arn
-    sqs_queue_name    = module.hmpps_tier_offender_events_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "hmpps_tier_sqs_tool_dead_letter_queue" {
-  metadata {
-    name      = "hmpps-tier-sqs-tool-dead-letter-queue"
-    namespace = "hmpps-tier-dev"
-  }
-  data = {
-    access_key_id     = module.hmpps_tier_offender_events_dead_letter_queue.access_key_id
-    secret_access_key = module.hmpps_tier_offender_events_dead_letter_queue.secret_access_key
-    sqs_queue_url     = module.hmpps_tier_offender_events_dead_letter_queue.sqs_id
-    sqs_queue_arn     = module.hmpps_tier_offender_events_dead_letter_queue.sqs_arn
-    sqs_queue_name    = module.hmpps_tier_offender_events_dead_letter_queue.sqs_name
-  }
-}
-
 resource "aws_sns_topic_subscription" "hmpps_tier_offender_events_subscription" {
   provider      = aws.london
   topic_arn     = module.probation_offender_events.topic_arn

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/hmpps-tier-sub-queue.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/hmpps-tier-sub-queue.tf
@@ -68,36 +68,6 @@ module "hmpps_tier_event_dead_letter_queue" {
   }
 }
 
-resource "kubernetes_secret" "hmpps_tier_event_queue" {
-  metadata {
-    name      = "hmpps-tier-sqs-instance-output"
-    namespace = "hmpps-tier-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_tier_event_queue.access_key_id
-    secret_access_key = module.hmpps_tier_event_queue.secret_access_key
-    sqs_id            = module.hmpps_tier_event_queue.sqs_id
-    sqs_arn           = module.hmpps_tier_event_queue.sqs_arn
-    sqs_name          = module.hmpps_tier_event_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "hmpps_tier_event_dead_letter_queue" {
-  metadata {
-    name      = "hmpps-tier-sqs-dl-instance-output"
-    namespace = "hmpps-tier-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_tier_event_dead_letter_queue.access_key_id
-    secret_access_key = module.hmpps_tier_event_dead_letter_queue.secret_access_key
-    sqs_id            = module.hmpps_tier_event_dead_letter_queue.sqs_id
-    sqs_arn           = module.hmpps_tier_event_dead_letter_queue.sqs_arn
-    sqs_name          = module.hmpps_tier_event_dead_letter_queue.sqs_name
-  }
-}
-
 resource "aws_sns_topic_subscription" "hmpps_tier_event_subscription" {
   provider      = aws.london
   topic_arn     = module.offender_assessments_events.topic_arn


### PR DESCRIPTION
The pipeline fails as it couldnot find/create resources between clusters. The secrets has to be copied manually.

Revert this PR back once the `offender-events-dev` namespace is migrated to `live`

@carlov20 FYI