### PR TITLE
Form Builder - add HPA permissions to saas-live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/05-circleci-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/05-circleci-service-account.yaml
@@ -58,6 +58,17 @@ rules:
       - "update"
       - "patch"
       - "delete"
+  - apiGroups:
+      - "autoscaling"
+    resources:
+      - "hpa"
+      - "horizontalpodautoscalers"
+    verbs:
+      - "get"
+      - "update"
+      - "patch"
+      - "delete"
+      - "create"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
This gives the circle service account in formbuilder-saas-live namespace
permissions to set horizontal autoscaling configuration