### PR TITLE
CCQ Staging: Switch off RDS at night

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-staging/resources/rds.tf
@@ -47,7 +47,7 @@ module "rds" {
   allow_major_version_upgrade = "false"
 
   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
-  # enable_rds_auto_start_stop  = true
+  enable_rds_auto_start_stop  = true
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
The CCQ staging environment doesn't need its RDS instance running overnight, so this PR allows it to be switched off to save costs.