### PR TITLE
Replacing dev namespace for VSiP project

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/book-a-prison-visit-api-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/book-a-prison-visit-api-dev/00-namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: book-a-prison-visit-api-dev
   labels:
     cloud-platform.justice.gov.uk/is-production: "false"
-    cloud-platform.justice.gov.uk/environment-name: "development"
+    cloud-platform.justice.gov.uk/environment-name: "old-dev"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/slack-channel: "prison-visit-booking"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/book-a-prison-visit-api-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/book-a-prison-visit-api-dev/06-certificate.yaml
@@ -10,4 +10,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - visit-scheduler-dev.hmpps.service.justice.gov.uk
+    - visit-scheduler-olddev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/book-a-prison-visit-api-dev/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/book-a-prison-visit-api-dev/07-certificate.yaml
@@ -10,4 +10,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - prisoner-contact-registry-dev.hmpps.service.justice.gov.uk
+    - prisoner-contact-registry-olddev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/book-a-prison-visit-api-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/book-a-prison-visit-api-dev/resources/variables.tf
@@ -27,7 +27,7 @@ variable "team_name" {
 
 variable "environment" {
   description = "The type of environment you're deploying to."
-  default     = "dev"
+  default     = "old dev"
 }
 
 variable "infrastructure_support" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/06-certificate.yaml
@@ -10,4 +10,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - visit-scheduler-staging.hmpps.service.justice.gov.uk
+    - visit-scheduler-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/07-certificate.yaml
@@ -10,4 +10,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - prisoner-contact-registry-staging.hmpps.service.justice.gov.uk
+    - prisoner-contact-registry-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
VSiP project

Switch visit-someone-in-prison-backend-svc-dev to be the new dev namespace for backend microservices

Displaces book-a-prison-visit-api-dev namespace which has been labelled 'old-dev'. once the switch is complete, the old namespace will be removed. 