### PR TITLE
Form Builder - Create new Datastore DB

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-datastore.tf
@@ -28,3 +28,34 @@ resource "kubernetes_secret" "user-datastore-rds-instance" {
   }
 }
 
+module "user-datastore-rds-instance-2" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.13"
+
+  vpc_name                   = var.vpc_name
+  db_backup_retention_period = var.db_backup_retention_period_user_datastore
+  application                = "formbuilderuserdatastore"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  namespace                  = var.namespace
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
+  db_engine_version          = "14"
+  rds_family                 = "postgres14"
+  db_instance_class          = var.db_instance_class
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "user-datastore-rds-instance-2" {
+  metadata {
+    name      = "rds-instance-formbuilder-user-datastore-2-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.user-datastore-rds-instance-2.database_username}:${module.user-datastore-rds-instance-2.database_password}@${module.user-datastore-rds-instance-2.rds_instance_endpoint}/${module.user-datastore-rds-instance-2.database_name}"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/variables.tf
@@ -34,3 +34,7 @@ variable "vpc_name" {
 variable "namespace" {
   default = "formbuilder-platform-test-production"
 }
+
+variable "db_instance_class" {
+  default = "db.m6g.medium"
+}


### PR DESCRIPTION
This creates a new RDS instsance for our datastore app in the formbuilder-platform-test-production namespace.

Using Postgres 14 and the Graviton instance type.

Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>