### PR TITLE
Update `laa-hmrc-interface-production` email

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/00-namespace.yaml
@@ -10,7 +10,7 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "LAA-HMRC Interface Service API"
-    cloud-platform.justice.gov.uk/owner: "apply-for-legal-aid: apply@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "apply-for-legal-aid: apply-for-civil-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-hmrc-interface-service-api"
     cloud-platform.justice.gov.uk/team-name: "laa-apply-for-legal-aid"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/variables.tf
@@ -35,7 +35,7 @@ variable "environment" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "apply@digital.justice.gov.uk"
+  default     = "apply-for-civil-legal-aid@digital.justice.gov.uk"
 }
 
 variable "is_production" {


### PR DESCRIPTION
The contact email for the Civil Apply team (who maintain the HMRC Interface API) was out of date and no longer existed.

This updates all references to the out-dated email in the `laa-hmrc-interface-production` namespace.