### PR TITLE
Add public read access ACL - 2 of 2

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/s3.tf
@@ -19,11 +19,10 @@ module "s3_bucket" {
 
   * Public Buckets: It is strongly advised to keep buckets 'private' and only make public where necessary.
                     By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
-
-  #                 acl                           = "public-read"
   */
 
- enable_allow_block_pub_access = false
+  acl                           = "public-read"
+  enable_allow_block_pub_access = false
 
   /*
                     For more information granting public access to S3 buckets, please see AWS documentation:


### PR DESCRIPTION
Allows public access to WordPress for s3 sync. Expectation is that the bucket will always be publicly accessible.