### PR TITLE
Create ECR for the Estimate Eligibility service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/ecr.tf
@@ -1,0 +1,95 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.7"
+  team_name = var.team_name
+  repo_name = "laa-estimate-financial-eligibility-for-legal-aid-ecr"
+
+  /*
+    By default scan_on_push is set to true. When this is enabled then all images pushed to the repo are scanned for any security
+    / software vulnerabilities in your image and the results can be viewed in the console. For further details, please see:
+    https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html
+    To disable 'scan_on_push', set it to false as below:
+  scan_on_push = "false"
+  */
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+
+  # list of github environments, to create the ECR secrets as environment secrets
+  # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets
+  # github_environments = ["my-environment"]
+
+/*
+  # Lifecycle_policy provides a way to automate the cleaning up of your container images by expiring images based on age or count.
+  # To apply multiple rules, combined them in one policy JSON.
+  # https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_examples.html
+
+  lifecycle_policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images older than 14 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 14
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Keep last 30 dev and staging images",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["dev", "staging"],
+                "countType": "imageCountMoreThan",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 3,
+            "description": "Keep the newest 100 images and mark the rest for expiration",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 100
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+*/
+
+}
+
+
+resource "kubernetes_secret" "ecr_credentials" {
+  metadata {
+    name      = "ecr-repo-laa-estimate-financial-eligibility-for-legal-aid"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.ecr_credentials.access_key_id
+    secret_access_key = module.ecr_credentials.secret_access_key
+    repo_arn          = module.ecr_credentials.repo_arn
+    repo_url          = module.ecr_credentials.repo_url
+  }
+}


### PR DESCRIPTION
On lines 10 and 85 of the `ecr.tf `I have changed the `repo_name` and  `name` values so that the environment (uat/staging/production) is not part of the ECR name. As this ECR repo will serve all of our environments it makes sense to have the name environment agnostic.
