### PR TITLE
adding gh actions secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-dev/resources/ecr.tf
@@ -20,7 +20,7 @@ module "ecr_credentials" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in
   # github actions CI/CD pipelines
-  # github_repositories = ["my-repo"]
+  github_repositories = ["analytical-platform-uploader"]
 }
 
 resource "kubernetes_secret" "ecr_credentials" {


### PR DESCRIPTION
Have added access to ecr creds to the  analytical-platform-uploader repo to enable automatic deployment of the docker image for the app. Current process is to build and deploy the image from the command line for each significant merge into the repo, which isn't terribly efficient.

Have followed the process outlined in the GitHub Actions section of the cloud platform user guidance [available here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#github-actions)

By way of background, the analytical-platform-uploader allows users to upload data to S3 through a web app, automatically creating the s3 buckets and glue schemas in the case of a new database, which is then more widely accessible through the tools provided on the ap and athena. 