### PR TITLE
Create new PostgreSQL14 instance on prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
@@ -1,0 +1,38 @@
+module "hmpps_interventions_postgres14" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.12"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  namespace              = var.namespace
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+
+  rds_family                  = "postgres14"
+  db_engine_version           = "14"
+  db_instance_class           = "db.m5.large"
+  allow_major_version_upgrade = "false"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "hmpps_interventions_postgres14" {
+  metadata {
+    name      = "postgres14"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.hmpps_interventions_postgres14.rds_instance_endpoint
+    database_name         = module.hmpps_interventions_postgres14.database_name
+    database_username     = module.hmpps_interventions_postgres14.database_username
+    database_password     = module.hmpps_interventions_postgres14.database_password
+    rds_instance_address  = module.hmpps_interventions_postgres14.rds_instance_address
+    access_key_id         = module.hmpps_interventions_postgres14.access_key_id
+    secret_access_key     = module.hmpps_interventions_postgres14.secret_access_key
+    url                   = "postgres://${module.hmpps_interventions_postgres14.database_username}:${module.hmpps_interventions_postgres14.database_password}@${module.hmpps_interventions_postgres14.rds_instance_endpoint}/${module.hmpps_interventions_postgres14.database_name}"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds.tf
@@ -8,8 +8,9 @@ module "hmpps_interventions_rds" {
   namespace              = var.namespace
   environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
-  rds_family             = var.rds_family
-  db_instance_class      = "db.m5.large"
+
+  rds_family        = "postgres10"
+  db_instance_class = "db.m5.large"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
We are running on PostgreSQL 10, which will be end-of-life soon.

This PR creates a new PostgreSQL 14 instance, so we have something to migrate to.