### PR TITLE
Update Postgres to 14 from 13 for cas-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
@@ -9,10 +9,10 @@ module "rds" {
   infrastructure-support       = var.infrastructure_support
   namespace                    = var.namespace
   performance_insights_enabled = true
-  db_engine_version            = "13"
+  db_engine_version            = "14"
   db_instance_class            = "db.t3.small"
-  rds_family                   = "postgres13"
-  allow_major_version_upgrade  = "false"
+  rds_family                   = "postgres14"
+  allow_major_version_upgrade  = "true"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
When creating pre-prod and prod environments we'd like parity. If we can use 14 with little effort then we should try to do so to avoid a bigger migration effort in the future.

This should upgrade in place and not lose any database state.