### PR TITLE
NN-4906: use AWS SSM to store offender-events-dev topic ARN

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/topic.tf
@@ -16,6 +16,23 @@ module "offender_events" {
   }
 }
 
+resource "aws_ssm_parameter" "param-store-topic-arn" {
+  type        = "String"
+  name        = "/${var.namespace}/topic-arn"
+  value       = module.offender_events.topic_arn
+  description = "SNS topic ARN for ${var.namespace}; use this parameter from other DPS dev namespaces"
+
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    owner                  = var.team_name
+    environment-name       = var.environment-name
+    infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
+  }
+}
+
 resource "kubernetes_secret" "offender_events" {
   metadata {
     name      = "offender-events-topic"


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/NN-4906

Same as https://github.com/ministryofjustice/cloud-platform-environments/pull/11155 but instead for `offender-events-dev`