### PR TITLE
Bugfix: use sum rather than max for request rates

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-recalls-dev/10-manage-recalls-api-dashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-recalls-dev/10-manage-recalls-api-dashboard.yaml
@@ -28,7 +28,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 2,
-      "iteration": 1646839848112,
+      "iteration": 1646841797680,
       "links": [],
       "panels": [
         {
@@ -524,7 +524,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -625,7 +625,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -726,7 +726,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -827,7 +827,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -928,7 +928,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -1029,7 +1029,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -1130,7 +1130,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -1231,7 +1231,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -1332,7 +1332,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -1433,7 +1433,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -1534,7 +1534,7 @@ data:
           },
           "pluginVersion": "7.5.9",
           "repeatDirection": "h",
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 34,
           "scopedVars": {
             "service": {
@@ -1624,7 +1624,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]) \n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
+                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
                   "interval": "",
                   "legendFormat": "Avg. Request Latency",
                   "refId": "A"
@@ -1728,7 +1728,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
+                  "expr": "sum(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
                   "interval": "",
                   "legendFormat": "Reqs / Minute",
                   "refId": "A"
@@ -2133,7 +2133,7 @@ data:
                 "h": 10,
                 "w": 12,
                 "x": 0,
-                "y": 27
+                "y": 26
               },
               "hiddenSeries": false,
               "id": 224,
@@ -2158,7 +2158,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 2,
               "repeatedByRow": true,
               "scopedVars": {
@@ -2175,7 +2175,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]) \n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
+                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
                   "interval": "",
                   "legendFormat": "Avg. Request Latency",
                   "refId": "A"
@@ -2240,7 +2240,7 @@ data:
                 "h": 10,
                 "w": 12,
                 "x": 12,
-                "y": 27
+                "y": 26
               },
               "hiddenSeries": false,
               "id": 225,
@@ -2265,7 +2265,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 15,
               "repeatedByRow": true,
               "scopedVars": {
@@ -2282,7 +2282,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
+                  "expr": "sum(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
                   "interval": "",
                   "legendFormat": "Reqs / Minute",
                   "refId": "A"
@@ -2347,7 +2347,7 @@ data:
                 "h": 10,
                 "w": 8,
                 "x": 0,
-                "y": 37
+                "y": 36
               },
               "hiddenSeries": false,
               "id": 226,
@@ -2372,7 +2372,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 46,
               "repeatedByRow": true,
               "scopedVars": {
@@ -2456,7 +2456,7 @@ data:
                 "h": 10,
                 "w": 8,
                 "x": 8,
-                "y": 37
+                "y": 36
               },
               "hiddenSeries": false,
               "id": 227,
@@ -2481,7 +2481,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 211,
               "repeatedByRow": true,
               "scopedVars": {
@@ -2565,7 +2565,7 @@ data:
                 "h": 10,
                 "w": 8,
                 "x": 16,
-                "y": 37
+                "y": 36
               },
               "hiddenSeries": false,
               "id": 228,
@@ -2590,7 +2590,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 78,
               "repeatedByRow": true,
               "scopedVars": {
@@ -2657,7 +2657,7 @@ data:
               }
             }
           ],
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 12,
           "scopedVars": {
             "upstream": {
@@ -2722,7 +2722,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 2,
               "repeatedByRow": true,
               "scopedVars": {
@@ -2739,7 +2739,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]) \n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
+                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
                   "interval": "",
                   "legendFormat": "Avg. Request Latency",
                   "refId": "A"
@@ -2829,7 +2829,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 15,
               "repeatedByRow": true,
               "scopedVars": {
@@ -2846,7 +2846,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
+                  "expr": "sum(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
                   "interval": "",
                   "legendFormat": "Reqs / Minute",
                   "refId": "A"
@@ -2936,7 +2936,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 46,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3045,7 +3045,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 211,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3154,7 +3154,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 78,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3221,7 +3221,7 @@ data:
               }
             }
           ],
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 12,
           "scopedVars": {
             "upstream": {
@@ -3286,7 +3286,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 2,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3303,7 +3303,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]) \n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
+                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
                   "interval": "",
                   "legendFormat": "Avg. Request Latency",
                   "refId": "A"
@@ -3393,7 +3393,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 15,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3410,7 +3410,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
+                  "expr": "sum(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
                   "interval": "",
                   "legendFormat": "Reqs / Minute",
                   "refId": "A"
@@ -3500,7 +3500,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 46,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3609,7 +3609,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 211,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3718,7 +3718,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 78,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3785,7 +3785,7 @@ data:
               }
             }
           ],
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 12,
           "scopedVars": {
             "upstream": {
@@ -3850,7 +3850,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 2,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3867,7 +3867,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]) \n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
+                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
                   "interval": "",
                   "legendFormat": "Avg. Request Latency",
                   "refId": "A"
@@ -3957,7 +3957,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 15,
               "repeatedByRow": true,
               "scopedVars": {
@@ -3974,7 +3974,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
+                  "expr": "sum(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
                   "interval": "",
                   "legendFormat": "Reqs / Minute",
                   "refId": "A"
@@ -4064,7 +4064,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 46,
               "repeatedByRow": true,
               "scopedVars": {
@@ -4173,7 +4173,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 211,
               "repeatedByRow": true,
               "scopedVars": {
@@ -4282,7 +4282,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 78,
               "repeatedByRow": true,
               "scopedVars": {
@@ -4349,7 +4349,7 @@ data:
               }
             }
           ],
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 12,
           "scopedVars": {
             "upstream": {
@@ -4389,7 +4389,7 @@ data:
                 "h": 10,
                 "w": 12,
                 "x": 0,
-                "y": 31
+                "y": 26
               },
               "hiddenSeries": false,
               "id": 248,
@@ -4414,7 +4414,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 2,
               "repeatedByRow": true,
               "scopedVars": {
@@ -4431,7 +4431,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]) \n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
+                  "expr": "max(\n  irate(http_client_requests_seconds_sum{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n  / \n  irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m])\n)",
                   "interval": "",
                   "legendFormat": "Avg. Request Latency",
                   "refId": "A"
@@ -4496,7 +4496,7 @@ data:
                 "h": 10,
                 "w": 12,
                 "x": 12,
-                "y": 31
+                "y": 26
               },
               "hiddenSeries": false,
               "id": 249,
@@ -4521,7 +4521,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 15,
               "repeatedByRow": true,
               "scopedVars": {
@@ -4538,7 +4538,7 @@ data:
               "targets": [
                 {
                   "exemplar": false,
-                  "expr": "max(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
+                  "expr": "sum(irate(http_client_requests_seconds_count{namespace=\"$namespace\", clientName=~\"$upstream\"}[1m]))",
                   "interval": "",
                   "legendFormat": "Reqs / Minute",
                   "refId": "A"
@@ -4603,7 +4603,7 @@ data:
                 "h": 10,
                 "w": 8,
                 "x": 0,
-                "y": 41
+                "y": 36
               },
               "hiddenSeries": false,
               "id": 250,
@@ -4628,7 +4628,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 46,
               "repeatedByRow": true,
               "scopedVars": {
@@ -4712,7 +4712,7 @@ data:
                 "h": 10,
                 "w": 8,
                 "x": 8,
-                "y": 41
+                "y": 36
               },
               "hiddenSeries": false,
               "id": 251,
@@ -4737,7 +4737,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 211,
               "repeatedByRow": true,
               "scopedVars": {
@@ -4821,7 +4821,7 @@ data:
                 "h": 10,
                 "w": 8,
                 "x": 16,
-                "y": 41
+                "y": 36
               },
               "hiddenSeries": false,
               "id": 252,
@@ -4846,7 +4846,7 @@ data:
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
-              "repeatIteration": 1646839848112,
+              "repeatIteration": 1646841797680,
               "repeatPanelId": 78,
               "repeatedByRow": true,
               "scopedVars": {
@@ -4913,7 +4913,7 @@ data:
               }
             }
           ],
-          "repeatIteration": 1646839848112,
+          "repeatIteration": 1646841797680,
           "repeatPanelId": 12,
           "scopedVars": {
             "upstream": {
@@ -5168,5 +5168,5 @@ data:
       "timezone": "browser",
       "title": "manage-recalls-api / Dashboard",
       "uid": "manage-recalls-api-dashboard",
-      "version": 2
+      "version": 3
     }


### PR DESCRIPTION
This meant that we were only showing the request rate from one pod...