### PR TITLE
Scale the manage-recalls-dev database to a t3.medium.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-recalls-dev/resources/manage-recalls-api-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-recalls-dev/resources/manage-recalls-api-rds.tf
@@ -18,7 +18,7 @@ module "manage_recalls_api_rds" {
   rds_family        = "postgres13"
   db_engine         = "postgres"
   db_engine_version = "13"
-  db_instance_class = "db.t3.small"
+  db_instance_class = "db.t3.medium"
   db_name           = "manage_recalls"
 
   providers = {


### PR DESCRIPTION
We're seeing some performance issues in dev due to data volumes, (that
we would expect in prod down the line), increasing the database RAM to
see the impact it has.