### PR TITLE
evidencelibrary-test: new domain cert

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: evidencelibrary-test-certificate
+  namespace: evidencelibrary-test
+spec:
+  secretName: evidencelibrary-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - test.analytical-evidence-library.service.justice.gov.uk


### PR DESCRIPTION
new domain: https://test.analytical-evidence-library.service.justice.gov.uk/