### PR TITLE
Add missing provider configuration to pact-broker

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/main.tf
@@ -16,3 +16,8 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}


### PR DESCRIPTION
Final piece to make #6834 work

Entire diff for reference
```diff
diff --git a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/main.tf b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/main.tf
index 0fd2f9470..8c3fa83f6 100644
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/main.tf
@@ -16,3 +16,8 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
diff --git a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/serviceaccount-github.tf b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/serviceaccount-github.tf
new file mode 100644
index 000000000..f50c37ba3
--- /dev/null
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/serviceaccount-github.tf
@@ -0,0 +1,6 @@
+module "serviceaccount" {
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.2"
+  namespace           = var.namespace
+  kubernetes_cluster  = var.kubernetes_cluster
+  github_repositories = ["hmpps-pact-broker"]
+}
diff --git a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/variables.tf b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/variables.tf
index 50e259116..62061a73a 100644
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/variables.tf
@@ -1,6 +1,18 @@
 variable "cluster_name" {
 }
 
+variable "kubernetes_cluster" {
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}
 
 variable "application" {
   description = "Name of Application you are deploying"
diff --git a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/versions.tf b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/versions.tf
index f5c9123bb..c56a58adf 100644
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/versions.tf
@@ -8,5 +8,8 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    github = {
+      source = "integrations/github"
+    }
   }
 }
```