### PR TITLE
Prisoner content hub - prod - Upgrade RDS to t3.xlarge

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
@@ -10,7 +10,6 @@ module "drupal_rds" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
   db_instance_class      = "db.t3.xlarge"
-  apply_immediately      = true
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
@@ -10,6 +10,7 @@ module "drupal_rds" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
   db_instance_class      = "db.t3.xlarge"
+  apply_immediately      = true
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
@@ -9,7 +9,7 @@ module "drupal_rds" {
   namespace              = var.namespace
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
-  db_instance_class      = "db.t3.large"
+  db_instance_class      = "db.t3.xlarge"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
This is to increase the resources for RDS to `xlarge`, as we are seeing errors in RDS related to max_connections.  E.g. 
```
2022-07-22 13:11:39 0 [Warning] Aborted connection 0 to db: 'unconnected' user: 'unauthenticated' host: 'connecting host' (Too many connections)
```

The max_connections configuration is tied to the db instance size.

Note we are **not** increasing the dev and staging environments, as these do not require such a large instance and would be an unnecessary cost.

Related Trello card: https://trello.com/c/EjfBYww7/1315-downtime-post-mortem
