### PR TITLE
live, test, versions integrity: set required_providers versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-testing-sw/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-testing-sw/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dex-ian-dotnet-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dex-ian-dotnet-test/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-test/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/versions.tf
@@ -6,7 +6,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/versions.tf
@@ -5,9 +5,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
     }
-    github = {
-      source = "integrations/github"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 2.3.1"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-test/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/versions.tf
@@ -6,7 +6,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-test/resources/versions.tf
@@ -7,11 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/versions.tf
@@ -7,11 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/versions.tf
@@ -7,11 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/nettest/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/nettest/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/paul-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/paul-test/resources/versions.tf
@@ -6,7 +6,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }


### PR DESCRIPTION
This PR does three things to the namespaces:

- adds missing required_providers to namespaces
- adds missing versions to required_providers
- removes unused providers from required_providers