### PR TITLE
Transfer namespaces to new team

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Check when to disclose cautions or convictions"
-    cloud-platform.justice.gov.uk/owner: "Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Central Digital Product Team: Central-Digital-Product-Team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/disclosure-checker"
-    cloud-platform.justice.gov.uk/slack-channel: "disclosure-checker"
-    cloud-platform.justice.gov.uk/team-name: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-central-digital-product-team"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:family-justice"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Check when to disclose cautions or convictions"
-    cloud-platform.justice.gov.uk/owner: "Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Central Digital Product Team: Central-Digital-Product-Team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/disclosure-checker"
-    cloud-platform.justice.gov.uk/slack-channel: "disclosure-checker"
-    cloud-platform.justice.gov.uk/team-name: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-central-digital-product-team"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:family-justice"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Family Mediators API"
-    cloud-platform.justice.gov.uk/owner: "Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Central Digital Product Team: Central-Digital-Product-Team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/family-mediators-api"
-    cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
-    cloud-platform.justice.gov.uk/team-name: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-central-digital-product-team"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:family-justice"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Family Mediators API"
-    cloud-platform.justice.gov.uk/owner: "Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Central Digital Product Team: Central-Digital-Product-Team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/family-mediators-api"
-    cloud-platform.justice.gov.uk/slack-channel: "cross_justice_team"
-    cloud-platform.justice.gov.uk/team-name: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-central-digital-product-team"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:family-justice"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-production/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Get help with child arrangements"
-    cloud-platform.justice.gov.uk/owner: "Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Central Digital Product Team: Central-Digital-Product-Team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pflr-cait"
-    cloud-platform.justice.gov.uk/slack-channel: "pflr-cait"
-    cloud-platform.justice.gov.uk/team-name: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-central-digital-product-team"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-production/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:family-justice"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-staging/00-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
     cloud-platform.justice.gov.uk/application: "Get help with child arrangements"
-    cloud-platform.justice.gov.uk/owner: "Cross Justice Delivery: crossjusticedelivery@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Central Digital Product Team: Central-Digital-Product-Team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pflr-cait"
-    cloud-platform.justice.gov.uk/slack-channel: "pflr-cait"
-    cloud-platform.justice.gov.uk/team-name: "family-justice"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-central-digital-product-team"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-staging/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:family-justice"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
These 3 apps will be maintained by `Central Digital Product Team` going forward.

Kept the previous `family-justice` team in the rbac for now so both have access in the interim. Also same ECR repo.

Not changing here where pingdom or prometheus alerts are going, these can be changed later once the new team decide this.