### PR TITLE
Remove kubernetes as required provider in template

### DIFF
--- a/namespace-resources-cli-template/resources/main.tf
+++ b/namespace-resources-cli-template/resources/main.tf
@@ -42,3 +42,5 @@ provider "github" {
   token = var.github_token
   owner = var.github_owner
 }
+
+provider "kubernetes" {}

--- a/namespace-resources-cli-template/resources/versions.tf
+++ b/namespace-resources-cli-template/resources/versions.tf
@@ -5,13 +5,5 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
     }
-    github = {
-      source  = "integrations/github"
-      version = "~> 5.17.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.18.0"
-    }
   }
 }

--- a/namespace-resources-cli-template/resources/versions.tf
+++ b/namespace-resources-cli-template/resources/versions.tf
@@ -5,5 +5,7 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
     }
+    github = {}
+    kubernetes = {}
   }
 }

--- a/namespace-resources-cli-template/resources/versions.tf
+++ b/namespace-resources-cli-template/resources/versions.tf
@@ -5,7 +5,5 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
     }
-    github = {}
-    kubernetes = {}
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/main.tf
@@ -42,3 +42,5 @@ provider "github" {
   token = var.github_token
   owner = var.github_owner
 }
+
+kubernetes = {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/main.tf
@@ -43,4 +43,4 @@ provider "github" {
   owner = var.github_owner
 }
 
-kubernetes = {}
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/versions.tf
@@ -5,13 +5,5 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
     }
-    github = {
-      source  = "integrations/github"
-      version = "~> 5.17.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.18.0"
-    }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/versions.tf
@@ -5,5 +5,7 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
     }
+    github = {}
+    kubernetes = {}
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tipstaff-dev/resources/versions.tf
@@ -5,7 +5,5 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.27.0"
     }
-    github = {}
-    kubernetes = {}
   }
 }


### PR DESCRIPTION
This is to fix the failing lint error:
 provider 'kubernetes' is declared in required_providers but not used by the
 module (terraform_unused_required_providers)