### PR TITLE
Add audit queue secrets for hmpps-community-accommodation-preprod/prod namespaces

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/hmpps-community-accommodation.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/hmpps-community-accommodation.tf
@@ -1,0 +1,14 @@
+resource "kubernetes_secret" "hmpps-community-accommodation_secret" {
+  metadata {
+    name      = "sqs-hmpps-audit-secret"
+    namespace = "hmpps-community-accommodation-preprod"
+  }
+
+  data = {
+    access_key_id     = module.hmpps_audit_queue.access_key_id
+    secret_access_key = module.hmpps_audit_queue.secret_access_key
+    sqs_queue_url     = module.hmpps_audit_queue.sqs_id
+    sqs_queue_arn     = module.hmpps_audit_queue.sqs_arn
+    sqs_queue_name    = module.hmpps_audit_queue.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/hmpps-community-accommodation.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/hmpps-community-accommodation.tf
@@ -1,0 +1,14 @@
+resource "kubernetes_secret" "hmpps-community-accommodation_secret" {
+  metadata {
+    name      = "sqs-hmpps-audit-secret"
+    namespace = "hmpps-community-accommodation-prod"
+  }
+
+  data = {
+    access_key_id     = module.hmpps_audit_queue.access_key_id
+    secret_access_key = module.hmpps_audit_queue.secret_access_key
+    sqs_queue_url     = module.hmpps_audit_queue.sqs_id
+    sqs_queue_arn     = module.hmpps_audit_queue.sqs_arn
+    sqs_queue_name    = module.hmpps_audit_queue.sqs_name
+  }
+}


### PR DESCRIPTION
Add audit queue secrets for hmpps-community-accommodation-preprod/prod namespaces, to allow the service to use the hmpps-audit-service