### PR TITLE
Simply service matching for prometheus scraping

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/06-service-monitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/06-service-monitor.yaml
@@ -21,8 +21,8 @@ metadata:
   namespace: hmpps-interventions-dev
 spec:
   selector:
-    matchExpressions:
-      - {key: app, operator: In, values: [hmpps-interventions-service, api-suspect, performance-report]}
+    matchLabels:
+      app: hmpps-interventions-service
   namespaceSelector:
     matchNames:
       - hmpps-interventions-dev


### PR DESCRIPTION
All the necessary services in interventions are now labelled with `app:
hmpps-interventions-service`