### PR TITLE
chore: Give github:dps-tech group access to BaSM API staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:pecs-developers"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
This is so that the HMPPS Auth team can rotate our secrets.

[P4-4132]

[P4-4132]: https://dsdmoj.atlassian.net/browse/P4-4132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ