### PR TITLE
Drop TFSec minimum severity level to HIGH, ignore aws-s3-encryption-customer-key and aws-sqs-enable-queue-encryption

### DIFF
--- a/.github/workflows/terraform-tools.yml
+++ b/.github/workflows/terraform-tools.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aquasecurity/tfsec-sarif-action@v0.1.4
         with:
-          tfsec_args: --force-all-dirs --no-module-downloads --soft-fail -m=HIGH -e=github-repositories-private,github-branch_protections-require_signed_commits,aws-iam-no-policy-wildcards,aws-ecr-enforce-immutable-repository,aws-rds-enable-performance-insights-encryption
+          tfsec_args: --force-all-dirs --soft-fail -m=HIGH -e=github-repositories-private,github-branch_protections-require_signed_commits,aws-iam-no-policy-wildcards,aws-ecr-enforce-immutable-repository,aws-rds-enable-performance-insights-encryption,aws-s3-encryption-customer-key,aws-sqs-enable-queue-encryption
           sarif_file: tfsec.sarif
       - uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
This PR drops the minimum severity reporting level to `HIGH` for `TFSec`, and downloads all modules to perform that scan.

To reduce noise, this starts to ignore these two errors:
- aws-s3-encryption-customer-key
- aws-sqs-enable-queue-encryption

Once less common 'issues' are resolved, we can start reporting on more common issues.

This change (specifically downloading all modules) does increase the scan time, but shouldn't take too long (~1-3 minutes).