### PR TITLE
PPD - Add transcribe data access role to prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/s3.tf
@@ -338,11 +338,11 @@ resource "kubernetes_secret" "pcms_document_s3_bucket" {
   }
 
   data = {
-    access_key_id              = module.hmpps_pin_phone_monitor_document_s3_bucket.access_key_id
-    secret_access_key          = module.hmpps_pin_phone_monitor_document_s3_bucket.secret_access_key
-    bucket_arn                 = module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn
-    bucket_name                = module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_name
-    translate_s3_data_role_arn = aws_iam_role.translate_s3_data_role.arn
+    access_key_id               = module.hmpps_pin_phone_monitor_document_s3_bucket.access_key_id
+    secret_access_key           = module.hmpps_pin_phone_monitor_document_s3_bucket.secret_access_key
+    bucket_arn                  = module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn
+    bucket_name                 = module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_name
+    translate_s3_data_role_arn  = aws_iam_role.translate_s3_data_role.arn
     transcribe_s3_data_role_arn = aws_iam_role.transcribe_s3_data_role.arn
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/s3.tf
@@ -172,6 +172,56 @@ resource "aws_iam_role_policy" "translate_s3_data_role_policy" {
   })
 }
 
+resource "aws_iam_role" "transcribe_s3_data_role" {
+  name = "pcms-prod-transcribe-s3-data-role"
+  path = "/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "transcribe.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "transcribe_s3_data_role_policy" {
+  name = "pcms-prod-transcribe-s3-data-role-policy"
+  role = aws_iam_role.transcribe_s3_data_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject"
+        ],
+        Resource = "${module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn}/*",
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket"
+        ],
+        Resource = module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn,
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:PutObject"
+        ],
+        Resource = "${module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn}/*",
+      }
+    ]
+  })
+}
+
 module "hmpps_pin_phone_monitor_s3_event_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.5"
 
@@ -293,6 +343,7 @@ resource "kubernetes_secret" "pcms_document_s3_bucket" {
     bucket_arn                 = module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn
     bucket_name                = module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_name
     translate_s3_data_role_arn = aws_iam_role.translate_s3_data_role.arn
+    transcribe_s3_data_role_arn = aws_iam_role.transcribe_s3_data_role.arn
   }
 }
 


### PR DESCRIPTION
Deferred execution of transcribe job requires a data access role with appropriate S3 permissions: 

https://docs.aws.amazon.com/transcribe/latest/dg/API_JobExecutionSettings.html