### PR TITLE
Create service account for laa-status-dashboard-development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/serviceaccount.tf
@@ -1,0 +1,14 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.8.1"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["laa-status-dashboard"]
+
+  # list of github environments, to create the service account secrets as environment secrets
+  # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets
+  github_environments = ["development"]
+}


### PR DESCRIPTION
Required to create a CI/CD pipeline with GitHub Actions.