### PR TITLE
Upgrade to `legal-framework-api-production` to PostgreSQL 14

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/resources/rds.tf
@@ -14,9 +14,9 @@ module "rds" {
   performance_insights_enabled = true
 
   # Database configuration
-  db_engine_version      = "11"
+  db_engine_version      = "14.4"
   db_instance_class      = "db.t3.large"
-  rds_family = "postgres11"
+  rds_family = "postgres14"
   allow_major_version_upgrade = "true"
 
   providers = {


### PR DESCRIPTION
This updates the database to the newest available target upgrade version for PostgreSQL 14 (i.e 14.4).