### PR TITLE
Update ecr module from 4.9 - 5.1.0

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ap-auth-proxy-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ap-auth-proxy-prod/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.9"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.9"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.9"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 


### PR DESCRIPTION
- grc-prod : Users use the pre-prod secrets so not a issue
- sjpr-prod - Updates the secret  automatically to github action secrets
- ap-auth-proxy-prod. No app deployed in the namespace