### PR TITLE
fix: 🐛 patch -> diff for the the code changes

### DIFF
--- a/cmd/check-terraform-modules-are-latest/main.go
+++ b/cmd/check-terraform-modules-are-latest/main.go
@@ -40,7 +40,7 @@ func main() {
 	repoName, prNumber, apiURL := initEnvVars()
 
 	client := github.NewClient(nil)
-	diff, _, err := client.PullRequests.GetRaw(context.Background(), "ministryofjustice", repoName, prNumber, github.RawOptions{Type: github.RawType(2)})
+	diff, _, err := client.PullRequests.GetRaw(context.Background(), "ministryofjustice", repoName, prNumber, github.RawOptions{Type: github.RawType(1)})
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
When the RawOption (the type of PR diff to fetch) is set to patch the request returns every change. This means the current module is actually set to the initial commit value, therefore failing even when newer commits are pushed. Using "diff" instead of patch allows the diff to contain only the latest change.

for example:
- [patch](https://patch-diff.githubusercontent.com/raw/ministryofjustice/cloud-platform-environments/pull/10294.patch)
- [diff](https://patch-diff.githubusercontent.com/raw/ministryofjustice/cloud-platform-environments/pull/10294.diff)