### PR TITLE
Update hmpps-temporary-accommodation-prod namespace to mirror hmpps-approved-premises-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/00-namespace.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -10,6 +11,5 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "community-accommodation-service-tier-3-team"
     cloud-platform.justice.gov.uk/application: "Temporary Accommodation"
     cloud-platform.justice.gov.uk/owner: "Temporary Accommodation: cas3@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/approved-premises-ui"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git"
     cloud-platform.justice.gov.uk/team-name: "hmpps-temporary-accommodation"
-    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/01-rbac.yaml
@@ -1,9 +1,13 @@
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hmpps-temporary-accommodation-prod-admin
   namespace: hmpps-temporary-accommodation-prod
 subjects:
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-temporary-accommodation"
     apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/02-limitrange.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: LimitRange
 metadata:
@@ -5,10 +6,10 @@ metadata:
   namespace: hmpps-temporary-accommodation-prod
 spec:
   limits:
-  - default:
-      cpu: 1000m
-      memory: 1000Mi
-    defaultRequest:
-      cpu: 10m
-      memory: 100Mi
-    type: Container
+    - default:
+        cpu: 2000m
+        memory: 1024Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 512Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/03-resourcequota.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ResourceQuota
 metadata:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/04-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -6,10 +7,10 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - podSelector: {}
+    - from:
+      - podSelector: {}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -19,9 +20,9 @@ metadata:
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          component: ingress-controllers
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/05-serviceaccount-circleci.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: hmpps-temporary-accommodation-prod
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: hmpps-temporary-accommodation-prod
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-temporary-accommodation-prod
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci
+  namespace: hmpps-temporary-accommodation-prod
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+      - "servicemonitors"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - "networkpolicies"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: circleci-prometheus
+  namespace: hmpps-temporary-accommodation-prod
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-temporary-accommodation-prod
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/06-certificates.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-temporary-accommodation-prod-cert
+  namespace: hmpps-temporary-accommodation-prod
+spec:
+  secretName: hmpps-temporary-accommodation-prod-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - temporary-accommodation.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-temporary-accommodation-api-prod-cert
+  namespace: hmpps-temporary-accommodation-prod
+spec:
+  secretName: hmpps-temporary-accommodation-api-prod-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - temporary-accommodation-api.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/elasticache.tf
@@ -1,0 +1,36 @@
+################################################################################
+# HMPPs Typescript Template Application Elasticache
+################################################################################
+
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.3"
+  cluster_name           = var.cluster_name
+  application            = var.application
+  environment-name       = var.environment
+  is-production          = var.is_production
+  infrastructure-support = var.infrastructure_support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = "cache.t2.small"
+  engine_version         = "4.0.10"
+  parameter_group_name   = "default.redis4.0"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/main.tf
@@ -17,7 +17,3 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-provider "github" {
-  token = var.github_token
-  owner = var.github_owner
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/rds.tf
@@ -1,0 +1,81 @@
+module "rds" {
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.11"
+  cluster_name                 = var.cluster_name
+  team_name                    = var.team_name
+  business-unit                = var.business_unit
+  application                  = var.application
+  is-production                = var.is_production
+  environment-name             = var.environment
+  infrastructure-support       = var.infrastructure_support
+  namespace                    = var.namespace
+  performance_insights_enabled = true
+  db_engine_version            = "13"
+  db_instance_class            = "db.t3.small"
+  rds_family                   = "postgres13"
+  allow_major_version_upgrade  = "false"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "read_replica" {
+  count  = 0
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
+
+  cluster_name           = var.cluster_name
+  application            = var.application
+  environment-name       = var.environment
+  is-production          = var.is_production
+  infrastructure-support = var.infrastructure_support
+  team_name              = var.team_name
+  db_name                = module.rds.database_name
+  replicate_source_db    = module.rds.db_identifier
+
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    access_key_id         = module.rds.access_key_id
+    secret_access_key     = module.rds.secret_access_key
+    url                   = "jdbc:postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+  }
+}
+
+
+resource "kubernetes_secret" "read_replica" {
+  count = 0
+
+  metadata {
+    name      = "rds-postgresql-read-replica-output"
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/variables.tf
@@ -2,12 +2,6 @@
 variable "cluster_name" {
 }
 
-variable "cluster_state_bucket" {
-}
-
-variable "kubernetes_cluster" {
-}
-
 variable "application" {
   description = "Name of Application you are deploying"
   default     = "Temporary Accommodation"
@@ -46,12 +40,6 @@ variable "slack_channel" {
   default     = "community-accommodation-service-tier-3-team"
 }
 
-variable "github_owner" {
-  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
-  default     = "ministryofjustice"
-}
-
-variable "github_token" {
-  description = "Required by the Github Terraform provider"
-  default     = ""
+variable "number_cache_clusters" {
+  default = "2"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prod/resources/versions.tf
@@ -6,8 +6,8 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
-    github = {
-      source = "integrations/github"
+    kubernetes = {
+      source = "hashicorp/kubernetes"
     }
   }
 }


### PR DESCRIPTION
Temporary Accommodation and Approved Premises will share a common codebase, so we want the environment to be closely aligned. This PR gives us the Temporary Accommodation Production equivalent of hmpps-approved-premises-dev

As with #8729, I've err-ed on the side of keeping things consistent with Approved Premises, which has resulted in some arbitrary-seeming changes 