### PR TITLE
Change db_instance_class to db.t4g.small

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/rds.tf
@@ -21,8 +21,8 @@ module "rds" {
   rds_family = "postgres14"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
-  allow_major_version_upgrade = "true"
-  db_instance_class = "db.t3.medium"
+  allow_major_version_upgrade = "false"
+  db_instance_class = "db.t4g.small"
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Change laa-hmrc-api-prod db_instance_class to db.t4g.small
from db.t3.medium, following upgrade to Postgres14