### PR TITLE
[laa-apply-for-legalaid-staging] Bump redis 4.0.10.0 to 6.2+

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
@@ -14,8 +14,8 @@ module "apply-for-legal-aid-elasticache" {
   is-production          = "false"
   environment-name       = "staging"
   infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
-  engine_version         = "4.0.10"
-  parameter_group_name   = "default.redis4.0"
+  engine_version         = "6.x"
+  parameter_group_name   = "default.redis6.x"
   namespace              = var.namespace
 
   providers = {


### PR DESCRIPTION
Bump redis 4.0.10.0 to 6.2+