### PR TITLE
Temporary remove cross reference namespace secrets during migration

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-allocations.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-allocations.tf
@@ -71,36 +71,6 @@ module "hmpps_allocation_required_dead_letter_queue" {
   }
 }
 
-resource "kubernetes_secret" "hmpps_allocation_required_queue" {
-  metadata {
-    name      = "sqs-hmpps-allocations-secret"
-    namespace = "workforce-management-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_allocation_required_queue.access_key_id
-    secret_access_key = module.hmpps_allocation_required_queue.secret_access_key
-    sqs_queue_url     = module.hmpps_allocation_required_queue.sqs_id
-    sqs_queue_arn     = module.hmpps_allocation_required_queue.sqs_arn
-    sqs_queue_name    = module.hmpps_allocation_required_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "hmpps_allocation_required_dead_letter_queue" {
-  metadata {
-    name      = "sqs-hmpps-allocations-dl-secret"
-    namespace = "workforce-management-dev"
-  }
-
-  data = {
-    access_key_id     = module.hmpps_allocation_required_dead_letter_queue.access_key_id
-    secret_access_key = module.hmpps_allocation_required_dead_letter_queue.secret_access_key
-    sqs_queue_url     = module.hmpps_allocation_required_dead_letter_queue.sqs_id
-    sqs_queue_arn     = module.hmpps_allocation_required_dead_letter_queue.sqs_arn
-    sqs_queue_name    = module.hmpps_allocation_required_dead_letter_queue.sqs_name
-  }
-}
-
 resource "aws_sns_topic_subscription" "hmpps_allocation_required_subscription" {
   provider      = aws.london
   topic_arn     = module.hmpps-domain-events.topic_arn


### PR DESCRIPTION
The pipeline fails as it couldnot find/create resources between clusters. The secrets has to be copied manually.

Revert this PR back once the hmpps-domain-events-dev namespace is migrated to live

@carlov20 FYI