### PR TITLE
Remove unused providers from required_versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-dev/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-preprod/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-prod/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-dev/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-preprod/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-prod/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-stage/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-stage/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-to-nomis-update-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-to-nomis-update-dev/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-to-nomis-update-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-to-nomis-update-preprod/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-to-nomis-update-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-to-nomis-update-prod/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-kotlin/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-kotlin/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    github = {
-      source = "integrations/github"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
@@ -8,9 +7,6 @@ terraform {
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
-    }
-    github = {
-      source = "integrations/github"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    github = {
-      source = "integrations/github"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    github = {
-      source = "integrations/github"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    github = {
-      source = "integrations/github"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
@@ -11,9 +10,6 @@ terraform {
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
-    }
-    random = {
-      source = "hashicorp/random"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-api-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-api-dev/resources/versions.tf
@@ -1,13 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
     }
   }
 }


### PR DESCRIPTION
This PR removes unused providers from namespace `required_versions` definitions.