### PR TITLE
live, formbuilder services, versions integrity: set required_providers versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-publisher-live/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/versions.tf
@@ -6,7 +6,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }


### PR DESCRIPTION
This PR does three things to the namespaces:

- adds missing required_providers to namespaces
- adds missing versions to required_providers
- removes unused providers from required_providers