### PR TITLE
Add interventions API healthcheck to pingdom

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/pingdom.tf
@@ -6,8 +6,24 @@ provider "pingdom" {
 
 resource "pingdom_check" "interventions-prod-check" {
   type                     = "http"
-  name                     = "HMPPS - refer-monitor-intervention.service.justice.gov.uk"
+  name                     = "HMPPS - refer-monitor-intervention UI"
   host                     = "refer-monitor-intervention.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [114225]
+}
+
+resource "pingdom_check" "interventions-prod-service-check" {
+  type                     = "http"
+  name                     = "HMPPS - refer-monitor-intervention API"
+  host                     = "hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     kubernetes = {


### PR DESCRIPTION
We had database connection failed errors and I would have expected a
pingdom alert but we never got any -- it was never setup 😅