### PR TITLE
Add `replicaset` Resource and `list` Verb to `app` apiGroup

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/05-serviceaccount.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/05-serviceaccount.yaml
@@ -35,12 +35,14 @@ rules:
       - "deployments"
       - "ingresses"
       - "statefulsets"
+      - "replicasets"
     verbs:
       - "get"
       - "update"
       - "delete"
       - "create"
       - "patch"
+      - "list"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
I am getting the following error when trying to deploy our Grafana Helm chart

```
helm_release.grafana: Creating...
╷
│ Warning: Helm release "grafana" was created but has a failed status. Use the `helm` command to investigate the error, correct it, then run Terraform again.
│ 
│   with helm_release.grafana,
│   on main.tf line 10, in resource "helm_release" "grafana":
│   10: resource "helm_release" "grafana" {
│ 
╵
╷
│ Error: replicasets.apps is forbidden: User "system:serviceaccount:hmpps-ems-prod:github-actions" cannot list resource "replicasets" in API group "apps" in the namespace "hmpps-ems-prod"
│ 
│   with helm_release.grafana,
│   on main.tf line 10, in resource "helm_release" "grafana":
│   10: resource "helm_release" "grafana" {
│ 
╵
ERRO[0012] 1 error occurred:
        * exit status 1
```