### PR TITLE
AAC-393 - Migrate to VCD Production to live namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/00-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-court-data-ui-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/application: "View court data"
+    cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
+    cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-court-data-ui"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-court-data-ui-production-admin
+  namespace: laa-court-data-ui-production
+subjects:
+  - kind: Group
+    name: "github:laa-get-paid"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-court-data-ui-production
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-court-data-ui-production
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/04-networkpolicy.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-court-data-ui-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-court-data-ui-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: laa-court-data-ui-production
+spec:
+  podSelector:
+    matchLabels:
+      app: laa-court-data-ui
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/05-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/05-servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: laa-court-data-ui
+  namespace: laa-court-data-ui-production
+spec:
+  selector:
+    matchLabels:
+      app: laa-court-data-ui-app-service
+  namespaceSelector:
+    matchNames:
+      - laa-court-data-ui-production
+  endpoints:
+    - port: metrics
+      interval: 30s

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: laa-court-data-ui-production-cert
+  namespace: laa-court-data-ui-production
+spec:
+  secretName: laa-court-data-ui-production-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - view-court-data.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/http_status_codes_grafana_dashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/http_status_codes_grafana_dashboard.yaml
@@ -1,0 +1,434 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-status-codes
+  namespace: laa-court-data-ui-production
+  labels:
+    grafana_dashboard: ""
+data:
+  laa-court-data-ui-status-codes-dashboard.json: |
+    {
+      "__inputs": [],
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "5.4.3"
+        },
+        {
+          "type": "panel",
+          "id": "graph",
+          "name": "Graph",
+          "version": "5.0.0"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "5.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "table",
+          "name": "Table",
+          "version": "5.0.0"
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": null,
+      "iteration": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "panels": [],
+          "repeat": null,
+          "title": "HTTP Status",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 10,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 0,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 0,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(ruby_http_requests_total{status=\"$status\", namespace=\"$namespace\"}[5m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "$status",
+              "legendLink": null,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "rate(5m) | $status | $namespace",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "columns": [],
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 1,
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 10
+          },
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "pageSize": null,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "scroll": true,
+          "seriesOverrides": [],
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "link": false,
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "__name__",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "namespace",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "service",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "endpoint",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "ruby_http_requests_total{status=\"$status\", namespace=\"$namespace\"}",
+              "format": "table",
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$status | $namespace",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transform": "table",
+          "type": "table",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "refresh": false,
+      "schemaVersion": 16,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": true,
+              "text": "Prometheus",
+              "value": "Prometheus"
+            },
+            "hide": 0,
+            "label": null,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "laa-court-data-ui-staging",
+              "value": "laa-court-data-ui-staging"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [
+              {
+                "selected": true,
+                "text": "laa-court-data-ui-staging",
+                "value": "laa-court-data-ui-staging"
+              },
+              {
+                "selected": false,
+                 "text": "laa-court-data-ui-uat",
+                "value": "laa-court-data-ui-uat"
+              },
+              {
+                "selected": false,
+                "text": "laa-court-data-ui-production",
+                "value": "laa-court-data-ui-production"
+              }
+            ],
+            "query": "laa-court-data-ui-staging,  laa-court-data-ui-uat,  laa-court-data-ui-production",
+            "skipUrlSync": false,
+            "type": "custom"
+          },
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "$datasource",
+            "definition": "label_values(ruby_http_requests_total{namespace=\"$namespace\"}, status)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "status",
+            "multi": false,
+            "name": "status",
+            "options": [],
+            "query": "label_values(ruby_http_requests_total{namespace=\"$namespace\"}, status)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 2,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-7d",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "LAA Court Data UI / HTTP Status codes",
+      "uid": "VxuKVkoMz",
+      "version": 1
+    }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/kubernetes_pods_dashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/kubernetes_pods_dashboard.yaml
@@ -1,0 +1,452 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-pods
+  namespace: laa-court-data-ui-production
+  labels:
+    grafana_dashboard: ""
+data:
+  laa-court-data-ui-kubernetes-pods-dashboard.json: |
+    {
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "5.4.2"
+        },
+        {
+          "type": "panel",
+          "id": "graph",
+          "name": "Graph",
+          "version": "5.0.0"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "5.0.0"
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "limit": 100,
+            "name": "Annotations & Alerts",
+            "showIn": 0,
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 1,
+      "id": null,
+      "iteration": 1548242989805,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 12,
+          "panels": [],
+          "title": "",
+          "type": "row"
+        },
+        {
+          "aliasColors": {
+            "Limit": "#bf1b00",
+            "Limit (hard limit)": "#bf1b00",
+            "Requested (soft limit)": "#f2c96d"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 450,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by(pod_name)(container_memory_usage_bytes{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "POD: {{` pod_name `}}",
+              "refId": "A"
+            },
+            {
+              "expr": "avg(kube_pod_container_resource_requests_memory_bytes{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Requested (soft limit)",
+              "refId": "C"
+            },
+            {
+              "expr": "avg(kube_pod_container_resource_limits_memory_bytes{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Limit (hard limit)",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Limit": "#bf1b00",
+            "Requested (soft limit)": "#f2c96d"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": null,
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 450,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (pod_name)(rate(container_cpu_usage_seconds_total{namespace='$namespace'}[5m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "POD: {{` pod_name `}}",
+              "refId": "A"
+            },
+            {
+              "expr": "avg(kube_pod_container_resource_requests_cpu_cores{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Requested (soft limit)",
+              "refId": "B"
+            },
+            {
+              "expr": "avg(kube_pod_container_resource_limits_cpu_cores{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Limit (hard limit)",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Limit": "#bf1b00"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": null,
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 17
+          },
+          "id": 14,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 450,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_receive_bytes_total{namespace='$namespace'}[5m]))))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Recv",
+              "refId": "A"
+            },
+            {
+              "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_transmit_bytes_total{namespace='$namespace'}[5m]))))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Sent",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Network",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "deckbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "schemaVersion": 16,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_deployment_metadata_generation, namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(kube_deployment_metadata_generation, namespace)",
+            "refresh": 1,
+            "regex": "/^laa-court-data-ui-/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-24h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "browser",
+      "title": "LAA Court Data UI / Kubernetes Pods",
+      "uid": null,
+      "version": 1
+    }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/prometheus.yaml
@@ -1,0 +1,56 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-court-data-ui-production
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-laa-court-data-ui
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Instance-Down
+      expr: absent(up{namespace="laa-court-data-ui-production"}) == 1
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-court-data-ui-production"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-court-data-ui-production"} > 0) > 90
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-production is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-ui-production"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-production More than a hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-production,type:phrase),type:phrase,value:laa-court-data-ui-production),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-production,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-production", status=~"5.."}[5m])) * 300 > 5
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-production An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-court-data-ui-production),type:phrase,value:laa-court-data-ui-production),query:(match:(log_processed.kubernetes_namespace:(query:laa-court-data-ui-production,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="laa-court-data-ui-production"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-court-data-ui-production"})
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-production Container disk space usage is more than 150Mb or is not reported
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-court-data-ui-production"} > 30
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: laa-court-data-ui-production Request is taking more than 30 seconds
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/elasticache.tf
@@ -1,0 +1,31 @@
+module "lcdui_elasticache" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.3"
+
+  cluster_name           = var.cluster_name
+  application            = var.application
+  environment-name       = var.environment-name
+  is-production          = var.is-production
+  infrastructure-support = var.infrastructure-support
+  team_name              = var.team_name
+  namespace              = var.namespace
+
+  engine_version        = "4.0.10"
+  parameter_group_name  = "default.redis4.0"
+  number_cache_clusters = "2"
+  node_type             = "cache.t2.micro"
+}
+
+resource "kubernetes_secret" "lcdui_elasticache" {
+  metadata {
+    name      = "lcdui-elasticache"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.lcdui_elasticache.primary_endpoint_address
+    auth_token               = module.lcdui_elasticache.auth_token
+    member_clusters          = jsonencode(module.lcdui_elasticache.member_clusters)
+    url                      = "rediss://dummyuser:${module.lcdui_elasticache.auth_token}@${module.lcdui_elasticache.primary_endpoint_address}:6379"
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/pingdom.tf
@@ -4,7 +4,7 @@ provider "pingdom" {
 resource "pingdom_check" "laa-court-data-ui-production" {
   type                     = "http"
   name                     = "View court data production - ping"
-  host                     = "${var.domain}"
+  host                     = var.domain
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/pingdom.tf
@@ -1,0 +1,19 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "laa-court-data-ui-production" {
+  type                     = "http"
+  name                     = "View court data production - ping"
+  host                     = "${var.domain}"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/ping"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_${var.business-unit},application_${var.application},component_ping,isproduction_${var.is-production},environment_${var.environment-name},infrastructuresupport_${var.application}"
+  probefilters             = "region:EU"
+  integrationids           = [94703]
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
@@ -1,0 +1,42 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+
+module "lcdui_rds" {
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
+  cluster_name                = var.cluster_name
+  team_name                   = var.team_name
+  business-unit               = var.business-unit
+  application                 = var.application
+  is-production               = var.is-production
+  namespace                   = var.namespace
+  environment-name            = var.environment-name
+  infrastructure-support      = var.infrastructure-support
+  db_allocated_storage        = "10"
+  db_instance_class           = "db.t3.small"
+  db_engine_version           = "11"
+  rds_family                  = "postgres11"
+  allow_major_version_upgrade = "true"
+
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "lcdui_rds" {
+  metadata {
+    name      = "lcdui-rds"
+    namespace = var.namespace
+  }
+
+  data = {
+    # postgres://username:password@instance_endpoint/database_name
+    url = "postgres://${module.lcdui_rds.database_username}:${module.lcdui_rds.database_password}@${module.lcdui_rds.rds_instance_endpoint}/${module.lcdui_rds.database_name}"
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "lcdui_route53_zone" {
+  name = var.domain
+
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "lcdui_route53_zone_sec" {
+  metadata {
+    name      = "lcdui-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.lcdui_route53_zone.zone_id
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/variables.tf
@@ -1,0 +1,50 @@
+variable "application" {
+  default = "laa-court-data-ui"
+}
+
+variable "namespace" {
+  default = "laa-court-data-ui-production"
+}
+
+variable "domain" {
+  default = "view-court-data.service.justice.gov.uk"
+}
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "legal-aid-agency"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "laa-get-paid"
+}
+
+variable "repo_name" {
+  description = "The name of github repo AND ecr repo"
+  default     = "laa-court-data-ui"
+}
+
+variable "environment-name" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "laa-get-paid@digital.justice.gov.uk"
+}
+
+variable "is-production" {
+  default = "true"
+}
+
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+variable "cluster_name" {
+}
+
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/versions.tf
@@ -9,7 +9,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     pingdom = {
-      source = "russellcardullo/pingdom"
+      source  = "russellcardullo/pingdom"
       version = "1.1.3"
     }
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/versions.tf
@@ -1,0 +1,16 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    pingdom = {
+      source = "russellcardullo/pingdom"
+      version = "1.1.3"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/serviceaccount-circleci.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: laa-court-data-ui-production
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-court-data-ui-production
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "pods"
+    verbs:
+      - "patch"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "extensions"
+      - "apps"
+      - "networking.k8s.io"
+    resources:
+      - "deployments"
+      - "ingresses"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "update"
+      - "delete"
+      - "create"
+      - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+      - "cronjobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: laa-court-data-ui-production
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: laa-court-data-ui-production
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Create live namespace for laa-court-data-ui-production following instructions from the [documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live.html#step-3-migrate-your-namespace-environment-to-quot-live-quot)