### PR TITLE
Remove deprecated version specification from provider to required_provider

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/main.tf
@@ -19,6 +19,4 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-provider "random" {
-  version = ">= 2.3.0, < 3.0.0"
-}
+provider "random" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -10,7 +9,8 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 2.3.1"
     }
   }
 }


### PR DESCRIPTION
The version argument inside provider configuration blocks has been deprecated since Terraform 0.12, so this PR moves the version constraint into the required_provider configuration instead.

[Source - under "UPGRADE NOTES"](https://github.com/hashicorp/terraform/blob/v0.14/CHANGELOG.md)

Note that the provider version for this provider is outdated, and will be updated in a subsequent PR.