### PR TITLE
Remove reference to delius-pre-prod-sqs-consumer role

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/iam-sqs-console-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/iam-sqs-console-role.tf
@@ -24,7 +24,6 @@ data "aws_iam_policy_document" "sqs_mgmt_common_policy_document" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::010587221707:role/delius-pre-prod-ecs-sqs-consumer",
-        "arn:aws:iam::010587221707:role/delius-pre-prod-sqs-consumer",
         aws_iam_role.sqs_mgmt_role.arn
       ]
     }


### PR DESCRIPTION
This has been removed in the Delius account