### PR TITLE
Add TLS certificate for custom staging domain

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: assure-hmrc-data-certificate
+  namespace: laa-assure-hmrc-data-staging
+spec:
+  secretName: assure-hmrc-data-tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - staging.assure-hmrc-data.service.justice.gov.uk


### PR DESCRIPTION
Add TLS certificate for custom staging domain

Friendlier domain name as sub domain of
intended, eventual, production domain assure-hmrc-data.
