### PR TITLE
Prefix development to Github trust store

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/s3.tf
@@ -55,7 +55,7 @@ data "github_repository_file" "truststore" {
 
 resource "aws_s3_object" "truststore" {
   bucket  = module.truststore_s3_bucket.bucket_name
-  key     = "truststore.pem"
+  key     = "development-truststore.pem"
   content = data.github_repository_file.truststore.content
 }
 


### PR DESCRIPTION
This makes it consistent with the other environments and allows for automation and scripting.