### PR TITLE
Prisoner content hub production - Output S3 bucket name to dev and staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3.tf
@@ -92,3 +92,26 @@ resource "kubernetes_secret" "drupal_content_storage_secret" {
     bucket_name       = module.drupal_content_storage.bucket_name
   }
 }
+
+# Output S3 bucket info to staging and development namespaces, to facilitate automated file syncing.
+# NOTE: We only share the bucket name.  We never share access keys.
+resource "kubernetes_secret" "drupal_content_storage_output_staging" {
+  metadata {
+    name      = "drupal-s3-output"
+    namespace = "prisoner-content-hub-staging"
+  }
+
+  data = {
+    bucket_name = module.drupal_content_storage.bucket_name
+  }
+}
+resource "kubernetes_secret" "drupal_content_storage_output_development" {
+  metadata {
+    name      = "drupal-s3-output"
+    namespace = "prisoner-content-hub-development"
+  }
+
+  data = {
+    bucket_name = module.drupal_content_storage.bucket_name
+  }
+}


### PR DESCRIPTION
Output the S3 bucket name as a k8ns secret, to the staging and development namespaces.

This is to facilitate automated file syncing.  I.e. development and staging will have cronjobs that run `aws s3 sync` to copy files down from prod.

Note that only the bucket name is shared, and not the access key.

See https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/482 for the PR to add the cronjob.