### PR TITLE
Add public assess via ACL

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/s3.tf
@@ -21,7 +21,7 @@ module "s3_bucket" {
                     By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
   */
 
- # acl                           = "public-read"
+ acl                           = "public-read"
  enable_allow_block_pub_access = false
 
  /*


### PR DESCRIPTION
WordPress needs public access to the s3 bucket.