### PR TITLE
[LAA Court Data Adaptor] Increase delay_seconds for prosecution_concluded SQS queue (test)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
@@ -302,7 +302,7 @@ module "prosecution_concluded_queue" {
   encrypt_sqs_kms           = var.encrypt_sqs_kms
   message_retention_seconds = var.message_retention_seconds
   namespace                 = var.namespace
-  delay_seconds             = "120"
+  delay_seconds             = "900"
 
   redrive_policy = <<EOF
   {


### PR DESCRIPTION
Increase delay_seconds for prosecution_concluded SQS queue (dev) from 2 to 15 minutes.