### PR TITLE
Remove IRSA SA from pathfinder-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/analytical-platform-access.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/analytical-platform-access.tf
@@ -1,5 +1,5 @@
 module "ap_irsa" {
-  source           = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=1.0.6"
+  source           = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=rm-sa"
   namespace        = var.namespace
   eks_cluster_name = var.eks_cluster_name
   role_policy_arns = [aws_iam_policy.ap_policy.arn]


### PR DESCRIPTION
This namespace has an `APPLY_SKIP` file so needs to be done separately.