### PR TITLE
Update api gateway for hmpps integration api development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -156,3 +156,8 @@ resource "kubernetes_secret" "api_keys" {
     "${var.team_name}" = aws_api_gateway_api_key.team.value
   }
 }
+
+resource "aws_api_gateway_base_path_mapping" "hostname" {
+  api_id      = aws_api_gateway_rest_api.api_gateway.id
+  domain_name = aws_api_gateway_domain_name.api_gateway_fqdn.domain_name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/iam.tf
@@ -15,16 +15,11 @@ resource "aws_iam_access_key" "api_gateway_user" {
 data "aws_iam_policy_document" "api_gateway" {
   statement {
     actions = [
-      "apigateway:GET",
-      "apigateway:POST",
-      "apigateway:DELETE",
+      "apigateway:*",
     ]
 
     resources = [
-      "${element(split("/", aws_api_gateway_rest_api.api_gateway.arn), 0)}/apikeys",
-      "${element(split("/", aws_api_gateway_rest_api.api_gateway.arn), 0)}/apikeys/*",
-      "${element(split("/", aws_api_gateway_rest_api.api_gateway.arn), 0)}/usageplans",
-      "${element(split("/", aws_api_gateway_rest_api.api_gateway.arn), 0)}/usageplans/**",
+      "${element(split("/", aws_api_gateway_rest_api.api_gateway.arn), 0)}/*",
     ]
   }
 }


### PR DESCRIPTION
This is to allow us to call API Gateway via the AWS CLI whilst we
continue to work out what resources we require. We'll reduce these
permissions once we've finalised the infrastructure.