### PR TITLE
Add slow query logging to Basm production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -16,6 +16,14 @@ module "rds-instance" {
 
   # enable performance insights
   performance_insights_enabled = true
+
+  db_parameter = [
+    {
+      "apply_method": "immediate",
+      "name": "log_min_duration_statement",
+      "value": "2000"
+    }
+  ]
 }
 
 resource "kubernetes_secret" "rds-instance" {


### PR DESCRIPTION
This will allow us to determine which queries might be the slowest and we could look in to improving them.

Based on the instructions here: https://aws.amazon.com/premiumsupport/knowledge-center/rds-postgresql-query-logging/

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3451)