### PR TITLE
[LAA Court Data Adaptor Prod] Add delay_seconds to prosecution_concluded SQS queue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/messaging-queues.tf
@@ -306,6 +306,7 @@ module "prosecution_concluded_queue" {
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
   namespace                 = var.namespace
+  delay_seconds             = "120"
 
   redrive_policy = <<EOF
   {


### PR DESCRIPTION
Introduce a 120 seconds delay to prosecution_concluded SQS queue messages (UAT).

ref. https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-queue-parameters.html