### PR TITLE
Migration of dso-monitoring namespaces to live cluster

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dso-monitoring-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "dso_internal"
+    cloud-platform.justice.gov.uk/application: "DSO Monitoring"
+    cloud-platform.justice.gov.uk/owner: "studio-webops: digital-studio-operations-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/prometheus"
+    cloud-platform.justice.gov.uk/team-name: "studio-webops" 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dso-monitoring-dev-admin
+  namespace: dso-monitoring-dev
+subjects:
+  - kind: Group
+    name: "github:studio-webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: dso-monitoring-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: dso-monitoring-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: dso-monitoring-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: dso-monitoring-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/resources/variables.tf
@@ -1,0 +1,52 @@
+
+variable "cluster_name" {
+}
+
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "DSO Monitoring"
+}
+
+variable "namespace" {
+  default = "dso-monitoring-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "studio-webops"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "digital-studio-operations-team@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "dso_internal"
+}
+
+variable "github_owner" {
+  description = "Required by the github terraform provider"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the github terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-dev/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.68.0"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dso-monitoring-prod
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "dso_internal"
+    cloud-platform.justice.gov.uk/application: "DSO Monitoring"
+    cloud-platform.justice.gov.uk/owner: "Digital Studio Operations: digital-studio-operations-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/dso-monitoring"
+    cloud-platform.justice.gov.uk/team-name: "studio-webops" 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dso-monitoring-prod-admin
+  namespace: dso-monitoring-prod
+subjects:
+  - kind: Group
+    name: "github:studio-webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: dso-monitoring-prod
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: dso-monitoring-prod
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/04-networkpolicy.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: dso-monitoring-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: dso-monitoring-prod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping  
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+  policyTypes:                                                                                                                                                         
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/05-offender-assessment-api-prometheusrule.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/05-offender-assessment-api-prometheusrule.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: dso-monitoring-prod
+  labels:
+    role: alert-rules
+  name: prometheus-custom-rules-offender-assessment-api
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: offender-assessment-api-down
+      expr: |-
+        probe_http_status_code{instance="offender-assessment-api-prod"}!=200
+      for: 3m
+      labels:
+        severity: dso
+      annotations:
+        message: Offender Assessment API has not responded in the last 5 minutes.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/serviceaccount.tf
@@ -1,0 +1,57 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["dso-monitoring"]
+
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "serviceaccounts",
+        "configmaps",
+      ]
+      verbs = [
+        "update",
+        "patch",
+        "get",
+        "create",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "networking.k8s.io",
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "servicemonitors",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
+
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/variables.tf
@@ -1,0 +1,55 @@
+
+variable "cluster_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "DSO Monitoring"
+}
+
+variable "namespace" {
+  default = "dso-monitoring-prod"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "studio-webops"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "digital-studio-operations-team@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "true"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "dso_internal"
+}
+
+variable "github_owner" {
+  description = "Required by the github terraform provider"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the github terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.68.0"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}


### PR DESCRIPTION
Migration of dso-monitoring-dev and dso-monitoring-prod to live cluster.  Note this is monitoring only so we are OK to break this during the migration.
There is a GHA for dso-monitoring-prod so we'll need to do the Service Account stuff, but presume that can be sorted afterwards.