### PR TITLE
DSO-1377: test of DSO studio hosting monitoring live-1 migration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/05-offender-assessment-api-prometheusrule.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dso-monitoring-prod/05-offender-assessment-api-prometheusrule.yaml
@@ -11,9 +11,9 @@ spec:
     rules:
     - alert: offender-assessment-api-down
       expr: |-
-        probe_http_status_code{instance="offender-assessment-api-prod"}!=200
+        probe_http_status_code{instance="offender-assessment-api-prod"}==200
       for: 3m
       labels:
         severity: dso
       annotations:
-        message: Offender Assessment API has not responded in the last 5 minutes.
+        message: DSO Cloud Platform migration test for offender assessment monitoring - please ignore


### PR DESCRIPTION
dso-monitoring-prod has been migrated to live environment and prometheus is collecting stats correctly.  This temporary change is to test the slack hook.