### PR TITLE
Update namespace apply-for-compensation-prototype

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype/resources/ecr.tf
@@ -4,7 +4,7 @@ module "ecr-repo" {
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 
-  github_repositories = [var.namespace]
+  # github_repositories = [var.namespace]
 }
 
 resource "kubernetes_secret" "ecr-repo" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype/resources/serviceaccount.tf
@@ -4,5 +4,5 @@ module "serviceaccount" {
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
 
-  github_repositories = [var.namespace]
+  # github_repositories = [var.namespace]
 }


### PR DESCRIPTION
Remove repo names used in module. Github repo used in the ecr and service account module is not within MOJ org,
This cause pipelines to fail as it don't have access to that repo