### PR TITLE
Add an API key and usage plan to API Gateway for HMPPS Integration API development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/variables.tf
@@ -63,3 +63,8 @@ variable "hostname" {
   description = "Host part of the FQDN"
   default     = "development.integration-api"
 }
+
+variable "cloud_platform_integration_api_url" {
+  description = "Pre-defined domain for the namespace provided by Cloud Platform"
+  default     = "https://hmpps-integration-api-development.apps.live.cloud-platform.service.justice.gov.uk"
+}


### PR DESCRIPTION
- Add an API key for testing purposes and output it to a Kubernetes secret.
- Add usage plan for API Gateway.