### PR TITLE
SDI-488 upping the visibility timeout on the events queue as processi…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-prisoner-nomis-update.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-prisoner-nomis-update.tf
@@ -10,6 +10,7 @@ module "hmpps_prisoner_to_nomis_queue" {
   sqs_name                  = "hmpps_prisoner_to_nomis_queue"
   encrypt_sqs_kms           = "true"
   message_retention_seconds = 1209600
+  visibility_timeout_seconds = 120
   namespace                 = var.namespace
 
   redrive_policy = <<EOF


### PR DESCRIPTION
…ng can exceed the default of 30 seconds - prod environment