### PR TITLE
🗃️  set database isolation level to READ-COMMITTED for prisoner content hub backend for production namespace.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
@@ -19,9 +19,15 @@ module "drupal_rds" {
   db_engine_version = "10.4"
   rds_family        = "mariadb10.4"
 
-  # We need to explicitly set this to an empty list, otherwise the module
-  # will add `rds.force_ssl`, which MariaDB doesn't support
-  db_parameter = []
+  # The recommended transaction isolation level for Drupal is READ-COMMITTED.
+  # See https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level
+  db_parameter = [
+    {
+      name         = "tx_isolation"
+      value        = "READ-COMMITTED"
+      apply_method = "immediate"
+    }
+  ]
 }
 
 resource "kubernetes_secret" "drupal_rds" {


### PR DESCRIPTION
As https://github.com/ministryofjustice/cloud-platform-environments/pull/11995 but for production