### PR TITLE
Add the OPA tests for env repo

### DIFF
--- a/.github/workflows/conftest-yaml.yml
+++ b/.github/workflows/conftest-yaml.yml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+name: Conftest YAML files
+jobs:
+  conftest-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ministryofjustice/github-actions/conftest-yaml@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conftest-yaml.yml
+++ b/.github/workflows/conftest-yaml.yml
@@ -7,15 +7,15 @@ jobs:
   conftest-yaml:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
+    - name: Check out repository code
+      uses: actions/checkout@v2
 
-      - name: Setup OPA
-        uses: open-policy-agent/setup-opa@v1
-        with:
-          version: latest
+    - name: Setup OPA
+      uses: open-policy-agent/setup-opa@v1
+      with:
+        version: latest
 
-      - name: Run conf tests
-      - uses: ministryofjustice/github-actions/conftest-yaml@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run conf tests
+      uses: ministryofjustice/github-actions/conftest-yaml@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conftest-yaml.yml
+++ b/.github/workflows/conftest-yaml.yml
@@ -15,7 +15,5 @@ jobs:
       with:
         version: latest
 
-    - name: Run conf tests
-      uses: ministryofjustice/github-actions/conftest-yaml@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run OPA Tests 
+      run: opa test policy/*.rego -v

--- a/.github/workflows/conftest-yaml.yml
+++ b/.github/workflows/conftest-yaml.yml
@@ -7,7 +7,15 @@ jobs:
   conftest-yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Setup OPA
+        uses: open-policy-agent/setup-opa@v1
+        with:
+          version: latest
+
+      - name: Run conf tests
       - uses: ministryofjustice/github-actions/conftest-yaml@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opa-tests.yml
+++ b/.github/workflows/opa-tests.yml
@@ -2,7 +2,7 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-name: Conftest YAML files
+name: OPA tests
 jobs:
   conftest-yaml:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-environments#4866

This test the OPA policies for environments repo when users have escalated rolebindings and business-unit other than what we expect.