### PR TITLE
CTSKF-225 - Bump Elasticache cluster to 6.x

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/elasticache.tf
@@ -8,11 +8,10 @@ module "lcdui_elasticache" {
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
   namespace              = var.namespace
-
-  engine_version        = "4.0.10"
-  parameter_group_name  = "default.redis4.0"
-  number_cache_clusters = "2"
-  node_type             = "cache.t2.micro"
+  engine_version         = "6.x"
+  parameter_group_name   = "default.redis6.x"
+  number_cache_clusters  = "2"
+  node_type              = "cache.t2.micro"
 }
 
 resource "kubernetes_secret" "lcdui_elasticache" {


### PR DESCRIPTION
# What
- Bump Elasticache engine_version to `6.x`
- Update parameter_group_name accordingly

Environment: Staging