### PR TITLE
Apply: Update prometheus alerts on production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/05-prometheus.yaml
@@ -61,14 +61,14 @@ spec:
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller!~"providers/application_merits_task/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections"} > 2
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller!~"providers/application_merits_task/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
       for: 1m
       labels:
         severity: apply-for-legal-aid-prod
       annotations:
         message: Request is taking more than 2 seconds
     - alert: "Long-Request: file_uploads"
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller="providers/application_merits_task/statement_of_cases|providers/uploaded_evidence_collections"} > 10
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller="providers/application_merits_task/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
       for: 1m
       labels:
         severity: apply-for-legal-aid-prod
@@ -81,13 +81,6 @@ spec:
         severity: apply-for-legal-aid-prod
       annotations:
         message: Means summary generation is taking more than 5 seconds
-    - alert: "Long-Request: admin-reports"
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller="admin/reports"} > 65
-      for: 1m
-      labels:
-        severity: apply-for-legal-aid-prod
-      annotations:
-        message: Admin report generation is taking more than 65 seconds
     - alert: Address lookup service
       expr: sum(rate(ruby_http_requests_total{status=~"4..|5..", namespace="laa-apply-for-legalaid-production", controller="providers/address_selections"}[30m])) * 1800 > 1
       for: 1m


### PR DESCRIPTION
Remove the admin report alert, this is now an overnight
build and download from S3 so should never exceed the
standard 2-second rule

Include v1/uploaded_evidence_collections in the 10 second
rule and exclude it from 2 seconds