### PR TITLE
Remove unused variables and tidy up the namespace-resources-cli-template

### DIFF
--- a/namespace-resources-cli-template/resources/variables.tf
+++ b/namespace-resources-cli-template/resources/variables.tf
@@ -1,58 +1,69 @@
-
-
 variable "vpc_name" {
-}
-
-variable "cluster_state_bucket" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
 }
 
 variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
 }
 
 variable "application" {
-  description = "Name of Application you are deploying"
+  description = "Name of the application you are deploying"
+  type        = string
   default     = "{{ .Application }}"
 }
 
 variable "namespace" {
-  default = "{{ .Namespace }}"
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "{{ .Namespace }}"
 }
 
 variable "business_unit" {
-  description = "Area of the MOJ responsible for the service."
+  description = "Area of the MOJ responsible for this service"
+  type        = string
   default     = "{{ .BusinessUnit }}"
 }
 
 variable "team_name" {
-  description = "The name of your development team"
+  description = "Name of the development team responsible for this service"
+  type        = string
   default     = "{{ .GithubTeam }}"
 }
 
 variable "environment" {
-  description = "The type of environment you're deploying to."
+  description = "Name of the environment type for this service"
+  type        = string
   default     = "{{ .Environment }}"
 }
 
 variable "infrastructure_support" {
-  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  description = "Email address of the team responsible this service"
+  type        = string
   default     = "{{ .InfrastructureSupport }}"
 }
 
 variable "is_production" {
-  default = "{{ .IsProduction }}"
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "{{ .IsProduction }}"
 }
 
 variable "slack_channel" {
-  description = "Team slack channel to use if we need to contact your team"
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
   default     = "{{ .SlackChannel }}"
 }
 
 variable "github_owner" {
   description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
   default     = "ministryofjustice"
 }
 
 variable "github_token" {
-  description = "Required by the Github Terraform provider"
+  type        = string
+  description = "Required by the GitHub Terraform provider"
   default     = ""
 }

--- a/namespace-resources-cli-template/resources/versions.tf
+++ b/namespace-resources-cli-template/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
@@ -7,7 +6,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }


### PR DESCRIPTION
This PR does a couple of things. It:

- adds an empty `outputs.tf` file to meet the standard Terraform structure
- removes the unused `cluster_state_bucket` variable, as it isn't used by any current namespace
- adds descriptions and value types to variables that were missing them
- pins the GitHub provider to `~> 5.17.0`