### PR TITLE
Update `laa-apply-for-legalaid-uat` email

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/00-namespace.yaml
@@ -10,5 +10,5 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
-    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply-for-civil-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/elasticache.tf
@@ -13,7 +13,7 @@ module "apply-for-legal-aid-elasticache" {
   application            = "laa-apply-for-legal-aid"
   is-production          = "false"
   environment-name       = "uat"
-  infrastructure-support = "apply@digital.justice.gov.uk"
+  infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
@@ -35,4 +35,3 @@ resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
     auth_token               = module.apply-for-legal-aid-elasticache.auth_token
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/s3.tf
@@ -7,7 +7,7 @@ module "authorized-keys" {
   application            = "laa-apply-for-legal-aid"
   is-production          = "false"
   environment-name       = "uat"
-  infrastructure-support = "apply@digital.justice.gov.uk"
+  infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
   namespace              = var.namespace
 
   providers = {
@@ -27,4 +27,3 @@ resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
     secret_access_key = module.authorized-keys.secret_access_key
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
@@ -36,7 +36,7 @@ variable "environment" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "apply@digital.justice.gov.uk"
+  default     = "apply-for-civil-legal-aid@digital.justice.gov.uk"
 }
 
 variable "is_production" {


### PR DESCRIPTION
The contact email for the Civil Apply team was out of date and no longer existed.

This updates all references to the out-dated email in the `laa-apply-for-legalaid-uat` namespace.