### PR TITLE
live-2, versions integrity: set required_providers versions

### DIFF
--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/versions.tf
@@ -1,14 +1,13 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "~> 4.27.0"
     }
     dns = {
       source  = "hashicorp/dns"
-      version = "3.2.3"
+      version = "~> 3.2.3"
     }
     helm = {
       source  = "hashicorp/helm"
@@ -16,11 +15,11 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.12.1"
+      version = "~> 2.12.1"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-dev/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-dev/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-dev/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-dev/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action-dev/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action-dev/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-reports-dev/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/jacksapp-dev/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/jacksapp-dev/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/monitoring/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/monitoring/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -6,12 +5,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
     }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
-    }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/poornima-dev/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/poornima-dev/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/vijay-beta/resources/versions.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/vijay-beta/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }


### PR DESCRIPTION
This PR does three things:

- removes unused providers for a namespace from `required_providers`
- bumps `hashicorp/aws` from `4.23.0` to `~> 4.27.0` to match `live.`
- adds in missing providers and specified versions

This means these namespaces, when run through Concourse, will use the latest patch in the version constraint that is declared, giving us some some further confidence that they're running the "correct"/declared version of the specific provider. It also means that where previously versions weren't defined, the namespace will not jump to the next major version of a release without explicitly updating it.