### PR TITLE
Remove "/development" path from API Gateway URL

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -95,7 +95,7 @@ resource "aws_api_gateway_integration" "proxy_http_proxy" {
 
 resource "aws_api_gateway_deployment" "development" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway.id
-  stage_name  = "development"
+  stage_name  = var.environment
 
   # Force recreate of the deployment resource
   stage_description = md5(file("api_gateway.tf"))
@@ -144,4 +144,5 @@ resource "kubernetes_secret" "api_keys" {
 resource "aws_api_gateway_base_path_mapping" "hostname" {
   api_id      = aws_api_gateway_rest_api.api_gateway.id
   domain_name = aws_api_gateway_domain_name.api_gateway_fqdn.domain_name
+  stage_name  = var.environment
 }


### PR DESCRIPTION
We want to serve API requests on the root path "/".