### PR TITLE
Increase memory of Basm frontend in production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1500Mi
+      memory: 2500Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
This follows up on https://github.com/ministryofjustice/cloud-platform-environments/pull/7498 as it hasn't solved the problem entirely.

We recently deployed a new release of the frontend and experienced memory limit reached issues, so we're going to increase the memory limit on the frontend in production.

The other environments haven't experienced any memory issues which indicated it's not a memory leak.