### PR TITLE
LCAM-325 New S3 lifecycle rule to expire intermediate tests reports

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/resources/s3.tf
@@ -86,32 +86,21 @@ module "s3_bucket" {
   lifecycle_rule = [
     {
       enabled = true
-      id      = "retire exports after 90 days"
-      prefix  = ""
+      id      = "Expire intermediate test reports after 7 days"
+      prefix  = "TEMP_REPORTS/"
 
       noncurrent_version_expiration = [
         {
-          days = 90
+          days = 7
         },
       ]
 
       expiration = [
         {
-          days = 90
+          days = 7
         },
       ]
-    },
-    {
-      enabled = true
-      id      = "retire imports after 90 days"
-      prefix  = "surveys/imports"
-
-      expiration = [
-        {
-          days = 90
-        },
-      ]
-    },
+    }
   ]
 
 


### PR DESCRIPTION
[Link to Story on Crime Apps Modernisation Board](https://dsdmoj.atlassian.net/browse/LCAM-325)

- Removed redundant S3 lifecycle rules
- New S3 lifecycle rule that expires intermediate test reports after 7 days