### PR TITLE
SDI-422: 🔧 Set migration instance class for hmpps-restricted-patients-api-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-preprod/resources/rds.tf
@@ -15,6 +15,10 @@ module "rp_rds" {
   namespace              = var.namespace
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
+  db_instance_class      = "db.t3.large"
+  db_engine              = "postgres"
+  db_engine_version      = "10.21"
+  rds_family             = "postgres10"
 
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-preprod/resources/rds.tf
@@ -17,8 +17,11 @@ module "rp_rds" {
   infrastructure-support = var.infrastructure-support
   db_instance_class      = "db.t3.large"
   db_engine              = "postgres"
-  db_engine_version      = "10.21"
-  rds_family             = "postgres10"
+  db_engine_version      = "14"
+  rds_family             = "postgres14"
+
+  # use "allow_major_version_upgrade" when upgrading the major version of an engine
+  allow_major_version_upgrade = "true"
 
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-preprod/resources/rds.tf
@@ -15,13 +15,13 @@ module "rp_rds" {
   namespace              = var.namespace
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
-  db_instance_class      = "db.t3.large"
+  db_instance_class      = "db.t4g.small"
   db_engine              = "postgres"
   db_engine_version      = "14"
   rds_family             = "postgres14"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
-  allow_major_version_upgrade = "true"
+  allow_major_version_upgrade = "false"
 
 
   providers = {


### PR DESCRIPTION
- SDI-422: 🔧 Skip apply pipeline for hmpps-restricted-patients-api-preprod
- SDI-422: 🔧 Upgrade to postgres 10_21 for hmpps-restricted-patients-api-preprod
- SDI-422: 🔧 Upgrade to postgres 14 for hmpps-restricted-patients-api-preprod
- SDI-422: 🔧 Set migration instance class for hmpps-restricted-patients-api-preprod
