### PR TITLE
Revert "SDIT-650 Experiment with CPU request to fix slow startup"

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-offender-search-preprod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
         cpu: 2000m
         memory: 2048Mi
       defaultRequest:
-        cpu: 1000m
+        cpu: 10m
         memory: 856Mi
       type: Container


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-environments#11263

This is setting the CPU requests for all pods in that namespace to have 1 core which leads to node scaling up.
Informed user to set the request per deployment and not namespace level
@mikehalmamoj FYI