### PR TITLE
live, uat, versions integrity: set required_providers versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-partner-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-partner-uat/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/versions.tf
@@ -7,10 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/versions.tf
@@ -7,11 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/versions.tf
@@ -7,10 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/versions.tf
@@ -7,10 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-uat/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/versions.tf
@@ -6,11 +6,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-uat/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/versions.tf
@@ -7,11 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-uat/resources/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-uat/resources/versions.tf
@@ -7,11 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-uat/resources/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/versions.tf
@@ -7,11 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-uat/resources/versions.tf
@@ -7,11 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/versions.tf
@@ -7,10 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/versions.tf
@@ -7,10 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/versions.tf
@@ -7,13 +7,16 @@ terraform {
       version = "~> 4.27.0"
     }
     http = {
-      source = "hashicorp/http"
+      source  = "hashicorp/http"
+      version = "~> 3.2.1"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }


### PR DESCRIPTION
This PR does three things to the namespaces:

- adds missing required_providers to namespaces
- adds missing versions to required_providers
- removes unused providers from required_providers