### PR TITLE
Timeout investigations

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/00-namespace.yaml
@@ -4,7 +4,6 @@ metadata:
   name: hmpps-auth-preprod
   labels:
     component: "hmpps-auth-preprod"
-    component: "make-recall-decision-preprod"
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "preprod"
   annotations:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/00-namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hmpps-auth-preprod
   labels:
     component: "hmpps-auth-preprod"
+    component: "make-recall-decision-preprod"
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "preprod"
   annotations:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
       - namespaceSelector:
           matchLabels:
             component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-make-recall-decision-preprod
+  namespace: hmpps-auth-preprod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: make-recall-decision-preprod


### PR DESCRIPTION
This is to enable cross-namespace networking from Make Recall Decisions pre-prod to HMPPS Auth pre-prod in order to help determine where the problem of ECONNABORT-related timeouts to auth is.

Background:
https://mojdt.slack.com/archives/C57UPMZLY/p1669283264160949
https://dsdmoj.atlassian.net/wiki/spaces/MRD/pages/4238213353/Connection+timeouts+on+make-recall-decisions-ui