### PR TITLE
Update cccd production redis instance to t4g 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
@@ -19,7 +19,7 @@ module "cccd_elasticache_redis" {
   engine_version        = "6.x"
   parameter_group_name  = "default.redis6.x"
   number_cache_clusters = "3"
-  node_type             = "cache.t2.small"
+  node_type             = "cache.t4g.small"
 }
 
 resource "kubernetes_secret" "cccd_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
@@ -16,8 +16,8 @@ module "cccd_elasticache_redis" {
   team_name              = var.team_name
   namespace              = var.namespace
 
-  engine_version        = "4.0.10"
-  parameter_group_name  = "default.redis4.0"
+  engine_version        = "6.x"
+  parameter_group_name  = "default.redis6.x"
   number_cache_clusters = "3"
   node_type             = "cache.t2.small"
 }


### PR DESCRIPTION
**Note:** This is branched off #10573 and that PR should be deployed first so that the redis server is upgraded successfully before a new instance type is used.