### PR TITLE
Allow any CCQ environments to use CFE-Civil Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/04-networkpolicy.yaml
@@ -42,4 +42,10 @@ spec:
               cloud-platform.justice.gov.uk/namespace: laa-estimate-financial-eligibility-for-legal-aid-production
         - namespaceSelector:
             matchLabels:
+              cloud-platform.justice.gov.uk/namespace: laa-estimate-financial-eligibility-for-legal-aid-staging
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: laa-estimate-financial-eligibility-for-legal-aid-uat
+        - namespaceSelector:
+            matchLabels:
               cloud-platform.justice.gov.uk/namespace: laa-apply-for-legalaid-production


### PR DESCRIPTION
Allow any CCQ environment to use CFE-Civil Prod (temporarily), in cases if there are temporary issues with CFE-Civil UAT/Staging.

Discussion:
https://mojdt.slack.com/archives/C04TQBBDG2D/p1681381262859979?thread_ts=1681376455.047959&cid=C04TQBBDG2D