### PR TITLE
Add ECR lifecycle policy to crime apply service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/ecr.tf
@@ -5,6 +5,25 @@ module "ecr-repo" {
   repo_name = var.repo_name
 
   github_repositories = [var.repo_name]
+
+  lifecycle_policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images keeping newest 25",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "imageCountMoreThan",
+                "countNumber": 25
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
 }
 
 resource "kubernetes_secret" "ecr-repo" {


### PR DESCRIPTION
ECR lifecycle to keep newest 25 untagged images.

Tagged images (like `staging`) should not be deleted by this policy, only untagged images.