### PR TITLE
Adding RDS auto start stop for VCMS dev db

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-victim-case-management-system-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-victim-case-management-system-dev/resources/rds.tf
@@ -52,6 +52,9 @@ module "rds" {
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "false"
 
+  # Turn on auto_start_stop to reduce cost
+  enable_rds_auto_start_stop = true
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london


### PR DESCRIPTION
Reducing cost by allowing auto stop/start for this VCMS dev DB.