### PR TITLE
Add certificate to laa-court-data-api-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: laa-court-data-api-production-cert
+  namespace: laa-court-data-api-production
+spec:
+  secretName: laa-court-data-api-production-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - court-data-api.service.justice.gov.uk


### PR DESCRIPTION
Add certificate to production namespace for laa-court-data-api-production after having new dns zone added.