### PR TITLE
Update RDS for prison visit

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/rds-prison-visits.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/rds-prison-visits.tf
@@ -32,10 +32,13 @@ module "prison-visits-rds" {
   environment-name       = "production"
   infrastructure-support = "pvb-technical-support@digital.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "12.8"
+  db_engine_version      = "12.11"
   db_name                = "visits"
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
   rds_family             = "postgres12"
+
+  # use "allow_major_version_upgrade" when upgrading the major version of an engine
+  allow_minor_version_upgrade = "false"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
This is to update the engine version to 12.11, which got auto-applied during the maintenance window.

This will also fix the pipeline failure