### PR TITLE
feat: 🎸 push updated terraform module version to api

### DIFF
--- a/cmd/check-terraform-modules-are-latest/README.md
+++ b/cmd/check-terraform-modules-are-latest/README.md
@@ -28,7 +28,7 @@ jobs:
       - uses: ministryofjustice/github-actions/check-terraform-modules-are-latest@main
         env:
           REPO_NAME: cloud-platform-environments
-          API_URL: ${{ env.API_URL }}
+          API_URL: ${{ vars.TERRAFORM_MODULE_VERSIONS_API_URL }}
           PR_NUMBER: ${{ github.event.number }}
 ```
 

--- a/cmd/check-terraform-modules-are-latest/go.mod
+++ b/cmd/check-terraform-modules-are-latest/go.mod
@@ -1,4 +1,4 @@
-module github.com/ministryofjustice/github-actions/check-terraform-modules-are-latest
+module github.com/ministryofjustice/cloud-platform-environments/cmd/check-terraform-modules-are-latest
 
 go 1.19
 

--- a/cmd/check-terraform-modules-are-latest/main.go
+++ b/cmd/check-terraform-modules-are-latest/main.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/google/go-github/v50/github"
-	"github.com/ministryofjustice/github-actions/check-terraform-modules-are-latest/utils"
+	"github.com/ministryofjustice/cloud-platform-environments/cmd/check-terraform-modules-are-latest/utils"
 )
 
 func initEnvVars() (string, int, string) {

--- a/cmd/push-terraform-module-version/Dockerfile
+++ b/cmd/push-terraform-module-version/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.19-alpine AS builder
+
+RUN addgroup -g 1000 -S appgroup && \
+    adduser -u 1000 -S appuser -G appgroup
+
+RUN mkdir app
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY . ./
+
+# Download all the dependencies
+RUN go mod download
+
+# Build the Go app
+RUN CGO_ENABLED=0 go build -o /app/main .
+
+RUN chown -R appuser:appgroup /app
+
+USER 1000
+
+# second stage to obtain a very small image
+FROM scratch
+
+ENV REPO_NAME ""
+
+ENV UPDATED_MODULE_VERSION ""
+
+ENV API_URL ""
+
+ENV API_KEY ""
+
+# copy the ca-certificate.crt from the build stage
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# copy user permissions from builder
+COPY --from=builder /etc/passwd /etc/passwd
+
+COPY --from=builder /app/main /app/main
+
+USER 1000
+
+ENTRYPOINT ["/app/main"]
+

--- a/cmd/push-terraform-module-version/README.md
+++ b/cmd/push-terraform-module-version/README.md
@@ -1,0 +1,50 @@
+# Push the latest terraform module version to be stored in the API
+
+## Context
+
+Pull requests (PRs) against the [environments repository][env-repo],
+raised by users of the [MoJ Cloud Platform][cloud-platform],
+have to be approved by the Cloud Platform team.
+
+If these PRs make use of any "cloud-platform-terraform-\*" modules then it is important that the user is using the most up-to-date module version.
+
+There is an action that queries the cloud platform [api][api-terraform-versions] and then verifies if the module in the PR is set to the latest module.
+
+
+## This Action
+
+The purpose of this action is to keep track of new terraform module releases. When a "cloud-platform-terraform-*" module releases a new version, this action will update the [api][api-terraform-versions] with this new version via a simple POST request.
+
+## USAGE
+
+Create a file in your repo called `.github/workflows/push-terraform-module-version.yaml` with the
+following contents:
+
+```
+on:
+  push:
+    tags:
+      - *
+
+jobs:
+  push-terraform-module-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ministryofjustice/cloud-platform-environments/cmd/push-terraform-module-version@main
+        env:
+          API_URL: ${{ vars.TERRAFORM_MODULE_VERSIONS_API_URL }}
+          API_KEY: ${{ secrets.TERRAFORM_MODULE_VERSIONS_API_KEY }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          UPDATED_MODULE_VERSION: ${{ github.ref_name }}
+
+```
+
+`API_URL` is the url of the [api][api-terraform-versions] which tracks cloud platforms terrform module versions.
+`API_KEY` the API route is protected for security
+`REPO_NAME` is the name of the repo where we watch for new releases
+`UPDATED_MODULE_VERSION` this is the new new release version to update the API with
+
+[env-repo]: https://github.com/ministryofjustice/cloud-platform-environments
+[cloud-platform]: https://github.com/ministryofjustice/cloud-platform
+[api-terraform-versions]: https://github.com/ministryofjustice/cloud-platform-go-get-module

--- a/cmd/push-terraform-module-version/README.md
+++ b/cmd/push-terraform-module-version/README.md
@@ -10,10 +10,9 @@ If these PRs make use of any "cloud-platform-terraform-\*" modules then it is im
 
 There is an action that queries the cloud platform [api][api-terraform-versions] and then verifies if the module in the PR is set to the latest module.
 
-
 ## This Action
 
-The purpose of this action is to keep track of new terraform module releases. When a "cloud-platform-terraform-*" module releases a new version, this action will update the [api][api-terraform-versions] with this new version via a simple POST request.
+The purpose of this action is to keep track of new terraform module releases. When a "cloud-platform-terraform-\*" module releases a new version, this action will update the [api][api-terraform-versions] with this new version via a simple POST request.
 
 ## USAGE
 

--- a/cmd/push-terraform-module-version/go.mod
+++ b/cmd/push-terraform-module-version/go.mod
@@ -1,0 +1,3 @@
+module github.com/ministryofjustice/cloud-platform-environments/cmd/push-terraform-module-version
+
+go 1.19

--- a/cmd/push-terraform-module-version/main.go
+++ b/cmd/push-terraform-module-version/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+)
+
+func initEnvVars() (string, string, string, string) {
+	repoName, repoNamePresent := os.LookupEnv("REPO_NAME")
+	if repoName == "" || !repoNamePresent {
+		log.Fatal("REPO_NAME is not set")
+	}
+
+	updatedVersion, versionPresent := os.LookupEnv("UPDATED_MODULE_VERSION")
+	if updatedVersion == "" || !versionPresent {
+		log.Fatal("UPDATED_MODULE_VERSION is not set")
+	}
+
+	apiURL, apiURLPresent := os.LookupEnv("API_URL")
+	if apiURL == "" || !apiURLPresent {
+		log.Fatal("API_URL is not set")
+	}
+
+	apiKey, apiKeyPresent := os.LookupEnv("API_KEY")
+	if apiKey == "" || !apiKeyPresent {
+		log.Fatal("API_KEY is not set")
+	}
+
+	return repoName, updatedVersion, apiURL, apiKey
+}
+
+func postHttpReq(apiURL, apiKey, name, version string) ([]byte, error) {
+	requestURL := fmt.Sprintf("%supdate/%s/%s", apiURL, name, version)
+	req, err := http.NewRequest(http.MethodPost, requestURL, nil)
+
+	if err != nil {
+		fmt.Printf("client: could not create request: %s\n", err)
+		return nil, err
+	}
+
+	req.Header.Set("X-API-Key", apiKey)
+
+	log.Println(req)
+
+	client := http.Client{}
+
+	res, err := client.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func main() {
+	repoName, updatedVersion, apiURL, apiKey := initEnvVars()
+
+	resp, err := postHttpReq(apiURL, apiKey, repoName, updatedVersion)
+
+	if err != nil {
+		log.Fatal("❌ ", err)
+	}
+
+	log.Println("API Updated with new terraform module version ✅", string(resp))
+}

--- a/cmd/push-terraform-module-version/push-terraform-module-version.yaml
+++ b/cmd/push-terraform-module-version/push-terraform-module-version.yaml
@@ -1,0 +1,7 @@
+name: Push the latest terraform module version to be stored in the API
+description: When a cloud-platform-terrform-* module version is updated also update the API
+
+runs:
+  using: "docker"
+  image: "Dockerfile"
+

--- a/cmd/push-terraform-module-version/push-terraform-module-version.yaml
+++ b/cmd/push-terraform-module-version/push-terraform-module-version.yaml
@@ -4,4 +4,3 @@ description: When a cloud-platform-terrform-* module version is updated also upd
 runs:
   using: "docker"
   image: "Dockerfile"
-


### PR DESCRIPTION
Add a GitHub action which should be added to `cloud-platform-terraform-*` repos, so that when a new module version is released we capture that new version in our API too.

The action is simple. It fires a post request that updates the api.