### PR TITLE
Create namespace for Approved Premises API Dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/00-namespace.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: approved-premises-api-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "approved-premises-team-dev"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
+    cloud-platform.justice.gov.uk/application: "Approved Premises API"
+    cloud-platform.justice.gov.uk/owner: "Approved Premises Team: unknown@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/approved-premises-api.git"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-tech"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/01-rbac.yaml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: approved-premises-api-dev-admin
+  namespace: approved-premises-api-dev
+subjects:
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/02-limitrange.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: approved-premises-api-dev
+spec:
+  limits:
+    - default:
+        cpu: 2000m
+        memory: 1024Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 512Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: approved-premises-api-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: approved-premises-api-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: approved-premises-api-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/05-serviceaccount-circleci.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: approved-premises-api-dev
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: approved-premises-api-dev
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: approved-premises-api-dev
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: approved-premises-api-dev
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: approved-premises-api-dev
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: approved-premises-api-dev
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/06-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: approved-premises-api-dev-cert
+  namespace: approved-premises-api-dev
+spec:
+  secretName: approved-premises-api-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - approved-premises-api-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/resources/variables.tf
@@ -1,0 +1,42 @@
+
+variable "cluster_name" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Approved Premises API"
+}
+
+variable "namespace" {
+  default = "approved-premises-api-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-tech"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "dps-hmpps@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "approved-premises-team-dev"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.68.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
This follows on from #8331 to create a namespace for the dev version of the Approved Premises API. Again, we're not diverging from defaults much at the mo, so this is just copied from the Kotlin template with any defaults changed.