### PR TITLE
Update `check-financial-eligibility-uat` email

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/00-namespace.yaml
@@ -9,6 +9,6 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "check-financial-eligibility"
-    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply-for-civil-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/check-financial-eligibility"
     cloud-platform.justice.gov.uk/slack-channel: "apply-alerts-prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/variables.tf
@@ -36,7 +36,7 @@ variable "environment" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "apply@digital.justice.gov.uk"
+  default     = "apply-for-civil-legal-aid@digital.justice.gov.uk"
 }
 
 variable "is_production" {
@@ -120,4 +120,3 @@ variable "serviceaccount_rules" {
     },
   ]
 }
-


### PR DESCRIPTION
The contact email for the Civil Apply team (who maintain the Check Financial Eligibility API) was out of date and no longer existed.

This updates all references to the out-dated email in the `check-financial-eligibility-uat` namespace.