### PR TITLE
Add a shorter dns name to stick to the 64 character limit - staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/08-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/08-certificate.yaml
@@ -10,4 +10,5 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    - prison-visits-orch-staging.prison.service.justice.gov.uk
     - hmpps-manage-prison-visits-orchestration-staging.prison.service.justice.gov.uk


### PR DESCRIPTION
Add a shorter dns name on staging to stick to the 64 character limit for a dns name.