### PR TITLE
Add PROTOTYPE_NAME github action secret for deployment pipeline

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/interventions-design-history/resources/github-repo.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/interventions-design-history/resources/github-repo.tf
@@ -1,0 +1,5 @@
+resource "github_actions_secret" "prototype" {
+  repository      = var.namespace
+  secret_name     = "PROTOTYPE_NAME"
+  plaintext_value = var.namespace
+}


### PR DESCRIPTION
This is needed even if the repository and the deployment files exists already. 
Refer: https://github.com/ministryofjustice/interventions-design-history