### PR TITLE
Upgrade BaSM UAT database

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
@@ -9,6 +9,7 @@ module "rds-instance" {
   namespace              = var.namespace
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
+  db_instance_class      = "db.t3.medium"
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
   backup_window          = var.backup_window
   maintenance_window     = var.maintenance_window


### PR DESCRIPTION
This environment, although not production, is used frequently for various reasons and we often see timeouts. It's used by our suppliers to test our API.

I'm hoping that by upgrading the databases from `t2.small` to `t3.medium` we'll get a small performance increase that should reduce the number of issues we see in the environment.
