### PR TITLE
Migrate hmcts-mock-api-dev to live cluster

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/00-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmcts-mock-api-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMCTS"
+    cloud-platform.justice.gov.uk/application: "HMCTS Mock API"
+    cloud-platform.justice.gov.uk/owner: "Crime Apps: laa@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmcts-common-platform-mock-api"
+    cloud-platform.justice.gov.uk/slack-channel: "laa-crime-apps"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmcts-mock-api-dev-admin
+  namespace: hmcts-mock-api-dev
+subjects:
+  - kind: Group
+    name: "github:laa-crime-apps-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmcts-mock-api-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmcts-mock-api-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmcts-mock-api-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmcts-mock-api-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/06-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/06-service-account.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: hmcts-mock-api-dev
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: hmcts-mock-api-dev
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/portforward"
+      - "deployment"
+      - "secrets"
+      - "services"
+      - "serviceaccounts"
+      - "pods"
+    verbs:
+      - "patch"
+      - "update"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+  - apiGroups: [extensions, apps, networking.k8s.io]
+    resources:
+      - "deployments"
+      - "ingresses"
+      - "replicasets"
+    verbs:
+      - "patch"
+      - "update"
+      - "get"
+      - "create"
+      - "delete"
+      - "list"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: hmcts-mock-api-dev
+subjects:
+- kind: ServiceAccount
+  name: circleci
+  namespace: hmcts-mock-api-dev
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/ecr.tf
@@ -1,0 +1,32 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "laa_crime_apps_team_ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.6"
+  repo_name = "hmcts-common-platform-mock-api"
+  team_name = "laa-crime-apps-team"
+
+  # aws_region = "eu-west-2"     # This input is deprecated from version 3.2 of this module
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "laa_crime_apps_team_ecr_credentials" {
+  metadata {
+    name      = "laa-crime-apps-team-ecr-credentials-output"
+    namespace = "hmcts-mock-api-dev"
+  }
+
+  data = {
+    access_key_id     = module.laa_crime_apps_team_ecr_credentials.access_key_id
+    secret_access_key = module.laa_crime_apps_team_ecr_credentials.secret_access_key
+    repo_arn          = module.laa_crime_apps_team_ecr_credentials.repo_arn
+    repo_url          = module.laa_crime_apps_team_ecr_credentials.repo_url
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
@@ -1,0 +1,36 @@
+variable "cluster_name" {
+}
+
+
+module "hmcts_mock_api_rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
+
+  cluster_name           = var.cluster_name
+  team_name              = "laa-crime-apps-team"
+  business-unit          = "Crime Apps"
+  application            = "hmcts-common-platform-mock-api"
+  is-production          = "false"
+  namespace              = var.namespace
+  db_engine_version      = "11"
+  environment-name       = "development"
+  infrastructure-support = "laa@digital.justice.gov.uk"
+  rds_family             = "postgres11"
+
+  allow_major_version_upgrade = "true"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "hmcts_mock_api_rds" {
+  metadata {
+    name      = "hmcts-mock-api-instance-output"
+    namespace = "hmcts-mock-api-dev"
+  }
+
+  data = {
+    url = "postgres://${module.hmcts_mock_api_rds.database_username}:${module.hmcts_mock_api_rds.database_password}@${module.hmcts_mock_api_rds.rds_instance_endpoint}/${module.hmcts_mock_api_rds.database_name}"
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/variables.tf
@@ -1,0 +1,3 @@
+variable "namespace" {
+  default = "hmcts-mock-api-dev"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.68.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
Migrate hmcts-mock-api-dev namespace to live cluster.