### PR TITLE
Add a serviceaccount_name variable

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mydemoapp-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mydemoapp-dev/resources/serviceaccount.tf
@@ -7,4 +7,5 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   # github_repositories = ["my-repo"]
+  serviceaccount_name = "circleci"
 }


### PR DESCRIPTION
Add a serviceaccount_name variable called circleci as per instructions:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html#creating-a-service-account-for-circleci