### PR TITLE
HAAR-1248: Upgraded token-verification-api-preprod elasticache redis

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "tva_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=6.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=6.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment-name       = var.environment-name
@@ -11,10 +11,11 @@ module "tva_elasticache_redis" {
   infrastructure-support = var.infrastructure_support
   team_name              = var.team_name
   number_cache_clusters  = var.number_cache_clusters
-  node_type              = "cache.t2.small"
-  engine_version         = "5.0.6"
-  parameter_group_name   = aws_elasticache_parameter_group.token_store.name
+  node_type              = "cache.t4g.micro"
+  engine_version         = "7.0"
+  parameter_group_name   = "default.redis7"
   namespace              = var.namespace
+  business-unit          = var.business_unit
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
Upgraded token-verification-api-preprod elasticache redis from "5.0.6" to V7