### PR TITLE
Fix multiple kubernetes secret resource

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -159,15 +159,13 @@ resource "aws_api_gateway_usage_plan_key" "clients" {
 }
 
 resource "kubernetes_secret" "api_keys" {
-  for_each = aws_api_gateway_api_key.clients
-
   metadata {
     name      = "api-gateway-api-keys"
     namespace = var.namespace
   }
 
   data = {
-    local.clients[index(local.clients, each.key)] = aws_api_gateway_api_key.clients[each.key].value
+    for client in local.clients : client => aws_api_gateway_api_key.clients[client].value
   }
 }
 


### PR DESCRIPTION
for_each cannot be used with a list of clients on this resource. It will attempt to create multiple secrets with different content but of the same name. A for loop is required to achieve this.