### PR TITLE
Fix missing quote on SQS-number-of-messages rule

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/09-prometheus-sqs-sns.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/offender-events-prod/09-prometheus-sqs-sns.yaml
@@ -24,7 +24,7 @@ spec:
         message: SQS - {{ $labels.queue_name }} - number of messages={{ $value }} (exceeds 100), check consumers are healthy.  https://grafana.live-1.cloud-platform.service.justice.gov.uk/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $labels.queue_name }}&from=now-6h&to=now
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NOM/pages/1739325587/DPS+Runbook
       expr: |-
-        sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name!~"Digital-Prison-Services-prod-hmpps_allocation_required|Digital-Prison-Services-prod-hmpps_tier_calculation_allocation",queue_name!~"Digital-Prison-Services-prod-hmpps_tier.*",queue_name!="Digital-Prison-Services-prod-cfo_queue",queue_name!="Digital-Prison-Services-prod-in_cell_hmpps_queue",queue_name=~"Digital-Prison-Services-prod.*", queue_name!~".*_dl|.*dlq} offset 5m) by (queue_name) > 100
+        sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name!~"Digital-Prison-Services-prod-hmpps_allocation_required|Digital-Prison-Services-prod-hmpps_tier_calculation_allocation",queue_name!~"Digital-Prison-Services-prod-hmpps_tier.*",queue_name!="Digital-Prison-Services-prod-cfo_queue",queue_name!="Digital-Prison-Services-prod-in_cell_hmpps_queue",queue_name=~"Digital-Prison-Services-prod.*", queue_name!~".*_dl|.*dlq"} offset 5m) by (queue_name) > 100
       for: 10m
       labels:
         severity: digital-prison-service


### PR DESCRIPTION
FYI: @markreesmoj . The prometheusrule seems to be failing because of missing quote in one of the rule.