### PR TITLE
Remove old domain cert

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courts-local-scorecard-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courts-local-scorecard-prod/05-certificate.yaml
@@ -10,18 +10,3 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - criminal-justice-scorecard.justice.gov.uk
-
----
-
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: criminal-justice-delivery-cert
-  namespace: courts-local-scorecard-prod
-spec:
-  secretName: criminal-justice-delivery-cert-secret
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
-    - criminal-justice-delivery-data-dashboards.justice.gov.uk


### PR DESCRIPTION
Remove the cert from the old site so that we can add this to the new site namespace.