### PR TITLE
Remove IAM policy from testing S3 bucket for HMPPS Incentives

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/s3.tf
@@ -10,26 +10,8 @@ module "analytical_platform_s3_bucket" {
   infrastructure-support = var.infrastructure_support
   namespace              = var.namespace
 
-  bucket_policy = data.aws_iam_policy_document.bucket-policy.json
-
   providers = {
     aws = aws.london
-  }
-}
-
-data "aws_iam_policy_document" "bucket-policy" {
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = [module.analytical-platform.aws_iam_role_arn]
-    }
-    actions = [
-      "s3:ListBucket",
-      "s3:GetBucketLocation",
-      "s3:ListObjectsV2",
-      "s3:GetObject",
-      "s3:GetObjectAcl",
-    ]
   }
 }
 


### PR DESCRIPTION
We're aiming to use the development namespace in the same way as the production one: namely that IRSA is used to grant access to an S3 bucket rather than using access tokens.

Once the bucket is created and its ARN is known, the policy can be reintroduced with a hard-coded resource. Because it seems that a bucket IAM policy must include a resource even if it's simply the bucket to which it is attached.