### PR TITLE
CAS dev upgraded to Redis 7

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/elasticache.tf
@@ -13,8 +13,8 @@ module "elasticache_redis" {
   business-unit          = var.business_unit
   number_cache_clusters  = var.number_cache_clusters
   node_type              = "cache.t2.small"
-  engine_version         = "4.0.10"
-  parameter_group_name   = "default.redis4.0"
+  engine_version         = "7.0"
+  parameter_group_name   = "default.redis7"
   namespace              = var.namespace
 
   providers = {
@@ -34,4 +34,3 @@ resource "kubernetes_secret" "elasticache_redis" {
     member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
   }
 }
-


### PR DESCRIPTION
The required pipeline skip has been merged https://github.com/ministryofjustice/cloud-platform-environments/pull/12213

We've tested the change locally. Next step is to test this on our dev environment before proceeding to other namespaces.

Following the guidance here for jumping straight to redis 7: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/redis/upgrade.html#upgrading-a-redis-version

