### PR TITLE
Increase prod Basm DB instance size to aid creation of index on tablewith 19 million plus rows.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds-instance" {
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
   db_allocated_storage   = 50
-  db_instance_class      = "db.t3.xlarge"
+  db_instance_class      = "db.t3.2xlarge"
   backup_window          = var.backup_window
   maintenance_window     = var.maintenance_window
 


### PR DESCRIPTION
Raising PR on back of advice from Cloud Platform team.

We are trying to create an index on a table with millions of rows in production and so far it hasn't worked.  Hopefully this will give us the boost we need to create it.