### PR TITLE
LAA Apply: Update prometheus alerts on staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/05-prometheus.yaml
@@ -61,19 +61,19 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller!~"providers/application_merits_task/statement_of_cases|providers/means_summaries"} > 2
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller!~"providers/application_merits_task/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections"} > 2
       for: 1m
       labels:
         severity: apply-for-legal-aid-staging
       annotations:
         message: Request is taking more than 2 seconds
-    - alert: "Long-Request: Statement of case"
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller="providers/application_merits_task/statement_of_cases"} > 10
+    - alert: "Long-Request: file_uploads"
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller="providers/application_merits_task/statement_of_cases|providers/uploaded_evidence_collections"} > 10
       for: 1m
       labels:
         severity: apply-for-legal-aid-staging
       annotations:
-        message: Statement of case request is taking more than 10 seconds
+        message: File upload request is taking more than 10 seconds    
     - alert: "Long-Request: means_summaries"
       expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller="providers/means_summaries"} > 5
       for: 1m


### PR DESCRIPTION
As we have switched some of the file uploads to a separate controller, this should only alert when a file upload exceeds 10
seconds and exclude it from the default 2 second checks