### PR TITLE
Allow CircleCI service account HPA permissions live-1

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml
@@ -58,6 +58,17 @@ rules:
       - "update"
       - "patch"
       - "delete"
+  - apiGroups:
+      - "autoscaling"
+    resources:
+      - "hpa"
+      - "horizontalpodautoscalers"
+    verbs:
+      - "get"
+      - "update"
+      - "patch"
+      - "delete"
+      - "create"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
We need to allow the CircleCI service account permissions to apply
horizontal scaling configuration in the formbuilder-saas-test namespace
in the live-1 cluster.