### PR TITLE
Temporary remove cross reference namespace secrets during migration

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-tier-calculation-complete.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-tier-calculation-complete.tf
@@ -71,66 +71,6 @@ module "hmpps_tier_calculation_complete_dead_letter_queue" {
   }
 }
 
-resource "kubernetes_secret" "hmpps_tier_calculation_complete_queue" {
-  metadata {
-    name      = "sqs-tier-to-delius-update-secret"
-    namespace = "hmpps-tier-to-delius-update-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_tier_calculation_complete_queue.access_key_id
-    secret_access_key = module.hmpps_tier_calculation_complete_queue.secret_access_key
-    sqs_queue_url     = module.hmpps_tier_calculation_complete_queue.sqs_id
-    sqs_queue_arn     = module.hmpps_tier_calculation_complete_queue.sqs_arn
-    sqs_queue_name    = module.hmpps_tier_calculation_complete_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "hmpps_tier_calculation_complete_dead_letter_queue" {
-  metadata {
-    name      = "sqs-tier-to-delius-update-dl-secret"
-    namespace = "hmpps-tier-to-delius-update-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_tier_calculation_complete_dead_letter_queue.access_key_id
-    secret_access_key = module.hmpps_tier_calculation_complete_dead_letter_queue.secret_access_key
-    sqs_queue_url     = module.hmpps_tier_calculation_complete_dead_letter_queue.sqs_id
-    sqs_queue_arn     = module.hmpps_tier_calculation_complete_dead_letter_queue.sqs_arn
-    sqs_queue_name    = module.hmpps_tier_calculation_complete_dead_letter_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "hmpps_tier_sqs_tool_main_queue" {
-  metadata {
-    name      = "hmpps-tier-sqs-tool-main-queue"
-    namespace = "hmpps-tier-to-delius-update-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_tier_calculation_complete_queue.access_key_id
-    secret_access_key = module.hmpps_tier_calculation_complete_queue.secret_access_key
-    sqs_queue_url     = module.hmpps_tier_calculation_complete_queue.sqs_id
-    sqs_queue_arn     = module.hmpps_tier_calculation_complete_queue.sqs_arn
-    sqs_queue_name    = module.hmpps_tier_calculation_complete_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "hmpps_tier_sqs_tool_dead_letter_queue" {
-  metadata {
-    name      = "hmpps-tier-sqs-tool-dead-letter-queue"
-    namespace = "hmpps-tier-to-delius-update-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_tier_calculation_complete_dead_letter_queue.access_key_id
-    secret_access_key = module.hmpps_tier_calculation_complete_dead_letter_queue.secret_access_key
-    sqs_queue_url     = module.hmpps_tier_calculation_complete_dead_letter_queue.sqs_id
-    sqs_queue_arn     = module.hmpps_tier_calculation_complete_dead_letter_queue.sqs_arn
-    sqs_queue_name    = module.hmpps_tier_calculation_complete_dead_letter_queue.sqs_name
-  }
-}
-
 resource "aws_sns_topic_subscription" "hmpps_tier_calculation_complete_subscription" {
   provider      = aws.london
   topic_arn     = module.hmpps-domain-events.topic_arn


### PR DESCRIPTION
The pipeline fails as it couldnot find/create resources between clusters. The secrets has to be copied manually.

Revert this PR back once the `hmpps-domain-events-dev` namespace is migrated to live

@carlov20 FYI