### PR TITLE
Adding life cycle policy to erc

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -338,6 +338,9 @@ module "ecr-repo-fb-base-adapter" {
 
   team_name = "formbuilder"
   repo_name = "fb-base-adapter"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 }
 
 resource "kubernetes_secret" "ecr-repo-fb-base-adapter" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/variables.tf
@@ -1,0 +1,24 @@
+variable "lifecycle_policy" {
+  default = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep the newest 50 images and mark the rest for expiration",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 50
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}
+
+variable "scan_on_push" {
+  default = "true"
+}


### PR DESCRIPTION
Adds policy to keep latest 50 images on 1 ecr repo.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>