### PR TITLE
Update db_engine_version with just major version 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds-pre-sentence-service.tf
@@ -9,7 +9,7 @@ module "pre_sentence_service_rds" {
   infrastructure-support       = var.infrastructure-support
   rds_family                   = "postgres13"
   db_instance_class            = "db.t3.small"
-  db_engine_version            = "13.3"
+  db_engine_version            = "13"
   allow_major_version_upgrade  = false
   performance_insights_enabled = true
 


### PR DESCRIPTION
This will fix conflict whenever aws do auto minor upgrades and the pipeline errors because of mismatch in terraform state.
