### PR TITLE
Incentives prototype: Disable override of Dockerfile

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-tool/resources/github-repo.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-tool/resources/github-repo.tf
@@ -5,5 +5,7 @@
 module "github-prototype" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-github-prototype?ref=0.1.1"
 
+  prototype_create_dockerfile = false
+
   namespace = var.namespace
 }


### PR DESCRIPTION
as suggested in #ask-cloud-platform, to allow prototype container to use
newer version of Node.js base image.