### PR TITLE
Amend the CNAME for the dashboard service to point to the CloudPlatfor…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/route53paas.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/route53paas.tf
@@ -73,6 +73,6 @@ resource "aws_route53_record" "dashboard_apply_gender_recognition_certificate" {
   type    = "CNAME"
   ttl     = 300
   records = [
-    "grc-production-dashboard.london.cloudapps.digital."
+    "grc-dashboard-service.grc-prod.svc.cluster.live.cloud-platform.service.justice.gov.uk"
   ]
 }


### PR DESCRIPTION
Amend the CNAME for the dashboard service to pint to the CloudPlatform service instead of the PaaS service.

A pre-migration test

Is this the correct target format for the service pods from the custom domain DNS records?