### PR TITLE
CVSL-331: Add a second, shorter DNS name.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-preprod/01-rbac.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: create-and-vary-a-licence-dev-api-admin
+  name: create-and-vary-a-licence-api-preprod-admin
   namespace: create-and-vary-a-licence-api-preprod
 subjects:
   - kind: Group
@@ -10,6 +10,9 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-production-releases"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-preprod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-preprod/06-certificate.yaml
@@ -10,4 +10,5 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    - create-a-licence-api-preprod.hmpps.service.justice.gov.uk
     - create-and-vary-a-licence-api-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Due the the 64-character limit in certificate CNs this PR adds two DNS names, one short, one long.
It failed to create a certificate previously with only the name `create-and-vary-a-licence-api-preprod.hmpps.service.justice.gov.uk` so also added a second, `create-a-licence-api-preprod.hmpps.service.justice.gov.uk`
Also updated the RBAC to include the group dps-production-releases.