### PR TITLE
AAC-557 - Update staging values

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-staging/resources/basic-auth.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-staging/resources/basic-auth.tf
@@ -1,9 +1,3 @@
-resource "random_password" "password" {
-  length           = 16
-  special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
-}
-
 resource "kubernetes_secret" "basic-auth" {
   metadata {
     name      = "basic-auth"
@@ -11,7 +5,6 @@ resource "kubernetes_secret" "basic-auth" {
   }
 
   data = {
-    username = var.basic-auth-username
-    password = random_password.password.result
+    aut = var.basic-auth-value
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-staging/resources/variables.tf
@@ -124,7 +124,7 @@ variable "serviceaccount_rules" {
   ]
 }
 
-variable "basic-auth-username" {
-  description = "Basic auth. username of the deployed prototype website"
-  default     = "courtdataui"
+variable "basic-auth-value" {
+  description = "Basic auth value. username of the deployed application"
+  default     = "Y291cnRkYXRhdWk6JGFwcjEkcGRTY0tuSDgkVE5Qc0NRcGN5ZWtHcFQweHFManBOLgo="
 }


### PR DESCRIPTION
After an issue where in the application was returning a 503 because the basic-auth secret was in username/password format and not auth, this is to update the secrets to utilise the correct format and prevent them being overwritten when changes are made.