### PR TITLE
Remove unnecessary username from redis url

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
@@ -30,7 +30,7 @@ resource "kubernetes_secret" "cccd_elasticache_redis" {
     primary_endpoint_address = module.cccd_elasticache_redis.primary_endpoint_address
     auth_token               = module.cccd_elasticache_redis.auth_token
     member_clusters          = jsonencode(module.cccd_elasticache_redis.member_clusters)
-    url                      = "rediss://dummyuser:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
+    url                      = "rediss://:${module.cccd_elasticache_redis.auth_token}@${module.cccd_elasticache_redis.primary_endpoint_address}:6379"
   }
 }
 


### PR DESCRIPTION
The latest major version of the redis gem requires that the dummy username is not present in the url. CCCD currently has a fix that will strip it out but this fix will be removed once the urls are fixed here.