### PR TITLE
Removed as advised by Poornima Krishnasamy so that the Assess Risks a…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prototypes/resources/github-repo.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prototypes/resources/github-repo.tf
@@ -40,13 +40,6 @@ resource "github_repository" "prototype" {
   }
 }
 
-resource "github_branch_protection" "default" {
-  repository_id          = github_repository.prototype.id
-  pattern                = "main"
-  enforce_admins         = true
-  require_signed_commits = true
-}
-
 resource "github_team_repository" "prototype" {
   for_each   = local.teams
   team_id    = each.value.id


### PR DESCRIPTION
…nd Needs interaction designer can update 'main' directly - this is a repo that will only hold prototypes based on the govuk prototyping kit and doesn't need additional protections.