### PR TITLE
fix(prototype): ignore changes in the terraform module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/github-repo.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/github-repo.tf
@@ -1,9 +1,11 @@
 
-# This module creates files to build docker image and 
+# This module creates files to build docker image and
 # continuous deployment (CD) workflow in prototype github repo.
 
 module "github-prototype" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-github-prototype?ref=0.1.1"
+
+  prototype_create_deployment_file = false
 
   namespace = var.namespace
 }


### PR DESCRIPTION
there is now a new function to create prototypes that ignores the prototype module, this is causing conflict when trying to change manually. https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html#2-create-your-prototype-kit-environment
