### PR TITLE
Upgrade `legal-framework-api-staging` db instance class

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/resources/rds.tf
@@ -15,7 +15,7 @@ module "rds" {
 
   # Database configuration
   db_engine_version = "14.4"
-  db_instance_class = "db.t3.large"
+  db_instance_class = "db.t4g.small"
   rds_family = "postgres14"
   allow_major_version_upgrade = "true"
 


### PR DESCRIPTION
Following the upgrade to PostgreSQL 14 in #11543, the db instance class can now be upgraded to the desired version (t4g) and updated to the previous size (small).