### PR TITLE
namespace-resources-cli-template, versions integrity: set kubernetes as a required provider

### DIFF
--- a/namespace-resources-cli-template/resources/versions.tf
+++ b/namespace-resources-cli-template/resources/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.17.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
+    }
   }
 }


### PR DESCRIPTION
Most namespaces utilise the `kubernetes` provider, so this adds it in by default to the `namespace-resources-cli-template`.