### PR TITLE
Migrate check-financial-eligibility-uat to live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/00-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: check-financial-eligibility-uat
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "uat"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/application: "check-financial-eligibility"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/check-financial-eligibility"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-alerts-prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/01-rbac.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: check-financial-eligibility-admin
+  namespace: check-financial-eligibility-uat
+subjects:
+  - kind: Group
+    name: "github:laa-apply-for-legal-aid"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: check-financial-eligibility-uat
+spec:
+  limits:
+  - default:
+      cpu: 250m
+      memory: 500Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: check-financial-eligibility-uat
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: check-financial-eligibility-uat
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: check-financial-eligibility-uat
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
@@ -1,0 +1,24 @@
+module "ecr-repo-check-financial-eligibility-service" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.5"
+
+  team_name = "laa-apply-for-legal-aid"
+  repo_name = "check-financial-eligibility-service"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "ecr-repo-check-financial-eligibility-service" {
+  metadata {
+    name      = "ecr-repo-check-financial-eligibility-service"
+    namespace = "check-financial-eligibility-uat"
+  }
+
+  data = {
+    repo_url          = module.ecr-repo-check-financial-eligibility-service.repo_url
+    access_key_id     = module.ecr-repo-check-financial-eligibility-service.access_key_id
+    secret_access_key = module.ecr-repo-check-financial-eligibility-service.secret_access_key
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {
+}
+
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/main.tf
@@ -25,5 +25,3 @@ provider "aws" {
 
 variable "cluster_name" {
 }
-
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/serviceaccount-admin.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/serviceaccount-admin.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: serviceaccount-admin
+  namespace: check-financial-eligibility-uat
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: check-financial-eligibility-uat
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/serviceaccount-circleci.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: check-financial-eligibility-uat
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: check-financial-eligibility-uat
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "update"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+      - "batch"
+    resources:
+      - "deployments"
+      - "ingresses"
+      - "statefulsets"
+      - "replicasets"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: check-financial-eligibility-uat
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: check-financial-eligibility-uat
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Migrates check-finanicial-ability-uat to the new live cluster.

This will trigger warnings about missing ingress annotations which can be ignored. We use this namespace for ephemeral test environments based on github branches. Ingress details are set dynamically by a [script](https://github.com/ministryofjustice/check-financial-eligibility/blob/main/bin/uat_deploy) in the application repo.