### PR TITLE
VCD Dev - Update HTTP_DURATION metrics to HTTP_REQUEST_DURATION for Prometheus

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/prometheus.yaml
@@ -47,7 +47,7 @@ spec:
       annotations:
         message: laa-court-data-ui-dev Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: ruby_http_duration_seconds{namespace="laa-court-data-ui-dev"} > 30
+      expr: ruby_http_request_duration_seconds{namespace="laa-court-data-ui-dev"} > 30
       for: 1m
       labels:
         severity: laa-court-get-paid


### PR DESCRIPTION
Major Prometheus-Exporter bundle update to 2.0.0 (https://github.com/discourse/prometheus_exporter/releases/tag/v2.0.0) gave this instruction:
"rename all http_duration metrics to http_request_duration to match prometheus official naming conventions"

Updated expression for Long-Request alert to use new ruby_http_request_duration_sections instead of ruby_http_duration_secconds to prevent alerts not working