### PR TITLE
Add new `hmpps-approved-premises` namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/00-namespace.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-approved-premises-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "approved-premises-team-dev"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
+    cloud-platform.justice.gov.uk/application: "Approved Premises"
+    cloud-platform.justice.gov.uk/owner: "Approved Premises Team: unknown@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git"
+    cloud-platform.justice.gov.uk/team-name: "approved-premises-team"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/01-rbac.yaml
@@ -1,0 +1,17 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-approved-premises-dev-admin
+  namespace: hmpps-approved-premises-dev
+subjects:
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:approved-premises-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/02-limitrange.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-approved-premises-dev
+spec:
+  limits:
+    - default:
+        cpu: 2000m
+        memory: 1024Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 512Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-approved-premises-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-approved-premises-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-approved-premises-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/05-serviceaccount-circleci.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: hmpps-approved-premises-dev
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: hmpps-approved-premises-dev
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-approved-premises-dev
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: hmpps-approved-premises-dev
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+      - "servicemonitors"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - "networkpolicies"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: hmpps-approved-premises-dev
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-approved-premises-dev
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/06-certificates.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-approved-premises-dev-cert
+  namespace: hmpps-approved-premises-dev
+spec:
+  secretName: hmpps-approved-premises-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - hmpps-approved-premises-dev.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: approved-premises-api-dev-cert
+  namespace: hmpps-approved-premises-dev
+spec:
+  secretName: approved-premises-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - approved-premises-api-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/elasticache.tf
@@ -1,0 +1,36 @@
+################################################################################
+# HMPPs Typescript Template Application Elasticache
+################################################################################
+
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.3"
+  cluster_name           = var.cluster_name
+  application            = var.application
+  environment-name       = var.environment
+  is-production          = var.is_production
+  infrastructure-support = var.infrastructure_support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = "cache.t2.small"
+  engine_version         = "4.0.10"
+  parameter_group_name   = "default.redis4.0"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/rds.tf
@@ -1,0 +1,81 @@
+module "rds" {
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.11"
+  cluster_name                 = var.cluster_name
+  team_name                    = var.team_name
+  business-unit                = var.business_unit
+  application                  = var.application
+  is-production                = var.is_production
+  environment-name             = var.environment
+  infrastructure-support       = var.infrastructure_support
+  namespace                    = var.namespace
+  performance_insights_enabled = true
+  db_engine_version            = "13"
+  db_instance_class            = "db.t3.small"
+  rds_family                   = "postgres13"
+  allow_major_version_upgrade  = "false"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "read_replica" {
+  count  = 0
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
+
+  cluster_name           = var.cluster_name
+  application            = var.application
+  environment-name       = var.environment
+  is-production          = var.is_production
+  infrastructure-support = var.infrastructure_support
+  team_name              = var.team_name
+  db_name                = module.rds.database_name
+  replicate_source_db    = module.rds.db_identifier
+
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    access_key_id         = module.rds.access_key_id
+    secret_access_key     = module.rds.secret_access_key
+    url                   = "jdbc:postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+  }
+}
+
+
+resource "kubernetes_secret" "read_replica" {
+  count = 0
+
+  metadata {
+    name      = "rds-postgresql-read-replica-output"
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/variables.tf
@@ -1,0 +1,45 @@
+
+variable "cluster_name" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Approved Premises"
+}
+
+variable "namespace" {
+  default = "approved-premises-api-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-tech"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "dps-hmpps@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "approved-premises-team-dev"
+}
+
+variable "number_cache_clusters" {
+  default = "2"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-approved-premises-dev/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.68.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
This adds a new namespace for the approved premises project that has the correct naming convention and also combines the API and UI for ease of use. Once this is created and deployed, the old `approved-premises-dev` and `approved-premises-api-dev` namespaces can be deleted.