### PR TITLE
Upgrade `money-to-prisoners` test database – step 2 of 3

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -20,9 +20,9 @@ module "rds" {
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure-support
 
-  rds_family           = "postgres10"
+  rds_family           = "postgres14"
   db_engine            = "postgres"
-  db_engine_version    = "10"
+  db_engine_version    = "14.3"
   db_instance_class    = "db.t3.large"
   db_allocated_storage = "5"
   db_name              = "mtp_api"


### PR DESCRIPTION
Retry of #10073
Depends on #9944

AWS docs have changed and suggest 10.21 can only go up to 14.3 (they used to say 14.4) but haven’t checked against API.