### PR TITLE
[DSE-607] generate random passwords for prototypes

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prototype/resources/basic-auth.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prototype/resources/basic-auth.tf
@@ -1,5 +1,10 @@
 # Username and password for the prototype kit website's http basic
 # authentication
+resource "random_password" "password" {
+  length  = 16
+  special = false
+}
+
 resource "kubernetes_secret" "basic-auth" {
   metadata {
     name      = "basic-auth"
@@ -8,6 +13,6 @@ resource "kubernetes_secret" "basic-auth" {
 
   data = {
     username = var.basic-auth-username
-    password = var.basic-auth-password
+    password = random_password.password.result
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prototype/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prototype/resources/variables.tf
@@ -62,8 +62,3 @@ variable "basic-auth-username" {
   description = "Basic auth. username of the deployed prototype website"
   default     = "manage-soc-cases-prototype-user"
 }
-
-variable "basic-auth-password" {
-  description = "Basic auth. password of the deployed prototype website"
-  default     = ""
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prototype/resources/basic-auth.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prototype/resources/basic-auth.tf
@@ -1,5 +1,10 @@
 # Username and password for the prototype kit website's http basic
 # authentication
+resource "random_password" "password" {
+  length  = 16
+  special = false
+}
+
 resource "kubernetes_secret" "basic-auth" {
   metadata {
     name      = "basic-auth"
@@ -8,6 +13,6 @@ resource "kubernetes_secret" "basic-auth" {
 
   data = {
     username = var.basic-auth-username
-    password = var.basic-auth-password
+    password = random_password.password.result
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prototype/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prototype/resources/variables.tf
@@ -62,8 +62,3 @@ variable "basic-auth-username" {
   description = "Basic auth. username of the deployed prototype website"
   default     = "pf-prototype-user"
 }
-
-variable "basic-auth-password" {
-  description = "Basic auth. password of the deployed prototype website"
-  default     = ""
-}


### PR DESCRIPTION
this ensures that the password set in the kube cluster is in sync with the IaC