### PR TITLE
Prisoner content hub - dev - downgrading RDS instance to medium

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -10,7 +10,7 @@ module "drupal_rds" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
   db_instance_class      = "db.t3.medium"
-  apply_immediately      = true
+
 
   snapshot_identifier = "rds:cloud-platform-2703fa2c8a00ad83-2020-10-16-04-52"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -9,7 +9,8 @@ module "drupal_rds" {
   namespace              = var.namespace
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
-  db_instance_class      = "db.t3.large"
+  db_instance_class      = "db.t3.medium"
+  apply_immediately      = true
 
   snapshot_identifier = "rds:cloud-platform-2703fa2c8a00ad83-2020-10-16-04-52"
 


### PR DESCRIPTION
This is to test changes ahead of https://github.com/ministryofjustice/cloud-platform-environments/pull/8282 (but instead we downgrade the instance on dev, as we do not need an xlarge here).