### PR TITLE
Remove maxReceiveCount from redrive policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sns-application-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sns-application-events.tf
@@ -45,7 +45,6 @@ resource "aws_sns_topic_subscription" "events-maat-subscription" {
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = module.application-events-dlq.sqs_arn
-    maxReceiveCount     = 3
   })
 }
 
@@ -59,7 +58,6 @@ resource "aws_sns_topic_subscription" "events-review-subscription" {
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = module.application-events-dlq.sqs_arn
-    maxReceiveCount     = 3
   })
 
   delivery_policy = jsonencode({


### PR DESCRIPTION
Follow up to PR #11514.

For SNS subscriptions it seems there is no `maxReceiveCount` attribute.

> (RedrivePolicy): InvalidParameter: Invalid parameter: RedrivePolicy: invalid JSON. Attribute maxReceiveCount is unknown.