### PR TITLE
offender-management-staging: Rotate redis token again

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
@@ -12,7 +12,7 @@ module "ec-cluster-offender-management-allocation-manager" {
   parameter_group_name   = "default.redis5.0"
   namespace              = var.namespace
 
-  auth_token_rotated_date = "2023-04-05T10:39:00Z"
+  auth_token_rotated_date = "2023-04-05T17:15:00Z"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
I believe that when trying to rotate with engine version 4.0, something got confused and now we cannot access redis even after the version upgrade. Hopefully this new rotation will set the auth token correctly everywhere - the cluster and the k8s secret - making it usable by us again.