### PR TITLE
The team name responsible for this service changed and was missed as part of the migration from live-1 to the live cluster.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: calculate-journey-variable-payments-dev
 subjects:
   - kind: Group
-    name: "github:calculate-journey-variable-payments"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: calculate-journey-variable-payments-preprod
 subjects:
   - kind: Group
-    name: "github:calculate-journey-variable-payments"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: calculate-journey-variable-payments-prod
 subjects:
   - kind: Group
-    name: "github:calculate-journey-variable-payments"
+    name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
The Github team name has changed for this project and was missed as part of the migration from the live1-1 to the live cluster.

This is linked to this [Jira](https://dsdmoj.atlassian.net/browse/P4-3398) and this [PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/7410).

