### PR TITLE
Apply fixes to webops-poc params for rds and redis dependencies

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/rds.tf
@@ -18,6 +18,7 @@ module "rds" {
   db_engine              = "mariadb"
   db_allocated_storage   = "5"                      # Default is 10 in the RDS module
   license_model          = "general-public-license" # Make this visible
+  db_parameter           = [] # Ensure no default parameters set (default param in TF module adds a parameter not relevant to MariaDB) 
 
   # If the rds_name is not specified a random name will be generated ( cp-* )
   # Changing the RDS name requires the RDS to be re-created (destroy + create)

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/redis.tf
@@ -6,7 +6,7 @@ module "elasticache_redis" {
   is-production          = var.is_production
   infrastructure-support = var.infrastructure_support
   team_name              = var.team_name
-  number_cache_clusters  = "1"
+  number_cache_clusters  = "2"
   node_type              = "cache.t2.small"
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-262

Fixes to param values for correct behaviour with default for RDS and Redis modules.