### PR TITLE
Revert prisoner money test DB to `t2`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -21,7 +21,7 @@ module "rds" {
   rds_family           = "postgres10"
   db_engine            = "postgres"
   db_engine_version    = "10"
-  db_instance_class    = "db.t4g.small"
+  db_instance_class    = "db.t2.small"
   db_allocated_storage = "5"
   db_name              = "mtp_api"
 


### PR DESCRIPTION
…because the services uses postgres 10 which is not supported on `t4g` (and we're not prepared to migrate DB versions right now).

C.f #8345