### PR TITLE
Add username to Redis URL string

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
@@ -30,7 +30,7 @@ resource "kubernetes_secret" "cccd_elasticache_redis" {
     primary_endpoint_address = module.cccd_elasticache_redis.primary_endpoint_address
     auth_token               = module.cccd_elasticache_redis.auth_token
     member_clusters          = jsonencode(module.cccd_elasticache_redis.member_clusters)
-    url                      = "rediss://${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
+    url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }
 }
 


### PR DESCRIPTION
The username is removed from the Redis URL string in a previous commit (#9098) for testing a newer version of the `redis` gem in CCCD. We are not yet ready to update this gem yet so the username needs to be added back in.