### PR TITLE
Amend role name to prevent clash with existing serviceaccount role

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
@@ -6,7 +6,7 @@ module "serviceaccount_github_actions" {
   serviceaccount_name  = "github-actions"
   serviceaccount_rules = var.serviceaccount_github_actions_rules
 
-  role_name = "serviceaccount-github-action-role"
+  role_name        = "serviceaccount-github-action-role"
   rolebinding_name = "serviceaccount-github-action-binding"
 
   # Uncomment and provide repository names to create github actions secrets

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
@@ -6,6 +6,9 @@ module "serviceaccount_github_actions" {
   serviceaccount_name  = "github-actions"
   serviceaccount_rules = var.serviceaccount_github_actions_rules
 
+  role_name = "serviceaccount-github-action-role"
+  rolebinding_name = "serviceaccount-github-action-binding"
+
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories                  = [var.repo_name]


### PR DESCRIPTION
prevent 

```
Error: roles.rbac.authorization.k8s.io "serviceaccount-role" already exists

  on .terraform/modules/serviceaccount_github_actions/main.tf line 15, in resource "kubernetes_role" "github_actions_role":
  15: resource "kubernetes_role" "github_actions_role" {

```