### PR TITLE
Add prometheus rules for elsa-relevant-search

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/prometheus.yml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elsa-relevant-search-production/prometheus.yml
@@ -1,0 +1,51 @@
+# Prometheus Alerts
+#
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html
+#
+# Note: we are using a regex in the namespace to filter and trigger alerts
+# in both, staging and production environments.
+#
+# To see the current alerts in this namespace:
+#   kubectl describe prometheusrule -n elsa-relevant-search-production
+#
+# Alerts will be sent to the slack channel: #cross_justice_team
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: elsa-relevant-search-prometheus-production
+  namespace: elsa-relevant-search-production
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: FJ-RS-DeploymentReplicasMismatch
+      expr: >-
+        kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"^elsa-relevant-search.*"}
+        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+      for: 30m
+      labels:
+        severity: family-justice
+      annotations:
+        message: Deployment `{{ $labels.deployment }}` has not matched the expected number of replicas for more than 30 mins.
+
+    - alert: FJ-RS-JobFailed
+      expr: >-
+        kube_job_status_failed{job="kube-state-metrics", namespace=~"^elsa-relevant-search.*"} > 0
+      for: 1h
+      labels:
+        severity: family-justice
+      annotations:
+        message: Job `{{ $labels.job_name }}` failed to complete.
+
+    - alert: FJ-RS-ContainerRestarting
+      expr: >-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"^elsa-relevant-search.*"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: family-justice
+      annotations:
+        message: Pod `{{ $labels.pod }}` has been restarting in `{{ $labels.namespace }}` for the last 5 minutes.


### PR DESCRIPTION
This is a fully migrated service. Both staging and production envs are on the `live` cluster now. But the production namespace is not really public, as in nobody is using it yet.

Just using the standard prometheus rules we use already in our services.