### PR TITLE
Increase memory limit for cjs-dashboard-development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
-      memory: 100Mi
+      memory: 1024Mi
     type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 2048Mi
+      memory: 3000Mi
     defaultRequest:
       cpu: 10m
-      memory: 1024Mi
+      memory: 2000Mi
     type: Container


### PR DESCRIPTION
This PR increases the default memory request up to 2GB and the upper limit to 3GB. I'll open a corresponding PR for the demo environment after testing.