### PR TITLE
Introduce TFSec to cloud-platform-environments

### DIFF
--- a/.github/workflows/terraform-tools.yml
+++ b/.github/workflows/terraform-tools.yml
@@ -1,0 +1,22 @@
+name: terraform-tools
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tfsec:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aquasecurity/tfsec-sarif-action@v0.1.4
+        with:
+          tfsec_args: --force-all-dirs --no-module-downloads --soft-fail -m=HIGH -e=github-repositories-private,github-branch_protections-require_signed_commits,aws-iam-no-policy-wildcards,aws-ecr-enforce-immutable-repository,aws-rds-enable-performance-insights-encryption
+          sarif_file: tfsec.sarif
+      - uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: tfsec.sarif


### PR DESCRIPTION
This PR introduces a job to run [tfsec](https://github.com/aquasecurity/tfsec) against this repository, and then upload the SARIF output to allow the users to view issues (if any) in the [Code Scanning](https://github.com/ministryofjustice/cloud-platform-infrastructure/security/code-scanning) view of the Security tab.

The current arguments provided to `tfsec` _exclude_ modules (i.e. any cloud-platform-terraform-*) and some checks. See notes below.

tfsec is currently configured to run with the following flags:

```sh
tfsec
--force-all-dirs # will recursively run tfsec
--no-module-downloads # won't download any modules, as we should fix direct terraform resources first to reduce noise
--soft-fail # doesn't fail the check, to still allow PRs to be merged
-m=HIGH # sets the minimum severity to HIGH, to reduce noise
-e=
    github-repositories-private, # turns off GitHub check for repositories to be private, as all of our repositories should be public
    github-branch_protections-require_signed_commits, # turns off GitHub required signed commits, as it is not widely used
    aws-iam-no-policy-wildcards, # turns off IAM no policy wildcards, as this creates a lot of noise and will need dedicated time to resolve any issues
    aws-ecr-enforce-immutable-repository, # turns off enforcing immutable repositories, as it is not widely used
    aws-rds-enable-performance-insights-encryption # turns off enabling Performance Insights encryption, as this needs a module update
```

The Code scanning results will always fail if there are any new errors listed in the SARIF file, as you can't [turn off Only errors reporting](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#defining-the-severities-causing-pull-request-check-failure).