### PR TITLE
Form Builder - Remove Pingdom alerts

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
@@ -7,7 +7,6 @@ locals {
     ccrc                           = "ccrc.form.service.justice.gov.uk",
     childrens-funeral-fund         = "claim-for-costs-of-a-childs-funeral.form.service.justice.gov.uk",
     cica                           = "same-roof-rule.form.service.justice.gov.uk",
-    cjsm-user-research-consent     = "cjsm-user-research-consent-form.form.service.justice.gov.uk"
     complain-about-a-court         = "complain-about-a-court-or-tribunal.form.service.justice.gov.uk",
     complain-to-the-cica           = "complain-to-the-cica.form.service.justice.gov.uk",
     contact-the-cica               = "contact-the-cica.form.service.justice.gov.uk",
@@ -17,7 +16,6 @@ locals {
     let-us-know                    = "let-us-know.form.service.justice.gov.uk",
     miscarriages-of-justice        = "miscarriages-of-justice.form.service.justice.gov.uk",
     moj-forms                      = "moj-forms.service.justice.gov.uk",
-    moj-user-research-consent      = "ministry-of-justice-user-research-consent-form.form.service.justice.gov.uk",
     money-claim-queries            = "money-claim-queries.form.service.justice.gov.uk",
     publisher                      = "fb-publisher-live.apps.live-1.cloud-platform.service.justice.gov.uk",
     report-security-incident       = "report-security-incident.form.service.justice.gov.uk",


### PR DESCRIPTION
The pingdom monitoring for these two services will be controlled using
our Editor app instead of the cloud platform environments repo.

Therefore we can remove them from here.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>