### PR TITLE
Create live namespace for laa-court-data-ui-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/00-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-court-data-ui-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "dev"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/application: "View court data"
+    cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
+    cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-court-data-ui"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-court-data-ui-dev-admin
+  namespace: laa-court-data-ui-dev
+subjects:
+  - kind: Group
+    name: "github:laa-get-paid"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-court-data-ui-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-court-data-ui-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/04-networkpolicy.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-court-data-ui-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-court-data-ui-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: laa-court-data-ui-dev
+spec:
+  podSelector:
+    matchLabels:
+      app: laa-court-data-ui
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/05-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/05-servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: laa-court-data-ui
+  namespace: laa-court-data-ui-dev
+spec:
+  selector:
+    matchLabels:
+      app: laa-court-data-ui-app-service
+  namespaceSelector:
+    matchNames:
+      - laa-court-data-ui-dev
+  endpoints:
+    - port: metrics
+      interval: 15s

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: laa-court-data-ui-dev-cert
+  namespace: laa-court-data-ui-dev
+spec:
+  secretName: laa-court-data-ui-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - dev.view-court-data.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/prometheus.yaml
@@ -1,0 +1,55 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-court-data-ui-dev
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-laa-court-data-ui
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Instance-Down
+      expr: absent(up{namespace="laa-court-data-ui-dev"}) == 1
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-court-data-ui-dev"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-court-data-ui-dev"} > 0) > 90
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-dev is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-ui-dev"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-dev More than a hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-dev,type:phrase),type:phrase,value:laa-court-data-ui-dev),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-dev,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-dev", status=~"5.."}[5m])) * 300 > 5
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-dev An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-court-data-ui-dev),type:phrase,value:laa-court-data-ui-dev),query:(match:(log_processed.kubernetes_namespace:(query:laa-court-data-ui-dev,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="laa-court-data-ui-dev"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-court-data-ui-dev"})
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-dev Container disk space usage is more than 150Mb or is not reported
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-court-data-ui-dev"} > 30
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-dev Request is taking more than 30 seconds

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/ecr.tf
@@ -1,0 +1,23 @@
+module "lcdui_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.5"
+  team_name = var.team_name
+  repo_name = var.repo_name
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "lcdui_ecr_credentials" {
+  metadata {
+    name      = "lcdui-ecr-credentials"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.lcdui_ecr_credentials.access_key_id
+    secret_access_key = module.lcdui_ecr_credentials.secret_access_key
+    repo_arn          = module.lcdui_ecr_credentials.repo_arn
+    repo_url          = module.lcdui_ecr_credentials.repo_url
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/elasticache.tf
@@ -1,0 +1,31 @@
+module "lcdui_elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.3"
+
+  cluster_name           = var.cluster_name
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  namespace              = var.namespace
+
+  engine_version        = "4.0.10"
+  parameter_group_name  = "default.redis4.0"
+  number_cache_clusters = "2"
+  node_type             = "cache.t2.micro"
+}
+
+resource "kubernetes_secret" "lcdui_elasticache" {
+  metadata {
+    name      = "lcdui-elasticache"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.lcdui_elasticache.primary_endpoint_address
+    auth_token               = module.lcdui_elasticache.auth_token
+    member_clusters          = jsonencode(module.lcdui_elasticache.member_clusters)
+    url                      = "rediss://dummyuser:${module.lcdui_elasticache.auth_token}@${module.lcdui_elasticache.primary_endpoint_address}:6379"
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/rds.tf
@@ -1,0 +1,42 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+
+module "lcdui_rds" {
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
+  cluster_name                = var.cluster_name
+  team_name                   = var.team_name
+  business-unit               = var.business-unit
+  application                 = var.application
+  is-production               = var.is-production
+  namespace                   = var.namespace
+  environment-name            = var.environment-name
+  infrastructure-support      = var.infrastructure-support
+  db_allocated_storage        = "10"
+  db_instance_class           = "db.t3.small"
+  db_engine_version           = "11"
+  rds_family                  = "postgres11"
+  allow_major_version_upgrade = "true"
+
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "lcdui_rds" {
+  metadata {
+    name      = "lcdui-rds"
+    namespace = var.namespace
+  }
+
+  data = {
+    # postgres://username:password@instance_endpoint/database_name
+    url = "postgres://${module.lcdui_rds.database_username}:${module.lcdui_rds.database_password}@${module.lcdui_rds.rds_instance_endpoint}/${module.lcdui_rds.database_name}"
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/variables.tf
@@ -1,0 +1,50 @@
+variable "application" {
+  default = "laa-court-data-ui"
+}
+
+variable "namespace" {
+  default = "laa-court-data-ui-dev"
+}
+
+variable "domain" {
+  default = "view-court-data.service.justice.gov.uk"
+}
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "legal-aid-agency"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "laa-get-paid"
+}
+
+variable "repo_name" {
+  description = "The name of github repo AND ecr repo"
+  default     = "laa-court-data-ui"
+}
+
+variable "environment-name" {
+  description = "The type of environment you're deploying to."
+  default     = "dev"
+}
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "laa-get-paid@digital.justice.gov.uk"
+}
+
+variable "is-production" {
+  default = "false"
+}
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+variable "cluster_name" {
+}
+
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/serviceaccount-circleci.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-court-data-ui-dev
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-court-data-ui-dev
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-court-data-ui-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-court-data-ui-dev
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Create live namespace for laa-court-data-ui-dev following instructions from the [documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live.html#step-3-migrate-your-namespace-environment-to-quot-live-quot)