### PR TITLE
Test RDS upgrade using lifecycle { create_before_destroy } for db_parameter_group

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hosting-data-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hosting-data-production/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.10"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=add-lifecycle-before-destroy-param-group"
   cluster_name           = var.cluster_name
   team_name              = var.team_name
   business-unit          = var.business_unit
@@ -24,14 +24,14 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "10"
+  db_engine_version = "14.2"
 
   # change the instance class as you see fit.
   db_instance_class = "db.t3.small"
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11, postgres12, postgres13
   # Pick the one that defines the postgres version the best
-  rds_family = "postgres10"
+  rds_family = "postgres14"
 
   # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".


### PR DESCRIPTION
This PR is testing the [`create_before_destroy` lifecycle attribute](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/commit/79dbf8a47f3962b272100a3336765f79695bacd9) for db_parameter_group as part of the RDS module; which is related to ministryofjustice/cloud-platform#3107.