### PR TITLE
Add cert to laa-court-data-api-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-staging/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-staging/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: laa-court-data-api-staging-cert
+  namespace: laa-court-data-api-staging
+spec:
+  secretName: laa-court-data-api-staging-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - staging.court-data-api.service.justice.gov.uk


### PR DESCRIPTION
Add certificate to staging namespace for laa-court-data-api-staging after having new dns zone added.