### PR TITLE
Update s3.tf

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -20,7 +20,6 @@ module "track_a_query_s3" {
       allowed_methods = ["GET", "POST", "PUT"]
       allowed_origins = [
         "https://development.track-a-query.service.justice.gov.uk",
-        "https://track-a-query-development.apps.live-1.cloud-platform.service.justice.gov.uk",
       ]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000


### PR DESCRIPTION
I was going to change it to `https://track-a-query-development.apps.live.cloud-platform.service.justice.gov.uk` but I have realised it's not live, so it may be a forgotten left over?