### PR TITLE
Detect deleted namespaces in live

### DIFF
--- a/bin/deleted-namespaces.rb
+++ b/bin/deleted-namespaces.rb
@@ -15,7 +15,7 @@ def send_notification(msg)
   ).notify(msg)
 end
 
-namespaces = deleted_namespaces("live-1.cloud-platform.service.justice.gov.uk")
+namespaces = deleted_namespaces("live.cloud-platform.service.justice.gov.uk")
 
 if namespaces.any?
   msg = <<~EOF

--- a/lib/cp_env/namespace_deleter.rb
+++ b/lib/cp_env/namespace_deleter.rb
@@ -14,7 +14,7 @@ class CpEnv
 
     attr_reader :namespace, :k8s_client
 
-    CLUSTER = "live-1.cloud-platform.service.justice.gov.uk"
+    CLUSTER = "live.cloud-platform.service.justice.gov.uk"
     AWS_REGION = "eu-west-2"
     NAMEPACES_DIR = "namespaces/#{CLUSTER}"
     PRODUCTION_LABEL = "cloud-platform.justice.gov.uk/is-production"


### PR DESCRIPTION
Run deleted-namespaces script through the pipeline
    
This will run through a pipeline "detect-deleted-namespaces" and send a low-priority alert.
    
Running this for some time will give us confidence to run auto-delete namespaces in "live"