### PR TITLE
Update `check-financial-eligbility-staging` email

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/00-namespace.yaml
@@ -9,6 +9,6 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/application: "check-financial-eligibility"
-    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply@digital.justice.gov.uk: apply@digital.justice.gov.uk: apply@digtal.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Apply For Legal Aid dev team: apply-for-civil-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/check-financial-eligibility"
     cloud-platform.justice.gov.uk/slack-channel: "apply-alerts-prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-staging/resources/rds.tf
@@ -14,7 +14,7 @@ module "check-financial-eligibility-rds" {
   is-production          = "false"
   namespace              = var.namespace
   environment-name       = "staging"
-  infrastructure-support = "apply@digital.justice.gov.uk"
+  infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
   db_engine              = "postgres"
   db_engine_version      = "11"
   db_name                = "check_financial_eligibility_staging"
@@ -40,4 +40,3 @@ resource "kubernetes_secret" "check-financial-eligibility-rds" {
     rds_instance_address  = module.check-financial-eligibility-rds.rds_instance_address
   }
 }
-


### PR DESCRIPTION
The contact email for the Civil Apply team (who maintain the Check Financial Eligibility API) was out of date and no longer existed.

This updates all references to the out-dated email in the `check-financial-eligibility-staging` namespace.