### PR TITLE
Formbuilder: Remove pingdom alert

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/pingdom.tf
@@ -16,7 +16,6 @@ locals {
     let-us-know                    = "let-us-know.form.service.justice.gov.uk",
     miscarriages-of-justice        = "miscarriages-of-justice.form.service.justice.gov.uk",
     moj-forms                      = "moj-forms.service.justice.gov.uk",
-    moj-user-research-consent      = "ministry-of-justice-user-research-consent-form.form.service.justice.gov.uk",
     money-claim-queries            = "money-claim-queries.form.service.justice.gov.uk",
     publisher                      = "fb-publisher-live.apps.live.cloud-platform.service.justice.gov.uk",
     report-security-incident       = "report-security-incident.form.service.justice.gov.uk",


### PR DESCRIPTION
The User Research Form will be deleted, remove alert so we do not get notified.