### PR TITLE
Update template to switch to v1 ingress controller

### DIFF
--- a/namespace-resources-cli-template/resources/prototype/github-repo.tf
+++ b/namespace-resources-cli-template/resources/prototype/github-repo.tf
@@ -1,9 +1,0 @@
-
-# This module creates files to build docker image and 
-# continuous deployment (CD) workflow in prototype github repo.
-
-module "github-prototype" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-github-prototype?ref=0.1.1"
-
-  namespace = var.namespace
-}

--- a/namespace-resources-cli-template/resources/prototype/templates/kubernetes-deploy.tpl
+++ b/namespace-resources-cli-template/resources/prototype/templates/kubernetes-deploy.tpl
@@ -48,10 +48,10 @@ kind: Ingress
 metadata:
   name: prototype-ingress-${BRANCH}
   annotations:
-    kubernetes.io/ingress.class: nginx
     external-dns.alpha.kubernetes.io/set-identifier: prototype-ingress-${BRANCH}-${KUBE_NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
+  ingressClassName: default
   tls:
   - hosts:
     - ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
This PR:
- Update the prototype template to use the v1 ingress controllers
- Remove the github-repo.tf which is no longer used by the Cloud Platform CLI