### PR TITLE
Fix typo in namespace name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/variables.tf
@@ -9,7 +9,7 @@ variable "application" {
 }
 
 variable "namespace" {
-  default = "hmpps-community-accommodation-dev"
+  default = "hmpps-community-accommodation-test"
 }
 
 variable "business_unit" {


### PR DESCRIPTION
In #9571, we introduced a new namepsace, which is essentially a copy of our dev environment, during the copy over, we forgot to change the tfvar with the name of the namespace, causing the pipeline to fail. This fixes it.