### PR TITLE
Change s3 bucket to public

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/s3.tf
@@ -15,25 +15,27 @@ module "s3_bucket" {
   infrastructure-support = var.infrastructure_support
   namespace              = var.namespace
 
-  /* 
+  /*
 
-  * Public Buckets: It is strongly advised to keep buckets 'private' and only make public where necessary. 
+  * Public Buckets: It is strongly advised to keep buckets 'private' and only make public where necessary.
                     By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
+  */
 
-                    acl                           = "public-read"
-                    enable_allow_block_pub_access = false
+  acl                           = "public-read"
+  enable_allow_block_pub_access = false
 
-                    For more information granting public access to S3 buckets, please see AWS documentation: 
+  /*
+                    For more information granting public access to S3 buckets, please see AWS documentation:
                     https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
 
   * Converting existing private bucket to public: If amending an existing private bucket that was created using version 4.3 or above then you will need to raise two PRs:
-                    
+
                     (1) First PR to add the var: enable_allow_block_pub_access = false
                     (2) Second PR to add the var: acl = "public-read"
 
   * Versioning: By default this is set to false. When set to true multiple versions of an object can be stored
                 For more details on versioning please visit: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
-  
+
   versioning             = true
 
   * Logging: By default set to false. When you enable logging, Amazon S3 delivers access logs for a source bucket to a target bucket that you choose.
@@ -43,21 +45,21 @@ module "s3_bucket" {
   logging_enabled        = true
   log_target_bucket      = "<TARGET_BUCKET_NAME>"
 
-  # NOTE: Important note that the target bucket for logging must have it's 'acl' property set to 'log-delivery-write'. 
+  # NOTE: Important note that the target bucket for logging must have it's 'acl' property set to 'log-delivery-write'.
           To apply this to an existing target bucket simply add the followng variable to its terraform module
           acl = "log-delivery-write"
-          
+
   log_path               = "<LOG_PATH>" e.g log/
-  
+
 */
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
     /*
-   * The following example can be used if you need to define CORS rules for your s3 bucket. 
+   * The following example can be used if you need to define CORS rules for your s3 bucket.
    *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-cors"
-   *  
+   *
 
   cors_rule =[
     {
@@ -78,7 +80,7 @@ module "s3_bucket" {
 
 
   /*
-   * The following example can be used if you need to set a lifecycle for your s3. 
+   * The following example can be used if you need to set a lifecycle for your s3.
    *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-object-lifecycle"
    *  "https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html"
    *

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/s3.tf
@@ -21,7 +21,7 @@ module "s3_bucket" {
                     By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
   */
 
-  #acl                           = "public-read"
+  # acl                           = "public-read"
   enable_allow_block_pub_access = false
 
   /*

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/s3.tf
@@ -21,7 +21,7 @@ module "s3_bucket" {
                     By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
   */
 
-  acl                           = "public-read"
+  #acl                           = "public-read"
   enable_allow_block_pub_access = false
 
   /*


### PR DESCRIPTION
WP needs access to a public s3 bucket to serve it's web content from.