### PR TITLE
Add depends_on to force resource execution order

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -167,6 +167,10 @@ resource "kubernetes_secret" "api_keys" {
   data = {
     for client in local.clients : client => aws_api_gateway_api_key.clients[client].value
   }
+
+  depends_on = [
+    aws_api_gateway_api_key.clients
+  ]
 }
 
 resource "aws_api_gateway_base_path_mapping" "hostname" {


### PR DESCRIPTION
Prevents a race condition by adding an explicit depends_on