### PR TITLE
Tagging resources for Read Only access to the AWS Console

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/main.tf
@@ -12,3 +12,12 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
+}


### PR DESCRIPTION
Adding default tag globally as per documentation. THis will allow read only access to the AWS console for resources in this namespace.