### PR TITLE
🗃 PIC-2591: Populate court-case-service preprod with prod snapshot

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
@@ -18,7 +18,9 @@ module "court_case_service_rds" {
   db_engine_version           = "13"
   db_instance_class           = "db.t3.small"
   rds_family                  = "postgres13"
-
+  
+  snapshot_identifier         = "court-case-service-manual-snapshot-1669738195"
+  db_allocated_storage        = 38
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
This is to allow testing of a complex migration on real data before pushing the change to prod. 