### PR TITLE
add-github-token-for-metrics

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-metrics/resources/secrets.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-metrics/resources/secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-platform-metrics-github-token
+type: Opaque
+data:
+  token: Z2hwXzdLM09xbWM4OEZiQ3pKSU85QnJ3bTgyb1lnZnhoazJkR2tBZA==


### PR DESCRIPTION
Create Github-token for cloud-platform-metrics - specifically infrastructure deploy metrics