### PR TITLE
Add github provider configuration to pact-broker 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/variables.tf
@@ -4,6 +4,16 @@ variable "cluster_name" {
 variable "kubernetes_cluster" {
 }
 
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}
+
 variable "application" {
   description = "Name of Application you are deploying"
   default     = "Pact broker"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/versions.tf
@@ -8,5 +8,8 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    github = {
+      source = "integrations/github"
+    }
   }
 }


### PR DESCRIPTION
Missed this from #6834, might explain the apply failure in https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/300

🤷 don't know enough about this, sorry

_Edit_ Thanks @razvan-moj and @jasonBirchall for your help