### PR TITLE
Give Approved Premises team namespace access (API)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-api-dev/01-rbac.yaml
@@ -8,6 +8,9 @@ subjects:
   - kind: Group
     name: "github:dps-tech"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:approved-premises-team"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
This was left over from copying from the template repos. We need to give the Approved Premises team access to the API application, as well as dps-tech.