### PR TITLE
Add Dev namespace for laa-crime-means-assessment service

### DIFF
--- a/.checksum
+++ b/.checksum
@@ -1,3 +1,3 @@
 #This file is used by the auto pr github action. Please commit
-bucket-data-uploader-dev
-h1:xweXFX32ON+zMxYLZ7Mxs/w1fZP7nDEwm+H0HDMmUu0=
+laa-crime-means-assessment-dev
+h1:I8dQPVSQAKsB4dENvcUKR4kSXybCSD+X+hQiSfP2atU=

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-crime-means-assessment-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
+    cloud-platform.justice.gov.uk/application: "laa-crime-means-assessment"
+    cloud-platform.justice.gov.uk/owner: "Crime Apps Team: laa-crime-apps@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-crime-means-assessment"
+    cloud-platform.justice.gov.uk/team-name: "laa-crime-apps-team"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-crime-means-assessment-dev-admin
+  namespace: laa-crime-means-assessment-dev
+subjects:
+  - kind: Group
+    name: "github:laa-crime-apps-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-crime-means-assessment-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-crime-means-assessment-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-crime-means-assessment-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-crime-means-assessment-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/variables.tf
@@ -1,0 +1,57 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "laa-crime-means-assessment"
+}
+
+variable "namespace" {
+  default = "laa-crime-means-assessment-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "LAA"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "laa-crime-apps-team"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "laa-crime-apps@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "laa-crimeapps-core"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}


### PR DESCRIPTION
This is to create a Dev namespace for the new laa-crime-means-assessment service

New Dev namespace has been created on the live cluster using the Cloud Platform CLI