### PR TITLE
Configure hmpps-manage-supervisions-prototype

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-manage-supervisions-prototype
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "probation-end-to-end-team"
+    cloud-platform.justice.gov.uk/application: "Gov.UK Prototype Kit"
+    cloud-platform.justice.gov.uk/owner: "Probation end to end: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-manage-supervisions-prototype"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-probation-end-to-end"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-manage-supervisions-prototype-admin
+  namespace: hmpps-manage-supervisions-prototype
+subjects:
+  - kind: Group
+    name: "github:hmpps-probation-end-to-end"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-manage-supervisions-prototype
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-manage-supervisions-prototype
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-manage-supervisions-prototype
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-manage-supervisions-prototype
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/basic-auth.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/basic-auth.tf
@@ -1,0 +1,13 @@
+# Username and password for the prototype kit website's http basic
+# authentication
+resource "kubernetes_secret" "basic-auth" {
+  metadata {
+    name      = "basic-auth"
+    namespace = var.namespace
+  }
+
+  data = {
+    username = var.basic-auth-username
+    password = var.basic-auth-password
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/ecr.tf
@@ -1,0 +1,22 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.5"
+
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  github_repositories = [var.namespace]
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
+    repo_arn          = module.ecr-repo.repo_arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/github-repo.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/github-repo.tf
@@ -1,0 +1,61 @@
+data "github_team" "default" {
+  slug = "hmpps-probation-end-to-end"
+}
+
+locals {
+  topics = ["gov-uk-prototype-kit", "moj-cloud-platform"]
+
+  # These teams will be granted admin access to the github repository
+  teams = {
+    "default" : { id = data.github_team.default.id },
+  }
+}
+
+# Repository basics
+resource "github_repository" "prototype" {
+  name                   = var.namespace
+  description            = "Gov.UK Prototype Kit. This repository is defined and managed in Terraform"
+  visibility             = "public"
+  has_issues             = false
+  has_projects           = false
+  has_wiki               = false
+  has_downloads          = false
+  is_template            = false
+  allow_merge_commit     = true
+  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  delete_branch_on_merge = true
+  auto_init              = false
+  archived               = false
+  vulnerability_alerts   = true
+  topics                 = local.topics
+
+  template {
+    owner      = "ministryofjustice"
+    repository = "moj-prototype-template"
+  }
+
+  lifecycle {
+    ignore_changes = [template]
+  }
+}
+
+resource "github_branch_protection" "default" {
+  repository_id          = github_repository.prototype.id
+  pattern                = "main"
+  enforce_admins         = true
+  require_signed_commits = true
+}
+
+resource "github_team_repository" "prototype" {
+  for_each   = local.teams
+  team_id    = each.value.id
+  repository = github_repository.prototype.name
+  permission = "admin"
+}
+
+resource "github_actions_secret" "prototype" {
+  repository      = github_repository.prototype.name
+  secret_name     = "PROTOTYPE_NAME"
+  plaintext_value = var.namespace
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/serviceaccount.tf
@@ -1,0 +1,8 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.2"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = [var.namespace]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/variables.tf
@@ -1,0 +1,69 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Gov.UK Prototype Kit"
+}
+
+variable "namespace" {
+  default = "hmpps-manage-supervisions-prototype"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-probation-end-to-end"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "platforms@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "probation-end-to-end-team"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}
+
+## Prototype kit variables
+
+variable "basic-auth-username" {
+  description = "Basic auth. username of the deployed prototype website"
+  default     = "manage"
+}
+
+variable "basic-auth-password" {
+  description = "Basic auth. password of the deployed prototype website"
+  default     = "supervisions"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}


### PR DESCRIPTION
First attempt at deploying this prototype to the cloud. 

The prototype already exists, it's using v11 of the kit on node 16 and this PR goes with:
 https://github.com/ministryofjustice/hmpps-manage-supervisions-prototype/pull/396

I've followed instructions in:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html

As the prototype repo exists already, I'm guessing the repo will be otherwise untouched?