### PR TITLE
Upgrade `legal-framework-api-production` db instance class

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/resources/rds.tf
@@ -7,24 +7,19 @@ module "rds" {
   application   = var.application
   is-production = var.is_production
   namespace     = var.namespace
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
 
   # enable performance insights
   performance_insights_enabled = true
 
-  # change the postgres version as you see fit.
+  # Database configuration
   db_engine_version      = "11"
-  environment-name       = var.environment
-  infrastructure-support = var.infrastructure_support
-
-  # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
-  # Pick the one that defines the postgres version the best
+  db_instance_class      = "db.t3.large"
   rds_family = "postgres11"
-
-  # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "true"
 
   providers = {
-    # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
 }


### PR DESCRIPTION
This temporarily updates the db instance class from `db.t2.small` to `db.t3.small` ahead of an engine version upgrade.

The current db instance class is deprecated and not supported for PostgreSQL 14.

Before we can upgrade to the recommended instance class (db.t4g.small), we need to update to a class that is compatible with v11 (i.e t3).

The size of the database has been temporarily upgraded to `large` to speed up the subsequent database upgrade.