### PR TITLE
INC-236: Add secret to Incentives prod namespace with S3 bucket details

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/s3.tf
@@ -1,0 +1,13 @@
+resource "kubernetes_secret" "analytical_platform_s3_bucket" {
+  metadata {
+    name      = "analytical-platform-s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = ""
+    secret_access_key = ""
+    bucket_arn        = "arn:aws:s3:::alpha-manage-my-prison"
+    bucket_name       = "alpha-manage-my-prison"
+  }
+}


### PR DESCRIPTION
…mirroring other environments which own their bucket, whereas this one is owned by a different AWS account. Having matching secrets will mean apps in different namespaces can work in the same systematic way.