### PR TITLE
Add default_tags for source-code, slack-channel to namespace-resources-cli-template

### DIFF
--- a/namespace-resources-cli-template/resources/main.tf
+++ b/namespace-resources-cli-template/resources/main.tf
@@ -5,16 +5,37 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
 }
 
 provider "github" {


### PR DESCRIPTION
This PR adds the `source-code` and `slack-channel` default tags to the namespace/*/resources CLI template. This allows us to start to do a couple of things amongst other stuff:

- identify resources created through cloud-platform-environments by viewing their tags
- automate slack channel alerts for resources based on resource tags

This only affects new namespaces created with the CLI, separate PRs incoming to backport this to previously created namespaces.