### PR TITLE
Refactor secrets generation and injection

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/api-auth-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/api-auth-secrets.tf
@@ -1,17 +1,49 @@
 resource "random_password" "passwords" {
   count   = 2
-  length  = 20
+  length  = 32
   special = true
 }
 
+locals {
+  # Declare consumers of the API, keeping the order.
+  datastore_api_consumers = {
+    "crime_apply" = {
+      namespace = "laa-apply-for-criminal-legal-aid-staging"
+      secret    = random_password.passwords[0].result
+    }
+    "crime_review" = {
+      namespace = "laa-review-criminal-legal-aid-staging"
+      secret    = random_password.passwords[1].result
+    }
+  }
+}
+
+# No need to touch anything below this line. The above map
+# should declare all consumers and namespaces. Code below
+# will dynamically use the keys and values accordingly.
+
 resource "kubernetes_secret" "api-auth-secrets" {
+  for_each = local.datastore_api_consumers
+
   metadata {
     name      = "api-auth-secrets"
     namespace = var.namespace
   }
 
   data = {
-    crime_apply  = random_password.passwords[0].result
-    crime_review = random_password.passwords[1].result
+    (each.key) = each.value.secret
+  }
+}
+
+resource "kubernetes_secret" "apply-api-auth-secret" {
+  for_each = local.datastore_api_consumers
+
+  metadata {
+    name      = "datastore-api-auth-secret"
+    namespace = each.value.namespace
+  }
+
+  data = {
+    secret = each.value.secret
   }
 }


### PR DESCRIPTION
This is a first attempt to change from a pull, to a push approach for API secrets. As we can have multiple consumers (for now 2, soon 3), using a `map` and `for_each` can DRY the code and make changes more robust.

Note: this should regenerate existing secrets (change from 20 to 32 chars), that is fine and expected.