### PR TITLE
disable performance insights for webops-poc mariadb

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/rds.tf
@@ -25,7 +25,7 @@ module "rds" {
   # rds_name             = "my-rds-name"
 
   # enable performance insights
-  performance_insights_enabled = true
+  performance_insights_enabled = false
 
   # change the postgres version as you see fit.
   db_engine_version = "10.5.12"


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-262

Disabling performance insights - missing dependent config but not needed for poc anyway.

