### PR TITLE
Use test-webops for paul-test namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/paul-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/paul-test/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: paul-test
 subjects:
   - kind: Group
-    name: "github:webops"
+    name: "github:test-webops"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
This is to test non-admin dummy-user permissions for modsec logs