### PR TITLE
[laa-hmrc-interface-production] Bump redis 4.0.10.0 to 6.2+

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/elasticache.tf
@@ -15,8 +15,8 @@ module "elasticache" {
   namespace              = var.namespace
   environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
-  engine_version         = "4.0.10"
-  parameter_group_name   = "default.redis4.0"
+  engine_version         = "6.x"
+  parameter_group_name   = "default.redis6.x"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
Bump redis 4.0.10.0 to 6.2+