### PR TITLE
SAA-33: Adding service monitors

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/activities-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/activities-dev/05-serviceaccount-circleci.yaml
@@ -31,6 +31,7 @@ rules:
       - "monitoring.coreos.com"
     resources:
       - "prometheusrules"
+      - "servicemonitors"
     verbs:
       - "*"
 


### PR DESCRIPTION
Minor change to add service monitors to prometheus (missing from template typescript project)