### PR TITLE
AAC-581 - Add Route53 for production court data api

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "cdapi_route53_zone" {
+  name = var.domain
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "cdapi_route53_zone_sec" {
+  metadata {
+    name      = "cdapi-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id      = aws_route53_zone.cdapi_route53_zone.zone_id
+    name_servers = join("\n", aws_route53_zone.cdapi_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/resources/variables.tf
@@ -9,7 +9,7 @@ variable "kubernetes_cluster" {
 }
 
 variable "domain" {
-  default = "laa-court-data-api.service.justice.gov.uk"
+  default = "court-data-api.service.justice.gov.uk"
 }
 
 variable "application" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/resources/variables.tf
@@ -8,6 +8,10 @@ variable "cluster_state_bucket" {
 variable "kubernetes_cluster" {
 }
 
+variable "domain" {
+  default = "laa-court-data-api.service.justice.gov.uk"
+}
+
 variable "application" {
   description = "Name of Application you are deploying"
   default     = "laa-court-data-api"


### PR DESCRIPTION
To enable us to use our own domain name, this PR sets up the Route53 config so that we can proceed to the next step for doing this. 