### PR TITLE
Add MYSQL tf config to hale-platform

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/rds.tf
@@ -1,0 +1,71 @@
+module "rds" {
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  cluster_name  = var.cluster_name
+  team_name     = var.team_name
+  business-unit = var.business_unit
+  application   = var.application
+  is-production = var.is_production
+  namespace     = var.namespace
+
+  # turn off performance insights
+  performance_insights_enabled = false
+
+  # general options
+  db_instance_class           = "db.t2.small"
+  environment-name            = var.environment
+  infrastructure-support      = var.infrastructure_support
+  allow_major_version_upgrade = "false"
+
+  # using mysql
+  db_engine         = "mysql"
+  db_engine_version = "8.0.25"
+  rds_family        = "mysql8.0"
+
+  # overwrite db_parameters
+  db_parameter = [
+    {
+      name         = "character_set_client"
+      value        = "utf8"
+      apply_method = "immediate"
+    },
+    {
+      name         = "character_set_server"
+      value        = "utf8"
+      apply_method = "immediate"
+    }
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    access_key_id         = module.rds.access_key_id
+    secret_access_key     = module.rds.secret_access_key
+  }
+}
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+
+  }
+}


### PR DESCRIPTION
Add the RDS configuration for the hale-plaform. WordPress requires a
MYSQL database to connect to rather than PostgreSQL.