### PR TITLE
Pin shared GitHub actions to v10

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ministryofjustice/github-actions/code-formatter@main
+      - uses: ministryofjustice/github-actions/code-formatter@v10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/iam-role-policy-changes-check.yaml
+++ b/.github/workflows/iam-role-policy-changes-check.yaml
@@ -25,7 +25,7 @@ jobs:
           git diff origin/main HEAD > changes
       - name: Run iam/role policy changes check
         id: review_pr
-        uses: ministryofjustice/github-actions/iam-role-policy-changes-check@main
+        uses: ministryofjustice/github-actions/iam-role-policy-changes-check@v10
       - name: Request changes in the PR
         uses: andrewmusgrave/automatic-pull-request-review@0.0.5
         if: steps.review_pr.outputs.review_pr_iam_check == 'false'

--- a/.github/workflows/malformed-yaml.yml
+++ b/.github/workflows/malformed-yaml.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ministryofjustice/github-actions/malformed-yaml@main
+      - uses: ministryofjustice/github-actions/malformed-yaml@v10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reject-multi-namespace-prs.yml
+++ b/.github/workflows/reject-multi-namespace-prs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ministryofjustice/github-actions/reject-multi-namespace-prs@main
+      - uses: ministryofjustice/github-actions/reject-multi-namespace-prs@v10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
`ministryofjustice/github-actions` is broken on `main`, so this pins the shared GitHub actions to the last working version, `v10`.