### PR TITLE
Create GitHub env secrets prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/serviceaccount.tf
@@ -12,6 +12,11 @@ module "serviceaccount" {
   # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets
   github_environments = ["prod"]
 
+  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
+  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
+  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+
 serviceaccount_rules = [
     {
       api_groups = [""]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/serviceaccount.tf
@@ -8,6 +8,10 @@ module "serviceaccount" {
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["hale-platform"]
 
+  # list of github environments, to create the service account secrets as environment secrets
+  # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets
+  github_environments = ["prod"]
+
 serviceaccount_rules = [
     {
       api_groups = [""]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/variables.tf
@@ -58,3 +58,23 @@ variable "github_token" {
   description = "Required by the Github Terraform provider"
   default     = ""
 }
+
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the kubernetes cluster name"
+  default     = "KUBE_CLUSTER_PROD"
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  default     = "KUBE_NAMESPACE_PROD"
+}
+
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  default     = "KUBE_CERT_PROD"
+}
+
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  default     = "KUBE_TOKEN_PROD"
+}


### PR DESCRIPTION
We use GitActions to deploy to our environments. The standard CloudPlatforms configuration for service accounts creates repository secrets that are not specific to environment. This change should allow for secrets to be generated into a specific GitAction environment (production in this instance). 