### PR TITLE
PI-377 Separate SQS statements to fit within allowed limit of 7

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/iam.tf
@@ -22,16 +22,27 @@ data "aws_iam_policy_document" "sqs_queue_policy_document" {
     resources = ["*"]
   }
   statement {
-    sid    = "QueueManagement"
+    sid    = "QueueManagementRead"
     effect = "Allow"
     actions = [
-      "sqs:ChangeMessageVisibility",
-      "sqs:DeleteMessage",
       "sqs:GetQueueAttributes",
       "sqs:GetQueueUrl",
       "sqs:ListDeadLetterSourceQueues",
       "sqs:ListQueueTags",
       "sqs:ListQueues",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.console_role.arn]
+    }
+    resources = ["*"]
+  }
+  statement {
+    sid    = "QueueManagementWrite"
+    effect = "Allow"
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
       "sqs:PurgeQueue",
       "sqs:ReceiveMessage",
       "sqs:SendMessage",
@@ -46,16 +57,23 @@ data "aws_iam_policy_document" "sqs_queue_policy_document" {
 
 data "aws_iam_policy_document" "sqs_console_role_policy_document" {
   statement {
-    sid    = "SQS"
+    sid    = "QueueManagementRead"
     effect = "Allow"
     actions = [
-      "sqs:ChangeMessageVisibility",
-      "sqs:DeleteMessage",
       "sqs:GetQueueAttributes",
       "sqs:GetQueueUrl",
       "sqs:ListDeadLetterSourceQueues",
       "sqs:ListQueueTags",
       "sqs:ListQueues",
+    ]
+    resources = local.managed_sqs_queues
+  }
+  statement {
+    sid    = "QueueManagementWrite"
+    effect = "Allow"
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
       "sqs:PurgeQueue",
       "sqs:ReceiveMessage",
       "sqs:SendMessage",


### PR DESCRIPTION
Fixes:
> Error: error setting SQS Queue Policy (https://sqs.eu-west-2.amazonaws.com/754256621582/probation-integration-dev-prison-case-notes-to-probation-queue): OverLimit: 10 actions were found in a statement from the submitted policy, max allowed is 7