### PR TITLE
Fix quotes in application annotation

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mydemoapp-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mydemoapp-dev/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
-    cloud-platform.justice.gov.uk/application: "“Hello, World” application"
+    cloud-platform.justice.gov.uk/application: "Hello, World application"
     cloud-platform.justice.gov.uk/owner: "Apply: apply-for-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-helloworld-ruby-app"
     cloud-platform.justice.gov.uk/team-name: "laa-apply-for-legal-aid"


### PR DESCRIPTION
This special characters broke the HOODAW hosted services and hence removing.

Need investigating on how to detect this before merging