### PR TITLE
feat(analytical-platform): add initial environment with basic cli config

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: analytical-platform-poc
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "analytical-platform"
+    cloud-platform.justice.gov.uk/application: "analytical-platform-control-panel"
+    cloud-platform.justice.gov.uk/owner: "analytical-platform: platforms@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/analytical-platform-external-tools"
+    cloud-platform.justice.gov.uk/team-name: "analytics-hq"
+    cloud-platform.justice.gov.uk/review-after: "2022-07-14"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: analytical-platform-poc-admin
+  namespace: analytical-platform-poc
+subjects:
+  - kind: Group
+    name: "github:analytics-hq"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: analytical-platform-poc
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: analytical-platform-poc
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: analytical-platform-poc
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: analytical-platform-poc
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/resources/variables.tf
@@ -1,0 +1,57 @@
+
+variable "cluster_name" {
+}
+
+variable "cluster_state_bucket" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "analytical-platform-control-panel"
+}
+
+variable "namespace" {
+  default = "analytical-platform-poc"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "analytics-hq"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "platforms@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "analytical-platform"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.68.0"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}


### PR DESCRIPTION
I want to see if I can emulate the analytical platform tools api on the Cloud Platform.