### PR TITLE
offender-management-staging: Clean up after the PG upgrade

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds-allocations-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds-allocations-api.tf
@@ -31,8 +31,6 @@ module "allocation-rds" {
   db_name                = "allocations"
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
 
-  allow_major_version_upgrade = true
-
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
Remove APPLY_PIPELINE_SKIP_THIS_NAMESPACE

Disallow major version upgrades