### PR TITLE
Upgrade BaSM preprod database instance type

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds-instance" {
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
   db_allocated_storage   = 20
-  db_instance_class      = "db.t3.medium"
+  db_instance_class      = "db.t3.xlarge"
   backup_window          = var.backup_window
   maintenance_window     = var.maintenance_window
 


### PR DESCRIPTION
We've been experiencing slowdowns recently related to our database being under-provisioned. We expect that upgrading the instance type will improve the performance of our database. I'm doing the upgrade first in our pre-production environment to gauge exactly what the downtime might be like for production.

We've selected the `db.t3.xlarge` instance type, rather than upgrading one level to `db.t3.large` as we expect our database usage to increase quickly over the next few months.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3424)