### PR TITLE
AAC-499 - Update UAT Team information

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/00-namespace.yaml
@@ -8,6 +8,6 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "View court data"
-    cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps-core"
-    cloud-platform.justice.gov.uk/owner: "LAA get paid team: laa-get-paid@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/slack-channel: "laa-assess-a-claim"
+    cloud-platform.justice.gov.uk/owner: "LAA get paid team: assessaclaim@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-court-data-ui"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-court-data-ui-uat
 subjects:
   - kind: Group
-    name: "github:laa-get-paid"
+    name: "github:laa-assess-a-claim"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/variables.tf
@@ -17,7 +17,7 @@ variable "business-unit" {
 
 variable "team_name" {
   description = "The name of your development team"
-  default     = "laa-get-paid"
+  default     = "laa-assess-a-claim"
 }
 
 variable "repo_name" {
@@ -32,7 +32,7 @@ variable "environment-name" {
 
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "laa-get-paid@digital.justice.gov.uk"
+  default     = "assessaclaim@digital.justice.gov.uk"
 }
 
 variable "is-production" {


### PR DESCRIPTION
The existing github team that we used seems to have been removed. This PR updates the team and email we use for this service so that details are as up to date as possible