### PR TITLE
SDI-422: 🔧 Set migration instance class for check-my-diary-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
@@ -9,6 +9,9 @@ module "checkmydiary_rds" {
   namespace              = var.namespace
   environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
+  db_instance_class      = "db.t3.large"
+  db_engine              = "postgres"
+  db_engine_version      = "10.21"
   rds_family             = "postgres10"
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
@@ -9,13 +9,13 @@ module "checkmydiary_rds" {
   namespace              = var.namespace
   environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
-  db_instance_class      = "db.t3.large"
+  db_instance_class      = "db.t4g.small"
   db_engine              = "postgres"
   db_engine_version      = "14"
   rds_family             = "postgres14"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
-  allow_major_version_upgrade = "true"
+  allow_major_version_upgrade = "false"
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
@@ -11,8 +11,11 @@ module "checkmydiary_rds" {
   infrastructure-support = var.infrastructure_support
   db_instance_class      = "db.t3.large"
   db_engine              = "postgres"
-  db_engine_version      = "10.21"
-  rds_family             = "postgres10"
+  db_engine_version      = "14"
+  rds_family             = "postgres14"
+
+  # use "allow_major_version_upgrade" when upgrading the major version of an engine
+  allow_major_version_upgrade = "true"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
- SDI-422: 🔧 Skip apply pipeline for check-my-diary-preprod
- SDI-422: 🔧 Upgrade to postgres 10_21 for check-my-diary-preprod
- SDI-422: 🔧 Upgrade to postgres 14 for check-my-diary-preprod
- SDI-422: 🔧 Set migration instance class for check-my-diary-preprod
