### PR TITLE
Prisoner content hub - dev- Add support for apache prometheus scraping.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/06-servicemonitor.yml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/06-servicemonitor.yml
@@ -1,0 +1,28 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: prisoner-content-hub-development
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prisoner-content-hub-development
+  namespace: prisoner-content-hub-development
+spec:
+  selector:
+    matchLabels:
+      app: prisoner-content-hub-backend-prometheus-metrics
+  endpoints:
+    - port: http
+      interval: 15s


### PR DESCRIPTION
To allow Apache status data to be scraped by Prometheus. 
See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/application-metrics.html#add-service-endpoint-and-servicemonitor

PR for enabling prometheus exporter from the app: https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/436

Note that there is a separate k8ns service that exports the data in the prometheus metric format (it does not come directly from the pods running the app).  This service does not have an ingress entry.  It can only be accessed from within the k8ns network.