### PR TITLE
[hmcts-mock-api-dev] Expose AWS creds in Kubernetes secret

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
@@ -36,7 +36,7 @@ resource "kubernetes_secret" "hmcts_mock_api_rds" {
     database_username     = module.hmcts_mock_api_rds.database_username
     rds_instance_address  = module.hmcts_mock_api_rds.rds_instance_address
     rds_instance_endpoint = module.hmcts_mock_api_rds.rds_instance_endpoint
-    url = "postgres://${module.hmcts_mock_api_rds.database_username}:${module.hmcts_mock_api_rds.database_password}@${module.hmcts_mock_api_rds.rds_instance_endpoint}/${module.hmcts_mock_api_rds.database_name}"
+    url                   = "postgres://${module.hmcts_mock_api_rds.database_username}:${module.hmcts_mock_api_rds.database_password}@${module.hmcts_mock_api_rds.rds_instance_endpoint}/${module.hmcts_mock_api_rds.database_name}"
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds.tf
@@ -30,6 +30,12 @@ resource "kubernetes_secret" "hmcts_mock_api_rds" {
   }
 
   data = {
+    access_key_id         = module.hmcts_mock_api_rds.access_key_id
+    secret_access_key     = module.hmcts_mock_api_rds.secret_access_key
+    database_name         = module.hmcts_mock_api_rds.database_name
+    database_username     = module.hmcts_mock_api_rds.database_username
+    rds_instance_address  = module.hmcts_mock_api_rds.rds_instance_address
+    rds_instance_endpoint = module.hmcts_mock_api_rds.rds_instance_endpoint
     url = "postgres://${module.hmcts_mock_api_rds.database_username}:${module.hmcts_mock_api_rds.database_password}@${module.hmcts_mock_api_rds.rds_instance_endpoint}/${module.hmcts_mock_api_rds.database_name}"
   }
 }


### PR DESCRIPTION
Expose AWS creds in Kubernetes secret to enable us to migrate the database, as described in https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/aws-rds-migration.html#migrating-an-rds-instance.