### PR TITLE
Add serviceaccount to HMRC Interface UAT namespace for github-action

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
@@ -1,0 +1,16 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
+
+  namespace            = var.namespace
+  kubernetes_cluster   = var.kubernetes_cluster
+  serviceaccount_name  = "github-actions"
+  serviceaccount_rules = var.serviceaccount_github_actions_rules
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories                  = [var.repo_name]
+  github_actions_secret_kube_cert      = "K8S_GHA_UAT_CLUSTER_CERT"
+  github_actions_secret_kube_token     = "K8S_GHA_UAT_TOKEN"
+  github_actions_secret_kube_cluster   = "K8S_GHA_UAT_CLUSTER_NAME"
+  github_actions_secret_kube_namespace = "K8S_GHA_UAT_NAMESPACE"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
@@ -1,4 +1,4 @@
-module "serviceaccount" {
+module "serviceaccount_github_actions" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
 
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/variables.tf
@@ -10,6 +10,11 @@ variable "application" {
   default     = "LAA-HMRC Interface Service API"
 }
 
+variable "repo_name" {
+  description = "The name of github repo"
+  default     = "laa-hmrc-interface-service-api"
+}
+
 variable "namespace" {
   default = "laa-hmrc-interface-uat"
 }
@@ -51,4 +56,67 @@ variable "github_owner" {
 variable "github_token" {
   description = "Required by the github terraform provider"
   default     = ""
+}
+
+variable "serviceaccount_github_actions_rules" {
+  description = "The capabilities of this serviceaccount"
+
+  type = list(object({
+    api_groups = list(string),
+    resources  = list(string),
+    verbs      = list(string)
+  }))
+
+  # These values are default plus custom to allow for deletion of UAT branches via CI/CD pipeline
+  default = [
+    {
+      api_groups = [""]
+      resources = [
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "pods/exec",
+        "pods/portforward",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "statefulsets",
+        "networkpolicies",
+        "servicemonitors",
+        "prometheusrules",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/versions.tf
@@ -6,6 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
     github = {
       source = "integrations/github"
     }


### PR DESCRIPTION
Adds all required variables and config
to create a separate serviceaccount that
can be used by github actions to delete
a UAT env deployment.

Also adds necessary vars/config to
automatically generate the secrets that
can be used
