### PR TITLE
Prisoner content hub - dev - increase max_allowed_packets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -27,7 +27,6 @@ module "drupal_rds" {
     }
   ]
 }
-}
 
 resource "kubernetes_secret" "drupal_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -18,9 +18,15 @@ module "drupal_rds" {
   db_engine_version = "10.4"
   rds_family        = "mariadb10.4"
 
-  # We need to explicitly set this to an empty list, otherwise the module
-  # will add `rds.force_ssl`, which MariaDB doesn't support
-  db_parameter = []
+  # Increase max_allowed_packets as Drupal can sometimes send large packets.
+  db_parameter = [
+    {
+      name         = "max_allowed_packet"
+      value        = "10000000" // 10MB
+      apply_method = "immediate"
+    }
+  ]
+}
 }
 
 resource "kubernetes_secret" "drupal_rds" {


### PR DESCRIPTION
We've been seeing errors like this in production:
```
2022-09-05 11:43:27 59589545 [Warning] Aborted connection 59589545 to db: '*******' user: '*****' host: '*****' (Got an error reading communication packets)
```

The doc from AWS suggest this could be down to a few issues. https://aws.amazon.com/premiumsupport/knowledge-center/rds-mysql-communication-packet-error/
One of which is the max_allowed_packet size (which has a 1MB default).

This PR increases it to 10MB.  From what I have read, this does not increase the initial allocation, so is safe to increase.