### PR TITLE
Add default_tags to cccd-production main.tf

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+  default_tags {
+    tags = {
+      GithubTeam = "laa-claim-for-payment"
+    }
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
The Claim for Payment team requires read-only access to AWS console to support the CCCD service in production.

This adds the necessary config to `resources/main.tf` specifying the GitHub team name.