### PR TITLE
Add a new certificate

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/06-certificates.yaml
@@ -37,3 +37,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - approved-premises-api-test.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-community-accommodation-wiremock-test-cert
+  namespace: hmpps-community-accommodation-test
+spec:
+  secretName: hmpps-community-accommodation-wiremock-test-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - community-accommodation-wiremock.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This is a certificate that we’ll us for our Wiremock instance in our test environment to stub out external services