### PR TITLE
VB-1716: Add HMPPS Audit secrets for VSiP staging env

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/visit-someone-in-prison-front-end-staging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/visit-someone-in-prison-front-end-staging.tf
@@ -1,6 +1,6 @@
-resource "kubernetes_secret" "vsip_audit_secret" {
+resource "kubernetes_secret" "vsip_audit_secret_staging" {
   metadata {
-    name      = "sqs-hmpps-audit-secret-staging"
+    name      = "sqs-hmpps-audit-secret"
     namespace = "visit-someone-in-prison-frontend-svc-staging"
   }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/visit-someone-in-prison-front-end-staging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/visit-someone-in-prison-front-end-staging.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_secret" "vsip_audit_secret" {
   metadata {
-    name      = "sqs-hmpps-audit-secret"
+    name      = "sqs-hmpps-audit-secret-staging"
     namespace = "visit-someone-in-prison-frontend-svc-staging"
   }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/visit-someone-in-prison-front-end-staging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/visit-someone-in-prison-front-end-staging.tf
@@ -1,0 +1,15 @@
+resource "kubernetes_secret" "vsip_audit_secret" {
+  metadata {
+    name      = "sqs-hmpps-audit-secret"
+    namespace = "visit-someone-in-prison-frontend-svc-staging"
+  }
+
+  data = {
+    access_key_id     = module.hmpps_audit_queue.access_key_id
+    secret_access_key = module.hmpps_audit_queue.secret_access_key
+    sqs_queue_url     = module.hmpps_audit_queue.sqs_id
+    sqs_queue_arn     = module.hmpps_audit_queue.sqs_arn
+    sqs_queue_name    = module.hmpps_audit_queue.sqs_name
+  }
+}
+


### PR DESCRIPTION
The VSiP staging namespace (`visit-someone-in-prison-frontend-svc-staging`) has a manually created `sqs-hmpps-audit-secret` - highlighted when this secret was recently rotated. This change is to manage this secret for the staging environment within code.