### PR TITLE
Update key of the Kubernetes secret for APIGW client cert

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-production/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-production/resources/api_gateway.tf
@@ -185,7 +185,7 @@ resource "kubernetes_secret" "api_gateway_client_certificate_secret" {
   }
 
   data = {
-    certificate = aws_api_gateway_client_certificate.api_gateway_client.pem_encoded_certificate
+    "ca.crt" = aws_api_gateway_client_certificate.api_gateway_client.pem_encoded_certificate
   }
 }
 


### PR DESCRIPTION
This auto generated client certificate acts as the CA as well. Store this in a Kubernetes secret with the corret key so it can be easily referenced.