### PR TITLE
Rework slowness alerts to be relative

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/10-alerts.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/10-alerts.yaml
@@ -50,3 +50,17 @@ spec:
       for: 3m
       labels:
         severity: hmpps-interventions-prod
+    - alert: SlownessOutage
+      annotations:
+        message: For 3 minutes, more than 10% of requests were slower than 10 seconds.
+        runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/IC/pages/3386179786/Recovery+scenarios#AlertManager-says-Refer-and-monitor-slow-responses
+      expr: |-
+        (
+           sum(increase(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace="hmpps-interventions-prod", exported_service="hmpps-interventions-ui", le="+Inf"}[1m]))
+          -sum(increase(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace="hmpps-interventions-prod", exported_service="hmpps-interventions-ui", le="10"}[1m]))
+        ) / (
+          sum(increase(nginx_ingress_controller_requests{exported_namespace="hmpps-interventions-prod", exported_service="hmpps-interventions-ui"}[1m]))
+        ) > 0.10
+      for: 3m
+      labels:
+        severity: hmpps-interventions-prod

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/10-alerts.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/10-alerts.yaml
@@ -38,11 +38,15 @@ spec:
         severity: hmpps-interventions-prod
     - alert: SlowResponses
       annotations:
-        message: Refer and monitor slow responses
+        message: For 3 minutes, more than 1% of requests were slower than 10 seconds.
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/IC/pages/3386179786/Recovery+scenarios#AlertManager-says-Refer-and-monitor-slow-responses
       expr: |-
-        (sum(60*rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace="hmpps-interventions-prod", exported_service="hmpps-interventions-ui", le="+Inf"}[1m]))
-        -sum(60*rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace="hmpps-interventions-prod", exported_service="hmpps-interventions-ui", le="10"}[1m]))) >= 10
+        (
+           sum(increase(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace="hmpps-interventions-prod", exported_service="hmpps-interventions-ui", le="+Inf"}[1m]))
+          -sum(increase(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace="hmpps-interventions-prod", exported_service="hmpps-interventions-ui", le="10"}[1m]))
+        ) / (
+          sum(increase(nginx_ingress_controller_requests{exported_namespace="hmpps-interventions-prod", exported_service="hmpps-interventions-ui"}[1m]))
+        ) > 0.01
       for: 3m
       labels:
         severity: hmpps-interventions-prod


### PR DESCRIPTION
[Alert on the relative volume of slowness, not fixed count](https://github.com/ministryofjustice/cloud-platform-environments/commit/ea8b95ca4e55489a212244a9a882815bbc35b02a) 

`SlowResponses` will now alert if more than 1% of requests are slow, rather than "at least 10 requests were slow".
This works better in high-traffic scenarios where some requests are inevitably slow.

| Before | After |
|---|---|
|  <img width="1760" alt="image" src="https://user-images.githubusercontent.com/1526295/201092752-48fa7dca-5a8c-4ab2-9afb-61453c82a218.png"> | <img width="1760" alt="image" src="https://user-images.githubusercontent.com/1526295/201092555-3df0a139-97b1-4ac9-8162-4eddc5544fa5.png"> |

[Add an alert for extreme slowness](https://github.com/ministryofjustice/cloud-platform-environments/commit/962343d7678b1e8fdfc15629b0e24c8cb47dc8ee) 

Adds an alert if more than 10% of our requests are in the "10-+Inf" bucket.

[~~Introduce higher priority severity~~](https://github.com/ministryofjustice/cloud-platform-environments/commit/b9929cdec5eb90241d21208ce697ce45fd9e6c5c)

~~To go directly to the primary `#interventions` channel for immediate action.~~

The new severity has been removed to allow this to go out.