### PR TITLE
Form Builder - Use large DB instance size

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/variables.tf
@@ -36,5 +36,5 @@ variable "namespace" {
 }
 
 variable "db_instance_class" {
-  default = "db.m6g.medium"
+  default = "db.m6g.large"
 }


### PR DESCRIPTION
The Medium instance size is only available with burstable performance which is something we do not require. Just use Large