### PR TITLE
Increasing the prod Basm write instance storage allocation on back of low disk space warnings in the AWS logs and advice from Cloud Platform.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -9,7 +9,7 @@ module "rds-instance" {
   namespace              = var.namespace
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
-  db_allocated_storage   = 50
+  db_allocated_storage   = 150
   db_instance_class      = "db.t3.2xlarge"
   backup_window          = var.backup_window
   maintenance_window     = var.maintenance_window


### PR DESCRIPTION
Basm prod write instance is getting low disk space warnings in production.

This change increases the storage allocation on the back of advice from talking to Cloud Platform.