### PR TITLE
This temporary memory increase to see if we can resolve a production issue in the short term whilst coming up with a longer term solution.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 2048Mi
+      memory: 4096Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
Temporarily increasing the available memory to the payment service whilst buying us time to come up with a longer term solution.

FYI I have tried the same in preprod and it worked so should for production in theory.  [preprod PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/8083)