### PR TITLE
Add tag for Apply team to uat resources

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/main.tf
@@ -11,6 +11,11 @@ provider "aws" {
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+  default_tags {
+    tags = {
+      GithubTeam = "laa-apply-for-legal-aid"
+    }
+  }
 }
 
 # To be use in case the resources need to be created in Ireland


### PR DESCRIPTION
Add team tag for Apply team resources

As per [guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html#tagging-your-resources)
