### PR TITLE
Revert "Upgrade licences postgres version"

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
@@ -1,17 +1,14 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.17.1"
-  vpc_name                    = var.vpc_name
-  team_name                   = var.team_name
-  business-unit               = var.business_unit
-  application                 = var.application
-  is-production               = var.is_production
-  namespace                   = var.namespace
-  environment-name            = var.environment-name
-  infrastructure-support      = var.infrastructure_support
-  allow_major_version_upgrade = "true"
-  db_instance_class           = "db.t3.large"
-  db_engine_version           = "14"
-  rds_family                  = "postgres14"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.17.1"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  namespace              = var.namespace
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure_support
+
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
Looks like the max postgres version we can migrate to from v10.21 is v14.3 rather than v14.6. 

Reverting to unblock the pipeline. 

Feel free to merge! 



Reverts ministryofjustice/cloud-platform-environments#11879