### PR TITLE
Update RDS engine version non-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds_new.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds_new.tf
@@ -7,7 +7,7 @@ module "hmcts_mock_api_rds_instance" {
   application            = "hmcts-common-platform-mock-api"
   is-production          = "false"
   namespace              = var.namespace
-  db_engine_version      = "14.2"
+  db_engine_version      = "14"
   environment-name       = "development"
   infrastructure-support = "laa@digital.justice.gov.uk"
   rds_family             = "postgres14"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/rds.tf
@@ -11,7 +11,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version      = "14.3"
+  db_engine_version      = "14"
   db_instance_class      = "db.t3.small"
   environment-name       = var.environment
   infrastructure-support = var.infrastructure_support

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
@@ -27,7 +27,7 @@ module "complexity-of-need-rds" {
   environment-name       = "staging"
   infrastructure-support = "omic@digital.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "14.3"
+  db_engine_version      = "14"
   rds_family             = "postgres14"
   db_name                = "hmpps_complexity_of_need"
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
@@ -11,7 +11,7 @@ module "court_data_adaptor_rds" {
   infrastructure-support = "laa@digital.justice.gov.uk"
 
   rds_family                  = "postgres14"
-  db_engine_version           = "14.2"
+  db_engine_version           = "14"
   db_instance_class           = "db.t3.small"
   allow_major_version_upgrade = "true"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds-instance.tf
@@ -10,7 +10,7 @@ module "court_data_adaptor_rds" {
   environment-name       = "stage"
   infrastructure-support = "laa@digital.justice.gov.uk"
   rds_family             = "postgres14"
-  db_engine_version      = "14.2"
+  db_engine_version      = "14"
 
   allow_major_version_upgrade = "true"
   db_instance_class           = "db.t3.small"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds-instance.tf
@@ -7,7 +7,7 @@ module "court_data_adaptor_rds" {
   application   = "laa-court-data-adaptor"
   is-production = "false"
 
-  db_engine_version      = "14.2"
+  db_engine_version      = "14"
   environment-name       = "test"
   infrastructure-support = "laa@digital.justice.gov.uk"
   rds_family             = "postgres14"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds-instance.tf
@@ -10,7 +10,7 @@ module "court_data_adaptor_rds" {
   environment-name       = "uat"
   infrastructure-support = "laa@digital.justice.gov.uk"
   rds_family             = "postgres14"
-  db_engine_version      = "14.2"
+  db_engine_version      = "14"
 
   allow_major_version_upgrade = "true"
   db_instance_class           = "db.t3.small"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/rds-allocations-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/rds-allocations-api.tf
@@ -27,7 +27,7 @@ module "allocation-rds" {
   environment-name       = "preprod"
   infrastructure-support = "omic@digital.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "14.3"
+  db_engine_version      = "14"
   rds_family             = "postgres14"
   db_name                = "allocations"
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds-allocations-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds-allocations-api.tf
@@ -27,7 +27,7 @@ module "allocation-rds" {
   infrastructure-support = "omic@digital.justice.gov.uk"
   db_engine              = "postgres"
   rds_family             = "postgres14"
-  db_engine_version      = "14.4"
+  db_engine_version      = "14"
   db_name                = "allocations"
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
 


### PR DESCRIPTION
This is to remove the pinned minor version

To fix the error:

Error: Error modifying DB Instance xxxxxxxx: InvalidParameterCombination: Cannot upgrade Postgres from 14.x to 14.x