### PR TITLE
Create an API key for each engineer on the team

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/locals.tf
@@ -10,5 +10,5 @@ locals {
     GithubTeam             = var.team_name
   }
 
-  clients = [var.team_name]
+  clients = ["emile", "ting", "april", "matt"]
 }


### PR DESCRIPTION
Use individual API keys so we can better monitor usage statistics. API keys are used in combination with client certificates and IP restrictions.