### PR TITLE
Add Domain Events secrets to Community Accommodation preprod namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-community-accommodation.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-community-accommodation.tf
@@ -1,0 +1,12 @@
+resource "kubernetes_secret" "hmpps-community-accommodation" {
+  metadata {
+    name      = "hmpps-domain-events-topic"
+    namespace = "hmpps-community-accommodation-preprod"
+  }
+
+  data = {
+    access_key_id     = module.hmpps-domain-events.access_key_id
+    secret_access_key = module.hmpps-domain-events.secret_access_key
+    topic_arn         = module.hmpps-domain-events.topic_arn
+  }
+}


### PR DESCRIPTION
The CAS1 (Approved Premises) service needs to emit domain events onto SNS and therefore needs credentials to do so.