### PR TITLE
Bump hashicorp/kubernetes to v1.13.0

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11.0"
+      version = "~> 1.13.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/versions.tf
@@ -7,11 +7,11 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11.0"
+      version = "~> 1.13.0"
     }
     pingdom = {
       source  = "russellcardullo/pingdom"
-      version = "1.1.3"
+      version = "~> 1.1.3"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
This PR bumps namespaces that use `hashicorp/kubernetes@1.x.x` to its latest minor release, in preparation for upgrading to `hashicorp/kubernetes@2.x.x`.