### PR TITLE
Prisoner content hub - dev - update S3 CORS allowed origin

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -15,7 +15,7 @@ module "drupal_content_storage" {
     {
       allowed_headers = ["Accept", "Content-Type", "Origin"]
       allowed_methods = ["GET", "PUT", "POST"]
-      allowed_origins = ["https://cms-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk"]
+      allowed_origins = ["https://cms-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk"]
       max_age_seconds = 3000
     }
   ]


### PR DESCRIPTION
This PR updates the allowed origin on the S3 CORS config with the new domain for the cloud platform environment.

Without this change, users are unable to upload files.