### PR TITLE
Migrate hmpps-interventions-dev namespace to live cluster

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-interventions-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "interventions"
+    cloud-platform.justice.gov.uk/application: "Providing rehabilitation services to service users"
+    cloud-platform.justice.gov.uk/owner: "Interventions: interventions-alpha-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-interventions-service"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-interventions"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/01-rbac.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-interventions-dev-admin
+  namespace: hmpps-interventions-dev
+subjects:
+  - kind: Group
+    name: "github:hmpps-interventions"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-interventions-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-interventions-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-interventions-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-interventions-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/05-serviceaccount-circleci.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: "hmpps-interventions-dev"
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: "hmpps-interventions-dev"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+      - "configmaps"
+    verbs:
+      - "patch"
+      - "get"
+      - "update"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+      - "replicasets"
+    verbs:
+      - "get"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+      - "list"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: "hmpps-interventions-dev"
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: "hmpps-interventions-dev"
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/analytical-platform-access.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/analytical-platform-access.tf
@@ -1,3 +1,15 @@
+module "ap_irsa" {
+  source           = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=1.0.2"
+  namespace        = var.namespace
+  role_policy_arns = [aws_iam_policy.ap_policy.arn]
+  service_account  = "to-ap-s3-service-account"
+}
+
+resource "aws_iam_policy" "ap_policy" {
+  name   = "${var.namespace}-ap-policy"
+  policy = data.aws_iam_policy_document.ap_access.json
+}
+
 data "aws_iam_policy_document" "ap_access" {
   statement {
     sid = "AllowRdsExportUserToListS3Buckets"
@@ -57,5 +69,17 @@ resource "kubernetes_secret" "ap_aws_secret" {
     user_arn           = aws_iam_user.user.arn
     access_key_id      = aws_iam_access_key.user.id
     secret_access_key  = aws_iam_access_key.user.secret
+  }
+}
+
+resource "kubernetes_secret" "ap_irsa" {
+  metadata {
+    name      = "to-ap-s3-irsa"
+    namespace = var.namespace
+  }
+
+  data = {
+    role           = module.ap_irsa.aws_iam_role_name
+    serviceaccount = module.ap_irsa.service_account_name.name
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/analytical-platform-access.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/analytical-platform-access.tf
@@ -1,0 +1,61 @@
+data "aws_iam_policy_document" "ap_access" {
+  statement {
+    sid = "AllowRdsExportUserToListS3Buckets"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+
+    resources = [
+      "arn:aws:s3:::*"
+    ]
+  }
+
+  statement {
+    sid = "AllowRdsExportUserWriteToS3"
+    actions = [
+      "s3:PutObject*",
+      "s3:PutObjectAcl",
+      "s3:GetObject*",
+      "s3:DeleteObject*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.namespace}-landing/*",
+      "arn:aws:s3:::${var.namespace}-landing/"
+    ]
+  }
+}
+
+resource "random_id" "id" {
+  byte_length = 16
+}
+
+resource "aws_iam_user" "user" {
+  name = "ap-s3-bucket-user-${random_id.id.hex}"
+  path = "/system/ap-s3-bucket-user/"
+}
+
+resource "aws_iam_access_key" "user" {
+  user = aws_iam_user.user.name
+}
+
+resource "aws_iam_user_policy" "policy" {
+  name   = "${var.namespace}-ap-s3-snapshots"
+  policy = data.aws_iam_policy_document.ap_access.json
+  user   = aws_iam_user.user.name
+}
+
+resource "kubernetes_secret" "ap_aws_secret" {
+  metadata {
+    name      = "analytical-platform-reporting-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    destination_bucket = "s3://${var.namespace}-landing"
+    user_arn           = aws_iam_user.user.arn
+    access_key_id      = aws_iam_access_key.user.id
+    secret_access_key  = aws_iam_access_key.user.secret
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/elasticache.tf
@@ -1,0 +1,36 @@
+################################################################################
+# Interventions Elasticache for ReDiS
+################################################################################
+
+module "hmpps_interventions_elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.3"
+  cluster_name           = var.cluster_name
+  application            = var.application
+  environment-name       = var.environment
+  is-production          = var.is_production
+  infrastructure-support = var.infrastructure_support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = "cache.t2.small"
+  engine_version         = "6.x"
+  parameter_group_name   = "default.redis6.x"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "hmpps_interventions_elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.hmpps_interventions_elasticache_redis.primary_endpoint_address
+    auth_token               = module.hmpps_interventions_elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.hmpps_interventions_elasticache_redis.member_clusters)
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds.tf
@@ -1,0 +1,34 @@
+module "hmpps_interventions_rds" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  cluster_name           = var.cluster_name
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  namespace              = var.namespace
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  rds_family             = var.rds_family
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "hmpps_interventions_rds" {
+  metadata {
+    name      = "postgres"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.hmpps_interventions_rds.rds_instance_endpoint
+    database_name         = module.hmpps_interventions_rds.database_name
+    database_username     = module.hmpps_interventions_rds.database_username
+    database_password     = module.hmpps_interventions_rds.database_password
+    rds_instance_address  = module.hmpps_interventions_rds.rds_instance_address
+    access_key_id         = module.hmpps_interventions_rds.access_key_id
+    secret_access_key     = module.hmpps_interventions_rds.secret_access_key
+    url                   = "postgres://${module.hmpps_interventions_rds.database_username}:${module.hmpps_interventions_rds.database_password}@${module.hmpps_interventions_rds.rds_instance_endpoint}/${module.hmpps_interventions_rds.database_name}"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/reporting-landing-access.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/reporting-landing-access.tf
@@ -10,6 +10,11 @@ resource "aws_iam_policy" "ndmis_policy" {
   policy = data.aws_iam_policy_document.reporting_access.json
 }
 
+locals {
+  bucket_name   = "eu-west-2-delius-mis-dev-dfi-extracts"
+  bucket_prefix = "dfinterventions/dfi"
+}
+
 data "aws_iam_policy_document" "reporting_access" {
   statement {
     sid = "AllowDataExportUserToListS3Buckets"
@@ -33,10 +38,8 @@ data "aws_iam_policy_document" "reporting_access" {
     ]
 
     resources = [
-      "arn:aws:s3:::eu-west-2-delius-mis-dev-dfi-extracts/dfinterventions/dfi/*",
-      "arn:aws:s3:::eu-west-2-delius-mis-dev-dfi-extracts/dfinterventions/dfi/",
-      "arn:aws:s3:::eu-west-2-delius-mis-dev-dfi-extracts/exports/csv/reports/*",
-      "arn:aws:s3:::eu-west-2-delius-mis-dev-dfi-extracts/exports/csv/reports/"
+      "arn:aws:s3:::${local.bucket_name}/${local.bucket_prefix}/*",
+      "arn:aws:s3:::${local.bucket_name}/${local.bucket_prefix}/"
     ]
   }
 }
@@ -67,11 +70,11 @@ resource "kubernetes_secret" "reporting_aws_secret" {
   }
 
   data = {
-    destination_bucket = "s3://eu-west-2-delius-mis-dev-dfi-extracts/dfinterventions/dfi"
+    destination_bucket = "s3://${local.bucket_name}/${local.bucket_prefix}"
     user_arn           = aws_iam_user.reporting_user.arn
     access_key_id      = aws_iam_access_key.reporting_user.id
     secret_access_key  = aws_iam_access_key.reporting_user.secret
-    bucket_name        = "eu-west-2-delius-mis-dev-dfi-extracts"
+    bucket_name        = local.bucket_name
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/reporting-landing-access.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/reporting-landing-access.tf
@@ -1,0 +1,64 @@
+data "aws_iam_policy_document" "reporting_access" {
+  statement {
+    sid = "AllowDataExportUserToListS3Buckets"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+
+    resources = [
+      "arn:aws:s3:::*"
+    ]
+  }
+
+  statement {
+    sid = "AllowDataExportUserToWriteToS3"
+    actions = [
+      "s3:PutObject*",
+      "s3:PutObjectAcl",
+      "s3:GetObject*",
+      "s3:DeleteObject*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::eu-west-2-delius-mis-dev-dfi-extracts/dfinterventions/dfi/*",
+      "arn:aws:s3:::eu-west-2-delius-mis-dev-dfi-extracts/dfinterventions/dfi/",
+      "arn:aws:s3:::eu-west-2-delius-mis-dev-dfi-extracts/exports/csv/reports/*",
+      "arn:aws:s3:::eu-west-2-delius-mis-dev-dfi-extracts/exports/csv/reports/"
+    ]
+  }
+}
+
+resource "random_id" "reporting_user_id" {
+  byte_length = 16
+}
+
+resource "aws_iam_user" "reporting_user" {
+  name = "reporting-s3-bucket-user-${random_id.reporting_user_id.hex}"
+  path = "/system/reporting-s3-bucket-user/"
+}
+
+resource "aws_iam_access_key" "reporting_user" {
+  user = aws_iam_user.reporting_user.name
+}
+
+resource "aws_iam_user_policy" "reporting_user_policy" {
+  name   = "${var.namespace}-reporting-s3-snapshots"
+  policy = data.aws_iam_policy_document.reporting_access.json
+  user   = aws_iam_user.reporting_user.name
+}
+
+resource "kubernetes_secret" "reporting_aws_secret" {
+  metadata {
+    name      = "reporting-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    destination_bucket = "s3://eu-west-2-delius-mis-dev-dfi-extracts/dfinterventions/dfi"
+    user_arn           = aws_iam_user.reporting_user.arn
+    access_key_id      = aws_iam_access_key.reporting_user.id
+    secret_access_key  = aws_iam_access_key.reporting_user.secret
+    bucket_name        = "eu-west-2-delius-mis-dev-dfi-extracts"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/s3.tf
@@ -1,0 +1,34 @@
+/*
+ Based on https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/tree/main/example
+ */
+module "interventions_s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.6"
+
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  infrastructure-support = var.infrastructure_support
+
+  is-production    = var.is_production
+  environment-name = var.environment
+  namespace        = var.namespace
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "interventions_s3_bucket" {
+  metadata {
+    name      = "storage-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.interventions_s3_bucket.access_key_id
+    secret_access_key = module.interventions_s3_bucket.secret_access_key
+    bucket_arn        = module.interventions_s3_bucket.bucket_arn
+    bucket_name       = module.interventions_s3_bucket.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/variables.tf
@@ -1,0 +1,50 @@
+
+variable "cluster_name" {
+}
+
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Providing rehabilitation services to service users"
+}
+
+variable "namespace" {
+  default = "hmpps-interventions-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-interventions"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "interventions-alpha-team@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "interventions"
+}
+
+variable "number_cache_clusters" {
+  default = "2"
+}
+
+variable "rds_family" {
+  default = "postgres10"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
The cross-account definition changes are in a7fedf15cee3e6c33d8ba8e28fa922753b427126 -- I don't know if these are right, could someone review them in-depth, please?