### PR TITLE
Tag resources for the formbuilder-saas-test namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/main.tf
@@ -5,6 +5,12 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
This will allow read-only access via the AWS console for
the resources provisioned in the namespace.

Followed the instructions in the cloud platform user guide.