### PR TITLE
Adding rds auto-stop-start for daso dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domestic-abuse-support-officers-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domestic-abuse-support-officers-dev/resources/rds.tf
@@ -37,6 +37,8 @@ module "rds" {
   # Pick the one that defines the mariadb version the best
   rds_family = "mariadb10.5"
 
+  enable_rds_auto_start_stop = true
+  
   # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".
   # db_parameter = [


### PR DESCRIPTION
The RDS instance in this environment is a dev instance and so we should be using any auto-stop/start feature