### PR TITLE
Updating prometheus rule to use the real max_connections value.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/09-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/09-prometheus.yaml
@@ -129,9 +129,9 @@ spec:
             severity: pfs-hub
         - alert: RDSMaxConnections
           annotations:
-            message: "[{{ $labels.dbinstance_identifier }}] RDS max connections above 80%."
+            message: "[{{ $labels.dbinstance_identifier }}] RDS connections above 80% of maximum."
             runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/HUB/pages/2160918618/Technical+documentation
-          expr: aws_rds_database_connections_average{dbinstance_identifier="cloud-platform-08a8cf9e6f678214"} > aws_rds_database_connections_maximum{dbinstance_identifier="cloud-platform-08a8cf9e6f678214"} * 0.80
+          expr: aws_rds_database_connections_maximum{dbinstance_identifier="cloud-platform-08a8cf9e6f678214"} > 1044
           for: 15m
           labels:
             severity: pfs-hub


### PR DESCRIPTION
Previously added prometheus rule was using the wrong metrics.  `aws_rds_database_connections_maximum` is not the max allowed connections (equivalent to `max_connections`).  It's the maximum number of active connections in the current time period.

Instead, we need to hard code the value for 80% of `max_connections`, I've worked this out to be 1044, so updating the rule here.