### PR TITLE
LAA apply-bot: Update RDS instance class

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-bot-production/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds" {
   infrastructure-support = "apply@digital.justice.gov.uk"
   db_engine              = "postgres"
   db_engine_version      = "13.4"
-  db_instance_class      = "db.t3.small"
+  db_instance_class      = "db.t4g.small"
   db_name                = "laa_apply_bot_production"
   rds_family             = "postgres13"
 


### PR DESCRIPTION
We wanted to switch to db.t4g.small to try the new graviton base image

This has already been applied via the AWS CLI so this should be a
relatively low impact change

This namespace has a SKIP FILE as we are in the progress of updating the Postgres versions