### PR TITLE
Rename GitHub Actions secrets for CJS dev environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/ecr.tf
@@ -9,6 +9,10 @@ module "ecr_credentials" {
   team_name           = var.team_name
   repo_name           = "${var.namespace}-ecr"
   github_repositories = ["cjs_scorecard_exploratory_analysis"]
+  github_actions_secret_ecr_name       = var.github_actions_secret_ecr_name
+  github_actions_secret_ecr_url        = var.github_actions_secret_ecr_url
+  github_actions_secret_ecr_access_key = var.github_actions_secret_ecr_access_key
+  github_actions_secret_ecr_secret_key = var.github_actions_secret_ecr_secret_key
 }
 
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/serviceaccount.tf
@@ -3,6 +3,10 @@ module "serviceaccount" {
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
+  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
+  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/variables.tf
@@ -58,3 +58,43 @@ variable "github_token" {
   description = "Required by the Github Terraform provider"
   default     = ""
 }
+
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the kubernetes cluster name"
+  default     = "KUBE_CLUSTER_DEV"
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  default     = "KUBE_NAMESPACE_DEV"
+}
+
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  default     = "KUBE_CERT_DEV"
+}
+
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  default     = "KUBE_TOKEN_DEV"
+}
+
+variable "github_actions_secret_ecr_name" {
+  description = "The name of the github actions secret containing the ECR name"
+  default     = "ECR_NAME_DEV"
+}
+
+variable "github_actions_secret_ecr_url" {
+  description = "The name of the github actions secret containing the ECR URL"
+  default     = "ECR_URL_DEV"
+}
+
+variable "github_actions_secret_ecr_access_key" {
+  description = "The name of the github actions secret containing the ECR AWS access key"
+  default     = "ECR_AWS_ACCESS_KEY_ID_DEV"
+}
+
+variable "github_actions_secret_ecr_secret_key" {
+  description = "The name of the github actions secret containing the ECR AWS secret key"
+  default     = "ECR_AWS_SECRET_ACCESS_KEY_DEV"
+}


### PR DESCRIPTION
Rename secrets used by GitHub Actions to clarify that these are for the development environment.