### PR TITLE
Move environment-name variable to environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/elasticache.tf
@@ -10,7 +10,7 @@ module "contact_moj_elasticache_redis" {
   business-unit          = "Central Digital"
   application            = "contact-moj"
   is-production          = "false"
-  environment-name       = "development"
+  environment-name       = var.environment
   infrastructure-support = "staffservices@digital.justice.gov.uk"
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
@@ -15,7 +15,7 @@ module "contact-moj_rds" {
   db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "contact_moj_development"
-  environment-name           = "development"
+  environment-name           = var.environment
   infrastructure-support     = "staffservices@digital.justice.gov.uk"
 
   rds_family = "postgres12"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/variables.tf
@@ -19,6 +19,6 @@ variable "is-production" {
   default = "false"
 }
 
-variable "environment-name" {
+variable "environment" {
   default = "development"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/elasticache.tf
@@ -10,7 +10,7 @@ module "contact_moj_elasticache_redis" {
   business-unit          = "Central Digital"
   application            = "contact-moj"
   is-production          = "false"
-  environment-name       = "staging"
+  environment-name       = var.environment
   infrastructure-support = "staffservices@digital.justice.gov.uk"
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/rds.tf
@@ -15,7 +15,7 @@ module "contact-moj_rds" {
   db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "contact_moj_staging"
-  environment-name           = "staging"
+  environment-name           = var.environment
   infrastructure-support     = "staffservices@digital.justice.gov.uk"
 
   rds_family = "postgres12"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/variables.tf
@@ -19,6 +19,6 @@ variable "is-production" {
   default = "false"
 }
 
-variable "environment-name" {
+variable "environment" {
   default = "staging"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/variables.tf
@@ -20,7 +20,7 @@ variable "team_name" {
   default     = "Digital Prison Services/DPS Tech Team"
 }
 
-variable "environment-name" {
+variable "environment" {
   description = "The type of environment you're deploying to."
   default     = "prod"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
@@ -25,7 +25,7 @@ module "complexity-of-need-rds" {
   application            = "hmpps-complexity-of-need"
   is-production          = "false"
   namespace              = var.namespace
-  environment-name       = "staging"
+  environment-name       = var.environment
   infrastructure-support = "omic@digital.justice.gov.uk"
   db_engine              = "postgres"
   db_engine_version      = "14"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/variables.tf
@@ -1,4 +1,4 @@
-variable "environment-name" {
+variable "environment" {
   default = "staging"
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/variables.tf
@@ -20,7 +20,7 @@ variable "team_name" {
   default     = "laa-get-paid"
 }
 
-variable "environment-name" {
+variable "environment" {
   description = "The type of environment you're deploying to."
   default     = "dev"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test/resources/variables.tf
@@ -1,4 +1,4 @@
-variable "environment-name" {
+variable "environment" {
   default = "test"
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test2/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test2/resources/variables.tf
@@ -1,4 +1,4 @@
-variable "environment-name" {
+variable "environment" {
   default = "test2"
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/elasticsearch.tf
@@ -9,7 +9,7 @@ module "peoplefinder_es" {
   eks_cluster_name                = var.eks_cluster_name
   application                     = "peoplefinder"
   business-unit                   = "Central Digital"
-  environment-name                = "demo"
+  environment-name                = var.environment
   infrastructure-support          = "people-finder-support@digital.justice.gov.uk"
   is-production                   = "false"
   team_name                       = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-demo/resources/variables.tf
@@ -19,7 +19,7 @@ variable "is-production" {
   default = "false"
 }
 
-variable "environment-name" {
+variable "environment" {
   default = "demo"
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/elasticsearch.tf
@@ -9,7 +9,7 @@ module "peoplefinder_es" {
   eks_cluster_name                = var.eks_cluster_name
   application                     = "peoplefinder"
   business-unit                   = "Central Digital"
-  environment-name                = "development"
+  environment-name                = var.environment
   infrastructure-support          = "people-finder-support@digital.justice.gov.uk"
   is-production                   = "false"
   team_name                       = "peoplefinder"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/variables.tf
@@ -19,7 +19,7 @@ variable "is-production" {
   default = "false"
 }
 
-variable "environment-name" {
+variable "environment" {
   default = "development"
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/rds.tf
@@ -15,7 +15,7 @@ module "peoplefinder_rds" {
   db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "peoplefinder_staging"
-  environment-name           = "staging"
+  environment-name           = var.environment
   infrastructure-support     = "people-finder-support@digital.justice.gov.uk"
 
   rds_family = "postgres12"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/variables.tf
@@ -19,7 +19,7 @@ variable "is-production" {
   default = "false"
 }
 
-variable "environment-name" {
+variable "environment" {
   default = "staging"
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-api-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-api-dev/resources/variables.tf
@@ -20,7 +20,7 @@ variable "team_name" {
   default     = "syscon-devs"
 }
 
-variable "environment-name" {
+variable "environment" {
   description = "The type of environment you're deploying to."
   default     = "dev"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/elasticache.tf
@@ -10,7 +10,7 @@ module "track_a_query_elasticache_redis" {
   business-unit          = "Central Digital"
   application            = "track-a-query"
   is-production          = "false"
-  environment-name       = "development"
+  environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
@@ -15,7 +15,7 @@ module "track_a_query_rds" {
   db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_development"
-  environment-name           = "development"
+  environment-name           = var.environment
   infrastructure-support     = var.infrastructure_support
 
   rds_family = "postgres12"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -10,7 +10,7 @@ module "track_a_query_s3" {
   business-unit          = "Central Digital"
   application            = "track-a-query"
   is-production          = "false"
-  environment-name       = "development"
+  environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
   namespace              = var.namespace
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/variables.tf
@@ -20,7 +20,7 @@ variable "is-production" {
   default = "false"
 }
 
-variable "environment-name" {
+variable "environment" {
   default = "development"
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/elasticache.tf
@@ -10,7 +10,7 @@ module "track_a_query_elasticache_redis" {
   business-unit          = "Central Digital"
   application            = "track-a-query"
   is-production          = "false"
-  environment-name       = "qa"
+  environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
@@ -15,7 +15,7 @@ module "track_a_query_rds" {
   db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_qa"
-  environment-name           = "qa"
+  environment-name           = var.environment
   infrastructure-support     = var.infrastructure_support
 
   rds_family = "postgres12"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/s3.tf
@@ -10,7 +10,7 @@ module "track_a_query_s3" {
   business-unit          = "Central Digital"
   application            = "track-a-query"
   is-production          = "false"
-  environment-name       = "qa"
+  environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
 
   cors_rule = [

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/variables.tf
@@ -20,7 +20,7 @@ variable "is-production" {
   default = "false"
 }
 
-variable "environment-name" {
+variable "environment" {
   default = "qa"
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/elasticache.tf
@@ -10,7 +10,7 @@ module "track_a_query_elasticache_redis" {
   business-unit          = "Central Digital"
   application            = "track-a-query"
   is-production          = "false"
-  environment-name       = "staging"
+  environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
   engine_version         = "4.0.10"
   parameter_group_name   = "default.redis4.0"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
@@ -15,7 +15,7 @@ module "track_a_query_rds" {
   db_engine_version          = "12"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_staging"
-  environment-name           = "staging"
+  environment-name           = var.environment
   infrastructure-support     = var.infrastructure_support
 
   rds_family = "postgres12"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/s3.tf
@@ -10,7 +10,7 @@ module "track_a_query_s3" {
   business-unit          = "Central Digital"
   application            = "track-a-query"
   is-production          = "false"
-  environment-name       = "staging"
+  environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
 
   cors_rule = [

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/variables.tf
@@ -20,7 +20,7 @@ variable "is-production" {
   default = "false"
 }
 
-variable "environment-name" {
+variable "environment" {
   default = "staging"
 }
 


### PR DESCRIPTION
This PR moves unused `environment-name` variables to `environment` and uses them for module variables.