### PR TITLE
SDI-422: 🔧 Upgrade to postgres 14 for offender-events-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/rds.tf
@@ -8,6 +8,10 @@ module "dps_rds" {
   namespace              = var.namespace
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  db_instance_class      = "db.t3.large"
+  db_engine              = "postgres"
+  db_engine_version      = "10.21"
+  rds_family             = "postgres10"
 
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/rds.tf
@@ -10,8 +10,11 @@ module "dps_rds" {
   infrastructure-support = var.infrastructure-support
   db_instance_class      = "db.t3.large"
   db_engine              = "postgres"
-  db_engine_version      = "10.21"
-  rds_family             = "postgres10"
+  db_engine_version      = "14"
+  rds_family             = "postgres14"
+
+  # use "allow_major_version_upgrade" when upgrading the major version of an engine
+  allow_major_version_upgrade = "true"
 
 
   providers = {


### PR DESCRIPTION
- SDI-422: 🔧 Skip apply pipeline for offender-events-preprod
- SDI-422: 🔧 Upgrade to postgres 10_21 for offender-events-preprod
- SDI-422: 🔧 Upgrade to postgres 14 for offender-events-preprod
