### PR TITLE
Prisoner content hub production - Upgrading redis instance size.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticache.tf
@@ -11,7 +11,7 @@ module "drupal_redis" {
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
   number_cache_clusters  = var.number_cache_clusters
-  node_type              = "cache.t3.small"
+  node_type              = "cache.t3.medium"
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace


### PR DESCRIPTION
We are seeing Redis errors such as 
```
OOM command not allowed when used memory > ‘maxmemory’
```
The error relates to the memory limit in Redis being reached. See https://ma.ttias.be/redis-oom-command-not-allowed-used-memory-maxmemory/
