### PR TITLE
Add missing verbs to service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/serviceaccount.tf
@@ -67,6 +67,8 @@ module "serviceaccount" {
         "issuers",
       ]
       verbs = [
+        "get",
+        "list",
         "update",
         "create",
         "patch",


### PR DESCRIPTION
Without these, it still fails to apply the resources.