### PR TITLE
Revert "Prisoner content hub - dev - increase max_allowed_packets"

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -18,14 +18,9 @@ module "drupal_rds" {
   db_engine_version = "10.4"
   rds_family        = "mariadb10.4"
 
-  # Increase max_allowed_packets as Drupal can sometimes send large packets.
-  db_parameter = [
-    {
-      name         = "max_allowed_packet"
-      value        = "10000000" // 10MB
-      apply_method = "immediate"
-    }
-  ]
+  # We need to explicitly set this to an empty list, otherwise the module
+  # will add `rds.force_ssl`, which MariaDB doesn't support
+  db_parameter = []
 }
 
 resource "kubernetes_secret" "drupal_rds" {


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-environments#8564

This breaks the build as it's below the minimum amount of 16MB.

Upon further investigation, we already have 16MB set in RDS (the default for mysql is 1MB, but it looks like RDS sets it's own value).

Therefore we don't need to increase this value.