### PR TITLE
Set up an environment for the apply prototype 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apply-for-legal-aid-prototype
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/slack-channel: "applyprivatebeta"
+    cloud-platform.justice.gov.uk/application: "Gov.UK Prototype Kit"
+    cloud-platform.justice.gov.uk/owner: "Apply for Legal Aid: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/apply-for-legal-aid-prototype"
+    cloud-platform.justice.gov.uk/team-name: "laa-apply-for-legal-aid"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: apply-for-legal-aid-prototype-admin
+  namespace: apply-for-legal-aid-prototype
+subjects:
+  - kind: Group
+    name: "github:laa-apply-for-legal-aid"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: apply-for-legal-aid-prototype
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: apply-for-legal-aid-prototype
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: apply-for-legal-aid-prototype
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: apply-for-legal-aid-prototype
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/basic-auth.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/basic-auth.tf
@@ -1,0 +1,13 @@
+# Username and password for the prototype kit website's http basic
+# authentication
+resource "kubernetes_secret" "basic-auth" {
+  metadata {
+    name      = "basic-auth"
+    namespace = var.namespace
+  }
+
+  data = {
+    username = var.basic-auth-username
+    password = var.basic-auth-password
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/ecr.tf
@@ -1,0 +1,22 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.6"
+
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  github_repositories = [var.namespace]
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
+    repo_arn          = module.ecr-repo.repo_arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/github-repo.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/github-repo.tf
@@ -1,0 +1,15 @@
+
+# This module creates files to build docker image and 
+# continuous deployment (CD) workflow in prototype github repo.
+
+module "github-prototype" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-github-prototype?ref=0.1.1"
+
+  namespace = var.namespace
+}
+
+resource "github_actions_secret" "prototype" {
+  repository      = var.namespace
+  secret_name     = "PROTOTYPE_NAME"
+  plaintext_value = var.namespace
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/serviceaccount.tf
@@ -1,0 +1,8 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = [var.namespace]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/variables.tf
@@ -1,0 +1,69 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Gov.UK Prototype Kit"
+}
+
+variable "namespace" {
+  default = "apply-for-legal-aid-prototype"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "LAA"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "laa-apply-for-legal-aid"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "platforms@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "applyprivatebeta"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}
+
+## Prototype kit variables
+
+variable "basic-auth-username" {
+  description = "Basic auth. username of the deployed prototype website"
+  default     = "apply"
+}
+
+variable "basic-auth-password" {
+  description = "Basic auth. password of the deployed prototype website"
+  default     = "prototype"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.68.0"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}


### PR DESCRIPTION
This is to set up an environment for the apply prototype on cloud platform, so that we can move away from hosting on Heroku