### PR TITLE
Introduce a shorter dns name for the orchestration service.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/08-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/08-certificate.yaml
@@ -12,3 +12,4 @@ spec:
   dnsNames:
     - prison-visits-orchestration-dev.prison.service.justice.gov.uk
     - hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/08-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/08-certificate.yaml
@@ -10,6 +10,5 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    - prison-visits-orchestration-dev.prison.service.justice.gov.uk
     - hmpps-manage-prison-visits-orchestration-dev.prison.service.justice.gov.uk
-
-


### PR DESCRIPTION
Introduce a shorter dns name as suggested on the user guide as the current dnsname is too long.