### PR TITLE
live, other non-production, versions integrity: set required_providers versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/accessibility-book-club/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/accessibility-book-club/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/anthony-britton/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/anthony-britton/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ap-app-poc-bde/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ap-app-poc-bde/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-design-history/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-design-history/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dex-ia-proto/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dex-ia-proto/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/eligibility-estimate/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/eligibility-estimate/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-demo/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-demo/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-education-design-history/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-education-design-history/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-design-history/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-design-history/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/interventions-design-history/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/interventions-design-history/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/isaiah-lakanu/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/isaiah-lakanu/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/jason-design-demo/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/jason-design-demo/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/versions.tf
@@ -6,10 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makerecalldecisions-design-history/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makerecalldecisions-design-history/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-pom-cases-design-history/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-pom-cases-design-history/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-supervisions-design-history/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-supervisions-design-history/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-exercise/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-exercise/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-sighting/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-sighting/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rob-sandbox/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rob-sandbox/resources/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 1.2.5"
   required_providers {
@@ -7,7 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }


### PR DESCRIPTION
This PR does three things to the namespaces:

- adds missing required_providers to namespaces
- adds missing versions to required_providers
- removes unused providers from required_providers