### PR TITLE
Change team ownership for interventions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-interventions-preprod
 subjects:
   - kind: Group
-    name: "github:interventions-ops"
+    name: "github:hmpps-interventions-dev"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:dps-tech"


### PR DESCRIPTION
We've decided to simplify authorizations by creating a dev-only team