### PR TITLE
Update 07-certificate.yaml

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/07-certificate.yaml
@@ -10,4 +10,5 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - hmpps-vsip-internal-admin-ui-preprod.prison.service.justice.gov.uk
+  - vsip-internal-admin-ui-preprod.prison.service.justice.gov.uk
+  - hmpps-vsip-internal-admin-ui-preprod.prison.service.justice.gov.uk


### PR DESCRIPTION
added short dns name vsip-internal-admin-ui-preprod.prison.service.justice.gov.uk