### PR TITLE
Increasing the prod Basm read and write instances storage allocation on back of low disk space warnings in the AWS logs and advice from Cloud Platform.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -9,7 +9,7 @@ module "rds-instance" {
   namespace              = var.namespace
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
-  db_allocated_storage   = 150
+  db_allocated_storage   = 200
   db_instance_class      = "db.t3.2xlarge"
   backup_window          = var.backup_window
   maintenance_window     = var.maintenance_window
@@ -48,7 +48,7 @@ module "rds-read-replica" {
   is-production          = var.is-production
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
-  db_allocated_storage   = 100
+  db_allocated_storage   = 200
   db_instance_class      = "db.t3.medium"
 
   db_name             = module.rds-instance.database_name


### PR DESCRIPTION
The read allocation must be either the same or more as the write allocation.