### PR TITLE
Remove unused pathfinder- variables

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/cross-iam-role-sa.tf
@@ -5,6 +5,7 @@ module "irsa" {
   role_policy_arns = [aws_iam_policy.pathfinder_preprod_ap_policy.arn]
   service_account  = "to-ap-s3-service-account"
 }
+
 data "aws_iam_policy_document" "pathfinder_preprod_ap_policy" {
   # "api" policy statements for the namespace
   # allows direct access to "landing" S3 bucket
@@ -18,21 +19,12 @@ data "aws_iam_policy_document" "pathfinder_preprod_ap_policy" {
     ]
   }
 }
+
 resource "aws_iam_policy" "pathfinder_preprod_ap_policy" {
   name   = "pathfinder_preprod_ap_policy"
   policy = data.aws_iam_policy_document.pathfinder_preprod_ap_policy.json
 }
-variable "pathfinder-preprod-tags" {
-  type = map(string)
-  default = {
-    business-unit          = "HMPPS"
-    application            = "pathfinder"
-    is-production          = "false"
-    environment-name       = "preprod"
-    owner                  = "Digital Prison Services"
-    infrastructure-support = "dps-hmpps@digital.justice.gov.uk"
-  }
-}
+
 resource "kubernetes_secret" "irsa" {
   metadata {
     name      = "to-ap-s3-irsa"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/cross-iam-role-sa.tf
@@ -5,6 +5,7 @@ module "irsa" {
   role_policy_arns = [aws_iam_policy.pathfinder_prod_ap_policy.arn]
   service_account  = "to-ap-s3-service-account-prod"
 }
+
 data "aws_iam_policy_document" "pathfinder_prod_ap_policy" {
   # "api" policy statements for the namespace
   # allows direct access to "landing" S3 bucket
@@ -18,21 +19,12 @@ data "aws_iam_policy_document" "pathfinder_prod_ap_policy" {
     ]
   }
 }
+
 resource "aws_iam_policy" "pathfinder_prod_ap_policy" {
   name   = "pathfinder_prod_ap_policy"
   policy = data.aws_iam_policy_document.pathfinder_prod_ap_policy.json
 }
-variable "pathfinder-prod-tags" {
-  type = map(string)
-  default = {
-    business-unit          = "HMPPS"
-    application            = "pathfinder"
-    is-production          = "false"
-    environment-name       = "prod"
-    owner                  = "Digital Prison Services"
-    infrastructure-support = "dps-hmpps@digital.justice.gov.uk"
-  }
-}
+
 resource "kubernetes_secret" "irsa" {
   metadata {
     name      = "to-ap-s3-irsa"


### PR DESCRIPTION
I compared these with the direct variables (e.g. `variable "is_production"`) and they're the same.