### PR TITLE
Update `laa-apply-for-legalaid-production` email

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/00-namespace.yaml
@@ -10,6 +10,6 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "laa-apply-for-legalaid"
-    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply-for-civil-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-apply-for-legal-aid"
     cloud-platform.justice.gov.uk/runbook: "https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/1386020990/The+Apply+for+legal+aid+service+runbook"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
@@ -13,7 +13,7 @@ module "apply-for-legal-aid-elasticache" {
   application            = "laa-apply-for-legal-aid"
   is-production          = "true"
   environment-name       = "production"
-  infrastructure-support = "apply@digital.justice.gov.uk"
+  infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"
   namespace              = var.namespace
@@ -35,4 +35,3 @@ resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {
     auth_token               = module.apply-for-legal-aid-elasticache.auth_token
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
@@ -14,7 +14,7 @@ module "apply-for-legal-aid-rds" {
   is-production          = "true"
   namespace              = var.namespace
   environment-name       = "production"
-  infrastructure-support = "apply@digital.justice.gov.uk"
+  infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
   db_engine              = "postgres"
   db_engine_version      = "11"
   db_name                = "apply_for_legal_aid_production"
@@ -42,4 +42,3 @@ resource "kubernetes_secret" "apply-for-legal-aid-rds" {
     url                   = "postgres://${module.apply-for-legal-aid-rds.database_username}:${module.apply-for-legal-aid-rds.database_password}@${module.apply-for-legal-aid-rds.rds_instance_endpoint}/${module.apply-for-legal-aid-rds.database_name}"
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/route53.tf
@@ -7,7 +7,7 @@ resource "aws_route53_zone" "apply_for_legal_aid_route53_zone" {
     is-production          = "true"
     environment-name       = "production"
     owner                  = "apply-for-legal-aid"
-    infrastructure-support = "apply@digital.justice.gov.uk"
+    infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
     namespace              = var.namespace
   }
 }
@@ -22,4 +22,3 @@ resource "kubernetes_secret" "apply_for_legal_aid_route_53_zone_sec" {
     zone_id = aws_route53_zone.apply_for_legal_aid_route53_zone.zone_id
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/s3.tf
@@ -7,7 +7,7 @@ module "authorized-keys" {
   application            = "laa-apply-for-legal-aid"
   is-production          = "true"
   environment-name       = "production"
-  infrastructure-support = "apply@digital.justice.gov.uk"
+  infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
   namespace              = var.namespace
 
   providers = {
@@ -27,4 +27,3 @@ resource "kubernetes_secret" "apply-for-legal-aid-s3-credentials" {
     secret_access_key = module.authorized-keys.secret_access_key
   }
 }
-


### PR DESCRIPTION
The contact email for the Civil Apply team was out of date and no longer existed.

This updates all references to the out-dated email in the `laa-apply-for-legalaid-production` namespace.