### PR TITLE
Remove cloudwatch log group for development and staging

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -3,39 +3,6 @@
 # Application Elasticsearch cluster
 #################################################################################
 
-# For logging elastic search on cloudwatch
-resource "aws_cloudwatch_log_group" "peoplefinder_cloudwatch_log_group" {
-  name              = "/aws/aes/domains/peoplefinder-development-es/application-logs"
-  retention_in_days = 365
-
-  tags = {
-    Environment = "development"
-    Application = "peoplefinder"
-  }
-}
-
-data "aws_iam_policy_document" "elasticsearch_log_publishing_policy_doc" {
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:PutLogEventsBatch",
-    ]
-
-    resources = [aws_cloudwatch_log_group.peoplefinder_cloudwatch_log_group.arn]
-
-    principals {
-      identifiers = ["es.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_policy" {
-  policy_document = data.aws_iam_policy_document.elasticsearch_log_publishing_policy_doc.json
-  policy_name     = "cloud-platform-elasticsearch-log-publishing-policy"
-}
-
 # Elastic search module
 module "peoplefinder_es" {
   source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.2"
@@ -52,8 +19,6 @@ module "peoplefinder_es" {
   aws-es-proxy-replica-count = 2
   instance_type              = "t3.medium.elasticsearch"
 
-  log_publishing_application_cloudwatch_log_group_arn = aws_cloudwatch_log_group.peoplefinder_cloudwatch_log_group.arn
-  log_publishing_application_enabled                  = true
 }
 
 module "ns_annotation" {

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "elasticsearch_log_publishing_policy_doc" {
 
 resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_policy" {
   policy_document = data.aws_iam_policy_document.elasticsearch_log_publishing_policy_doc.json
-  policy_name     = "peoplefinder-dev-elasticsearch-log-publishing-policy"
+  policy_name     = "cloud-platform-elasticsearch-log-publishing-policy"
 }
 
 # Elastic search module

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "elasticsearch_log_publishing_policy_doc" {
 
 resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_policy" {
   policy_document = data.aws_iam_policy_document.elasticsearch_log_publishing_policy_doc.json
-  policy_name     = "cloud-platform-elasticsearch-log-publishing-policy"
+  policy_name     = "peoplefinder-prod-elasticsearch-log-publishing-policy"
 }
 
 # Elastic search module

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -6,7 +6,7 @@
 # For logging elastic search on cloudwatch
 resource "aws_cloudwatch_log_group" "peoplefinder_cloudwatch_log_group" {
   name              = "/aws/aes/domains/peoplefinder-production-es/application-logs"
-  retention_in_days = 365
+  retention_in_days = 60
 
   tags = {
     Environment = "production"

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "elasticsearch_log_publishing_policy_doc" {
 
 resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_policy" {
   policy_document = data.aws_iam_policy_document.elasticsearch_log_publishing_policy_doc.json
-  policy_name     = "peoplefinder-prod-elasticsearch-log-publishing-policy"
+  policy_name     = "cloud-platform-elasticsearch-log-publishing-policy"
 }
 
 # Elastic search module

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "elasticsearch_log_publishing_policy_doc" {
 
 resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_policy" {
   policy_document = data.aws_iam_policy_document.elasticsearch_log_publishing_policy_doc.json
-  policy_name     = "peoplefinder-dev-elasticsearch-log-publishing-policy"
+  policy_name     = "cloud-platform-elasticsearch-log-publishing-policy"
 }
 
 # Elastic search module

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -2,38 +2,6 @@
 # Peoplefinder
 # Application Elasticsearch cluster
 #################################################################################
-# For logging elastic search on cloudwatch
-resource "aws_cloudwatch_log_group" "peoplefinder_cloudwatch_log_group" {
-  name              = "/aws/aes/domains/peoplefinder-staging-es/application-logs"
-  retention_in_days = 60
-
-  tags = {
-    Environment = "staging"
-    Application = "peoplefinder"
-  }
-}
-
-data "aws_iam_policy_document" "elasticsearch_log_publishing_policy_doc" {
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:PutLogEventsBatch",
-    ]
-
-    resources = [aws_cloudwatch_log_group.peoplefinder_cloudwatch_log_group.arn]
-
-    principals {
-      identifiers = ["es.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_policy" {
-  policy_document = data.aws_iam_policy_document.elasticsearch_log_publishing_policy_doc.json
-  policy_name     = "cloud-platform-elasticsearch-log-publishing-policy"
-}
 
 # Elastic search module
 module "peoplefinder_es" {
@@ -50,9 +18,6 @@ module "peoplefinder_es" {
   elasticsearch_version      = "7.9"
   aws-es-proxy-replica-count = 1
   instance_type              = "t3.medium.elasticsearch"
-
-  log_publishing_application_cloudwatch_log_group_arn = aws_cloudwatch_log_group.peoplefinder_cloudwatch_log_group.arn
-  log_publishing_application_enabled                  = true
 }
 
 module "ns_annotation" {


### PR DESCRIPTION
- Remove cloudwatch log group for development and staging
- Reduce the cloudwatch log retention to 60 days
-
@ymao2, as discussed in Slack with @jasonBirchall , are you happy with the changes?