### PR TITLE
Use hard-coded S3 bucket ARN in its attached IAM policy for HMPPS Incentives

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/s3.tf
@@ -17,6 +17,10 @@ module "analytical_platform_s3_bucket" {
   }
 }
 
+locals {
+  bucket_arn = "arn:aws:s3:::cloud-platform-280508bd289f5ea3cf77c019c927e693"
+}
+
 data "aws_iam_policy_document" "bucket-policy" {
   statement {
     principals {
@@ -29,6 +33,10 @@ data "aws_iam_policy_document" "bucket-policy" {
       "s3:ListObjectsV2",
       "s3:GetObject",
       "s3:GetObjectAcl",
+    ]
+    resources = [
+      "${local.bucket_arn}/*",
+      local.bucket_arn
     ]
   }
 }


### PR DESCRIPTION
We're aiming to use the development namespace in the same way as the production one: namely that IRSA is used to grant access to an S3 bucket rather than using access tokens.

It seems that a bucket IAM policy must include a resource even if it's simply the bucket to which it is attached. Hence the policy must refer to the bucket itself – this causes a circular reference unless the generated bucket ARN is not hard-coded.