### PR TITLE
Add depends_on to certificate validation resource

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -24,13 +24,16 @@ resource "aws_acm_certificate" "api_gateway_custom_hostname" {
     namespace              = var.namespace
   }
 }
+
 resource "aws_acm_certificate_validation" "api_gateway_custom_hostname" {
   certificate_arn         = aws_acm_certificate.api_gateway_custom_hostname.arn
   validation_record_fqdns = aws_route53_record.cert_validations.*.fqdn
 
   timeouts {
-    create = "5m"
+    create = "10m"
   }
+
+  depends_on = [aws_route53_record.cert_validations]
 }
 
 resource "aws_route53_record" "cert_validations" {


### PR DESCRIPTION
Double timeout to allow the certificate time to validate the route53 record