### PR TITLE
renamed cert to match cert name defined in ingress

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/08-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/08-certificate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: submit-information-report-test.hmpps.service.justice.gov.uk
   namespace: hmpps-manage-intelligence-test
 spec:
-  secretName: submit-information-report-cert
+  secretName: hmpps-submit-information-report-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer


### PR DESCRIPTION
Sorting mis-match between cert name defined on ingress and cert name for hmpps-manage-intelligence-test namespace