### PR TITLE
Update ingress package to use networking/v1 instead of v1beta1

### DIFF
--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -3,14 +3,14 @@ package ingress
 import (
 	"context"
 
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-// GetAllIngresses takes a Kubernetes clientset and returns all ingress with type *v1beta1.IngressList and an error.
-func GetAllIngressesFromCluster(clientset *kubernetes.Clientset) (*v1beta1.IngressList, error) {
-	ingressList, err := clientset.NetworkingV1beta1().Ingresses("").List(context.TODO(), metav1.ListOptions{})
+// GetAllIngresses takes a Kubernetes clientset and returns all ingress with type *v1.IngressList and an error.
+func GetAllIngressesFromCluster(clientset *kubernetes.Clientset) (*networkingv1.IngressList, error) {
+	ingressList, err := clientset.NetworkingV1().Ingresses("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -19,7 +19,7 @@ func GetAllIngressesFromCluster(clientset *kubernetes.Clientset) (*v1beta1.Ingre
 
 // IngressWithClass gets IngressClassName looping over all ingress objects and set the IngressClass if present,
 // if not present, set as undefined
-func IngressWithClass(ingressList *v1beta1.IngressList) ([]map[string]string, error) {
+func IngressWithClass(ingressList *networkingv1.IngressList) ([]map[string]string, error) {
 	s := make([]map[string]string, 0)
 
 	for _, i := range ingressList.Items {

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -4,14 +4,14 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIngressWithClass(t *testing.T) {
 	ingressClass := "default"
 	type args struct {
-		ingressList *v1beta1.IngressList
+		ingressList *networkingv1.IngressList
 	}
 	tests := []struct {
 		name    string
@@ -22,14 +22,14 @@ func TestIngressWithClass(t *testing.T) {
 		{
 			name: "Get ingressClass default",
 			args: args{
-				ingressList: &v1beta1.IngressList{
-					Items: []v1beta1.Ingress{
+				ingressList: &networkingv1.IngressList{
+					Items: []networkingv1.Ingress{
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "namespace-1",
 								Name:      "ingress-1",
 							},
-							Spec: v1beta1.IngressSpec{
+							Spec: networkingv1.IngressSpec{
 								IngressClassName: &ingressClass,
 							},
 						},


### PR DESCRIPTION
This PR update the ingress object to use networking/V1 API instead of v1beta1. 
All clusters on CP have upgraded to v1.22 where the v1beta1 Ingress API is deprecated. The reports which uses this package fails after the upgrade. This PR will fix that.
