### PR TITLE
live, cloud-platform services, versions integrity: set required_providers versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     dns = {
       source  = "hashicorp/dns"
-      version = "3.2.3"
+      version = "~> 3.2.3"
     }
     helm = {
       source  = "hashicorp/helm"
@@ -15,11 +15,11 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.12.1"
+      version = "~> 2.12.1"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-metrics/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-metrics/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app-github-action/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reference-app/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloudplatformdiscovery-fs/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloudplatformdiscovery-fs/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }


### PR DESCRIPTION
This PR does three things to the namespaces:

- adds missing required_providers to namespaces
- adds missing versions to required_providers
- removes unused providers from required_providers