### PR TITLE
EL-434: Add TXT records to verify rogue subdomains on Google Search Console

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-uat/resources/route53-efe.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-uat/resources/route53-efe.tf
@@ -1,5 +1,9 @@
+data "aws_route53_zone" "cloud_platform" {
+  name = "cloud-platform.service.justice.gov.uk"
+}
+
 resource "aws_route53_record" "bundler-debug-1-6-3-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "bundler-debug-1-6-3-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -7,7 +11,7 @@ resource "aws_route53_record" "bundler-debug-1-6-3-estimate-financial-eligibilit
 }
 
 resource "aws_route53_record" "bundler-faraday-2-6-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "bundler-faraday-2-6-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -15,7 +19,7 @@ resource "aws_route53_record" "bundler-faraday-2-6-estimate-financial-eligibilit
 }
 
 resource "aws_route53_record" "bundler-rspec-3-12-0-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "bundler-rspec-3-12-0-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -23,7 +27,7 @@ resource "aws_route53_record" "bundler-rspec-3-12-0-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "bundler-rubocop-govu-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "bundler-rubocop-govu-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -31,7 +35,7 @@ resource "aws_route53_record" "bundler-rubocop-govu-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-334-start-page-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-334-start-page-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -39,7 +43,7 @@ resource "aws_route53_record" "el-334-start-page-estimate-financial-eligibility-
 }
 
 resource "aws_route53_record" "el-336-add-analytics-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-336-add-analytics-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -47,7 +51,7 @@ resource "aws_route53_record" "el-336-add-analytics-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-358-update-income-page-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-358-update-income-page-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -55,7 +59,7 @@ resource "aws_route53_record" "el-358-update-income-page-estimate-financial-elig
 }
 
 resource "aws_route53_record" "el-363-initial-brnac-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-363-initial-brnac-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -63,7 +67,7 @@ resource "aws_route53_record" "el-363-initial-brnac-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-377-money-input-f-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-377-money-input-f-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -71,7 +75,7 @@ resource "aws_route53_record" "el-377-money-input-f-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-386-axe-checks-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-386-axe-checks-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -79,7 +83,7 @@ resource "aws_route53_record" "el-386-axe-checks-estimate-financial-eligibility-
 }
 
 resource "aws_route53_record" "el-386-other-income-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-386-other-income-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -87,7 +91,7 @@ resource "aws_route53_record" "el-386-other-income-estimate-financial-eligibilit
 }
 
 resource "aws_route53_record" "el-387-phase-banner-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-387-phase-banner-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -95,7 +99,7 @@ resource "aws_route53_record" "el-387-phase-banner-estimate-financial-eligibilit
 }
 
 resource "aws_route53_record" "el-411-benefits-chec-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-411-benefits-chec-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -103,7 +107,7 @@ resource "aws_route53_record" "el-411-benefits-chec-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-413-use-redis-ses-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-413-use-redis-ses-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -111,7 +115,7 @@ resource "aws_route53_record" "el-413-use-redis-ses-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-416-check-outgoin-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-416-check-outgoin-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -119,7 +123,7 @@ resource "aws_route53_record" "el-416-check-outgoin-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-417-remove-asset-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-417-remove-asset-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -127,7 +131,7 @@ resource "aws_route53_record" "el-417-remove-asset-estimate-financial-eligibilit
 }
 
 resource "aws_route53_record" "el-418-update-vehicl-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-418-update-vehicl-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -135,7 +139,7 @@ resource "aws_route53_record" "el-418-update-vehicl-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-420-remove-partne-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-420-remove-partne-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -143,7 +147,7 @@ resource "aws_route53_record" "el-420-remove-partne-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-427-results-panel-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-427-results-panel-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -151,7 +155,7 @@ resource "aws_route53_record" "el-427-results-panel-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-429-property-smod-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-429-property-smod-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -159,7 +163,7 @@ resource "aws_route53_record" "el-429-property-smod-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-430-smod-vehicles-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-430-smod-vehicles-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -167,7 +171,7 @@ resource "aws_route53_record" "el-430-smod-vehicles-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el-431-assets-smod-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-431-assets-smod-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -175,15 +179,19 @@ resource "aws_route53_record" "el-431-assets-smod-estimate-financial-eligibility
 }
 
 resource "aws_route53_record" "el-433-smod-results-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-433-smod-results-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
   records = ["google-site-verification=B0pIS0ly615jgPN7PVy8sSXNSE95se-RJHo1IvTLroQ"]
 }
 
+data "aws_route53_zone" "cloud_platform" {
+  name = "cloud-platform.service.justice.gov.uk"
+}
+
 resource "aws_route53_record" "el-434-do-not-index-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-434-do-not-index-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -191,7 +199,7 @@ resource "aws_route53_record" "el-434-do-not-index-estimate-financial-eligibilit
 }
 
 resource "aws_route53_record" "el356-simple-check-a-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el356-simple-check-a-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -199,7 +207,7 @@ resource "aws_route53_record" "el356-simple-check-a-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "el361-vehicle-screens-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el361-vehicle-screens-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -207,7 +215,7 @@ resource "aws_route53_record" "el361-vehicle-screens-estimate-financial-eligibil
 }
 
 resource "aws_route53_record" "estimate-financial-eligibility-staging" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "estimate-financial-eligibility-staging.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -215,7 +223,7 @@ resource "aws_route53_record" "estimate-financial-eligibility-staging" {
 }
 
 resource "aws_route53_record" "income-section-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "income-section-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -223,7 +231,7 @@ resource "aws_route53_record" "income-section-estimate-financial-eligibility-uat
 }
 
 resource "aws_route53_record" "main-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "main-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -231,7 +239,7 @@ resource "aws_route53_record" "main-estimate-financial-eligibility-uat" {
 }
 
 resource "aws_route53_record" "merge-errors-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "merge-errors-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -239,7 +247,7 @@ resource "aws_route53_record" "merge-errors-estimate-financial-eligibility-uat" 
 }
 
 resource "aws_route53_record" "npm-and-yarn-esbuild-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "npm-and-yarn-esbuild-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -247,7 +255,7 @@ resource "aws_route53_record" "npm-and-yarn-esbuild-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "print-results-screen-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "print-results-screen-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -255,7 +263,7 @@ resource "aws_route53_record" "print-results-screen-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "refactor-proceeding-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "refactor-proceeding-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -263,7 +271,7 @@ resource "aws_route53_record" "refactor-proceeding-estimate-financial-eligibilit
 }
 
 resource "aws_route53_record" "remove-commented-out-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "remove-commented-out-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"
@@ -271,7 +279,7 @@ resource "aws_route53_record" "remove-commented-out-estimate-financial-eligibili
 }
 
 resource "aws_route53_record" "step-sections-spike-estimate-financial-eligibility-uat" {
-  zone_id = aws_route53_zone.route53_zone.zone_id
+  zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "step-sections-spike-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
   type    = "TXT"
   ttl     = "300"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-uat/resources/route53-efe.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-uat/resources/route53-efe.tf
@@ -1,0 +1,279 @@
+resource "aws_route53_record" "bundler-debug-1-6-3-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "bundler-debug-1-6-3-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=jJPStTQR2npOsMHwgcUaOqkQrYzIR4NDndwbdC1uiao"]
+}
+
+resource "aws_route53_record" "bundler-faraday-2-6-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "bundler-faraday-2-6-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=5Xz0Xiv_5V7QroVfmJ_iM8pAumvrd54eiAs-i9Rx3GQ"]
+}
+
+resource "aws_route53_record" "bundler-rspec-3-12-0-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "bundler-rspec-3-12-0-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=BBKL0gC8Yu2iho_k8rJENQZsLIgJrt3lUQrmuAxr1Ro"]
+}
+
+resource "aws_route53_record" "bundler-rubocop-govu-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "bundler-rubocop-govu-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=pkrB3tkU8QXv1SpVvM-_oVz8EWvgZOa-DZiyo0gR2NU"]
+}
+
+resource "aws_route53_record" "el-334-start-page-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-334-start-page-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=8uB_b7gNFZ9VfvI5UqKCOIiIWYez4fRN13dqIKxXtWE"]
+}
+
+resource "aws_route53_record" "el-336-add-analytics-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-336-add-analytics-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=xR8JSKmPAJkC5sPOsoaS3vWibycy0PHUD5Lgt4aKSQo"]
+}
+
+resource "aws_route53_record" "el-358-update-income-page-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-358-update-income-page-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=dXf5cipK0oHxeVy5jmxjFgzqABiehYUehGbDRVJGa8Y"]
+}
+
+resource "aws_route53_record" "el-363-initial-brnac-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-363-initial-brnac-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=1dN1jHi7fzbYR5MiPPu5eF85xlzInu0wRBfcH-gQOVI"]
+}
+
+resource "aws_route53_record" "el-377-money-input-f-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-377-money-input-f-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=LPiyd3z-putLroTFF01Ya7T82mefrJfbywIHoVLuO8U"]
+}
+
+resource "aws_route53_record" "el-386-axe-checks-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-386-axe-checks-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=w0-Qf-nHHZxedXea4oUTez0BNZDv1WWCkESZ_KMPTns"]
+}
+
+resource "aws_route53_record" "el-386-other-income-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-386-other-income-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=EY5D412xeIZ8ZdNAdgfodOZDogV6wh45KusBodW-QQo"]
+}
+
+resource "aws_route53_record" "el-387-phase-banner-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-387-phase-banner-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=weXHcppR1EOz2qsuAkbGD2GG8fMtaQGQIdk-cSDbrU8"]
+}
+
+resource "aws_route53_record" "el-411-benefits-chec-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-411-benefits-chec-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=mhBmKQqbfDdeT3JhmZHmW-HGDt-wMUbMOzYyqzhwb7c"]
+}
+
+resource "aws_route53_record" "el-413-use-redis-ses-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-413-use-redis-ses-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=xlkwc8KgTIT4DJtYsJkit4x0_PTmJ8ZukWNcEJiJueE"]
+}
+
+resource "aws_route53_record" "el-416-check-outgoin-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-416-check-outgoin-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=2bsdgngFNMSyc9AZcn9uekhVcQR38xf-pPveXrB7V2Y"]
+}
+
+resource "aws_route53_record" "el-417-remove-asset-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-417-remove-asset-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=2xjOkdqcBiGdyywyl9bORa6gKREJY_nx4LG7MIWHQ90"]
+}
+
+resource "aws_route53_record" "el-418-update-vehicl-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-418-update-vehicl-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=o2f3AXHmnw-lfwRFlH6FsZki2c_9rtesSAzQXvX3Fqc"]
+}
+
+resource "aws_route53_record" "el-420-remove-partne-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-420-remove-partne-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=0S8iBUErzP4pAvTXh6cARVf9khOcs-EWsYtfZha38bE"]
+}
+
+resource "aws_route53_record" "el-427-results-panel-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-427-results-panel-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=Fb6wpRx4PsgUzcr7--CUzWRqnSQvjS9imC_q6szt2uM"]
+}
+
+resource "aws_route53_record" "el-429-property-smod-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-429-property-smod-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=BDvTM5fUvuGzHk4scybpsRhioZqLMgRvI8oepwntYJk"]
+}
+
+resource "aws_route53_record" "el-430-smod-vehicles-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-430-smod-vehicles-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=2Nzsk8PPt8EgGKHNwl9-CLqD27CbzwQFspRwdqmU5WU"]
+}
+
+resource "aws_route53_record" "el-431-assets-smod-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-431-assets-smod-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=gGXFqVkDwGbxUyjWzgaWQvVR4YXDhTrMW2MBo8xVwdw"]
+}
+
+resource "aws_route53_record" "el-433-smod-results-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-433-smod-results-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=B0pIS0ly615jgPN7PVy8sSXNSE95se-RJHo1IvTLroQ"]
+}
+
+resource "aws_route53_record" "el-434-do-not-index-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el-434-do-not-index-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=N6sW7Cu3sGqEmf_XQ9y4PQVMLDQnVNLdswB8QIaYB-A"]
+}
+
+resource "aws_route53_record" "el356-simple-check-a-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el356-simple-check-a-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=Qa74PB4qPu9aqUO-gTHmaGAadbR3g8COBVkGqGt1DSM"]
+}
+
+resource "aws_route53_record" "el361-vehicle-screens-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "el361-vehicle-screens-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=UZW-W9c3p6RD4oNJRc8vik_o1x_jQugAGe1rhou_hdI"]
+}
+
+resource "aws_route53_record" "estimate-financial-eligibility-staging" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "estimate-financial-eligibility-staging.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["	google-site-verification=9XlFxs80ciBCucw8U8GnSmnkW1dziYbgCNHU1eH5Jp4"]
+}
+
+resource "aws_route53_record" "income-section-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "income-section-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=PRCs_klu-xkHlQ0y3du1j_aChK6_EOFF5WYOjO7J_f8"]
+}
+
+resource "aws_route53_record" "main-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "main-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["	google-site-verification=WPFbWB8QIay_465TBCXx0CM6bU91H0U6joHv6IPkcJY"]
+}
+
+resource "aws_route53_record" "merge-errors-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "merge-errors-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=UFD7WLFGjy4SmccH94liRr2atOkcpMYW1obIvwYCatU"]
+}
+
+resource "aws_route53_record" "npm-and-yarn-esbuild-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "npm-and-yarn-esbuild-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=-pSTg3aQYg9HnSjHV2MszLQCjmjKPtdbpTuPi9NxEVQ"]
+}
+
+resource "aws_route53_record" "print-results-screen-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "print-results-screen-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=OrORNyIkBqkqRmcoeoWGZFZC9ph9uqgkLCs4BnDDPDo"]
+}
+
+resource "aws_route53_record" "refactor-proceeding-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "refactor-proceeding-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=GgoepgipRuxuDNDcj2cKRUts8HPHnqrrlmEr_GO0Hz8"]
+}
+
+resource "aws_route53_record" "remove-commented-out-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "remove-commented-out-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=5Gh1c19XmDx3ek_r0DQgMAAp5ySU2t_vljlqZXSzNXM"]
+}
+
+resource "aws_route53_record" "step-sections-spike-estimate-financial-eligibility-uat" {
+  zone_id = aws_route53_zone.route53_zone.zone_id
+  name    = "step-sections-spike-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=UZBh2CJgaGcPnLvG6nmGDUjKVumSVmpZHaFcPIxUGgI"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-uat/resources/route53-efe.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-uat/resources/route53-efe.tf
@@ -186,10 +186,6 @@ resource "aws_route53_record" "el-433-smod-results-estimate-financial-eligibilit
   records = ["google-site-verification=B0pIS0ly615jgPN7PVy8sSXNSE95se-RJHo1IvTLroQ"]
 }
 
-data "aws_route53_zone" "cloud_platform" {
-  name = "cloud-platform.service.justice.gov.uk"
-}
-
 resource "aws_route53_record" "el-434-do-not-index-estimate-financial-eligibility-uat" {
   zone_id = data.aws_route53_zone.cloud_platform.zone_id
   name    = "el-434-do-not-index-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"


### PR DESCRIPTION
We accidentally allowed Google to index every page on ephemeral UAT branch we've created so far. We need to verify a bunch of UAT subdomains on Google in order to ask them to _un_-index them now. 