### PR TITLE
Add self-signed CA for production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-production/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-production/resources/s3.tf
@@ -50,11 +50,11 @@ resource "kubernetes_secret" "truststore_s3_bucket" {
 
 data "github_repository_file" "truststore" {
   repository = "ministryofjustice/hmpps-integration-api"
-  file       = "temporary_certificates/truststore.pem"
+  file       = "temporary_certificates/production-truststore.pem"
 }
 
 resource "aws_s3_object" "truststore" {
   bucket  = module.truststore_s3_bucket.bucket_name
-  key     = "truststore.pem"
+  key     = "production-truststore.pem"
   content = data.github_repository_file.truststore.content
 }


### PR DESCRIPTION
This is used to do the mutual TLS, and requires a common name that points to the production URL