### PR TITLE
Update PECS namespaces access rules

### DIFF
--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: calculate-journey-variable-payments-dev
 subjects:
   - kind: Group
-    name: "github:calculate-journey-variable-payments"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: calculate-journey-variable-payments-preprod
 subjects:
   - kind: Group
-    name: "github:calculate-journey-variable-payments"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/01-rbac.yaml
+++ b/namespaces/live-1.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: calculate-journey-variable-payments-prod
 subjects:
   - kind: Group
-    name: "github:calculate-journey-variable-payments"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-api-dev
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-api-preprod
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-api-production
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-api-staging
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-api-uat
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-preprod
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-production
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-staging
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-book-secure-move-frontend-uat
 subjects:
   - kind: Group
-    name: "github:book-a-secure-move"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
The Calculate journey variable payments, Book a secure move API and Book a secure move frontend apps all fall under the PECS team. We'd like to consolidate the number of GitHub teams we have by removing superfluous teams. This means changing the access rules to reference the new all-encompassing team.

I've raised this as a single commit rather than having a PR for each namespace to save time.