### PR TITLE
Add deployment manifest and gh action file template for prototype

### DIFF
--- a/namespace-resources-cli-template/resources/prototype/templates/cd.yaml
+++ b/namespace-resources-cli-template/resources/prototype/templates/cd.yaml
@@ -1,0 +1,49 @@
+name: Continuous Deployment
+
+# For a description of how this works, see this Cloud Platform User Guide page:
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/github-actions-continuous-deployment.html
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'branch-name'
+
+env:
+  ECR_NAME: ${{ secrets.ECR_NAME }}
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+  KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+  PROTOTYPE_NAME: ${{ secrets.PROTOTYPE_NAME }}
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: docker build -t foo .
+      - name: Push to ECR
+        id: ecr
+        uses: jwalton/gh-ecr-push@v1
+        with:
+          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          region: eu-west-2
+          local-image: foo
+          image: ${ECR_NAME}:${{ github.sha }}
+      - name: Update image tag and branch name
+        run: export IMAGE_TAG=${{ github.sha }} && export BRANCH=${GITHUB_REF##*/} && cat kubernetes-deploy-${GITHUB_REF##*/}.tpl | envsubst > kubernetes-deploy.yaml
+      - name: Authenticate to the cluster
+        env:
+          KUBE_CERT: ${{ secrets.KUBE_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+        run: |
+          echo "${KUBE_CERT}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+      - name: Apply the updated manifest
+        run: |
+          kubectl -n ${KUBE_NAMESPACE} apply -f kubernetes-deploy.yaml

--- a/namespace-resources-cli-template/resources/prototype/templates/kubernetes-deploy.tpl
+++ b/namespace-resources-cli-template/resources/prototype/templates/kubernetes-deploy.tpl
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moj-prototype-${BRANCH}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prototype-${BRANCH}
+  template:
+    metadata:
+      labels:
+        app: prototype-${BRANCH}
+    spec:
+      containers:
+      - name: nginx
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/${ECR_NAME}:${IMAGE_TAG}
+        env:
+          - name: USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: basic-auth
+                key: username
+          - name: PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basic-auth
+                key: password
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service-${BRANCH}
+  labels:
+    app: nginx-service-${BRANCH}
+spec:
+  ports:
+  - port: 3000
+    name: http
+    targetPort: 3000
+  selector:
+    app: prototype-${BRANCH}
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: prototype-ingress-${BRANCH}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: prototype-ingress-${BRANCH}-${KUBE_NAMESPACE}-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+spec:
+  tls:
+  - hosts:
+    - ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: nginx-service-${BRANCH}
+          servicePort: 3000


### PR DESCRIPTION
Template files to be fetched by the CLI for prototype deployment

Earlier we maintained these file in the repo: https://github.com/ministryofjustice/cloud-platform-terraform-github-prototype/tree/main/templates. Since, the deployments are branch based, the template will be automatically pulled and updated based on what branch the cli command is executed.