### PR TITLE
Update elastic search to use the latest version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
@@ -19,5 +19,3 @@ module "abundance_es" {
   elasticsearch_version = "7.10"
 
 }
-
-haar-dev-historical-prisoner

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -19,3 +19,5 @@ module "abundance_es" {
   elasticsearch_version = "7.10"
 
 }
+
+haar-dev-historical-prisoner

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-staging/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-staging/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-staging/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "hmpps_historical_prisoner_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "hmpps_historical_prisoner_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "hmpps_historical_prisoner_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
 
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
 
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
 
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "probation_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/jakemulley-refactor/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/jakemulley-refactor/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/jakemulley-refactor/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/jakemulley-refactor/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/jakemulley-refactor/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/jakemulley-refactor/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "abundance_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   eks_cluster_name       = var.eks_cluster_name
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
 
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
 
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "manage_intelligence_elasticsearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
 
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_poli
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_poli
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/elasticsearch.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_publishing_poli
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -5,7 +5,7 @@
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -5,7 +5,7 @@
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/elasticsearch.tf
@@ -5,7 +5,7 @@
 
 # Elastic search module
 module "peoplefinder_es" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                   = var.vpc_name
   eks_cluster_name           = var.eks_cluster_name
   application                = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "content_hub_elasticsearch" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name               = var.vpc_name
   eks_cluster_name       = var.eks_cluster_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-dev/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=update-length"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-prod/resources/es.tf
@@ -1,5 +1,5 @@
 module "prisoner_offender_search_elasticsearch" {
-  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.4"
+  source                          = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.0.5"
   vpc_name                        = var.vpc_name
   eks_cluster_name                = var.eks_cluster_name
   application                     = var.application


### PR DESCRIPTION
This release have a fix for domain_name no more than 28 characters long