### PR TITLE
ARN-1283-add-pingdom-checks

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/pingdom.tf
@@ -1,0 +1,18 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "hmpps-assess-risks-and-needs-prod" {
+  type                     = "http"
+  name                     = "HMPPS - assess-risks-and-needs API"
+  host                     = "assess-risks-and-needs.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [127850]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/versions.tf
@@ -9,5 +9,9 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    pingdom = {
+      source  = "russellcardullo/pingdom"
+      version = "1.1.3"
+    }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/00-namespace.yaml
@@ -11,4 +11,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Assess risks and needs"
     cloud-platform.justice.gov.uk/owner: "Assess risks and needs: assess-risks-and-needs@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-assessments-api"
-    cloud-platform.justice.gov.uk/team-name: "hmpps-assessments" 
+    cloud-platform.justice.gov.uk/team-name: "hmpps-assess-risks-and-needs"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/pingdom.tf
@@ -1,0 +1,18 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "hmpps-assessments-prod" {
+  type                     = "http"
+  name                     = "HMPPS - Unpaid Work Assessments API"
+  host                     = "hmpps-arn-risks-api.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "hmpps,cloudplatform-managed"
+  probefilters             = "region:EU"
+  integrationids           = [127850]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/versions.tf
@@ -9,5 +9,9 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    pingdom = {
+      source  = "russellcardullo/pingdom"
+      version = "1.1.3"
+    }
   }
 }


### PR DESCRIPTION
Adds Pingdom checks, versions.tf files and Slack integrations for hmpps-assess-risks-and-needs and hmpps-assessments production environments.