### PR TITLE
update sns topics to latest release

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/sns.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/sns.tf
@@ -5,7 +5,7 @@
  *
  */
 module "abundant_namespace_dev_sns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name     = "test-sns"
   business_unit          = "hq"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/messaging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "cccd-claims-submitted"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "cccd-claims-submitted"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "cccd-claims-submitted"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-staging/resources/messaging.tf
@@ -1,5 +1,5 @@
 module "cccd_claims_submitted" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "cccd-claims-submitted"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/court-case-events-sns-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/court-case-events-sns-topic.tf
@@ -1,5 +1,5 @@
 module "court-case-events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "court-case-events"
   encrypt_sns_kms    = true

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/court-case-events-sns-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/court-case-events-sns-topic.tf
@@ -1,5 +1,5 @@
 module "court-case-events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "court-case-events"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/court-case-events-sns-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/court-case-events-sns-topic.tf
@@ -1,5 +1,5 @@
 module "court-case-events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "court-case-events"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-domain-events-topic.tf
@@ -1,5 +1,5 @@
 module "hmpps-domain-events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "hmpps-domain-events"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-domain-events-topic.tf
@@ -1,5 +1,5 @@
 module "hmpps-domain-events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "hmpps-domain-events"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-domain-events-topic.tf
@@ -1,5 +1,5 @@
 module "hmpps-domain-events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "hmpps-domain-events"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sns-application-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sns-application-events.tf
@@ -1,5 +1,5 @@
 module "application-events-sns-topic" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "datastore-application-events"
   encrypt_sns_kms    = true

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/topic.tf
@@ -1,5 +1,5 @@
 module "offender_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "offender-events"
 
@@ -56,7 +56,7 @@ resource "kubernetes_secret" "prison-data-compliance" {
 }
 
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
   topic_display_name = "probation-offender-events"
 
   business_unit          = var.business_unit
@@ -73,7 +73,7 @@ module "probation_offender_events" {
 }
 
 module "offender_assessments_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
   topic_display_name = "offender-assessments-events"
 
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic-perf.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic-perf.tf
@@ -1,5 +1,5 @@
 module "probation_offender_events_perf" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
   topic_display_name = "probation-offender-events-perf"
 
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/topic.tf
@@ -1,5 +1,5 @@
 module "offender_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "offender-events"
 
@@ -56,7 +56,7 @@ resource "kubernetes_secret" "prison-data-compliance" {
 }
 
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
   topic_display_name = "probation-offender-events"
 
   business_unit          = var.business_unit
@@ -73,7 +73,7 @@ module "probation_offender_events" {
 }
 
 module "offender_assessments_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
   topic_display_name = "offender-assessments-events"
 
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/topic.tf
@@ -1,5 +1,5 @@
 module "offender_events" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "offender-events"
 
@@ -43,7 +43,7 @@ resource "kubernetes_secret" "offender_case_notes" {
 }
 
 module "probation_offender_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
   topic_display_name = "probation-offender-events"
 
   business_unit          = var.business_unit
@@ -73,7 +73,7 @@ resource "kubernetes_secret" "prison_data_compliance" {
 }
 
 module "offender_assessments_events" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
   topic_display_name = "offender-assessments-events"
 
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/sns.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/sns.tf
@@ -1,5 +1,5 @@
 module "events_sns_topic" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.8.0"
 
   topic_display_name = "offender-management-staging-events"
   encrypt_sns_kms    = true


### PR DESCRIPTION
sns module now supports provisioning of additional IAM user/keys for shared topics as per:
https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4383