### PR TITLE
NN-4479: temporarily bump keyworker-api-preprod/rds to db.t3.large

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
@@ -1,14 +1,17 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.13"
-  vpc_name               = var.vpc_name
-  team_name              = var.team_name
-  business-unit          = var.business-unit
-  application            = var.application
-  is-production          = var.is-production
-  namespace              = var.namespace
-  environment-name       = var.environment-name
-  infrastructure-support = var.infrastructure-support
-
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.13"
+  vpc_name                    = var.vpc_name
+  team_name                   = var.team_name
+  business-unit               = var.business-unit
+  application                 = var.application
+  is-production               = var.is-production
+  namespace                   = var.namespace
+  environment-name            = var.environment-name
+  infrastructure-support      = var.infrastructure-support
+  allow_major_version_upgrade = "false"
+  db_instance_class           = "db.t3.large"
+  db_engine_version           = "10"
+  rds_family                  = "postgres10"
 
   providers = {
     aws = aws.london
@@ -48,4 +51,3 @@ resource "kubernetes_secret" "dps_rds_refresh_creds" {
     rds_instance_address  = module.dps_rds.rds_instance_address
   }
 }
-


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/NN-4479

Same as https://github.com/ministryofjustice/cloud-platform-environments/pull/9247