### PR TITLE
Remove the VPC ID

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/legacy-ppud-api-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ppud-replacement-prod/resources/legacy-ppud-api-rds.tf
@@ -3,14 +3,12 @@
 ##
 
 locals {
-  mod_platform_vpc_id = "vpc-0a16bb6858dd27aea" # hmpps-production VPC
   mod_platform_subnet_cidr = "10.27.8.0/24" # hmpps-production-general-private-eu-west-2a subnet
 }
 
 resource "aws_security_group" "modernisation_platform_rds_sg" {
   name        = "ppud-replica-prod-modernisation-platform-rds-sg"
   description = "Allow all traffic to/from the modernisation platform"
-  vpc_id      = local.mod_platform_vpc_id
 
   ingress {
     from_port   = 0


### PR DESCRIPTION
It's an optional param and as the user running the apply cannot access
the VPC it's causing failures.