### PR TITLE
Remove legacy-style dash variables from namespaces that already have the new style: business-unit

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/variables.tf
@@ -52,11 +52,6 @@ variable "slack_channel" {
 # have been left in place until all code has been updated to use snake-case
 # variable names.
 
-variable "business-unit" {
-  description = "Area of the MOJ responsible for the service."
-  default     = "HMPPS"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "calculatejourneypayments@digital.justice.gov.uk"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/variables.tf
@@ -52,11 +52,6 @@ variable "slack_channel" {
 # have been left in place until all code has been updated to use snake-case
 # variable names.
 
-variable "business-unit" {
-  description = "Area of the MOJ responsible for the service."
-  default     = "HMPPS"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "pecs-digital-tech@digital.justice.gov.uk"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/variables.tf
@@ -52,11 +52,6 @@ variable "slack_channel" {
 # have been left in place until all code has been updated to use snake-case
 # variable names.
 
-variable "business-unit" {
-  description = "Area of the MOJ responsible for the service."
-  default     = "HMPPS"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "pecs-digital-tech@digital.justice.gov.uk"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/variables.tf
@@ -56,11 +56,6 @@ variable "domain" {
 # have been left in place until all code has been updated to use snake-case
 # variable names.
 
-variable "business-unit" {
-  description = "Area of the MOJ responsible for the service."
-  default     = "HMPPS"
-}
-
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "assess-risks-and-needs@digital.justice.gov.uk"
@@ -73,4 +68,3 @@ variable "is-production" {
 variable "rds-family" {
   default = "postgres10"
 }
-


### PR DESCRIPTION
All these namespaces have both `business-unit` and `business_unit` variables, so this removes `business-unit` from them.