### PR TITLE
Remove reference to delius-test-sqs-consumer role

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/iam-sqs-console-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/iam-sqs-console-role.tf
@@ -24,7 +24,6 @@ data "aws_iam_policy_document" "sqs_mgmt_common_policy_document" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::728765553488:role/delius-test-ecs-sqs-consumer",
-        "arn:aws:iam::728765553488:role/delius-test-sqs-consumer",
         aws_iam_role.sqs_mgmt_role.arn
       ]
     }


### PR DESCRIPTION
This has been removed in the Delius account