### PR TITLE
[LAA Court Data Adaptor Prod] Increase CPU/memory request

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/02-limitrange.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 1000Mi
     defaultRequest:
-      cpu: 10m
-      memory: 100Mi
+      cpu: 25m
+      memory: 250Mi
     type: Container


### PR DESCRIPTION
Increase CPU request from 10 to 25Mi, and memory request from 100 to 250Mi to get back within bounds.

https://grafana.live-1.cloud-platform.service.justice.gov.uk/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=default&var-cluster

<img width="357" alt="Screenshot 2021-12-13 at 11 37 28" src="https://user-images.githubusercontent.com/3141541/145797455-c302bafa-4bbe-4148-b386-3d68951f31af.png">

<img width="360" alt="Screenshot 2021-12-13 at 11 37 39" src="https://user-images.githubusercontent.com/3141541/145797458-ec290165-0df8-4e6a-953b-c4dbea211e6d.png">
=&var-namespace=laa-court-data-adaptor-prod&from=now-24h&to=now