### PR TITLE
Update Laa-court-data-ui severity labels

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/prometheus.yaml
@@ -14,12 +14,12 @@ spec:
       expr: absent(up{namespace="laa-court-data-ui-dev"}) == 1
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
     - alert: Quota-Exceeded
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-court-data-ui-dev"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-court-data-ui-dev"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-dev is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -27,7 +27,7 @@ spec:
       expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-ui-dev"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-dev More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-dev,type:phrase),type:phrase,value:laa-court-data-ui-dev),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-dev,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -35,7 +35,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-dev", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-dev An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-court-data-ui-dev),type:phrase,value:laa-court-data-ui-dev),query:(match:(log_processed.kubernetes_namespace:(query:laa-court-data-ui-dev,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -43,13 +43,13 @@ spec:
       expr: container_fs_usage_bytes{namespace="laa-court-data-ui-dev"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-court-data-ui-dev"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-dev Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
       expr: ruby_http_request_duration_seconds{namespace="laa-court-data-ui-dev"} > 30
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-dev Request is taking more than 30 seconds

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/prometheus.yaml
@@ -14,12 +14,12 @@ spec:
       expr: absent(up{namespace="laa-court-data-ui-production"}) == 1
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui
     - alert: Quota-Exceeded
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-court-data-ui-production"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-court-data-ui-production"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui
       annotations:
         message: laa-court-data-ui-production is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -27,7 +27,7 @@ spec:
       expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-ui-production"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui
       annotations:
         message: laa-court-data-ui-production More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-production,type:phrase),type:phrase,value:laa-court-data-ui-production),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-production,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -35,7 +35,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-production", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui
       annotations:
         message: laa-court-data-ui-production An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-court-data-ui-production),type:phrase,value:laa-court-data-ui-production),query:(match:(log_processed.kubernetes_namespace:(query:laa-court-data-ui-production,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -43,14 +43,14 @@ spec:
       expr: container_fs_usage_bytes{namespace="laa-court-data-ui-production"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-court-data-ui-production"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui
       annotations:
         message: laa-court-data-ui-production Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
       expr: ruby_http_request_duration_seconds{namespace="laa-court-data-ui-production"} > 30
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui
       annotations:
         message: laa-court-data-ui-production Request is taking more than 30 seconds
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/prometheus.yaml
@@ -14,12 +14,12 @@ spec:
       expr: absent(up{namespace="laa-court-data-ui-staging"}) == 1
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
     - alert: Quota-Exceeded
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-court-data-ui-staging"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-court-data-ui-staging"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-staging is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -27,7 +27,7 @@ spec:
       expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-ui-staging"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-staging More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-staging,type:phrase),type:phrase,value:laa-court-data-ui-staging),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-staging,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -35,7 +35,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-staging", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-staging An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-court-data-ui-staging),type:phrase,value:laa-court-data-ui-staging),query:(match:(log_processed.kubernetes_namespace:(query:laa-court-data-ui-staging,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -43,14 +43,14 @@ spec:
       expr: container_fs_usage_bytes{namespace="laa-court-data-ui-staging"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-court-data-ui-staging"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-staging Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
       expr: ruby_http_request_duration_seconds{namespace="laa-court-data-ui-staging"} > 30
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-staging Request is taking more than 30 seconds
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/prometheus.yaml
@@ -14,12 +14,12 @@ spec:
       expr: absent(up{namespace="laa-court-data-ui-uat"}) == 1
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
     - alert: Quota-Exceeded
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-court-data-ui-uat"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-court-data-ui-uat"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-uat is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -27,7 +27,7 @@ spec:
       expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-court-data-ui-uat"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-uat More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-uat,type:phrase),type:phrase,value:laa-court-data-ui-uat),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-uat,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -35,7 +35,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-uat", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-uat An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-court-data-ui-uat),type:phrase,value:laa-court-data-ui-uat),query:(match:(log_processed.kubernetes_namespace:(query:laa-court-data-ui-uat,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -43,14 +43,14 @@ spec:
       expr: container_fs_usage_bytes{namespace="laa-court-data-ui-uat"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-court-data-ui-uat"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-uat Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
       expr: ruby_http_request_duration_seconds{namespace="laa-court-data-ui-uat"} > 30
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-court-data-ui-preprod
       annotations:
         message: laa-court-data-ui-uat Request is taking more than 30 seconds
 


### PR DESCRIPTION
Update severity labels to match the correct slack webhook for reporting to slack channels for production and non-production environments