### PR TITLE
Form Builder - Add new DB in platform test-dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
@@ -28,3 +28,34 @@ resource "kubernetes_secret" "submitter-rds-instance" {
   }
 }
 
+module "submitter-rds-instance-2" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.13"
+
+  vpc_name                   = var.vpc_name
+  db_backup_retention_period = var.db_backup_retention_period_submitter
+  application                = "formbuildersubmitter"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  namespace                  = var.namespace
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
+  db_engine_version          = "14"
+  rds_family                 = "postgres14"
+  db_instance_class          = var.db_instance_class
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "submitter-rds-instance-2" {
+  metadata {
+    name      = "rds-instance-formbuilder-submitter-2-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.submitter-rds-instance-2.database_username}:${module.submitter-rds-instance-2.database_password}@${module.submitter-rds-instance-2.rds_instance_endpoint}/${module.submitter-rds-instance-2.database_name}"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -29,3 +29,34 @@ resource "kubernetes_secret" "user-datastore-rds-instance" {
   }
 }
 
+module "user-datastore-rds-instance-2" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.13"
+
+  vpc_name                   = var.vpc_name
+  db_backup_retention_period = var.db_backup_retention_period_user_datastore
+  application                = "formbuilderuserdatastore"
+  environment-name           = var.environment-name
+  is-production              = var.is-production
+  namespace                  = var.namespace
+  infrastructure-support     = var.infrastructure-support
+  team_name                  = var.team_name
+  db_engine_version          = "14"
+  rds_family                 = "postgres14"
+  db_instance_class          = var.db_instance_class
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "user-datastore-rds-instance-2" {
+  metadata {
+    name      = "rds-instance-formbuilder-user-datastore-2-${var.environment-name}"
+    namespace = "formbuilder-platform-${var.environment-name}"
+  }
+
+  data = {
+    # postgres://USER:PASSWORD@HOST:PORT/NAME
+    url = "postgres://${module.user-datastore-rds-instance-2.database_username}:${module.user-datastore-rds-instance-2.database_password}@${module.user-datastore-rds-instance-2.rds_instance_endpoint}/${module.user-datastore-rds-instance-2.database_name}"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/variables.tf
@@ -33,3 +33,7 @@ variable "vpc_name" {
 variable "namespace" {
   default = "formbuilder-platform-test-dev"
 }
+
+variable "db_instance_class" {
+  default = "db.m6g.large"
+}


### PR DESCRIPTION
Creating a new Graviton RDS instances in the
formbuilder-platform-test-dev namespace for the datastore and the
submitter.