### PR TITLE
Add IRSA permission to list objects in S3 bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/ap-data.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/ap-data.tf
@@ -1,4 +1,3 @@
-
 module "analytical-platform" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=1.0.3"
 
@@ -30,6 +29,7 @@ data "aws_iam_policy_document" "analytical-platform" {
     actions = [
       "s3:GetObject",
       "s3:GetObjectAcl",
+      "s3:ListObjectsV2",
     ]
     resources = [
       "arn:aws:s3:::alpha-manage-my-prison/incentives_visuals/*",


### PR DESCRIPTION
HMPPS Incentives applications in `prod` namespace can already get objects from a particular bucket in Analytical Platform. The bucket policy already has listing permissions, so the IRSA policy also needs to mirror this.