### PR TITLE
PIC-1981 Rename target s3 bucket for data exporter

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/analytical-platform-access.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/analytical-platform-access.tf
@@ -21,8 +21,8 @@ data "aws_iam_policy_document" "ap_access" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.namespace}-landing/*",
-      "arn:aws:s3:::${var.namespace}-landing/"
+      "arn:aws:s3:::${var.ap-stack-court-case}-landing/*",
+      "arn:aws:s3:::${var.ap-stack-court-case}-landing/"
     ]
   }
 }
@@ -41,7 +41,7 @@ resource "aws_iam_access_key" "user" {
 }
 
 resource "aws_iam_user_policy" "policy" {
-  name   = "${var.namespace}-ap-s3-snapshots"
+  name   = "${var.ap-stack-court-case}-ap-s3-snapshots"
   policy = data.aws_iam_policy_document.ap_access.json
   user   = aws_iam_user.user.name
 }
@@ -53,7 +53,7 @@ resource "kubernetes_secret" "ap_aws_secret" {
   }
 
   data = {
-    destination_bucket = "s3://${var.namespace}-landing"
+    destination_bucket = "s3://${var.ap-stack-court-case}-landing"
     user_arn           = aws_iam_user.user.arn
     access_key_id      = aws_iam_access_key.user.id
     secret_access_key  = aws_iam_access_key.user.secret

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/variables.tf
@@ -38,3 +38,6 @@ variable "number_cache_clusters" {
   default = "2"
 }
 
+variable "ap-stack-court-case" {
+  default = "hmpps-court-case-dev"
+}


### PR DESCRIPTION
Renaming the target bucket from being derived from the namespace to being specific to the database as it appears in the Analytics Platform.  This will allow us to accommodate future databases within the namespace, e.g. the PSR service.