### PR TITLE
Bump new namespaces terraform-aws-provider to ~> 4.27.0

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     github = {
       source = "integrations/github"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-preprod/resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     github = {
       source = "integrations/github"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     github = {
       source = "integrations/github"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-contacts-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-contacts-preprod/resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-contacts-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-contacts-prod/resources/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-prod/resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     github = {
       source = "integrations/github"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-staging/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-staging/resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     github = {
       source = "integrations/github"


### PR DESCRIPTION
These are all new namespaces set up in the past couple of days, so bumps their provider to match everyone elses.