### PR TITLE
PPD - Upgrade Dev RDS postgres DB to v12.7

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds-aurora.tf
@@ -9,7 +9,7 @@ module "rds_aurora" {
   environment-name            = var.environment-name
   infrastructure-support      = var.infrastructure-support
   engine                      = "aurora-postgresql"
-  engine_version              = "12.6"
+  engine_version              = "13.3"
   engine_mode                 = "provisioned"
   replica_count               = 1
   instance_type               = "db.t3.medium"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds-aurora.tf
@@ -9,7 +9,7 @@ module "rds_aurora" {
   environment-name            = var.environment-name
   infrastructure-support      = var.infrastructure-support
   engine                      = "aurora-postgresql"
-  engine_version              = "13.3"
+  engine_version              = "12.7"
   engine_mode                 = "provisioned"
   replica_count               = 1
   instance_type               = "db.t3.medium"


### PR DESCRIPTION
Attempt to upgrade RDS Postgres 12.6 -> v13 failed. Upgrade path for a db.t3 is to 12.7 first and then to v13. Graviton chips can go from 12.4 straight to 13.