### PR TITLE
Bump cloud-platform-terraform-elasticsearch to 3.9.5

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
@@ -6,7 +6,7 @@
  *
  */
 module "example_team_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name           = var.cluster_name
   application            = "testApp"
   business-unit          = "HQ"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
@@ -6,7 +6,7 @@
  *
  */
 module "example_team_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name           = var.cluster_name
   application            = "testApp"
   business-unit          = "HQ"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
 
   cluster_name                    = var.cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
 
   cluster_name                    = var.cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
@@ -16,4 +16,8 @@ module "peoplefinder_es" {
   namespace              = "peoplefinder-demo"
   elasticsearch_version  = "7.9"
   instance_type          = "t2.small.elasticsearch"
+
+  advanced_options = {
+    override_main_response_version = true
+  }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name           = var.cluster_name
   application            = "peoplefinder"
   business-unit          = "Central Digital"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name           = var.cluster_name
   application            = "peoplefinder"
   business-unit          = "Central Digital"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -5,7 +5,7 @@
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name               = var.cluster_name
   application                = "peoplefinder"
   business-unit              = "Central Digital"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -5,7 +5,7 @@
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name               = var.cluster_name
   application                = "peoplefinder"
   business-unit              = "Central Digital"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -18,4 +18,8 @@ module "peoplefinder_es" {
   elasticsearch_version      = "7.9"
   aws-es-proxy-replica-count = 2
   instance_type              = "t3.medium.elasticsearch"
+
+  advanced_options = {
+    override_main_response_version = true
+  }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -54,4 +54,8 @@ module "peoplefinder_es" {
 
   log_publishing_application_cloudwatch_log_group_arn = aws_cloudwatch_log_group.peoplefinder_cloudwatch_log_group.arn
   log_publishing_application_enabled                  = true
+
+  advanced_options = {
+    override_main_response_version = true
+  }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_poli
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name               = var.cluster_name
   application                = "peoplefinder"
   business-unit              = "Central Digital"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_poli
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name               = var.cluster_name
   application                = "peoplefinder"
   business-unit              = "Central Digital"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -5,7 +5,7 @@
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name               = var.cluster_name
   application                = "peoplefinder"
   business-unit              = "Central Digital"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -5,7 +5,7 @@
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name               = var.cluster_name
   application                = "peoplefinder"
   business-unit              = "Central Digital"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -20,6 +20,6 @@ module "peoplefinder_es" {
   instance_type              = "t3.medium.elasticsearch"
 
   advanced_options = {
-    override_main_response_version = true
+    override_main_response_version = false
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -18,5 +18,8 @@ module "peoplefinder_es" {
   elasticsearch_version      = "7.9"
   aws-es-proxy-replica-count = 1
   instance_type              = "t3.medium.elasticsearch"
-}
 
+  advanced_options = {
+    override_main_response_version = true
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name           = var.cluster_name
   application            = var.application
   business-unit          = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name           = var.cluster_name
   application            = var.application
   business-unit          = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name           = var.cluster_name
   application            = var.application
   business-unit          = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name           = var.cluster_name
   application            = var.application
   business-unit          = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name           = var.cluster_name
   application            = var.application
   business-unit          = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name           = var.cluster_name
   application            = var.application
   business-unit          = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.5"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-offender-search-staging/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.3"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=3.9.4"
   cluster_name                    = var.cluster_name
   application                     = var.application
   business-unit                   = var.business-unit


### PR DESCRIPTION
Bumps [ministryofjustice/cloud-platform-terraform-elasticsearch](https://github.com/ministryofjustice/cloud-platform-terraform-elasticsearch) to 3.9.5.