### PR TITLE
[interventions-preprod] Switching to RoleBinding and enable prometheusrules

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/05-serviceaccount-circleci.yaml
@@ -1,8 +1,24 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: circleci
   namespace: "hmpps-interventions-preprod"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: "hmpps-interventions-preprod"
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: "hmpps-interventions-preprod"
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
 
 ---
 kind: Role
@@ -12,60 +28,22 @@ metadata:
   namespace: "hmpps-interventions-preprod"
 rules:
   - apiGroups:
-      - ""
+      - "monitoring.coreos.com"
     resources:
-      - "pods/portforward"
-      - "deployment"
-      - "secrets"
-      - "services"
-      - "pods"
-      - "configmaps"
+      - "prometheusrules"
     verbs:
-      - "patch"
-      - "get"
-      - "update"
-      - "create"
-      - "delete"
-      - "list"
-  - apiGroups:
-      - "extensions"
-      - "apps"
-      - "networking.k8s.io"
-    resources:
-      - "deployments"
-      - "ingresses"
-      - "replicasets"
-    verbs:
-      - "get"
-      - "update"
-      - "delete"
-      - "create"
-      - "patch"
-      - "list"
-  - apiGroups:
-      - "batch"
-    resources:
-      - "jobs"
-      - "cronjobs"
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
-      - "create"
-      - "update"
-      - "patch"
-      - "delete"
+      - "*"
 
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: circleci
+  name: circleci-prometheus
   namespace: "hmpps-interventions-preprod"
 subjects:
-- kind: ServiceAccount
-  name: circleci
-  namespace: "hmpps-interventions-preprod"
+  - kind: ServiceAccount
+    name: circleci
+    namespace: "hmpps-interventions-preprod"
 roleRef:
   kind: Role
   name: circleci


### PR DESCRIPTION
To make the namespace compatible with
https://github.com/ministryofjustice/hmpps-helm-charts

Similar to #7998 