### PR TITLE
Migrate laa-apply-for-legalaid-uat to live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-apply-for-legalaid-uat
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "uat"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
+    cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/01-rbac.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-apply-for-legalaid-uat-admin
+  namespace: laa-apply-for-legalaid-uat
+subjects:
+  - kind: Group
+    name: "github:laa-apply-for-legal-aid"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-apply-for-legalaid-uat
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 2Gi
+    defaultRequest:
+      cpu: 10m
+      memory: 512Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-apply-for-legalaid-uat
+spec:
+  hard:
+    pods: "100"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-apply-for-legalaid-uat
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-apply-for-legalaid-uat
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
@@ -1,0 +1,104 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-apply-for-legalaid-uat
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-laa-apply-for-legal-aid
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Instance-Down
+      expr: absent(up{namespace="laa-apply-for-legalaid-uat"}) == 1
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-apply-for-legalaid-uat"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-apply-for-legalaid-uat"} > 0) > 90
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-apply-for-legalaid-uat"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: More than one hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-apply-for-legalaid-uat,type:phrase),type:phrase,value:laa-apply-for-legalaid-uat),query:(match:(kubernetes.namespace_name:(query:laa-apply-for-legalaid-uat,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-apply-for-legalaid-uat", status=~"5.."}[5m]))*270 > 0
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-apply-for-legalaid-uat),type:phrase,value:laa-apply-for-legalaid-uat),query:(match:(log_processed.kubernetes_namespace:(query:laa-apply-for-legalaid-uat,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: SidekiqQueueSize-Threshold-Reached
+      expr: sum(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-uat"}) > 10
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Sidekiq queue size is more than 10
+    - alert: SidekiqQueue-absent
+      expr: absent(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-uat"})
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-uat"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-uat"})
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Container disk space usage is more than 150Mb or is not reported
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-uat", controller!="providers/statement_of_cases"} > 2
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Request is taking more than 2 seconds
+    - alert: "Long-Request: Statement of case"
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-uat", controller="providers/statement_of_cases"} > 10
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Statement of case request is taking more than 10 seconds
+    - alert: Address lookup service
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-apply-for-legalaid-uat", controller="providers/address_selections"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Address lookup service request has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: Benefit Checker
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-apply-for-legalaid-uat", controller="providers/check_benefits"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Benefit Checker request has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: Provider Details API
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-apply-for-legalaid-uat", controller="providers/saml/sign_in"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: Provider Details API request has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes
+    - alert: CCMS Submission
+      expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-apply-for-legalaid-uat", controller="check_merits_answers/continue"}[30m])) * 1800 > 1
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-uat
+      annotations:
+        message: CCMS Submission request has multiple consecutive HTTP 4xx or 5xx status errors over the last 30 minutes

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-serviceaccount.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-serviceaccount.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/exec"
+    verbs:
+      - "create"
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+      - "pods"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "ingresses"
+      - "deployments"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+      - "HorizontalPodAutoscaler"
+    verbs:
+      - "delete"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+      - "batch"
+      - "monitoring.coreos.com"
+    resources:
+      - "deployments"
+      - "cronjobs"
+      - "ingresses"
+      - "statefulsets"
+      - "replicasets"
+      - "networkpolicies"
+      - "servicemonitors"
+      - "prometheusrules"
+    verbs:
+      - "delete"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+subjects:
+- kind: ServiceAccount
+  name: "slackbot"
+  namespace: "laa-apply-for-legalaid-uat"
+roleRef:
+  kind: Role
+  name: "slackbot"
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
@@ -1,0 +1,38 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "apply-for-legal-aid-elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.3"
+
+  cluster_name           = var.cluster_name
+  team_name              = "apply-for-legal-aid"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "false"
+  environment-name       = "uat"
+  infrastructure-support = "apply@digital.justice.gov.uk"
+  engine_version         = "4.0.10"
+  parameter_group_name   = "default.redis4.0"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
+  metadata {
+    name      = "apply-for-legal-aid-elasticache-instance-output"
+    namespace = "laa-apply-for-legalaid-uat"
+  }
+
+  data = {
+    primary_endpoint_address = module.apply-for-legal-aid-elasticache.primary_endpoint_address
+    member_clusters          = jsonencode(module.apply-for-legal-aid-elasticache.member_clusters)
+    auth_token               = module.apply-for-legal-aid-elasticache.auth_token
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in London
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in Ireland
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {
+}
+
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -1,0 +1,30 @@
+module "authorized-keys" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
+
+  team_name              = "apply-for-legal-aid"
+  acl                    = "private"
+  business-unit          = "laa"
+  application            = "laa-apply-for-legal-aid"
+  is-production          = "false"
+  environment-name       = "uat"
+  infrastructure-support = "apply@digital.justice.gov.uk"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
+  metadata {
+    name      = "apply-for-legal-aid-s3-instance-output"
+    namespace = "laa-apply-for-legalaid-uat"
+  }
+
+  data = {
+    bucket_name       = module.authorized-keys.bucket_name
+    access_key_id     = module.authorized-keys.access_key_id
+    secret_access_key = module.authorized-keys.secret_access_key
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
@@ -1,0 +1,3 @@
+variable "namespace" {
+  default = "laa-apply-for-legalaid-uat"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-admin.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-admin.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: serviceaccount-admin
+  namespace: laa-apply-for-legalaid-uat
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: laa-apply-for-legalaid-uat
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-uat
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-uat
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+      - "HorizontalPodAutoscaler"
+    verbs:
+      - "patch"
+      - "get"
+      - "update"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+      - "batch"
+      - "monitoring.coreos.com"
+    resources:
+      - "deployments"
+      - "cronjobs"
+      - "ingresses"
+      - "statefulsets"
+      - "replicasets"
+      - "networkpolicies"
+      - "servicemonitors"
+      - "prometheusrules"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-apply-for-legalaid-uat
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-apply-for-legalaid-uat
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Migrates the `laa-apply-for-legalaid-uat` to the new live cluster. 

This will trigger warnings about missing ingress annotations which can be ignored. We use this namespace for ephemeral test environments based on github branches. Ingress details are set dynamically by a [script](https://github.com/ministryofjustice/laa-apply-for-legal-aid/blob/main/bin/uat_deploy) in the application repo.