### PR TITLE
adding the kube cluster auth info to gh repo secrets 

### DIFF
--- a/cmd/check-ingress/README.md
+++ b/cmd/check-ingress/README.md
@@ -14,7 +14,7 @@ name: Check ingress weighting annotation
 on:
   pull_request:
     paths:
-      - 'namespaces/live.cloud-platform.service.justice.gov.uk/**'
+      - "namespaces/live.cloud-platform.service.justice.gov.uk/**"
 
 env:
   # GITHUB_OAUTH_TOKEN created manually by the cloud-platform-bot-user in last pass.

--- a/cmd/rbac-permissions-check/README.md
+++ b/cmd/rbac-permissions-check/README.md
@@ -13,8 +13,7 @@ Here is a really basic example of the GitHub Action working in the Cloud Platfor
 ```yaml
 name: Check if user can amend namespace
 
-on:
-  pull_request
+on: pull_request
 
 env:
   PR_OWNER: ${{ github.event.pull_request.user.login }}
@@ -43,6 +42,7 @@ jobs:
 ## How to run locally
 
 To run the application locally, you must have the following:
+
 - A personal access token, with permission to view your organisation (this will require you to setup and enable SSO).
 - An environment variable set called `GITHUB_OAUTH_TOKEN` with the value of your personal access token.
 - An environment variable set called `PR_OWNER` that contains the valid username of a GitHub user.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-dev/resources/serviceaccount.tf
@@ -1,0 +1,8 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = ["analytical-platform-uploader"]
+}


### PR DESCRIPTION
Adding the analytical-platform-uploader github repo to the serviceaccount.tf file to add the kube cluster auth info secrets to the aforementioned repo, following the process outlined in the cloud platform guidance [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/github-actions-continuous-deployment.html#update-the-manifest) to automate deployment.

By way of background, the analytical-platform-uploader app allows users to upload data and automates production of the S3 buckets, glue schemas, etc so that the data can be accessed through athena and other tools available on the ap.