### PR TITLE
HAAR-1248: Upgrade token-verification-api-prod to redis 7 - Step 1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-prod/resources/elasticache.tf
@@ -10,7 +10,6 @@ module "tva_elasticache_redis" {
   is-production          = var.is_production
   infrastructure-support = var.infrastructure_support
   team_name              = var.team_name
-  business-unit          = var.business_unit
   number_cache_clusters  = var.number_cache_clusters
   node_type              = "cache.t2.small"
   engine_version         = "5.0.6"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-prod/resources/elasticache.tf
@@ -14,8 +14,10 @@ module "tva_elasticache_redis" {
   number_cache_clusters  = var.number_cache_clusters
   node_type              = "cache.t2.small"
   engine_version         = "5.0.6"
-  parameter_group_name   = aws_elasticache_parameter_group.token_store.name
+  parameter_group_name   = "default.redis5.0"
+  # parameter_group_name   = aws_elasticache_parameter_group.token_store.name
   namespace              = var.namespace
+  business-unit          = var.business_unit
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
Step 1. Move to use default redis 5 param group