### PR TITLE
build(ap-poc): bump the serviceaccount module version to 0.7.4

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-poc/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster


### PR DESCRIPTION
0.7.4 is the latest release of this module. I'm not sure why the reports.cloud-platform... didn't pick this up
