### PR TITLE
Add secret rotation blocking file

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -14,6 +14,7 @@ def main(cluster)
       cluster: cluster,
       dir: dir,
       enable_skip_namespaces: true, # Honour any APPLY_PIPELINE_SKIP_THIS_NAMESPACE files
+      block_secret_rotation: true, # Don't allow the pipeline to run as there are secrets to rotate.
     ).apply
   end
 

--- a/bin/apply-namespace-changes
+++ b/bin/apply-namespace-changes
@@ -12,6 +12,7 @@ def main(cluster)
       cluster: cluster,
       dir: dir,
       enable_skip_namespaces: false, # Ignore APPLY_PIPELINE_SKIP_THIS_NAMESPACE files
+      block_secret_rotation: true, # Don't allow the pipeline to run as there are secrets to rotate.
     ).apply
   end
 

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -16,7 +16,7 @@ class CpEnv
       @dir = args.fetch(:dir)
       @cluster = args.fetch(:cluster)
       @executor = args.fetch(:executor) { Executor.new }
-      @enable_skip_namespaces = args.fetch(:enable_skip_namespaces) { true }
+      @enable_skip_namespaces = args.fetch(:enable_skip_namespaces, true)
     end
 
     def apply
@@ -30,7 +30,7 @@ class CpEnv
 
     def ignore_this_namespace?
       return true unless FileTest.directory?(dir)
-      if (block_secret_rotation && FileTest.exist?("#{dir}/#{SECRET_ROTATE_FILE}"))
+      if block_secret_rotation && FileTest.exist?("#{dir}/#{SECRET_ROTATE_FILE}")
         log("red", "#{namespace}/#{SECRET_ROTATE_FILE}} file exists, which means a secret is about to be rotated. Skipping this namespace. To remove this, delete the #{SECRET_ROTATE_FILE} file.")
         return true
       end
@@ -49,7 +49,7 @@ class CpEnv
 
     def team_name
       @team_name ||= begin
-        yaml = YAML.load(File.read("#{dir}/01-rbac.yaml"))
+        yaml = YAML.safe_load(File.read("#{dir}/01-rbac.yaml"))
         team = yaml["subjects"][0].dig("name").split(":")[1]
         abort("Team name not found") if team.nil?
         team

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -16,8 +16,8 @@ class CpEnv
       @dir = args.fetch(:dir)
       @cluster = args.fetch(:cluster)
       @executor = args.fetch(:executor) { Executor.new }
-      @enable_skip_namespaces = args.fetch(:enable_skip_namespaces) { true }
-      @block_secret_rotation = args.fetch(:block_secret_rotation) { true }
+      @enable_skip_namespaces = args.fetch(:enable_skip_namespaces, true)
+      @block_secret_rotation = args.fetch(:block_secret_rotation, true)
     end
 
     def apply

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -1,6 +1,6 @@
 class CpEnv
   class NamespaceDir
-    attr_reader :cluster, :dir, :enable_skip_namespaces
+    attr_reader :cluster, :dir, :enable_skip_namespaces :block_secret_rotation
     attr_reader :executor
 
     # Hardcoded context is required to switch to the manager cluster
@@ -16,7 +16,8 @@ class CpEnv
       @dir = args.fetch(:dir)
       @cluster = args.fetch(:cluster)
       @executor = args.fetch(:executor) { Executor.new }
-      @enable_skip_namespaces = args.fetch(:enable_skip_namespaces, true)
+      @enable_skip_namespaces = args.fetch(:enable_skip_namespaces) { true }
+      @block_secret_rotation = args.fetch(:block_secret_rotation) { true }
     end
 
     def apply

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -1,6 +1,6 @@
 class CpEnv
   class NamespaceDir
-    attr_reader :cluster, :dir, :enable_skip_namespaces :block_secret_rotation
+    attr_reader :cluster, :dir, :enable_skip_namespaces, :block_secret_rotation
     attr_reader :executor
 
     # Hardcoded context is required to switch to the manager cluster

--- a/lib/cp_env/namespace_dir.rb
+++ b/lib/cp_env/namespace_dir.rb
@@ -10,6 +10,7 @@ class CpEnv
     # `true`, calling `apply` on the namespace will do nothing.
     SKIP_FILE = "APPLY_PIPELINE_SKIP_THIS_NAMESPACE"
     MIGRATE_SKIP_FILE = "MIGRATED_SKIP_APPLY_THIS_NAMESPACE"
+    SECRET_ROTATE_FILE = "SECRET_ROTATE_BLOCK"
 
     def initialize(args)
       @dir = args.fetch(:dir)
@@ -29,6 +30,10 @@ class CpEnv
 
     def ignore_this_namespace?
       return true unless FileTest.directory?(dir)
+      if (block_secret_rotation && FileTest.exist?("#{dir}/#{SECRET_ROTATE_FILE}"))
+        log("red", "#{namespace}/#{SECRET_ROTATE_FILE}} file exists, which means a secret is about to be rotated. Skipping this namespace. To remove this, delete the #{SECRET_ROTATE_FILE} file.")
+        return true
+      end
 
       if (enable_skip_namespaces && FileTest.exist?("#{dir}/#{SKIP_FILE}")) || FileTest.exist?("#{dir}/#{MIGRATE_SKIP_FILE}")
         log("red", "#{namespace}/#{SKIP_FILE} or #{namespace}/#{MIGRATE_SKIP_FILE} file exists. Skipping this namespace.")

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -110,6 +110,7 @@ describe CpEnv::NamespaceDir do
 
     context "when enable_skip_namespaces is not set" do
       let(:enable_skip_namespaces) { false }
+      let(:block_secret_rotation) { false }
 
       context "and a migrate skip file is present" do
         let(:yaml_files) { [1, 2, 3] } # just has to be a non-empty array that responds to 'any?'

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -13,7 +13,7 @@ describe CpEnv::NamespaceDir do
   let(:kubectl_apply) { "kubectl -n #{namespace} apply -f #{dir}" }
   let(:yaml_files) { [] }
   let(:enable_skip_namespaces) { true }
-  let(:block_secret_rotation) { true }
+  # let(:block_secret_rotation) { true }
 
   let(:params) {
     {
@@ -21,7 +21,7 @@ describe CpEnv::NamespaceDir do
       cluster: cluster,
       executor: executor,
       enable_skip_namespaces: enable_skip_namespaces
-      block_secret_rotation: block_secret_rotation
+      # block_secret_rotation: block_secret_rotation
     }
   }
 

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -13,7 +13,7 @@ describe CpEnv::NamespaceDir do
   let(:kubectl_apply) { "kubectl -n #{namespace} apply -f #{dir}" }
   let(:yaml_files) { [] }
   let(:enable_skip_namespaces) { true }
-  # let(:block_secret_rotation) { true }
+  let(:block_secret_rotation) { true }
 
   let(:params) {
     {
@@ -21,7 +21,7 @@ describe CpEnv::NamespaceDir do
       cluster: cluster,
       executor: executor,
       enable_skip_namespaces: enable_skip_namespaces
-      # block_secret_rotation: block_secret_rotation
+      block_secret_rotation: block_secret_rotation
     }
   }
 
@@ -85,6 +85,7 @@ describe CpEnv::NamespaceDir do
 
     context "when enable_skip_namespaces is set" do
       let(:enable_skip_namespaces) { true }
+      let(:block_secret_rotation) { false }
 
       context "and a skip file is present" do
         let(:yaml_files) { [1, 2, 3] } # just has to be a non-empty array that responds to 'any?'

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -20,7 +20,7 @@ describe CpEnv::NamespaceDir do
       dir: dir,
       cluster: cluster,
       executor: executor,
-      enable_skip_namespaces: enable_skip_namespaces
+      enable_skip_namespaces: enable_skip_namespaces,
       block_secret_rotation: block_secret_rotation
     }
   }

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -13,6 +13,7 @@ describe CpEnv::NamespaceDir do
   let(:kubectl_apply) { "kubectl -n #{namespace} apply -f #{dir}" }
   let(:yaml_files) { [] }
   let(:enable_skip_namespaces) { true }
+  let(:block_secret_rotation) { true }
 
   let(:params) {
     {
@@ -20,6 +21,7 @@ describe CpEnv::NamespaceDir do
       cluster: cluster,
       executor: executor,
       enable_skip_namespaces: enable_skip_namespaces
+      block_secret_rotation: block_secret_rotation
     }
   }
 

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -157,6 +157,5 @@ describe CpEnv::NamespaceDir do
         end
       end
     end
-
   end
 end

--- a/spec/namespace_dir_spec.rb
+++ b/spec/namespace_dir_spec.rb
@@ -132,5 +132,31 @@ describe CpEnv::NamespaceDir do
         end
       end
     end
+
+    context "when block_secret_rotation is set" do
+      let(:enable_skip_namespaces) { false }
+      let(:block_secret_rotation) { true }
+
+      context "and a block file is present" do
+        let(:yaml_files) { [1, 2, 3] } # just has to be a non-empty array that responds to 'any?'
+
+        before do
+          allow(FileTest).to receive(:exist?)
+            .with("#{dir}/#{CpEnv::NamespaceDir::SECRET_ROTATE_FILE}")
+            .and_return(true)
+        end
+
+        it "does not run kubectl apply" do
+          expect(executor).to_not receive(:execute).with(kubectl_apply)
+          namespace_dir.apply
+        end
+
+        it "does not run terraform apply" do
+          expect(terraform).to_not receive(:apply)
+          namespace_dir.apply
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This PR contains changes to the apply-pipeline and apply-changes-pipeline that will ignore a namespace that contains an empty file called `SECRET_ROTATE_BLOCK`.

The premise behind this change is to present the namespace owner with a PR containing a removal of this file. Once removed, all namespace IAM user credentials will be rotated, and the owner will then have to delete their pods.
