### PR TITLE
Remove the alerts for an sqs queue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/11-prometheus-sqs-sns.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/11-prometheus-sqs-sns.yaml
@@ -25,6 +25,7 @@ spec:
           queue_name!="Digital-Prison-Services-dev-cfo_queue",
           queue_name!="Digital-Prison-Services-dev-in_cell_hmpps_queue",
           queue_name!="Digital-Prison-Services-dev-dps_smoketest_dev_hmpps_queue",
+          queue_name!="Digital-Prison-Services-dev-data_engineering_hackathon",
           queue_name=~"Digital-Prison-Services-dev.*",
           queue_name!~"Digital-Prison-Services-dev-.*_dl.*|dps-dev-.*_dl.*"
         } offset 1m) by (queue_name) > 2 * 60


### PR DESCRIPTION
Hi, I want to remove the alerts for a queue which has been created for a hackathon we are doing so I don't have to keep purging the queue before I get the data consuming working