### PR TITLE
Remove legacy-style dash variables: team-name, slack-channel

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/variables.tf
@@ -57,11 +57,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "calculate-journey-variable-payments"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "calculatejourneypayments@digital.justice.gov.uk"
@@ -70,9 +65,3 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "calculate-journey-payments"
-}
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/variables.tf
@@ -57,11 +57,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "calculate-journey-variable-payments"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "pecs-digital-tech@digital.justice.gov.uk"
@@ -70,9 +65,3 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "calculate-journey-payments"
-}
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/variables.tf
@@ -57,11 +57,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "calculate-journey-variable-payments"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "pecs-digital-tech@digital.justice.gov.uk"
@@ -70,9 +65,3 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "calculate-journey-payments"
-}
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/variables.tf
@@ -61,11 +61,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "hmpps-assessments"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "assess-risks-and-needs@digital.justice.gov.uk"
@@ -73,11 +68,6 @@ variable "infrastructure-support" {
 
 variable "is-production" {
   default = "false"
-}
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "hmpps-assessments-dev"
 }
 
 variable "rds-family" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/variables.tf
@@ -55,11 +55,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "hmpps-ems-team"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "hmpps-ems-platform-team@digital.justice.gov.uk"
@@ -68,9 +63,3 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "hmpps-ems-platform-team"
-}
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/variables.tf
@@ -58,11 +58,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -72,12 +67,6 @@ variable "is-production" {
   default = "false"
 }
 
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_adjudications"
-}
-
 variable "number_cache_clusters" {
   default = "2"
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-preprod/resources/variables.tf
@@ -58,11 +58,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -72,12 +67,6 @@ variable "is-production" {
   default = "false"
 }
 
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_adjudications"
-}
-
 variable "number_cache_clusters" {
   default = "2"
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/variables.tf
@@ -58,11 +58,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -72,12 +67,6 @@ variable "is-production" {
   default = "false"
 }
 
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_adjudications"
-}
-
 variable "number_cache_clusters" {
   default = "2"
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-dev/resources/variables.tf
@@ -57,11 +57,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -69,11 +64,6 @@ variable "infrastructure-support" {
 
 variable "is-production" {
   default = "false"
-}
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_adjudications"
 }
 
 variable "number_cache_clusters" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-preprod/resources/variables.tf
@@ -58,11 +58,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -70,11 +65,6 @@ variable "infrastructure-support" {
 
 variable "is-production" {
   default = "false"
-}
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_adjudications"
 }
 
 variable "number_cache_clusters" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-prod/resources/variables.tf
@@ -58,11 +58,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -72,12 +67,6 @@ variable "is-production" {
   default = "false"
 }
 
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_adjudications"
-}
-
 variable "number_cache_clusters" {
   default = "2"
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/variables.tf
@@ -53,11 +53,6 @@ variable "business-unit" {
   default     = "Platforms"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "operations-engineering"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "operations-engineering@digital.justice.gov.uk"
@@ -66,12 +61,6 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "true"
 }
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "operations-engineering-team"
-}
-
 
 variable "domains" {
   description = "List of domains to be put in maintenance"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-dev/resources/variables.tf
@@ -51,11 +51,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -64,9 +59,3 @@ variable "infrastructure-support" {
 variable "is-production" {
   default = "false"
 }
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_core"
-}
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-preprod/resources/variables.tf
@@ -48,11 +48,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -60,9 +55,4 @@ variable "infrastructure-support" {
 
 variable "is-production" {
   default = "false"
-}
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_adjudications"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-prod/resources/variables.tf
@@ -52,11 +52,6 @@ variable "business-unit" {
   default     = "HMPPS"
 }
 
-variable "team-name" {
-  description = "The name of your development team"
-  default     = "dps-core"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"
@@ -64,9 +59,4 @@ variable "infrastructure-support" {
 
 variable "is-production" {
   default = "false"
-}
-
-variable "slack-channel" {
-  description = "Team slack channel to use if we need to contact your team"
-  default     = "dps_adjudications"
 }


### PR DESCRIPTION
These namespaces already have an equivalent (`team_name`, `slack_channel`) so this removes the unused, legacy-style dash variables.