### PR TITLE
🗃️  set database isolation level to READ-COMMITTED for prisoner content hub backend in staging namespace.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/rds.tf
@@ -16,9 +16,15 @@ module "drupal_rds" {
   rds_family        = "mariadb10.4"
   db_password_rotated_date    = "2023-03-22"
 
-  # We need to explicitly set this to an empty list, otherwise the module
-  # will add `rds.force_ssl`, which MariaDB doesn't support
-  db_parameter = []
+  # The recommended transaction isolation level for Drupal is READ-COMMITTED.
+  # See https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level
+  db_parameter = [
+    {
+      name         = "tx_isolation"
+      value        = "READ-COMMITTED"
+      apply_method = "immediate"
+    }
+  ]
 }
 
 resource "kubernetes_secret" "drupal_rds" {


### PR DESCRIPTION
As https://github.com/ministryofjustice/cloud-platform-environments/pull/11979 but for staging instead of development.