### PR TITLE
Allow internal routing from CCQ UAT to CFE-Partner UAT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-partner-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-partner-uat/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-source-namespace
+  namespace: check-financial-eligibility-partner-uat
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: laa-estimate-financial-eligibility-for-legal-aid-uat


### PR DESCRIPTION
Enable pods in `laa-estimate-financial-eligibility-for-legal-aid-uat` namespace to make requests across network to pods in `check-financial-eligibility-partner-uat`.