### PR TITLE
Remove interventions-research SNS topic secret

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-interventions.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-interventions.tf
@@ -11,19 +11,6 @@ resource "kubernetes_secret" "intervention_global_events_sns" {
   }
 }
 
-resource "kubernetes_secret" "intervention_research_global_events_sns" {
-  metadata {
-    name      = "hmpps-domain-events-topic"
-    namespace = "hmpps-interventions-research"
-  }
-
-  data = {
-    access_key_id     = module.hmpps-domain-events.access_key_id
-    secret_access_key = module.hmpps-domain-events.secret_access_key
-    topic_arn         = module.hmpps-domain-events.topic_arn
-  }
-}
-
 module "hmpps-delius-interventions-event-listener-queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.4"
 


### PR DESCRIPTION
We no longer use the `hmpps-interventions-research` environment