### PR TITLE
Replace deprecated interpolation syntax

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-application-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-application-queue.tf
@@ -20,7 +20,7 @@ module "claim-criminal-injuries-application-queue" {
 }
 
 resource "aws_sqs_queue_policy" "claim-criminal-injuries-application-queue-policy" {
-  queue_url = "${module.claim-criminal-injuries-application-queue.sqs_id}"
+  queue_url = module.claim-criminal-injuries-application-queue.sqs_id
 
   policy = <<EOF
   {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -134,6 +134,14 @@ resource "aws_api_gateway_usage_plan_key" "team" {
   usage_plan_id = aws_api_gateway_usage_plan.default.id
 }
 
+# This block gets around the deprecation notice/ambiguous interpolation warning when using
+# a variable for a key
+locals {
+  api_keys_data = {
+    for team_name in [var.team_name]:
+    team_name => aws_api_gateway_api_key.team.value
+  }
+}
 
 resource "kubernetes_secret" "api_keys" {
   metadata {
@@ -141,9 +149,7 @@ resource "kubernetes_secret" "api_keys" {
     namespace = var.namespace
   }
 
-  data = {
-    var.team_name = aws_api_gateway_api_key.team.value
-  }
+  data = local.api_keys_data
 }
 
 resource "aws_api_gateway_base_path_mapping" "hostname" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -142,7 +142,7 @@ resource "kubernetes_secret" "api_keys" {
   }
 
   data = {
-    "${var.team_name}" = aws_api_gateway_api_key.team.value
+    var.team_name = aws_api_gateway_api_key.team.value
   }
 }
 


### PR DESCRIPTION
Terraform v0.12.4 deprecated interpolation-only expressions, so this PR replaces where it was in use to call the value directly.

See [Terraform v0.12.4 release notes](https://github.com/hashicorp/terraform/releases/tag/v0.12.14) for more details.