### PR TITLE
Prisoner content hub -prod - Add prometheus RDS max connections alert.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/09-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/09-prometheus.yaml
@@ -127,6 +127,14 @@ spec:
           for: 15m
           labels:
             severity: pfs-hub
+        - alert: RDSMaxConnections
+          annotations:
+            message: "[{{ $labels.dbinstance_identifier }}] RDS max connections above 80%."
+            runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/2160918618/Technical+documentation
+          expr: aws_rds_database_connections_average{dbinstance_identifier="cloud-platform-08a8cf9e6f678214"} > aws_rds_database_connections_maximum{dbinstance_identifier="cloud-platform-08a8cf9e6f678214"} * 0.80
+          for: 15m
+          labels:
+            severity: pfs-hub
         - alert: ElasticSearchClusterRedStatus
           annotations:
             message: "[{{ $labels.domain_name }}] At least one primary ElasticSearch shard and its replicas are not allocated to a node."


### PR DESCRIPTION
Add prometheus rule to alert when max connections is above 80% of the maximum.

We are often seeing errors in the RDS logs relating to exceeding max_connections.  

Note this is my first Prometheus rule, so hopefully I got this right (I've already tested the expression directly in prometheus).