### PR TITLE
demote namespace prior to deletion

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/judicial-reviews-app/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/judicial-reviews-app/00-namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: judicial-reviews-app
   labels:
-    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "production"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "Platforms"


### PR DESCRIPTION
judicial-reviews-app namespace needs to be removed. This demotes it from production prior to that step.