### PR TITLE
Include actual allocated storage

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-live.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-live.tf
@@ -20,6 +20,8 @@ module "rds-live" {
   rds_family    = "postgres11"
   backup_window = "02:00-03:00"
 
+  db_allocated_storage        = "59"
+
   snapshot_identifier = "rds:cloud-platform-78407cd5fbd86ed5-2021-11-25-02-13"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-live.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-live.tf
@@ -20,7 +20,7 @@ module "rds-live" {
   rds_family    = "postgres11"
   backup_window = "02:00-03:00"
 
-  db_allocated_storage        = "59"
+  db_allocated_storage = "59"
 
   snapshot_identifier = "rds:cloud-platform-78407cd5fbd86ed5-2021-11-25-02-13"
 


### PR DESCRIPTION
The actual value of the db_allocated_storage has to be set when doing snapshot restore. This is to prevent terraform overriding to default value of 10 which throw error during snapshot restore.