### PR TITLE
Create namespace for make-recall-decision-db-analysis

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: make-recall-decision-db-analysis
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "making-recall-decisions"
+    cloud-platform.justice.gov.uk/application: "Make A Recall Decision - PPUD database analysis"
+    cloud-platform.justice.gov.uk/owner: "Make Recall Decisions: making-recall-decisions-tech@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice"
+    cloud-platform.justice.gov.uk/team-name: "making-recall-decision"
+    cloud-platform.justice.gov.uk/review-after: "2023-05-21"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: make-recall-decision-db-analysis-admin
+  namespace: make-recall-decision-db-analysis
+subjects:
+  - kind: Group
+    name: "github:making-recall-decision"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: make-recall-decision-db-analysis
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: make-recall-decision-db-analysis
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: make-recall-decision-db-analysis
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: make-recall-decision-db-analysis
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/variables.tf
@@ -1,0 +1,69 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Make A Recall Decision - PPUD database analysis"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "make-recall-decision-db-analysis"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "making-recall-decision"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "making-recall-decisions-tech@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "making-recall-decisions"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.27.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+  }
+}


### PR DESCRIPTION
Created using cloud-platform environment create for spinning up resources to analyse the PPUD database as part of an exploratory phase for make recall decisions.