### PR TITLE
Temporary remove cross reference namespace secrets during migration

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-allocations.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-allocations.tf
@@ -1,15 +1,3 @@
-resource "kubernetes_secret" "hmpps-allocations" {
-  metadata {
-    name      = "hmpps-domain-events-topic"
-    namespace = "workforce-management-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps-domain-events.access_key_id
-    secret_access_key = module.hmpps-domain-events.secret_access_key
-    topic_arn         = module.hmpps-domain-events.topic_arn
-  }
-}
 
 module "hmpps_allocation_required_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.4"


### PR DESCRIPTION
The pipeline fails as it couldnot find/create resources between clusters. The secrets has to be copied manually.

Revert this PR back once the hmpps-domain-events-dev namespace is migrated to live

@carlov20 FYI