### PR TITLE
Fixing refererences to the Basm AWS read replica DB.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -34,7 +34,7 @@ resource "kubernetes_secret" "rds-instance" {
   data = {
     access_key_id     = module.rds-instance.access_key_id
     secret_access_key = module.rds-instance.secret_access_key
-    url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-instance.rds_instance_endpoint}/${module.rds-instance.database_name}"
+    url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-read-replica.rds_instance_endpoint}/${module.rds-read-replica.database_name}"
   }
 }
 
@@ -72,8 +72,8 @@ resource "kubernetes_secret" "rds-read-replica" {
   }
 
   data = {
-    access_key_id     = module.rds-instance.access_key_id
-    secret_access_key = module.rds-instance.secret_access_key
-    url               = "postgres://${module.rds-instance.database_username}:${module.rds-instance.database_password}@${module.rds-read-replica.rds_instance_endpoint}/${module.rds-read-replica.database_name}"
+    access_key_id     = module.rds-read-replica.access_key_id
+    secret_access_key = module.rds-read-replica.secret_access_key
+    url               = "postgres://${module.rds-read-replica.database_username}:${module.rds-read-replica.database_password}@${module.rds-read-replica.rds_instance_endpoint}/${module.rds-read-replica.database_name}"
   }
 }


### PR DESCRIPTION
The AWS RDS data attributes were set to the actual write instance and not the read replica DB.  This meant you could not see the correct values when trying to use the AWS CLI.