### PR TITLE
Add service account for github actions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/serviceaccount.tf
@@ -1,0 +1,16 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
+
+  namespace            = var.namespace
+  kubernetes_cluster   = var.kubernetes_cluster
+  serviceaccount_name  = "github-actions"
+  serviceaccount_rules = var.serviceaccount_rules
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories                  = [var.repo_name]
+  github_actions_secret_kube_cert      = "K8S_GHA_UAT_CLUSTER_CERT"
+  github_actions_secret_kube_token     = "K8S_GHA_UAT_TOKEN"
+  github_actions_secret_kube_cluster   = "K8S_GHA_UAT_CLUSTER_NAME"
+  github_actions_secret_kube_namespace = "K8S_GHA_UAT_NAMESPACE"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/variables.tf
@@ -1,15 +1,23 @@
+variable "namespace" {
+  default = "legal-framework-api-uat"
+}
+
+variable "repo_name" {
+  description = "The name of github repo"
+  default     = "legal-framework-api"
+}
 
 variable "cluster_name" {
+}
+
+
+variable "kubernetes_cluster" {
 }
 
 
 variable "application" {
   description = "Name of Application you are deploying"
   default     = "Legal Framework API"
-}
-
-variable "namespace" {
-  default = "legal-framework-api-uat"
 }
 
 variable "business_unit" {
@@ -33,12 +41,12 @@ variable "infrastructure_support" {
 }
 
 variable "is_production" {
-  default = "true"
+  default = "false"
 }
 
 variable "slack_channel" {
   description = "Team slack channel to use if we need to contact your team"
-  default     = "applyprivatebeta"
+  default     = "apply-dev"
 }
 
 variable "github_owner" {
@@ -49,4 +57,67 @@ variable "github_owner" {
 variable "github_token" {
   description = "Required by the github terraform provider"
   default     = ""
+}
+
+variable "serviceaccount_rules" {
+  description = "The capabilities of this serviceaccount"
+
+  type = list(object({
+    api_groups = list(string),
+    resources  = list(string),
+    verbs      = list(string)
+  }))
+
+  # These values are default plus custom to allow for deletion of UAT branches via CI/CD pipeline
+  default = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "HorizontalPodAutoscaler",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "statefulsets",
+        "networkpolicies",
+        "servicemonitors",
+        "prometheusrules",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/versions.tf
@@ -6,6 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
     github = {
       source = "integrations/github"
     }


### PR DESCRIPTION
Adds all required variables and config
to create a separate serviceaccount that
can be used by github actions to delete
a UAT env deployment.

Related app PR [AP-3184](https://github.com/ministryofjustice/legal-framework-api/pull/662)
