### PR TITLE
Fetch domain to be pinged from variables.tf rather than hardcoded

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/pingdom.tf
@@ -4,7 +4,7 @@ provider "pingdom" {
 resource "pingdom_check" "laa-court-data-adaptor-dev" {
   type                     = "http"
   name                     = "LAA Court Data Adaptor - dev"
-  host                     = "laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
+  host                     = var.domain
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 3

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/pingdom.tf
@@ -4,7 +4,7 @@ provider "pingdom" {
 resource "pingdom_check" "laa-court-data-adaptor-prod" {
   type                     = "http"
   name                     = "LAA Court Data Adaptor - production"
-  host                     = "laa-court-data-adaptor.apps.live-1.cloud-platform.service.justice.gov.uk"
+  host                     = var.domain
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 3

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/pingdom.tf
@@ -4,7 +4,7 @@ provider "pingdom" {
 resource "pingdom_check" "laa-court-data-adaptor-uat" {
   type                     = "http"
   name                     = "LAA Court Data Adaptor - UAT"
-  host                     = "laa-court-data-adaptor-uat.apps.live-1.cloud-platform.service.justice.gov.uk"
+  host                     = var.domain
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 3


### PR DESCRIPTION
The host is hard-coded, and points to live-1. Fetching from
variables.tf gets the domain name that is independant from
the cluster name.