### PR TITLE
Form Builder - Migrate Publisher Test namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/00-namespace.yaml
@@ -1,0 +1,18 @@
+---
+# Source: formbuilder-publisher/templates/00-namespace.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: formbuilder-publisher-test
+  labels:
+    # for fb's own purposes
+    name: formbuilder-publisher-test
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "test"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/application: "formbuilder-publisher"
+    cloud-platform.justice.gov.uk/owner: "Form Builder: formbuilder@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/fb-publisher"
+    cloud-platform.justice.gov.uk/slack-channel: "moj-online-devs"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/01-rbac.yaml
@@ -1,0 +1,21 @@
+---
+# Source: formbuilder-publisher/templates/01-rbac.yaml
+# auto-generated from fb-cloud-platforms-environments
+# Bind admin role for namespace to team group
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: formbuilder-publisher-test-admins
+  namespace: formbuilder-publisher-test
+subjects:
+  - kind: Group
+    name: "github:form-builder"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+# Further roles defined in:
+# - publisher-workers-service-account.yaml

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/02-limitrange.yaml
@@ -1,0 +1,17 @@
+---
+# Source: formbuilder-publisher/templates/02-limitrange.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: formbuilder-publisher-test
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 250Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: formbuilder-publisher-test
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/04-networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# Source: formbuilder-publisher/templates/04-networkpolicy.yaml
+# auto-generated from fb-cloud-platforms-environments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: formbuilder-publisher-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: formbuilder-publisher-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/circleci-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/circleci-service-account.yaml
@@ -1,0 +1,26 @@
+---
+# Source: formbuilder-publisher/templates/circleci-service-account.yaml
+---
+# Source: formbuilder-publisher/templates/circleci-service-account.yaml
+# auto-generated from fb-cloud-platform-environments
+# This service account allows circleci to deploy into this environment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci-formbuilder-publisher-test
+  namespace: formbuilder-publisher-test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-formbuilder-publisher-test
+  namespace: formbuilder-publisher-test
+subjects:
+- kind: ServiceAccount
+  name: circleci-formbuilder-publisher-test
+  namespace: formbuilder-publisher-test
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/publisher-workers-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/publisher-workers-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# Source: formbuilder-publisher/templates/publisher-workers-service-account.yaml
+# auto-generated from fb-cloud-platforms-environments
+# We need to run the publisher worker pod as a distinct service account
+# so that the workers (and only the workers) can be granted admin access
+# over the formbuilder-services-test-(deploymentEnvironment)
+# namespaces so that they can deploy services there
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: formbuilder-publisher-workers-test
+  namespace: formbuilder-publisher-test

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/main.tf
@@ -1,0 +1,15 @@
+# auto-generated from fb-cloud-platforms-environments
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/publisher.tf
@@ -1,0 +1,64 @@
+module "publisher-rds-instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+
+  cluster_name               = var.cluster_name
+  db_backup_retention_period = var.db_backup_retention_period
+  application                = "formbuilderpublisher"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  namespace                  = var.namespace
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
+  db_engine_version          = "10"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "publisher-rds-instance" {
+  metadata {
+    name      = "rds-instance-formbuilder-publisher-${var.environment-name}"
+    namespace = "formbuilder-publisher-${var.environment-name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.publisher-rds-instance.database_username}:${module.publisher-rds-instance.database_password}@${module.publisher-rds-instance.rds_instance_endpoint}/${module.publisher-rds-instance.database_name}"
+  }
+}
+
+##################################################
+
+########################################################
+# Publisher Elasticache Redis (for resque + job logging)
+module "publisher-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.3"
+
+  cluster_name           = var.cluster_name
+  application            = "formbuilderpublisher"
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  engine_version         = "4.0.10"
+  parameter_group_name   = "default.redis4.0"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "publisher-elasticache" {
+  metadata {
+    name      = "elasticache-formbuilder-publisher-${var.environment-name}"
+    namespace = "formbuilder-publisher-${var.environment-name}"
+  }
+
+  data = {
+    primary_endpoint_address = module.publisher-elasticache.primary_endpoint_address
+    auth_token               = module.publisher-elasticache.auth_token
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/variables.tf
@@ -1,0 +1,30 @@
+# auto-generated from fb-cloud-platforms-environments
+variable "environment-name" {
+  default = "test"
+}
+
+variable "team_name" {
+  default = "formbuilder"
+}
+
+variable "namespace" {
+  default = "formbuilder-publisher-test"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+variable "db_backup_retention_period" {
+  default = "2"
+}
+
+variable "infrastructure-support" {
+  default = "Form Builder form-builder-team@digital.justice.gov.uk"
+}
+
+// The following two variables are provided at runtime by the pipeline.
+variable "cluster_name" {
+}
+
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
This moves the Publisher Test namespace to EKS

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>