### PR TITLE
INC-958: Unsubscribe from `.prisoner.updated` domain events (DEV)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-incentives.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-incentives.tf
@@ -115,5 +115,5 @@ resource "aws_sns_topic_subscription" "hmpps_incentives_subscription" {
   topic_arn     = module.hmpps-domain-events.topic_arn
   protocol      = "sqs"
   endpoint      = module.hmpps_incentives_queue.sqs_arn
-  filter_policy = "{\"eventType\":[\"prison-offender-events.prisoner.merged\", \"prisoner-offender-search.prisoner.received\", \"prisoner-offender-search.prisoner.updated\", \"prisoner-offender-search.prisoner.alerts-updated\"]}"
+  filter_policy = "{\"eventType\":[\"prison-offender-events.prisoner.merged\", \"prisoner-offender-search.prisoner.received\", \"prisoner-offender-search.prisoner.alerts-updated\"]}"
 }


### PR DESCRIPTION
The `incentives-api` service now uses the newer/more specific `prisoner-offender-search.prisoner.alerts-updated` domain events so as soon as the code to process those newer events is deployed we can unsubscribe from the older events.