### PR TITLE
Add ECR lifecycle policy to all formbuilder repos

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -6,6 +6,9 @@ module "ecr-repo-fb-publisher-base" {
   team_name = "formbuilder"
   repo_name = "fb-publisher-base"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -30,6 +33,9 @@ module "ecr-repo-fb-publisher-web" {
   team_name = "formbuilder"
   repo_name = "fb-publisher-web"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -53,6 +59,9 @@ module "ecr-repo-fb-publisher-worker" {
 
   team_name = "formbuilder"
   repo_name = "fb-publisher-worker"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 
   providers = {
     aws = aws.london
@@ -81,6 +90,9 @@ module "ecr-repo-fb-runner-node" {
   team_name = "formbuilder"
   repo_name = "fb-runner-node"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -107,6 +119,9 @@ module "ecr-repo-fb-service-token-cache" {
 
   team_name = "formbuilder"
   repo_name = "fb-service-token-cache"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 
   providers = {
     aws = aws.london
@@ -135,6 +150,9 @@ module "ecr-repo-fb-submitter-base" {
   team_name = "formbuilder"
   repo_name = "fb-submitter-base"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -159,6 +177,9 @@ module "ecr-repo-fb-submitter-api" {
   team_name = "formbuilder"
   repo_name = "fb-submitter-api"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -182,6 +203,9 @@ module "ecr-repo-fb-submitter-workers" {
 
   team_name = "formbuilder"
   repo_name = "fb-submitter-workers"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 
   providers = {
     aws = aws.london
@@ -210,6 +234,9 @@ module "ecr-repo-fb-user-datastore-api" {
   team_name = "formbuilder"
   repo_name = "fb-user-datastore-api"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -236,6 +263,9 @@ module "ecr-repo-fb-user-filestore-api" {
 
   team_name = "formbuilder"
   repo_name = "fb-user-filestore-api"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 
   providers = {
     aws = aws.london
@@ -264,6 +294,9 @@ module "ecr-repo-fb-av" {
   team_name = "formbuilder"
   repo_name = "fb-av"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -291,6 +324,9 @@ module "ecr-repo-fb-builder" {
   team_name = "formbuilder"
   repo_name = "fb-builder"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -316,6 +352,10 @@ module "ecr-repo-fb-pdf-generator" {
 
   team_name = "formbuilder"
   repo_name = "fb-pdf-generator"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
 }
 
 resource "kubernetes_secret" "ecr-repo-fb-pdf-generator" {
@@ -364,6 +404,9 @@ module "ecr-repo-hmcts-complaints-formbuilder-adapter-api" {
   team_name = "formbuilder"
   repo_name = "hmcts-complaints-formbuilder-adapter-api"
 
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
+
   providers = {
     aws = aws.london
   }
@@ -387,6 +430,9 @@ module "ecr-repo-hmcts-complaints-formbuilder-adapter-worker" {
 
   team_name = "formbuilder"
   repo_name = "hmcts-complaints-formbuilder-adapter-worker"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 
   providers = {
     aws = aws.london
@@ -413,6 +459,9 @@ module "ecr-repo-fb-metadata-api" {
 
   team_name = "formbuilder"
   repo_name = "fb-metadata-api"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 }
 
 resource "kubernetes_secret" "ecr-repo-fb-metadata-api" {
@@ -435,6 +484,9 @@ module "ecr-repo-fb-editor-web" {
 
   team_name = "formbuilder"
   repo_name = "fb-editor-web"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 }
 
 resource "kubernetes_secret" "ecr-repo-fb-editor-web" {
@@ -455,6 +507,9 @@ module "ecr-repo-fb-editor-workers" {
 
   team_name = "formbuilder"
   repo_name = "fb-editor-workers"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 }
 
 resource "kubernetes_secret" "ecr-repo-fb-editor-workers" {
@@ -476,6 +531,9 @@ module "ecr-repo-fb-runner" {
 
   team_name = "formbuilder"
   repo_name = "fb-runner"
+
+  scan_on_push = var.scan_on_push
+  lifecycle_policy = var.lifecycle_policy
 }
 
 resource "kubernetes_secret" "ecr-repo-fb-runner" {


### PR DESCRIPTION
This PR adds the lifecyle policy to only keep the latest 50 images on all formbuilder images.