### PR TITLE
Add new route53 configs for multisite domains

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/ccrc-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/ccrc-route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "ccrc_route53_zone" {
-  name = "ccrc.service.justice.gov.uk"
+  name = "ccrc.gov.uk"
 
   tags = {
     business-unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/ccrc-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/ccrc-route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "ccrc_route53_zone" {
+  name = "ccrc.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "ccrc_route53_zone_sec" {
+  metadata {
+    name      = "ccrc-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.ccrc_route53_zone.zone_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/imb-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/imb-route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "imb_route53_zone" {
+  name = "imb.org.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "imb_route53_zone_sec" {
+  metadata {
+    name      = "imb-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.imb_route53_zone.zone_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/magistrates-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/magistrates-route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "magistrates_route53_zone" {
+  name = "magistrates.judiciary.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "magistrates_route53_zone_sec" {
+  metadata {
+    name      = "magistrates-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.magistrates_route53_zone.zone_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/publicdefenderservice-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/publicdefenderservice-route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "publicdefenderservice_route53_zone" {
+  name = "publicdefenderservice.org.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "publicdefenderservice_route53_zone_sec" {
+  metadata {
+    name      = "publicdefenderservice-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.publicdefenderservice_route53_zone.zone_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/victimscommissioner-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/victimscommissioner-route53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "victimscommissioner_route53_zone" {
+  name = "victimscommissioner.org.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "victimscommissioner_route53_zone_sec" {
+  metadata {
+    name      = "victimscommissioner-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.victimscommissioner_route53_zone.zone_id
+  }
+}


### PR DESCRIPTION
When migrating over to CloudPlatforms we need to have our route53 configuratins setup for our domains that reside on multisite.

