### PR TITLE
Resolve aws_acm_certificate lifecycle by telling Terraform to create a new certificate before destroying the old one (if necessary)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -17,6 +17,10 @@ resource "aws_api_gateway_domain_name" "api_gateway_fqdn" {
 resource "aws_acm_certificate" "api_gateway_custom_hostname" {
   domain_name       = "${var.hostname}.${var.base_domain}"
   validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_acm_certificate_validation" "api_gateway_custom_hostname" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-dev/resources/acm.tf
@@ -11,6 +11,10 @@ resource "aws_acm_certificate" "apigw_custom_hostname" {
     infrastructure-support = var.infrastructure_support
     namespace              = var.namespace
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_acm_certificate_validation" "apigw_custom_hostname" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-prod/resources/acm.tf
@@ -11,6 +11,10 @@ resource "aws_acm_certificate" "apigw_custom_hostname" {
     infrastructure-support = var.infrastructure_support
     namespace              = var.namespace
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_acm_certificate_validation" "apigw_custom_hostname" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-move-uat/resources/acm.tf
@@ -11,6 +11,10 @@ resource "aws_acm_certificate" "apigw_custom_hostname" {
     infrastructure-support = var.infrastructure_support
     namespace              = var.namespace
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_acm_certificate_validation" "apigw_custom_hostname" {


### PR DESCRIPTION
This PR updates `aws_acm_certificate` resources by adding a `lifecycle` block, so in the event of the certificate needing to be recreated, Terraform will create a new certificate before revoking the previous one.