### PR TITLE
Pin actions/checkout to v3.0.2 in malformed-yaml.yml

### DIFF
--- a/.github/workflows/malformed-yaml.yml
+++ b/.github/workflows/malformed-yaml.yml
@@ -6,7 +6,7 @@ jobs:
   reject-malformed-yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3.0.2
       - uses: ministryofjustice/github-actions/malformed-yaml@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR pins `actions/checkout` to `v3.0.2` in `malformed-yaml.yml` rather than `master` to reduce the risk of introducing changes that are not yet released for wider use within the action.