### PR TITLE
Create test environment for CAS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/00-namespace.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-community-accommodation-test
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "test"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "community-accommodation-service-tier-3-team"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
+    cloud-platform.justice.gov.uk/application: "Community Accommodation"
+    cloud-platform.justice.gov.uk/owner: "Community Accommodation: cas3@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-community-accommodation"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/01-rbac.yaml
@@ -1,0 +1,17 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-community-accommodation-test-admin
+  namespace: hmpps-community-accommodation-test
+subjects:
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-community-accommodation"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/02-limitrange.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-community-accommodation-test
+spec:
+  limits:
+    - default:
+        cpu: 2000m
+        memory: 1024Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 512Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-community-accommodation-test
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-community-accommodation-test
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-community-accommodation-test
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/05-serviceaccount-circleci.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: hmpps-community-accommodation-test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: circleci
+  namespace: hmpps-community-accommodation-test
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-community-accommodation-test
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: circleci
+  namespace: hmpps-community-accommodation-test
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+      - "servicemonitors"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - "networkpolicies"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: circleci-prometheus
+  namespace: hmpps-community-accommodation-test
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-community-accommodation-test
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/06-certificates.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-approved-premises-test-cert
+  namespace: hmpps-community-accommodation-test
+spec:
+  secretName: hmpps-approved-premises-test-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - approved-premises-test.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-temporary-accommodation-test-cert
+  namespace: hmpps-community-accommodation-test
+spec:
+  secretName: hmpps-temporary-accommodation-test-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - temporary-accommodation-test.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-approved-premises-api-test-cert
+  namespace: hmpps-community-accommodation-test
+spec:
+  secretName: hmpps-approved-premises-api-test-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - approved-premises-api-test.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/elasticache.tf
@@ -1,0 +1,36 @@
+################################################################################
+# HMPPs Typescript Template Application Elasticache
+################################################################################
+
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.5"
+  vpc_name               = var.vpc_name
+  application            = var.application
+  environment-name       = var.environment
+  is-production          = var.is_production
+  infrastructure-support = var.infrastructure_support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = "cache.t2.small"
+  engine_version         = "4.0.10"
+  parameter_group_name   = "default.redis4.0"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds.tf
@@ -1,0 +1,81 @@
+module "rds" {
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.14"
+  vpc_name                     = var.vpc_name
+  team_name                    = var.team_name
+  business-unit                = var.business_unit
+  application                  = var.application
+  is-production                = var.is_production
+  environment-name             = var.environment
+  infrastructure-support       = var.infrastructure_support
+  namespace                    = var.namespace
+  performance_insights_enabled = true
+  db_engine_version            = "14"
+  db_instance_class            = "db.t3.small"
+  rds_family                   = "postgres14"
+  allow_major_version_upgrade  = "true"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "read_replica" {
+  count  = 0
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.14"
+
+  vpc_name               = var.vpc_name
+  application            = var.application
+  environment-name       = var.environment
+  is-production          = var.is_production
+  infrastructure-support = var.infrastructure_support
+  team_name              = var.team_name
+  db_name                = null # "db_name": conflicts with replicate_source_db
+  replicate_source_db    = module.rds.db_identifier
+
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    access_key_id         = module.rds.access_key_id
+    secret_access_key     = module.rds.secret_access_key
+    url                   = "jdbc:postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+  }
+}
+
+
+resource "kubernetes_secret" "read_replica" {
+  count = 0
+
+  metadata {
+    name      = "rds-postgresql-read-replica-output"
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/variables.tf
@@ -1,0 +1,46 @@
+
+
+variable "vpc_name" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Community Accommodation"
+}
+
+variable "namespace" {
+  default = "hmpps-community-accommodation-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-community-accommodation"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "test"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "cas3@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "community-accommodation-service-tier-3-team"
+}
+
+variable "number_cache_clusters" {
+  default = "2"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/versions.tf
@@ -1,0 +1,13 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.27.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
The CAS team need an enviroment that:

- has no real data
- can be stable for fixed periods to enable penetration tests and user research without the risk of deploying new features

We can see that there's a[ convention in the bootstrap](https://github.com/ministryofjustice/dps-project-bootstrap/blob/00708d619dd9bf352e4e98a48c3635d7f9cebba3/scripts/kubectl.sh#L112) for using `dev`, `staging`, `preprod` and `prod`. We'd like to use the name 'test' because we don't intend to use the environment as a staging area. 

There look to be a few existing namespaces with this suffix, though none of these appear in the bootstrap:

- [justicedata-test](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-test)
- [laa-crime-maat-test](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test)
- [laa-crown-court-proceeding-test](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test)
- [money-to-prisoners-test](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test)

Given the bootstrap sets up a bunch of things we _hope_ we'll be able to hook the two together with the following?

```
    "k8s_namespace_stage": "hmpps-community-accommodation-test",
```

If this isn't possible to do [here](https://github.com/ministryofjustice/dps-project-bootstrap/blob/main/projects.json#L1521) then we will have to switch to using "staging", what do you think?
