### PR TITLE
Add serviceaccount_rules

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/serviceaccount.tf
@@ -7,4 +7,66 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   # github_repositories = ["my-repo"]
+
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "policy",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "poddisruptionbudgets",
+        "statefulsets",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "prometheusrules",
+      ]
+      verbs = [
+        "*",
+      ]
+    },
+  ]
 }


### PR DESCRIPTION
Hello, I am trying to use CircleCI to deploy the multi-container-app and ran intot he following error when helm install:

Error: rendered manifests contain a resource that already exists. Unable to continue with install: could not get information about the resource: statefulsets.apps "multi-container-app-postgresql" is forbidden: User "system:serviceaccount:hmpps-probation-webops-poc:cd-serviceaccount" cannot get resource "statefulsets" in API group "apps" in the namespace "hmpps-probation-webops-poc"

This PR is to add statefulsets to serviceaccount_rules to provide service account with permissions. I cannot confirm if this is all the permissions required, is there a way to check locally first please?