### PR TITLE
Add serviceaccount to CFE UAT namespace for github-action

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/main.tf
@@ -17,11 +17,7 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-/*
- * When using this module through the cloud-platform-environments, the following
- * two variables are automatically supplied by the pipeline.
- *
- */
-
-variable "cluster_name" {
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/serviceaccount.tf
@@ -1,0 +1,16 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
+
+  namespace            = var.namespace
+  kubernetes_cluster   = var.kubernetes_cluster
+  serviceaccount_name  = "github-actions"
+  serviceaccount_rules = var.serviceaccount_rules
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories                  = [var.repo_name]
+  github_actions_secret_kube_cert      = "K8S_GHA_UAT_CLUSTER_CERT"
+  github_actions_secret_kube_token     = "K8S_GHA_UAT_TOKEN"
+  github_actions_secret_kube_cluster   = "K8S_GHA_UAT_CLUSTER_NAME"
+  github_actions_secret_kube_namespace = "K8S_GHA_UAT_NAMESPACE"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/variables.tf
@@ -1,0 +1,122 @@
+variable "namespace" {
+  default = "check-financial-eligibility-uat"
+}
+
+variable "repo_name" {
+  description = "The name of github repo"
+  default     = "check-financial-eligibility"
+}
+
+variable "cluster_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "check-financial-eligibility"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "LAA"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "laa-apply-for-legal-aid"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "uat"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "apply@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "apply-dev"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the github terraform provider"
+  default     = ""
+}
+
+variable "serviceaccount_rules" {
+  description = "The capabilities of this serviceaccount"
+
+  type = list(object({
+    api_groups = list(string),
+    resources  = list(string),
+    verbs      = list(string)
+  }))
+
+  # These values are default plus custom to allow for deletion of UAT branches via CI/CD pipeline
+  default = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "HorizontalPodAutoscaler",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "statefulsets",
+        "networkpolicies",
+        "servicemonitors",
+        "prometheusrules",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
@@ -9,5 +9,8 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    github = {
+      source = "integrations/github"
+    }
   }
 }


### PR DESCRIPTION
Adds all required variables and config
to create a separate serviceaccount that
can be used by github actions to delete
a UAT env deployment.

Should also add necessary vars/config to
automatically generate the secrets that can be used

Related app PR [AP-3184](https://github.com/ministryofjustice/check-financial-eligibility/pull/959)
