### PR TITLE
Create ECR for new hale-platform namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/ecr.tf
@@ -1,0 +1,38 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.6"
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  /*
+    By default scan_on_push is set to true. When this is enabled then all images pushed to the repo are scanned for any security
+    / software vulnerabilities in your image and the results can be viewed in the console. For further details, please see:
+    https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html
+    To disable 'scan_on_push', set it to false as below:
+  scan_on_push = "false"
+  */
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+
+resource "kubernetes_secret" "ecr_credentials" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.ecr_credentials.access_key_id
+    secret_access_key = module.ecr_credentials.secret_access_key
+    repo_arn          = module.ecr_credentials.repo_arn
+    repo_url          = module.ecr_credentials.repo_url
+  }
+}


### PR DESCRIPTION
This adds the terraform config to setup the new ECR repo in AWS
for the hale-platform-dev namespace.