### PR TITLE
Fix Cloud Platform URL used for API Gateway HTTP proxy in production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-production/resources/variables.tf
@@ -69,5 +69,5 @@ variable "hostname" {
 
 variable "cloud_platform_integration_api_url" {
   description = "Pre-defined domain for the namespace provided by Cloud Platform"
-  default     = "https://hmpps-integration-api.apps.live.cloud-platform.service.justice.gov.uk"
+  default     = "https://hmpps-integration-api-production.apps.live.cloud-platform.service.justice.gov.uk"
 }


### PR DESCRIPTION
We're using API Gateway to forward requests to our API in Cloud Platform but we used the incorrect URL which meant that we were getting a 404 page when calling our API.