### PR TITLE
Bump AWS version to ~> 4.27.0 to match namespace-resources-cli-template

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/versions.tf
@@ -1,10 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "~> 4.27.0"
     }
     dns = {
       source  = "hashicorp/dns"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-event-logger-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-event-logger-dev/resources/versions.tf
@@ -1,10 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-event-logger-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-event-logger-preprod/resources/versions.tf
@@ -1,10 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-event-logger-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-event-logger-prod/resources/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.68.0"
+      version = "~> 4.27.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/paul-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/paul-test/resources/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = "~> 4.27.0"
     }
     github = {
       source = "integrations/github"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/swestest-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/swestest-dev/resources/versions.tf
@@ -1,10 +1,9 @@
-
 terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = "~> 4.27.0"
     }
 
     github = {


### PR DESCRIPTION
This PR bumps 6 namespaces' Terraform AWS provider version to match the mostly-used `~> 4.27.0` version, which is also the default in [`namespace-resources-cli-template`](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespace-resources-cli-template/resources/versions.tf#L6).

There are 3 other namespaces that use `~> 4.29.0`, which need some testing to either drop to `~> 4.27.0` to match everyone else, or leave as is.