### PR TITLE
Replace // comment syntax with #

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticache.tf
@@ -1,7 +1,7 @@
 module "test_ec_cluster" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.6"
 
-  // The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
+  # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name               = var.vpc_name
   team_name              = "webops"
   business-unit          = "platforms"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/paul-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/paul-test/resources/elasticache.tf
@@ -1,7 +1,7 @@
 module "rotate_token_ec_cluster" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=add-keepers"
 
-  // The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
+  # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name               = var.vpc_name
   team_name              = "webops"
   business-unit          = "platforms"


### PR DESCRIPTION
Although Terraform supports both // and # for single line comments, the # single-line comment style is the default comment style and should be used in most cases. This brings the example in line with [Terraform best practices](https://developer.hashicorp.com/terraform/language/syntax/configuration#comments).

See also the update to ministryofjustice/cloud-platform-terraform-elasticache-cluster#37.