### PR TITLE
Add certificate to laa-court-data-api-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-uat/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-uat/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: laa-court-data-api-uat-cert
+  namespace: laa-court-data-api-uat
+spec:
+  secretName: laa-court-data-api-uat-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - uat.court-data-api.service.justice.gov.uk


### PR DESCRIPTION
Add certificate to uat namespace for laa-court-data-api-uat after having new dns zone added.