### PR TITLE
Change team ownership for interventions

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-interventions-prod
 subjects:
   - kind: Group
-    name: "github:interventions-ops"
+    name: "github:hmpps-interventions-dev"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:dps-tech"


### PR DESCRIPTION
We've decided to simplify authorizations by creating a dev-only team