### PR TITLE
Amend db_engine_version with major version number

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds-pre-sentence-service.tf
@@ -9,7 +9,7 @@ module "pre_sentence_service_rds" {
   infrastructure-support      = var.infrastructure-support
   rds_family                  = "postgres13"
   db_instance_class           = "db.t3.small"
-  db_engine_version           = "13.4"
+  db_engine_version           = "13"
   allow_major_version_upgrade = false
 
   providers = {


### PR DESCRIPTION
auto_minor_version_upgrade is enabled so mention just the major version. Pipeline fails when aws auto upgrades minor versions