### PR TITLE
Increase memory for hmpps-interventions-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2000Mi
     defaultRequest:
       cpu: 10m
-      memory: 100Mi
+      memory: 200Mi
     type: Container


### PR DESCRIPTION
Pods are running out of memory, causing outages of the service.