### PR TITLE
🔐 PIC-2679: Grant dps-tech access to hmpps-user-preferences-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:probation-in-court"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
This is to allow the dps-bootstrap scripts to be run