### PR TITLE
[laa-assure-hmrc-data-production] Add serviceaccount with named secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/serviceaccount.tf
@@ -1,0 +1,13 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.8.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = [var.repo_name]
+
+  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
+  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
+  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/variables.tf
@@ -20,6 +20,10 @@ variable "namespace" {
   default     = "laa-assure-hmrc-data-production"
 }
 
+variable "repo_name" {
+  default = "laa-assure-hmrc-data"
+}
+
 variable "business_unit" {
   description = "Area of the MOJ responsible for this service"
   type        = string
@@ -66,4 +70,21 @@ variable "github_token" {
   type        = string
   description = "Required by the GitHub Terraform provider"
   default     = ""
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  default     = "KUBE_PRODUCTION_NAMESPACE"
+}
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  default     = "KUBE_PRODUCTION_CERT"
+}
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  default     = "KUBE_PRODUCTION_TOKEN"
+}
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the serviceaccount cluster"
+  default     = "KUBE_PRODUCTION_CLUSTER"
 }


### PR DESCRIPTION
Add serviceaccount with named secrets

Serviceaccount for GHA pipeline

Because we need to deploy to several environments
via GHA this pattern allows secrets to be authomtically created
with an "environment" specific name. Automatic or CP initiated
rotation of these secrets, in the event of a breach, would then
be transparent.