### PR TITLE
Add dnsName for thestudio development prison

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/07-certificates-frontend.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/07-certificates-frontend.yaml
@@ -22,6 +22,7 @@ spec:
   - styal.content-hub.prisoner.service.justice.gov.uk
   - swaleside.content-hub.prisoner.service.justice.gov.uk
   - themount.content-hub.prisoner.service.justice.gov.uk
+  - thestudio.content-hub.prisoner.service.justice.gov.uk
   - wayland.content-hub.prisoner.service.justice.gov.uk
   - werrington.content-hub.prisoner.service.justice.gov.uk
   - wetherby.content-hub.prisoner.service.justice.gov.uk


### PR DESCRIPTION
The Studio is a new (fake) prison that has been set up within the studio. When visiting the production domain https://thestudio.content-hub.prisoner.service.justice.gov.uk/ this is not currently served over HTTPS. This record has been added to enable this. 