### PR TITLE
Remove deprecated version specification from provider to required_provider

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/main.tf
@@ -17,9 +17,7 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-provider "kubernetes" {
-  version = "~> 1.11"
-}
+provider "kubernetes" {}
 
 provider "helm" {
   kubernetes {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 1.11.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/main.tf
@@ -20,9 +20,7 @@ provider "aws" {
 }
 
 # For Push gateway
-provider "kubernetes" {
-  version = "~> 1.11"
-}
+provider "kubernetes" {}
 
 # For Push gateway
 provider "helm" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 1.11.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"


### PR DESCRIPTION
The version argument inside provider configuration blocks has been deprecated since Terraform 0.12, so this PR moves the `version` constraint into the `required_provider` configuration instead.

[Source - under "UPGRADE NOTES"](https://github.com/hashicorp/terraform/blob/v0.14/CHANGELOG.md)

Note that the provider version for this provider is outdated, and will be updated in a subsequent PR.