### PR TITLE
Fix 64 char limit issue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-application-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-application-dev/06-certificate.yaml
@@ -22,4 +22,5 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    - historical-prisoner-app-api-dev.hmpps.service.justice.gov.uk
     - historical-prisoner-application-api-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This is for hmpps-historical-prisoner-application-dev certificate
using guidence:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/custom-domain-cert.html#certificate-character-limit