### PR TITLE
Fix HMPPS Incentives testing S3 bucket policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/s3.tf
@@ -28,8 +28,6 @@ data "aws_iam_policy_document" "bucket-policy" {
       identifiers = [module.analytical-platform.aws_iam_role_arn]
     }
     actions = [
-      "s3:ListBucket",
-      "s3:GetBucketLocation",
       "s3:ListObjectsV2",
       "s3:GetObject",
       "s3:GetObjectAcl",


### PR DESCRIPTION
… because `s3:ListBucket` is not a valid permission and `s3:GetBucketLocation` is unnecessary