### PR TITLE
fix(cmd): fix to stop mismatching with empty namespace blocks

### DIFF
--- a/.github/workflows/compare-namespaces.yaml
+++ b/.github/workflows/compare-namespaces.yaml
@@ -1,44 +1,44 @@
-# name: Compare Respository Namespace with Terraform Resource Namespace
+name: Compare Respository Namespace with Terraform Resource Namespace
 
-# on:
-#   pull_request:
-#     paths:
-#       - 'namespaces/live.cloud-platform.service.justice.gov.uk/**'
-#       - 'namespaces/live-2.cloud-platform.service.justice.gov.uk/**'
-#   workflow_dispatch:
+on:
+  pull_request:
+    paths:
+      - 'namespaces/live.cloud-platform.service.justice.gov.uk/**'
+      - 'namespaces/live-2.cloud-platform.service.justice.gov.uk/**'
+  workflow_dispatch:
 
-# env:
-#   GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+env:
+  GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-# jobs:
-#   compare-namespaces:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v3
+jobs:
+  compare-namespaces:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       
-#       - id: compare-namespace
-#         name: Check Cross Namespace Deployments  
-#         uses: ministryofjustice/cloud-platform-environments/cmd/compare-namespace@main
+      - id: compare-namespace
+        name: Check Cross Namespace Deployments  
+        uses: ministryofjustice/cloud-platform-environments/cmd/compare-namespace@main
     
-#       - name: Comment Mismatch to Pull Request
-#         uses: actions/github-script@v6
-#         if: steps.compare-namespace.outputs.mismatch == 'true'
-#         env:
-#           RESULT: "Please review the following:\n${{ steps.compare-namespace.outputs.result }}"
-#         with:
-#           github-token: "${{ secrets.GITHUB_TOKEN }}"
-#           script: |
-#                 const output = `#### Namespace Mismatch Found:
-#                 <details><summary>Show</summary>
+      - name: Comment Mismatch to Pull Request
+        uses: actions/github-script@v6
+        if: steps.compare-namespace.outputs.mismatch == 'true'
+        env:
+          RESULT: "Please review the following:\n${{ steps.compare-namespace.outputs.result }}"
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+                const output = `#### Namespace Mismatch Found:
+                <details><summary>Show</summary>
                 
-#                 \`\`\`${process.env.RESULT}\`\`\`
+                \`\`\`${process.env.RESULT}\`\`\`
                 
-#                 </details>
-#                 *Pusher: @${{ github.actor }}, Workflow: \`${{ github.workflow }}\`*`;
-#                 github.rest.issues.createComment({
-#                   issue_number: context.issue.number,
-#                   owner: context.repo.owner,
-#                   repo: context.repo.repo,
-#                   body: output
-#                 })
+                </details>
+                *Pusher: @${{ github.actor }}, Workflow: \`${{ github.workflow }}\`*`;
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: output
+                })

--- a/cmd/compare-namespace/compare-namespace.go
+++ b/cmd/compare-namespace/compare-namespace.go
@@ -245,14 +245,18 @@ func main() {
 					rtn := block.Labels()
 					mm.ResourceTypeName = rtn[1]
 					mm.ResourceNamespace, mm.ResourceName = resourceType(block)
-					if !strings.Contains(mm.ResourceNamespace, mm.RepositoryNamespace) {
+					if mm.ResourceNamespace == "" {
+						fmt.Println("Namespace not found in Resource, skipping")
+					} else if !strings.Contains(mm.ResourceNamespace, mm.RepositoryNamespace) {
 						prMessage("resource")
 					}
 				case block.Type() == "module":
 					rtn := block.Labels()
 					mm.ModuleTypeName = rtn[0]
 					mm.ModuleNamespace = moduleType(block)
-					if !strings.Contains(mm.ModuleNamespace, mm.RepositoryNamespace) {
+					if mm.ModuleNamespace == "" {
+						fmt.Println("Namespace not found in Resource, skipping")
+					} else if !strings.Contains(mm.ModuleNamespace, mm.RepositoryNamespace) {
 						prMessage("module")
 					}
 				}

--- a/cmd/compare-namespace/templates/resources/test.tf
+++ b/cmd/compare-namespace/templates/resources/test.tf
@@ -15,3 +15,12 @@ resource "resource-test" "test" {
     namespace = var.namespace
   }
 }
+
+resource "resource-test" "test" {
+  metadata {
+
+  }
+  tags = {
+    "test" = "test"
+  }
+}


### PR DESCRIPTION
- fix(workflow): Comment out workflow for namespace check to forward fix go script
- fix(cmd): fix to stop mismatching with empty namespace blocks
