### PR TITLE
PI-832 Reduce volume size to 128GB

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/es.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/es.tf
@@ -20,6 +20,6 @@ module "probation_search_elasticsearch" {
   dedicated_master_count          = 3
   instance_count                  = 6
   instance_type                   = "m5.xlarge.elasticsearch"
-  ebs_volume_size                 = 256
+  ebs_volume_size                 = 128
 }
 


### PR DESCRIPTION
Due to errors relating to throughput:
```
Error: error updating Elasticsearch Domain config: LimitExceededException: Throughput must be between 250 and 593
```