### PR TITLE
DST-12189 Re-enable prison-to-probation-update mirror queue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/prison-to-probation-update-mirror.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/prison-to-probation-update-mirror.tf
@@ -1,5 +1,5 @@
 locals {
-  enable_prison_to_probation_update_mirror_queue = 0 # Set to 1 to enable the queue while testing
+  enable_prison_to_probation_update_mirror_queue = 1 # Set to 1 to enable the queue while testing
 }
 
 # Queue to mirror data into preprod for testing


### PR DESCRIPTION
To capture release/recall messages during the data refresh in pre-prod.