### PR TITLE
[CCCD namespaces] Bump max memory limit 2Gi to 3Gi for all pods

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 2Gi
+      memory: 3Gi
     defaultRequest:
       cpu: 10m
       memory: 1000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 2Gi
+      memory: 3Gi
     defaultRequest:
       cpu: 10m
-      memory: 100Mi
+      memory: 1000Mi
     type: Container

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-dev/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 2Gi
+      memory: 3Gi
     defaultRequest:
       cpu: 10m
       memory: 1000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-production/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 2Gi
+      memory: 3Gi
     defaultRequest:
       cpu: 10m
       memory: 1000Mi

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/cccd-staging/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 2Gi
+      memory: 3Gi
     defaultRequest:
       cpu: 10m
       memory: 1000Mi


### PR DESCRIPTION
Bump max memory limit 2Gi to 3Gi for all pods

We use a scheduler_daemon and sidekiq worker
that when running a particular query against
a prod-like data scale that can exceed the 2Gi limit.