### PR TITLE
Keep RDS same as in live-1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
@@ -13,22 +13,6 @@ module "rds-instance" {
   infrastructure-support = var.infrastructure_support
   namespace              = var.namespace
 
-  # enable performance insights
-  performance_insights_enabled = false
-
-  # instance class
-  db_instance_class = "db.t3.small"
-
-  # change the postgres version as you see fit.
-  db_engine_version = "13"
-
-  # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11, postgres12, postgres13
-  # Pick the one that defines the postgres version the best
-  rds_family = "postgres13"
-
-  # use "allow_major_version_upgrade" when upgrading the major version of an engine
-  allow_major_version_upgrade = "false"
-
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london


### PR DESCRIPTION
Trying to migrate to new cluster and bump postgres to a major version might not be the best of the ideas.