### PR TITLE
Form Builder - remove old datastore DB from test-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/user-datastore.tf
@@ -1,33 +1,3 @@
-module "user-datastore-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.13"
-
-  vpc_name                   = var.vpc_name
-  db_backup_retention_period = var.db_backup_retention_period_user_datastore
-  application                = "formbuilderuserdatastore"
-  environment-name           = var.environment-name
-  is-production              = var.is-production
-  namespace                  = var.namespace
-  infrastructure-support     = var.infrastructure-support
-  team_name                  = var.team_name
-  db_engine_version          = "10"
-
-  providers = {
-    aws = aws.london
-  }
-}
-
-resource "kubernetes_secret" "user-datastore-rds-instance" {
-  metadata {
-    name      = "rds-instance-formbuilder-user-datastore-${var.environment-name}"
-    namespace = "formbuilder-platform-${var.environment-name}"
-  }
-
-  data = {
-    # postgres://USER:PASSWORD@HOST:PORT/NAME
-    url = "postgres://${module.user-datastore-rds-instance.database_username}:${module.user-datastore-rds-instance.database_password}@${module.user-datastore-rds-instance.rds_instance_endpoint}/${module.user-datastore-rds-instance.database_name}"
-  }
-}
-
 module "user-datastore-rds-instance-2" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.13"
 


### PR DESCRIPTION
This removes the old DB from formbuilder-platform-test-production as we are now fully using the new DB.