### PR TITLE
Add a service account to namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mydemoapp-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mydemoapp-dev/resources/serviceaccount.tf
@@ -1,0 +1,10 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}


### PR DESCRIPTION
Add a service account to namespace as per instructions:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#add-a-service-account-to-your-namespace