### PR TITLE
Update s3 policy to apply to user not bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/s3.tf
@@ -57,39 +57,39 @@ module "s3_bucket" {
   }
 
   user_policy = <<EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Sid": "Stmt1392016154000",
-        "Effect": "Allow",
-        "Action": [
-          "s3:AbortMultipartUpload",
-          "s3:DeleteObject",
-          "s3:GetBucketAcl",
-          "s3:GetBucketLocation",
-          "s3:GetBucketPolicy",
-          "s3:GetObject",
-          "s3:GetObjectAcl",
-          "s3:ListBucket",
-          "s3:ListBucketMultipartUploads",
-          "s3:ListMultipartUploadParts",
-          "s3:PutObject",
-          "s3:PutObjectAcl"
-        ],
-        "Resource": [
-          "$${bucket_arn}/*"
-        ]
-      },
-      {
-        "Sid": "AllowRootAndHomeListingOfBucket",
-        "Action": ["s3:ListBucket"],
-        "Effect": "Allow",
-        "Resource": ["$${bucket_arn}"],
-        "Condition":{"StringLike":{"s3:prefix":["*"]}}
-      }
-    ]
-  }
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Stmt1392016154000",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:DeleteObject",
+        "s3:GetBucketAcl",
+        "s3:GetBucketLocation",
+        "s3:GetBucketPolicy",
+        "s3:GetObject",
+        "s3:GetObjectAcl",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": [
+        "$${bucket_arn}/*"
+      ]
+    },
+    {
+      "Sid": "AllowRootAndHomeListingOfBucket",
+      "Action": ["s3:ListBucket"],
+      "Effect": "Allow",
+      "Resource": ["$${bucket_arn}"],
+      "Condition":{"StringLike":{"s3:prefix":["*"]}}
+    }
+  ]
+}
   EOF
 
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/s3.tf
@@ -56,16 +56,13 @@ module "s3_bucket" {
     aws = aws.london
   }
 
-  bucket_policy = <<EOF
+  user_policy = <<EOF
   {
     "Version": "2012-10-17",
     "Statement": [
       {
         "Sid": "Stmt1392016154000",
         "Effect": "Allow",
-        "Principal": {
-          "Service": "cloudfront.amazonaws.com"
-        },
         "Action": [
           "s3:AbortMultipartUpload",
           "s3:DeleteObject",
@@ -81,14 +78,14 @@ module "s3_bucket" {
           "s3:PutObjectAcl"
         ],
         "Resource": [
-          "arn:aws:s3:::cloud-platform-e8ef9051087439cca56bf9caa26d0a3f/*"
+          "$${bucket_arn}/*"
         ]
       },
       {
         "Sid": "AllowRootAndHomeListingOfBucket",
         "Action": ["s3:ListBucket"],
         "Effect": "Allow",
-        "Resource": ["arn:aws:s3:::cloud-platform-e8ef9051087439cca56bf9caa26d0a3f"],
+        "Resource": ["$${bucket_arn}"],
         "Condition":{"StringLike":{"s3:prefix":["*"]}}
       }
     ]


### PR DESCRIPTION
We are using a plugin that connects from within the pod to the s3 bucket and requires access to push/pull files. We initially tried using a bucket policy but it looks like we actually needed to switch this to a user level policy which these changes reflect.