### PR TITLE
Pin actions/checkout to v3.0.2 in auto-approve-pr.yaml

### DIFF
--- a/.github/workflows/auto-approve-pr.yaml
+++ b/.github/workflows/auto-approve-pr.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3.0.2
 
       - name: Get changes and save to json
         id: get_changes


### PR DESCRIPTION
This PR pins `actions/checkout` to `v3.0.2` in `auto-approve-pr.yaml` rather than `master` to reduce the risk of introducing changes that are not yet released for wider use within the action.