### PR TITLE
[laa-assure-hmrc-data-production] Add TLS certificate for custom domain

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: assure-hmrc-data-certificate
+  namespace: laa-assure-hmrc-data-production
+spec:
+  secretName: assure-hmrc-data-tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - assure-hmrc-data.service.justice.gov.uk


### PR DESCRIPTION
Add TLS certificate for custom domain name in hosted zone

Intended domain name.
