### PR TITLE
Update alerts to only capture probation search

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/11-prometheus-elastic-search.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/11-prometheus-elastic-search.yaml
@@ -14,21 +14,21 @@ spec:
       annotations:
         message: ElasticSearch cluster status is RED {{ $labels.domain_name }}. https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&from=now-1h&to=now&refresh=1m&var-datasource=Cloudwatch&var-region=default&var-domainName={{ $labels.domain_name }}&var-clientId={{ $labels.client_id }}
         runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html
-      expr: aws_es_cluster_status_red_maximum{domain_name=~"^dps-prod.*"} >= 1
+      expr: aws_es_cluster_status_red_maximum{domain_name="dps-prod-search-probation"} >= 1
       labels:
         severity: probation-integration-notifications
     - alert: ElasticSearchClusterStateYellow
       annotations:
         message: ElasticSearch cluster status is Yellow {{ $labels.domain_name }}. https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&from=now-1h&to=now&refresh=1m&var-datasource=Cloudwatch&var-region=default&var-domainName={{ $labels.domain_name }}&var-clientId={{ $labels.client_id }}
         runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html
-      expr: aws_es_cluster_status_yellow_maximum{domain_name=~"^dps-prod.*"} >= 1
+      expr: aws_es_cluster_status_yellow_maximum{domain_name="dps-prod-search-probation"} >= 1
       labels:
         severity: probation-integration-notifications
     - alert: ElasticSearchClusterFreeStorageSpace
       annotations:
         message: ElasticSearch cluster {{ $labels.domain_name }} is running low on storage space. https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&from=now-1h&to=now&refresh=1m&var-datasource=Cloudwatch&var-region=default&var-domainName={{ $labels.domain_name }}&var-clientId={{ $labels.client_id }}
         runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html
-      expr: aws_es_free_storage_space_maximum{domain_name=~"^dps-prod.*"} <= 3072
+      expr: aws_es_free_storage_space_maximum{domain_name="dps-prod-search-probation"} <= 3072
       for: 1m
       labels:
         severity: probation-integration-notifications
@@ -36,7 +36,7 @@ spec:
       annotations:
         message: ElasticSearch cluster index writes blocked {{ $labels.domain_name }}. https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&from=now-1h&to=now&refresh=1m&var-datasource=Cloudwatch&var-region=default&var-domainName={{ $labels.domain_name }}&var-clientId={{ $labels.client_id }}
         runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html
-      expr: aws_es_cluster_index_writes_blocked_maximum{domain_name=~"^dps-prod.*"} >= 1
+      expr: aws_es_cluster_index_writes_blocked_maximum{domain_name="dps-prod-search-probation"} >= 1
       for: 5m
       labels:
         severity: probation-integration-notifications
@@ -44,7 +44,7 @@ spec:
       annotations:
         message: ElasticSearch {{ $labels.domain_name }}. An automated snapshot failed. This failure is often the result of a red cluster health status.  https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&from=now-1h&to=now&refresh=1m&var-datasource=Cloudwatch&var-region=default&var-domainName={{ $labels.domain_name }}&var-clientId={{ $labels.client_id }}
         runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html
-      expr: aws_es_automated_snapshot_failure_maximum{domain_name=~"^dps-prod.*"} >= 1
+      expr: aws_es_automated_snapshot_failure_maximum{domain_name="dps-prod-search-probation"} >= 1
       for: 1m
       labels:
         severity: probation-integration-notifications
@@ -52,7 +52,7 @@ spec:
       annotations:
         message: ElasticSearch {{ $labels.domain_name }}. The cluster could encounter out of memory errors if usage increases.  https://grafana.live.cloud-platform.service.justice.gov.uk/d/eCN_s8yWk/aws-elasticsearch?orgId=1&from=now-1h&to=now&refresh=1m&var-datasource=Cloudwatch&var-region=default&var-domainName={{ $labels.domain_name }}&var-clientId={{ $labels.client_id }}
         runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html
-      expr: aws_es_jvmmemory_pressure_maximum{domain_name=~"^dps-prod.*"} >= 80
+      expr: aws_es_jvmmemory_pressure_maximum{domain_name="dps-prod-search-probation"} >= 80
       for: 15m
       labels:
         severity: probation-integration-notifications


### PR DESCRIPTION
Previously this was matching `^dps-prod.*` which meant the prison search alerts were also being sent to the #probation-integration-notifications channel.