### PR TITLE
Upgrade `legal-framework-api-staging` to PostgreSQL 14.4

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # Database configuration
-  db_engine_version = "14"
+  db_engine_version = "14.4"
   db_instance_class = "db.t3.large"
   rds_family = "postgres14"
   allow_major_version_upgrade = "true"


### PR DESCRIPTION
In #11543, we attempted to upgrade to postgres 14, however the [subsequent build failed](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/4308).

This attempts to resolve the issue by specifying a valid upgrade target version explicitly.