### PR TITLE
AAC-558 - Add dev cert to laa-court-data-api-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-dev/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-dev/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: laa-court-data-api-dev-cert
+  namespace: laa-court-data-api-dev
+spec:
+  secretName: laa-court-data-api-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - dev.court-data-api.service.justice.gov.uk


### PR DESCRIPTION
Add certificate to dev namespace for laa-court-data-api-dev after having new dns zone added. 