### PR TITLE
Tag AWS resources with GitHub team name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/main.tf
@@ -5,16 +5,34 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+    
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+    
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "github" {


### PR DESCRIPTION
This PR adds tags to the AWS resources within `cjs-dashboard-development` so we can view them in the AWS console.