### PR TITLE
Add BT access key to allow controlled rotation of IAM key to BT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/iam.tf
@@ -7,7 +7,7 @@ resource "aws_iam_access_key" "bt_upload_user_key" {
   user = aws_iam_user.bt_upload_user.name
 }
 
-resource "aws_iam_access_key" "bt_upload_user_key_2" {
+resource "aws_iam_access_key" "key_2023" {
   user = aws_iam_user.bt_upload_user.name
 }
 
@@ -57,8 +57,8 @@ resource "kubernetes_secret" "pcms_bt_upload_user" {
     arn               = aws_iam_user.bt_upload_user.arn
     access_key_id     = aws_iam_access_key.bt_upload_user_key.id
     secret_access_key = aws_iam_access_key.bt_upload_user_key.secret
-    bt_access_key_id     = aws_iam_access_key.bt_upload_user_key_2.id
-    bt_secret_access_key = aws_iam_access_key.bt_upload_user_key_2.secret
+    bt_access_key_id     = aws_iam_access_key.key_2023.id
+    bt_secret_access_key = aws_iam_access_key.key_2023.secret
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/iam.tf
@@ -7,6 +7,10 @@ resource "aws_iam_access_key" "bt_upload_user_key" {
   user = aws_iam_user.bt_upload_user.name
 }
 
+resource "aws_iam_access_key" "bt_upload_user_key_2" {
+  user = aws_iam_user.bt_upload_user.name
+}
+
 data "aws_iam_policy_document" "bt_upload_policy" {
   statement {
     actions = ["s3:PutObject"]
@@ -53,6 +57,8 @@ resource "kubernetes_secret" "pcms_bt_upload_user" {
     arn               = aws_iam_user.bt_upload_user.arn
     access_key_id     = aws_iam_access_key.bt_upload_user_key.id
     secret_access_key = aws_iam_access_key.bt_upload_user_key.secret
+    bt_access_key_id     = aws_iam_access_key.bt_upload_user_key_2.id
+    bt_secret_access_key = aws_iam_access_key.bt_upload_user_key_2.secret
   }
 }
 


### PR DESCRIPTION
This change will allow BT to perform a controlled rollout of a new limited permission IAM key to the BT kit at each prison.