### PR TITLE
Change prisoner money test DB instance type

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/main.tf
@@ -5,11 +5,23 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = "prisoner-money"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = "prisoner-money"
+    }
+  }
 }
 
 variable "namespace" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -21,7 +21,7 @@ module "rds" {
   rds_family           = "postgres10"
   db_engine            = "postgres"
   db_engine_version    = "10"
-  db_instance_class    = "db.t2.small"
+  db_instance_class    = "db.t4g.small"
   db_allocated_storage = "5"
   db_name              = "mtp_api"
 


### PR DESCRIPTION
…from `t2` to `t4g`, which is cheaper and more performant/energy-efficient. Apparently, cross-architecture migrations are possible (`t4g` is an AWS Graviton2 / ARM type) but this is a test DB so doesn't matter if it is destroyed.