### PR TITLE
Add namespace for Accredited Programmes Test env

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/00-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-accredited-programmes-test
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "test"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "accredited-programme-team"
+    cloud-platform.justice.gov.uk/application: "Accredited Programmes"
+    cloud-platform.justice.gov.uk/owner: "Accredited Programmes: team-acp@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-accredited-programmes-ui,https://github.com/ministryofjustice/hmpps-accredited-programmes-api"
+    cloud-platform.justice.gov.uk/team-name: "accredited-programmes-team"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/01-rbac.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-accredited-programmes-test-admin
+  namespace: hmpps-accredited-programmes-test
+subjects:
+  - kind: Group
+    name: "github:accredited-programmes-team"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-accredited-programmes-test
+spec:
+  limits:
+    - default:
+        cpu: 2000m
+        memory: 1024Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 512Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-accredited-programmes-test
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-accredited-programmes-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-accredited-programmes-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/05-serviceaccount-circleci.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: circleci
+  namespace: hmpps-accredited-programmes-test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: circleci
+  namespace: hmpps-accredited-programmes-test
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-accredited-programmes-test
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: circleci
+  namespace: hmpps-accredited-programmes-test
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "prometheusrules"
+      - "servicemonitors"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - "networkpolicies"
+    verbs:
+      - "*"
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: circleci-prometheus
+  namespace: hmpps-accredited-programmes-test
+subjects:
+  - kind: ServiceAccount
+    name: circleci
+    namespace: hmpps-accredited-programmes-test
+roleRef:
+  kind: Role
+  name: circleci
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/06-certificates.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-accredited-programmes-test-cert
+  namespace: hmpps-accredited-programmes-test
+spec:
+  secretName: hmpps-accredited-programmes-test-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - accredited-programmes-test.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-accredited-programmes-api-dev-cert
+  namespace: hmpps-accredited-programmes-test
+spec:
+  secretName: hmpps-accredited-programmes-api-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - accredited-programmes-api-test.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/resources/elasticache.tf
@@ -1,0 +1,40 @@
+################################################################################
+# HMPPs Typescript Template Application Elasticache
+################################################################################
+
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=6.1.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  namespace              = var.namespace
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+
+  number_cache_clusters = var.number_cache_clusters
+  node_type             = "cache.t4g.small"
+  engine_version        = "6.x"
+  parameter_group_name  = "default.redis6.x"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    replication_group_id     = module.elasticache_redis.replication_group_id
+    access_key_id            = module.elasticache_redis.access_key_id
+    secret_access_key        = module.elasticache_redis.secret_access_key
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/resources/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/resources/variables.tf
@@ -1,0 +1,56 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Accredited Programmes"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "hmpps-accredited-programmes-test"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "accredited-programmes-team"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "test"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "team-acp@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "accredited-programme-team"
+}
+
+variable "number_cache_clusters" {
+  default = "2"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-test/resources/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.27.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.18.0"
+    }
+  }
+}


### PR DESCRIPTION
This creates a new namespace for the test environment for the Accredited Programmes project, and is heavily adapted from the dev environment PR #11731.

Again, please let me know if I've missed anything here.
