### PR TITLE
Upgrade RDS sql to use the latest version

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hwpv_sqlserver" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
   cluster_name           = var.cluster_name
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
   cluster_name  = var.cluster_name
   team_name     = var.team_name
   business-unit = var.business_unit
@@ -26,6 +26,14 @@ module "rds" {
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "true"
+
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/legacy-ppud-api-rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/legacy-ppud-api-rds.tf
@@ -33,7 +33,7 @@ module "ppud_replica_dev_rds" {
   providers = {
     aws = aws.london
   }
-  
+
 }
 
 resource "aws_db_option_group" "ppud_replica_rds_option_group" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/legacy-ppud-api-rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-dev/resources/legacy-ppud-api-rds.tf
@@ -3,7 +3,7 @@
 ##
 
 module "ppud_replica_dev_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
 
   cluster_name           = var.cluster_name
   namespace              = var.namespace
@@ -23,9 +23,17 @@ module "ppud_replica_dev_rds" {
   license_model        = "license-included"
   option_group_name    = aws_db_option_group.ppud_replica_rds_option_group.name
 
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
   providers = {
     aws = aws.london
   }
+  
 }
 
 resource "aws_db_option_group" "ppud_replica_rds_option_group" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/legacy-ppud-api-rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-preprod/resources/legacy-ppud-api-rds.tf
@@ -3,7 +3,7 @@
 ##
 
 module "ppud_replica_preprod_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
 
   cluster_name           = var.cluster_name
   namespace              = var.namespace
@@ -23,6 +23,13 @@ module "ppud_replica_preprod_rds" {
   license_model        = "license-included"
   option_group_name    = aws_db_option_group.ppud_replica_rds_option_group.name
 
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
   providers = {
     aws = aws.london
   }

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/rds.tf
@@ -45,7 +45,7 @@ resource "kubernetes_secret" "ppud_replacement_prod_rds_secrets" {
 ##
 
 module "ppud_replica_prod_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
 
   cluster_name           = var.cluster_name
   namespace              = var.namespace
@@ -65,6 +65,13 @@ module "ppud_replica_prod_rds" {
   license_model        = "license-included"
   option_group_name    = aws_db_option_group.ppud_replica_rds_option_group.name
 
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
   providers = {
     aws = aws.london
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hwpv_sqlserver" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
   cluster_name           = var.cluster_name
   team_name              = var.team_name
   business-unit          = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hwpv_sqlserver" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
   cluster_name           = var.cluster_name
   team_name              = var.team_name
   business-unit          = var.business-unit


### PR DESCRIPTION
For sql rds which don’t specify db_parameter as [ ], set them to below
  db_parameter = [
    {
      name         = "rds.force_ssl"
      value        = "1"
      apply_method = "pending-reboot"
    }
  ]