### PR TITLE
Prepare CJS dashboard production environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/00-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
-    cloud-platform.justice.gov.uk/slack-channel: "cjs-dashboard"
+    cloud-platform.justice.gov.uk/slack-channel: "cjs-data-dashboard"
     cloud-platform.justice.gov.uk/application: "CJS Dashboard"
     cloud-platform.justice.gov.uk/owner: "Data Science Hub (CJS): jeremy.collins@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/moj-analytical-services/cjs_scorecard_exploratory_analysis"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2500Mi
     defaultRequest:
       cpu: 10m
-      memory: 100Mi
+      memory: 2000Mi
     type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/resources/ecr.tf
@@ -8,6 +8,11 @@ module "ecr_credentials" {
   source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
+  github_repositories                  = ["cjs_scorecard_exploratory_analysis"]
+  github_actions_secret_ecr_name       = var.github_actions_secret_ecr_name
+  github_actions_secret_ecr_url        = var.github_actions_secret_ecr_url
+  github_actions_secret_ecr_access_key = var.github_actions_secret_ecr_access_key
+  github_actions_secret_ecr_secret_key = var.github_actions_secret_ecr_secret_key
 }
 
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/resources/main.tf
@@ -5,16 +5,34 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "github" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/resources/variables.tf
@@ -56,3 +56,43 @@ variable "github_token" {
   description = "Required by the Github Terraform provider"
   default     = ""
 }
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  default     = "KUBE_NAMESPACE_PROD"
+}
+
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  default     = "KUBE_CERT_PROD"
+}
+
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  default     = "KUBE_TOKEN_PROD"
+}
+
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the serviceaccount cluster"
+  default     = "KUBE_CLUSTER_PROD"
+}
+
+variable "github_actions_secret_ecr_name" {
+  description = "The name of the github actions secret containing the ECR name"
+  default     = "ECR_NAME_PROD"
+}
+
+variable "github_actions_secret_ecr_url" {
+  description = "The name of the github actions secret containing the ECR URL"
+  default     = "ECR_URL_PROD"
+}
+
+variable "github_actions_secret_ecr_access_key" {
+  description = "The name of the github actions secret containing the ECR AWS access key"
+  default     = "ECR_AWS_ACCESS_KEY_ID_PROD"
+}
+
+variable "github_actions_secret_ecr_secret_key" {
+  description = "The name of the github actions secret containing the ECR AWS secret key"
+  default     = "ECR_AWS_SECRET_ACCESS_KEY_PROD"
+}


### PR DESCRIPTION
Some edits to the existing CJS production placeholder environment:
- Increase memory
- Rename secrets used by GitHub Actions to avoid overlap with demo and dev