### PR TITLE
To allow circleci to execute commands in kube pod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/serviceaccount.tf
@@ -18,6 +18,7 @@ module "serviceaccount" {
         "services",
         "configmaps",
         "pods",
+        "pods/exec",
 
       ]
       verbs = [


### PR DESCRIPTION
I would like to run commands using kubectl exec as part of the my CircleCI pipeline, for example:

kubectl -n ${K8S_NAMESPACE} exec -t $POD_NAME -- bash -c "php artisan migrate --force"

But ran into the following error:

Error from server (Forbidden): pods "vcms-artisan-678ddf7455-jk7cc" is forbidden: User "system:serviceaccount:**************************:cd-serviceaccount" cannot create resource "pods/exec" in API group "" in the namespace "**************************"
