### PR TITLE
Remove Athena from pathfinder dev (#9669)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/athena.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/athena.tf
@@ -1,5 +1,0 @@
-resource "aws_athena_database" "database" {
-  name   = "pathfinder_${var.environment-name}"
-  bucket = module.pathfinder_reporting_s3_bucket.bucket_name
-  force_destroy = true
-}


### PR DESCRIPTION
This PR replays #9669 as `aws_athena_database` needed to have `force_destroy = true` set; and reverts #9708 as #9669 blocked the apply pipeline.

Needs approval from @jonhindle before merge; and then #9685 can be merged after this too.