### PR TITLE
enable rds auto start stop for laa-hmrc-interface

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/rds.tf
@@ -24,6 +24,9 @@ module "rds" {
   allow_major_version_upgrade = "true"
   db_instance_class           = "db.t4g.small"
 
+  # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
+  enable_rds_auto_start_stop = true
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london


### PR DESCRIPTION
Enable rds auto start stop for laa-hmrc-interface