### PR TITLE
Increasing the book a secure move db read replica instance size due to low disk space error in db logs.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -48,7 +48,8 @@ module "rds-read-replica" {
   is-production          = var.is-production
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
-  db_allocated_storage   = 50
+  db_allocated_storage   = 100
+  db_instance_class      = "db.t3.medium"
 
   db_name             = module.rds-instance.database_name
   replicate_source_db = module.rds-instance.db_identifier


### PR DESCRIPTION
We are seeing low disk space errors in the read only instance logs in the Basm production RDS.

Overriding the default t3.small and bumping to t3.medium to see if this is enough to alleviate the issue and also increasing the allocated storage.