### PR TITLE
[LAA Court Data Adaptor Prod] Increase CPU/memory request

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 1000Mi
     defaultRequest:
-      cpu: 25m
-      memory: 250Mi
+      cpu: 75m
+      memory: 750Mi
     type: Container


### PR DESCRIPTION
Increase CPU request from 25 to 75Mi, and memory request from 250 to 750Mi to get back within bounds.

https://grafana.live.cloud-platform.service.justice.gov.uk/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=default&var-cluster=&var-namespace=laa-court-data-adaptor-prod