### PR TITLE
Adding new prisoner-content-hub-db-backups namespace.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/00-namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "prisoner-content-hub"
     cloud-platform.justice.gov.uk/owner: "Prisoner Facing Services: thehub@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git,https://github.com/ministryofjustice/prisoner-content-hub-backend.git,https://github.com/ministryofjustice/prisoner-content-hub-frontend.git"
-    cloud-platform.justice.gov.uk/slack-channel: "pfs_dev"
+    cloud-platform.justice.gov.uk/slack-channel: "the_content_hub"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/00-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prisoner-content-hub-db-backups
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "db-backups"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/application: "prisoner-content-hub"
+    cloud-platform.justice.gov.uk/owner: "Prisoner Facing Services: thehub@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prisoner-content-hub.git,https://github.com/ministryofjustice/prisoner-content-hub-backend.git,https://github.com/ministryofjustice/prisoner-content-hub-frontend.git"
+    cloud-platform.justice.gov.uk/slack-channel: "pfs_dev"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prisoner-content-hub-db-backups-admin
+  namespace: prisoner-content-hub-db-backups
+subjects:
+  - kind: Group
+    name: "github:prisoner-content-hub-developers"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in London
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in Ireland
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/s3.tf
@@ -31,7 +31,7 @@ module "db_backups_storage" {
   ]
 }
 
-resource "kubernetes_secret" "db_backups_secret" {
+resource "kubernetes_secret" "db_backups_s3_production" {
   metadata {
     name      = "db-backups-s3"
     namespace = prisoner-content-hub-production
@@ -45,7 +45,7 @@ resource "kubernetes_secret" "db_backups_secret" {
   }
 }
 
-resource "kubernetes_secret" "db_backups_secret" {
+resource "kubernetes_secret" "db_backups_s3_staging" {
   metadata {
     name      = "db-backups-s3"
     namespace = prisoner-content-hub-staging
@@ -59,7 +59,7 @@ resource "kubernetes_secret" "db_backups_secret" {
   }
 }
 
-resource "kubernetes_secret" "db_backups_secret" {
+resource "kubernetes_secret" "db_backups_s3_development" {
   metadata {
     name      = "db-backups-s3"
     namespace = prisoner-content-hub-development

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/s3.tf
@@ -8,6 +8,7 @@ module "db_backups_storage" {
   is-production          = var.is-production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  namespace              = var.namespace
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/s3.tf
@@ -35,41 +35,41 @@ module "db_backups_storage" {
 resource "kubernetes_secret" "db_backups_s3_production" {
   metadata {
     name      = "db-backups-s3"
-    namespace = prisoner-content-hub-production
+    namespace = "prisoner-content-hub-production"
   }
 
   data = {
-    access_key_id     = module.drupal_content_storage.access_key_id
-    secret_access_key = module.drupal_content_storage.secret_access_key
-    bucket_arn        = module.drupal_content_storage.bucket_arn
-    bucket_name       = module.drupal_content_storage.bucket_name
+    access_key_id     = module.db_backups_storage.access_key_id
+    secret_access_key = module.db_backups_storage.secret_access_key
+    bucket_arn        = module.db_backups_storage.bucket_arn
+    bucket_name       = module.db_backups_storage.bucket_name
   }
 }
 
 resource "kubernetes_secret" "db_backups_s3_staging" {
   metadata {
     name      = "db-backups-s3"
-    namespace = prisoner-content-hub-staging
+    namespace = "prisoner-content-hub-staging"
   }
 
   data = {
-    access_key_id     = module.drupal_content_storage.access_key_id
-    secret_access_key = module.drupal_content_storage.secret_access_key
-    bucket_arn        = module.drupal_content_storage.bucket_arn
-    bucket_name       = module.drupal_content_storage.bucket_name
+    access_key_id     = module.db_backups_storage.access_key_id
+    secret_access_key = module.db_backups_storage.secret_access_key
+    bucket_arn        = module.db_backups_storage.bucket_arn
+    bucket_name       = module.db_backups_storage.bucket_name
   }
 }
 
 resource "kubernetes_secret" "db_backups_s3_development" {
   metadata {
     name      = "db-backups-s3"
-    namespace = prisoner-content-hub-development
+    namespace = "prisoner-content-hub-development"
   }
 
   data = {
-    access_key_id     = module.drupal_content_storage.access_key_id
-    secret_access_key = module.drupal_content_storage.secret_access_key
-    bucket_arn        = module.drupal_content_storage.bucket_arn
-    bucket_name       = module.drupal_content_storage.bucket_name
+    access_key_id     = module.db_backups_storage.access_key_id
+    secret_access_key = module.db_backups_storage.secret_access_key
+    bucket_arn        = module.db_backups_storage.bucket_arn
+    bucket_name       = module.db_backups_storage.bucket_name
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/s3.tf
@@ -1,0 +1,74 @@
+module "db_backups_storage" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.7.1"
+
+  team_name              = var.team_name
+  versioning             = false
+  business-unit          = var.business-unit
+  application            = var.application
+  is-production          = var.is-production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure-support
+
+  providers = {
+    aws = aws.london
+  }
+
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "retire backups after 90 days"
+      noncurrent_version_expiration = [
+        {
+          days = 90
+        },
+      ]
+      expiration = [
+        {
+          days = 90
+        },
+      ]
+    }
+  ]
+}
+
+resource "kubernetes_secret" "db_backups_secret" {
+  metadata {
+    name      = "db-backups-s3"
+    namespace = prisoner-content-hub-production
+  }
+
+  data = {
+    access_key_id     = module.drupal_content_storage.access_key_id
+    secret_access_key = module.drupal_content_storage.secret_access_key
+    bucket_arn        = module.drupal_content_storage.bucket_arn
+    bucket_name       = module.drupal_content_storage.bucket_name
+  }
+}
+
+resource "kubernetes_secret" "db_backups_secret" {
+  metadata {
+    name      = "db-backups-s3"
+    namespace = prisoner-content-hub-staging
+  }
+
+  data = {
+    access_key_id     = module.drupal_content_storage.access_key_id
+    secret_access_key = module.drupal_content_storage.secret_access_key
+    bucket_arn        = module.drupal_content_storage.bucket_arn
+    bucket_name       = module.drupal_content_storage.bucket_name
+  }
+}
+
+resource "kubernetes_secret" "db_backups_secret" {
+  metadata {
+    name      = "db-backups-s3"
+    namespace = prisoner-content-hub-development
+  }
+
+  data = {
+    access_key_id     = module.drupal_content_storage.access_key_id
+    secret_access_key = module.drupal_content_storage.secret_access_key
+    bucket_arn        = module.drupal_content_storage.bucket_arn
+    bucket_name       = module.drupal_content_storage.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/variables.tf
@@ -1,0 +1,39 @@
+variable "application" {
+  default = "prisoner-content-hub"
+}
+
+variable "namespace" {
+  default = "prisoner-content-hub-db-backups"
+}
+
+# this is injected by Cloud Platform automatically so we do not need to populate it here
+variable "cluster_name" {
+}
+
+
+variable "business-unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+# We chose pfs because this variable is used to create domain names for resources
+# e.g. ElasticSearch. When concatenated with the environment name and unique name,
+# this only leaves a handful of characters for the team_name.
+variable "team_name" {
+  description = "DNS compliant name of the development team"
+  default     = "pfs"
+}
+
+variable "environment-name" {
+  description = "The type of environment you're deploying to."
+  default     = "db-backups"
+}
+
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "thehub@digital.justice.gov.uk"
+}
+
+variable "is-production" {
+  default = "false"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.68.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
This adds a new namespace `prisoner-content-hub-db-backups`.  This will contain an s3 bucket to store database backups of the `prisoner-content-hub-production` database.  (There will be no other services running in this namespace).
Backups will be created using a cronjob, in `.sql` format.

**Why not use the `prisoner-content-hub-production` namespace?**
The reason for using a separate namespace, is that we want dev and staging to also be able to connect to the s3 bucket, in order to run automated database refresh jobs, syncing the db with production.  
If we placed the s3 bucket in production, we would have to expose the creds for this onto non-prod environments.  Having a separate namespace is much cleaner.

Note that there is no sensitive prisoner data in this application, just content added in Drupal.

**Whatabout RDS snapshots?**
We are aware that we have RDS snapshots enabled by default, so we already have backups there.
However, we would be unable to automatically restore the db between environments from an RDS snapshot.
We also would benefit from a secondary backup option, that stores backups in a format that is easier to inspect and restore from.
