### PR TITLE
live, hmpps services, versions integrity: set required_providers versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domestic-abuse-support-officers-shared/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domestic-abuse-support-officers-shared/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-tool/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-tool/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/versions.tf
@@ -7,10 +7,12 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-education/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-education/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-typescript/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-typescript/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-victim-case-management-system-shared/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-victim-case-management-system-shared/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-a-workforce/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-a-workforce/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pfs-education-admin-tool/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pfs-education-admin-tool/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-db-backups/resources/versions.tf
@@ -7,7 +7,8 @@ terraform {
       version = "~> 4.27.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management/resources/versions.tf
@@ -6,7 +6,8 @@ terraform {
       version = "~> 4.27.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 5.17.0"
     }
   }
 }


### PR DESCRIPTION
This PR does three things to the namespaces:

- adds missing required_providers to namespaces
- adds missing versions to required_providers
- removes unused providers from required_providers