### PR TITLE
PI-399 Create queue for prison-custody-status-to-delius service (prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/github.tf
@@ -1,0 +1,7 @@
+data "github_repository" "hmpps-probation-integration-services" {
+  full_name = "ministryofjustice/hmpps-probation-integration-services"
+}
+
+data "github_actions_public_key" "hmpps-probation-integration-services" {
+  repository = data.github_repository.hmpps-probation-integration-services.name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-pre-sentence-report-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-pre-sentence-report-queue.tf
@@ -20,7 +20,7 @@ module "pre_sentence_report_queue" {
 
 data "aws_iam_policy_document" "pre_sentence_report_queue_policy" {
   source_policy_documents = [
-    data.aws_iam_policy_document.sqs_mgmt_common_policy_document[module.pre_sentence_report_queue.sqs_arn].json
+    data.aws_iam_policy_document.sqs_mgmt_common_policy_document.json
   ]
   statement {
     sid     = "TopicToQueue"
@@ -61,7 +61,7 @@ module "pre_sentence_report_dlq" {
 
 resource "aws_sqs_queue_policy" "pre_sentence_report_dlq_policy" {
   queue_url = module.pre_sentence_report_dlq.sqs_id
-  policy    = data.aws_iam_policy_document.sqs_mgmt_common_policy_document[module.pre_sentence_report_dlq.sqs_arn].json
+  policy    = data.aws_iam_policy_document.sqs_mgmt_common_policy_document.json
 }
 
 resource "aws_sns_topic_subscription" "pre_sentence_report_queue_subscription" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-prison-custody-status-to-delius-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-prison-custody-status-to-delius-queue.tf
@@ -1,0 +1,86 @@
+resource "aws_sns_topic_subscription" "hmpps-prison-custody-status-to-delius-queue-subscription" {
+  provider  = aws.london
+  topic_arn = module.hmpps-domain-events.topic_arn
+  protocol  = "sqs"
+  endpoint  = module.hmpps-prison-custody-status-to-delius-queue.sqs_arn
+  filter_policy = jsonencode({
+    eventType = [
+      "prison-offender-events.prisoner.released",
+      "prison-offender-events.prisoner.received",
+    ]
+  })
+}
+
+module "hmpps-prison-custody-status-to-delius-queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.8"
+
+  environment-name       = var.environment-name
+  namespace              = var.namespace
+  infrastructure-support = var.infrastructure-support
+  team_name              = "hmpps-probation-integration"
+  application            = "prison-custody-status-to-delius"
+  sqs_name               = "prison-custody-status-to-delius-queue"
+
+  message_retention_seconds = 14 * 86400 # 2 weeks
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.hmpps-prison-custody-status-to-delius-dlq.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+data "aws_iam_policy_document" "hmpps-prison-custody-status-to-delius-queue-policy" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.sqs_mgmt_common_policy_document.json
+  ]
+  statement {
+    sid     = "TopicToQueue"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      variable = "aws:SourceArn"
+      test     = "ArnEquals"
+      values   = [module.hmpps-domain-events.topic_arn]
+    }
+    resources = [module.hmpps-prison-custody-status-to-delius-queue.sqs_arn]
+  }
+}
+
+resource "aws_sqs_queue_policy" "hmpps-prison-custody-status-to-delius-queue-policy" {
+  queue_url = module.hmpps-prison-custody-status-to-delius-queue.sqs_id
+  policy    = data.aws_iam_policy_document.hmpps-prison-custody-status-to-delius-queue-policy.json
+}
+
+module "hmpps-prison-custody-status-to-delius-dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.8"
+
+  environment-name       = var.environment-name
+  namespace              = var.namespace
+  infrastructure-support = var.infrastructure-support
+  team_name              = "hmpps-probation-integration"
+  application            = "prison-custody-status-to-delius"
+  sqs_name               = "prison-custody-status-to-delius-dlq"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "hmpps-prison-custody-status-to-delius-dlq-policy" {
+  queue_url = module.hmpps-prison-custody-status-to-delius-dlq.sqs_id
+  policy    = data.aws_iam_policy_document.sqs_mgmt_common_policy_document.json
+}
+
+resource "github_actions_environment_secret" "hmpps-prison-custody-status-to-delius-queue-name-secret" {
+  repository      = data.github_repository.hmpps-probation-integration-services.name
+  environment     = "prod"
+  secret_name     = "PRISON_CUSTODY_STATUS_TO_DELIUS_QUEUE_NAME"
+  plaintext_value = module.hmpps-prison-custody-status-to-delius-queue.sqs_name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-workforce-allocation-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-workforce-allocation-queue.tf
@@ -20,7 +20,7 @@ module "workforce_allocation_queue" {
 
 data "aws_iam_policy_document" "workforce_allocation_queue_policy" {
   source_policy_documents = [
-    data.aws_iam_policy_document.sqs_mgmt_common_policy_document[module.workforce_allocation_queue.sqs_arn].json
+    data.aws_iam_policy_document.sqs_mgmt_common_policy_document.json
   ]
   statement {
     sid     = "TopicToQueue"
@@ -61,7 +61,7 @@ module "workforce_allocation_dlq" {
 
 resource "aws_sqs_queue_policy" "workforce_allocation_dlq_policy" {
   queue_url = module.workforce_allocation_dlq.sqs_id
-  policy    = data.aws_iam_policy_document.sqs_mgmt_common_policy_document[module.workforce_allocation_dlq.sqs_arn].json
+  policy    = data.aws_iam_policy_document.sqs_mgmt_common_policy_document.json
 }
 
 resource "aws_sns_topic_subscription" "workforce_allocation_queue_subscription" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/iam-sqs-console-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/iam-sqs-console-role.tf
@@ -4,11 +4,12 @@ locals {
     module.workforce_allocation_dlq.sqs_arn,
     module.pre_sentence_report_queue.sqs_arn,
     module.pre_sentence_report_dlq.sqs_arn,
+    module.hmpps-prison-custody-status-to-delius-queue.sqs_arn,
+    module.hmpps-prison-custody-status-to-delius-dlq.sqs_arn,
   ]
 }
 
 data "aws_iam_policy_document" "sqs_mgmt_common_policy_document" {
-  for_each = toset(local.managed_queues)
   statement {
     sid    = "QueueToConsumer"
     effect = "Allow"
@@ -27,7 +28,7 @@ data "aws_iam_policy_document" "sqs_mgmt_common_policy_document" {
         aws_iam_role.sqs_mgmt_role.arn
       ]
     }
-    resources = [each.value]
+    resources = ["*"]
   }
   statement {
     sid    = "QueueManagement"
@@ -43,7 +44,7 @@ data "aws_iam_policy_document" "sqs_mgmt_common_policy_document" {
       type        = "AWS"
       identifiers = [aws_iam_role.sqs_mgmt_role.arn]
     }
-    resources = [each.value]
+    resources = ["*"]
   }
   statement {
     sid     = "ListQueues"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/main.tf
@@ -19,3 +19,8 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "github" {
+  owner = "ministryofjustice"
+  token = var.github_token
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/prison-to-probation-update.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/prison-to-probation-update.tf
@@ -1,4 +1,4 @@
-
+# Deprecated. This queue will be removed once the prison-custody-status-to-delius service is live
 
 module "prison_to_probation_update_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.8"
@@ -99,14 +99,3 @@ resource "kubernetes_secret" "prison_to_probation_update_dlq" {
     sqs_queue_name    = module.prison_to_probation_update_dead_letter_queue.sqs_name
   }
 }
-
-
-resource "aws_sns_topic_subscription" "prison_to_probation_update_subscription" {
-  provider      = aws.london
-  topic_arn     = module.hmpps-domain-events.topic_arn
-  protocol      = "sqs"
-  endpoint      = module.prison_to_probation_update_queue.sqs_arn
-  filter_policy = "{\"eventType\":[\"prison-offender-events.prisoner.released\", \"prison-offender-events.prisoner.received\"]}"
-}
-
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/variables.tf
@@ -34,3 +34,8 @@ variable "is-production" {
   default = "true"
 }
 
+variable "github_token" {
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+


### PR DESCRIPTION
Also:
* deprecate and remove the subscription for the prison-to-probation-update queue
* tidy up sqs console policy