### PR TITLE
interventions-prod: Re-enable injecting pre-prod credentials to prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds.tf
@@ -35,20 +35,20 @@ resource "kubernetes_secret" "hmpps_interventions_rds" {
 }
 
 # Inject pre-prod DB credentials for refresh job running on production
-# resource "kubernetes_secret" "hmpps_interventions_refresh_secret" {
-#   metadata {
-#     name      = "postgres-preprod"
-#     namespace = "hmpps-interventions-prod"
-#   }
+resource "kubernetes_secret" "hmpps_interventions_refresh_secret" {
+  metadata {
+    name      = "postgres-preprod"
+    namespace = "hmpps-interventions-prod"
+  }
 
-#   data = {
-#     rds_instance_endpoint = module.hmpps_interventions_rds.rds_instance_endpoint
-#     database_name         = module.hmpps_interventions_rds.database_name
-#     database_username     = module.hmpps_interventions_rds.database_username
-#     database_password     = module.hmpps_interventions_rds.database_password
-#     rds_instance_address  = module.hmpps_interventions_rds.rds_instance_address
-#     access_key_id         = module.hmpps_interventions_rds.access_key_id
-#     secret_access_key     = module.hmpps_interventions_rds.secret_access_key
-#     url                   = "postgres://${module.hmpps_interventions_rds.database_username}:${module.hmpps_interventions_rds.database_password}@${module.hmpps_interventions_rds.rds_instance_endpoint}/${module.hmpps_interventions_rds.database_name}"
-#   }
-# }
+  data = {
+    rds_instance_endpoint = module.hmpps_interventions_rds.rds_instance_endpoint
+    database_name         = module.hmpps_interventions_rds.database_name
+    database_username     = module.hmpps_interventions_rds.database_username
+    database_password     = module.hmpps_interventions_rds.database_password
+    rds_instance_address  = module.hmpps_interventions_rds.rds_instance_address
+    access_key_id         = module.hmpps_interventions_rds.access_key_id
+    secret_access_key     = module.hmpps_interventions_rds.secret_access_key
+    url                   = "postgres://${module.hmpps_interventions_rds.database_username}:${module.hmpps_interventions_rds.database_password}@${module.hmpps_interventions_rds.rds_instance_endpoint}/${module.hmpps_interventions_rds.database_name}"
+  }
+}


### PR DESCRIPTION
Consequence of #6819, but couldn't do it in the same PR

This re-enables adding pre-prod DB credentials for weekly database refresh