### PR TITLE
Fix syntax for kubernetes secret with multiple values

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-pre-production/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-pre-production/resources/api_gateway.tf
@@ -167,6 +167,10 @@ resource "kubernetes_secret" "api_keys" {
   data = {
     for client in local.clients : client => aws_api_gateway_api_key.clients[client].value
   }
+
+  depends_on = [
+    aws_api_gateway_api_key.clients
+  ]
 }
 
 resource "aws_api_gateway_base_path_mapping" "hostname" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-pre-production/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-pre-production/resources/api_gateway.tf
@@ -159,15 +159,13 @@ resource "aws_api_gateway_usage_plan_key" "clients" {
 }
 
 resource "kubernetes_secret" "api_keys" {
-  for_each = aws_api_gateway_api_key.clients
-
   metadata {
     name      = "api-gateway-api-keys"
     namespace = var.namespace
   }
 
   data = {
-    local.clients[index(local.clients, each.key)] = aws_api_gateway_api_key.clients[each.key].value
+    for client in local.clients : client => aws_api_gateway_api_key.clients[client].value
   }
 }
 


### PR DESCRIPTION
Use `for` to build up a map, which contains the API Gateway API keys of all the engineers on the team.