### PR TITLE
Add permissions for Jobs resources for track-a-query

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-demo/06-circleci-serviceaccount.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-demo/06-circleci-serviceaccount.yaml
@@ -40,6 +40,12 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+    verbs:
+      - "*"
 
 ---
 kind: RoleBinding

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/06-circleci-serviceaccount.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/06-circleci-serviceaccount.yaml
@@ -40,6 +40,12 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+    verbs:
+      - "*"
 
 ---
 kind: RoleBinding

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/06-circleci-serviceaccount.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/06-circleci-serviceaccount.yaml
@@ -44,6 +44,7 @@ rules:
       - "batch"
     resources:
       - "cronjobs"
+      - "jobs"
     verbs:
       - "*"
 ---

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/06-circleci-serviceaccount.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/06-circleci-serviceaccount.yaml
@@ -44,6 +44,7 @@ rules:
       - "batch"
     resources:
       - "cronjobs"
+      - "jobs"
     verbs:
       - "*"
 ---

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/06-circleci-serviceaccount.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/06-circleci-serviceaccount.yaml
@@ -40,6 +40,12 @@ rules:
       - "delete"
       - "create"
       - "patch"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+    verbs:
+      - "*"
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
A change has been made to the application to run data migrations from a Kubernetes Job, but the circleci user does not have permissions to use those resources.