### PR TITLE
Prisoner content hub development - increase memory limits

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 360m
-      memory: 1024Mi
+      cpu: 1000m
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
-      memory: 512Mi
+      memory: 1024Mi
     type: Container


### PR DESCRIPTION
Increase memory and cpu limits on development to match production.

We are seeing OOM errors related to a deployment.  We want to ensure the limit range on development matches that of production so we can test the deployment with real world settings.