### PR TITLE
Remove username from Redis URL string

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
@@ -30,7 +30,7 @@ resource "kubernetes_secret" "cccd_elasticache_redis" {
     primary_endpoint_address = module.cccd_elasticache_redis.primary_endpoint_address
     auth_token               = module.cccd_elasticache_redis.auth_token
     member_clusters          = jsonencode(module.cccd_elasticache_redis.member_clusters)
-    url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
+    url                      = "rediss://${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }
 }
 


### PR DESCRIPTION
The latest update to the redis gem in CCCD requires that the username does not appear in `REDIS_URL`. We are testing this first on the dev-lgfs environment before making the same change in other environments.