### PR TITLE
Remove deprecated interpolation

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/iam.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "bt_upload_policy" {
     actions = ["s3:*"]
 
     resources = [
-      "${module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn}",
+      module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn,
       "${module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn}/*"
     ]
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/s3.tf
@@ -112,12 +112,12 @@ resource "aws_s3_bucket_policy" "hmpps_pin_phone_monitor_s3_ip_deny_policy" {
               "35.176.93.186/32"
             ]
           },
-          "Bool" : { "aws:ViaAWSService" : "false" },
-          "StringNotEquals" : {
-            "aws:PrincipalArn" : [
-              "${aws_iam_role.translate_s3_data_role.arn}",
-              "${aws_iam_role.transcribe_s3_data_role.arn}",
-              "${aws_iam_user.bt_upload_user.arn}"
+          "Bool" = { "aws:ViaAWSService" : "false" },
+          "StringNotEquals" = {
+            "aws:PrincipalArn" = [
+              aws_iam_role.translate_s3_data_role.arn,
+              aws_iam_role.transcribe_s3_data_role.arn,
+              aws_iam_user.bt_upload_user.arn
             ]
           }
         }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/iam.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "bt_upload_policy" {
     actions = ["s3:*"]
 
     resources = [
-      "${module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn}",
+      module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn,
       "${module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn}/*"
     ]
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/s3.tf
@@ -128,12 +128,12 @@ resource "aws_s3_bucket_policy" "hmpps_pin_phone_monitor_s3_ip_deny_policy" {
               "194.33.249.0/24"
             ]
           },
-          "Bool" : { "aws:ViaAWSService" : "false" },
-          "StringNotEquals" : {
-            "aws:PrincipalArn" : [
-              "${aws_iam_role.translate_s3_data_role.arn}",
-              "${aws_iam_role.transcribe_s3_data_role.arn}",
-              "${aws_iam_user.bt_upload_user.arn}"
+          "Bool" = { "aws:ViaAWSService" : "false" },
+          "StringNotEquals" = {
+            "aws:PrincipalArn" = [
+              aws_iam_role.translate_s3_data_role.arn,
+              aws_iam_role.transcribe_s3_data_role.arn,
+              aws_iam_user.bt_upload_user.arn
             ]
           }
         }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/iam.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "bt_upload_policy" {
     actions = ["s3:*"]
 
     resources = [
-      "${module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn}",
+      module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn,
       "${module.hmpps_pin_phone_monitor_document_s3_bucket.bucket_arn}/*"
     ]
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/s3.tf
@@ -111,11 +111,11 @@ resource "aws_s3_bucket_policy" "hmpps_pin_phone_monitor_s3_ip_deny_policy" {
             ]
           },
           "Bool" : { "aws:ViaAWSService" : "false" },
-          "StringNotEquals" : {
-            "aws:PrincipalArn" : [
-              "${aws_iam_role.translate_s3_data_role.arn}",
-              "${aws_iam_role.transcribe_s3_data_role.arn}",
-              "${aws_iam_user.bt_upload_user.arn}"
+          "StringNotEquals" = {
+            "aws:PrincipalArn" = [
+              aws_iam_role.translate_s3_data_role.arn,
+              aws_iam_role.transcribe_s3_data_role.arn,
+              aws_iam_user.bt_upload_user.arn
             ]
           }
         }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-webops-poc/resources/s3.tf
@@ -149,7 +149,7 @@ EOF
 
 */
 
-  user_policy = "${data.aws_iam_policy_document.bucket_user_policy.json}"
+  user_policy = data.aws_iam_policy_document.bucket_user_policy.json
 
 }
 
@@ -163,7 +163,7 @@ data "aws_iam_policy_document" "bucket_user_policy" {
       "s3:ListBucketMultipartUploads"
     ]
 
-    resources = ["${module.s3_bucket.bucket_arn}"]
+    resources = [module.s3_bucket.bucket_arn]
 
   }
   statement {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "manage_soc_cases_dev_rds_to_s3_export_policy" {
     ]
 
     resources = [
-      "${module.manage_soc_cases_rds_to_s3_bucket.bucket_arn}",
+      module.manage_soc_cases_rds_to_s3_bucket.bucket_arn,
       "${module.manage_soc_cases_rds_to_s3_bucket.bucket_arn}/*",
       "arn:aws:s3:::mojap-land/hmpps/manage_soc_cases/",
       "arn:aws:s3:::mojap-land/hmpps/manage_soc_cases/*"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/rds.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "manage_soc_cases_preprod_rds_to_s3_export_policy
     ]
 
     resources = [
-      "${module.manage_soc_cases_rds_to_s3_bucket.bucket_arn}",
+      module.manage_soc_cases_rds_to_s3_bucket.bucket_arn,
       "${module.manage_soc_cases_rds_to_s3_bucket.bucket_arn}/*",
       "arn:aws:s3:::mojap-land/hmpps/manage_soc_cases/",
       "arn:aws:s3:::mojap-land/hmpps/manage_soc_cases/*"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/rds.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "manage_soc_cases_prod_rds_to_s3_export_policy" {
     ]
 
     resources = [
-      "${module.manage_soc_cases_rds_to_s3_bucket.bucket_arn}",
+      module.manage_soc_cases_rds_to_s3_bucket.bucket_arn,
       "${module.manage_soc_cases_rds_to_s3_bucket.bucket_arn}/*",
       "arn:aws:s3:::mojap-land/hmpps/manage_soc_cases/",
       "arn:aws:s3:::mojap-land/hmpps/manage_soc_cases/*"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/athena-iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/athena-iam.tf
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "athena" {
     ]
 
     resources = [
-      "${aws_athena_workgroup.queries.arn}",
+      aws_athena_workgroup.queries.arn,
       "${aws_athena_workgroup.queries.arn}/*",
       "arn:aws:athena:eu-west-2:*:datacatalog/AwsDataCatalog",
       "arn:aws:glue:eu-west-2:*:catalog",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
     ]
 
     resources = [
-      "${module.pathfinder_rds_to_s3_bucket.bucket_arn}",
+      module.pathfinder_rds_to_s3_bucket.bucket_arn,
       "${module.pathfinder_rds_to_s3_bucket.bucket_arn}/*",
       "arn:aws:s3:::mojap-land/hmpps/pathfinder/",
       "arn:aws:s3:::mojap-land/hmpps/pathfinder/*"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
     ]
 
     resources = [
-      "${module.pathfinder_rds_to_s3_bucket.bucket_arn}",
+      module.pathfinder_rds_to_s3_bucket.bucket_arn,
       "${module.pathfinder_rds_to_s3_bucket.bucket_arn}/*",
       "arn:aws:s3:::mojap-land/hmpps/pathfinder/",
       "arn:aws:s3:::mojap-land/hmpps/pathfinder/*"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
     ]
 
     resources = [
-      "${module.pathfinder_rds_to_s3_bucket.bucket_arn}",
+      module.pathfinder_rds_to_s3_bucket.bucket_arn,
       "${module.pathfinder_rds_to_s3_bucket.bucket_arn}/*",
       "arn:aws:s3:::mojap-land/hmpps/pathfinder/",
       "arn:aws:s3:::mojap-land/hmpps/pathfinder/*"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/athena-iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/athena-iam.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "athena" {
     ]
 
     resources = [
-      "${aws_athena_workgroup.queries.arn}",
+      aws_athena_workgroup.queries.arn,
       "${aws_athena_workgroup.queries.arn}/*",
       "arn:aws:glue:eu-west-2:*:catalog",
       "arn:aws:glue:eu-west-2:*:database/${aws_athena_database.database.id}",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/book-a-secure-move-api-iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/book-a-secure-move-api-iam.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "book-a-secure-move-api" {
     ]
 
     resources = [
-      "${aws_athena_workgroup.queries.arn}",
+      aws_athena_workgroup.queries.arn,
       "${aws_athena_workgroup.queries.arn}/*",
       "arn:aws:glue:eu-west-2:*:catalog",
       "arn:aws:glue:eu-west-2:*:database/${aws_athena_database.database.id}",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/athena-iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/athena-iam.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "athena" {
     ]
 
     resources = [
-      "${aws_athena_workgroup.queries.arn}",
+      aws_athena_workgroup.queries.arn,
       "${aws_athena_workgroup.queries.arn}/*",
       "arn:aws:glue:eu-west-2:*:catalog",
       "arn:aws:glue:eu-west-2:*:database/${aws_athena_database.database.id}",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/book-a-secure-move-api-iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/book-a-secure-move-api-iam.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "book-a-secure-move-api" {
     ]
 
     resources = [
-      "${aws_athena_workgroup.queries.arn}",
+      aws_athena_workgroup.queries.arn,
       "${aws_athena_workgroup.queries.arn}/*",
       "arn:aws:glue:eu-west-2:*:catalog",
       "arn:aws:glue:eu-west-2:*:database/${aws_athena_database.database.id}",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/athena-iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/athena-iam.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "athena" {
     ]
 
     resources = [
-      "${aws_athena_workgroup.queries.arn}",
+      aws_athena_workgroup.queries.arn,
       "${aws_athena_workgroup.queries.arn}/*",
       "arn:aws:glue:eu-west-2:*:catalog",
       "arn:aws:glue:eu-west-2:*:database/${aws_athena_database.database.id}",


### PR DESCRIPTION
This PR replaces interpolation-only strings as deprecated in [Terraform 0.12.14](https://github.com/hashicorp/terraform/releases/tag/v0.12.14):

- Interpolation-only expressions are deprecated: an expression like "${foo}" should be rewritten as just foo.

