### PR TITLE
Fix Approved Premises Prototype team access

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-prototype/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-prototype/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: approved-premises-prototype
 subjects:
   - kind: Group
-    name: "github:approved-premises-prototype"
+    name: "github:approved-premises-team"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
The team that was specified to access the prototype does not exist. Changed it to the correct team.