### PR TITLE
Fix typo bug - remove https protocol from app host url for pingdom

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/pingdom.tf
@@ -4,7 +4,7 @@ provider "pingdom" {
 resource "pingdom_check" "laa-apply-for-criminal-legal-aid-healthcheck" {
   type                     = "http"
   name                     = "laa-apply-for-criminal-legal-aid-healthcheck - staging - cloud-platform"
-  host                     = "https://laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk"
+  host                     = "laa-apply-for-criminal-legal-aid-staging.apps.live.cloud-platform.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6


### PR DESCRIPTION

HTTPS protocol mistakenly left in host URL due to copy paste error - removed HTTPS protocol to allow apply to happen.