### PR TITLE
CAS preprod upgraded to Redis 7

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/elasticache.tf
@@ -12,7 +12,7 @@ module "elasticache_redis" {
   team_name              = var.team_name
   business-unit          = var.business_unit
   number_cache_clusters  = var.number_cache_clusters
-  node_type              = "cache.t2.small"
+  node_type              = "cache.t4g.micro"
   engine_version         = "7.0"
   parameter_group_name   = "default.redis7"
   namespace              = var.namespace


### PR DESCRIPTION
Skip file in place https://github.com/ministryofjustice/cloud-platform-environments/pull/12268

Following the guidance here for jumping straight to redis 7: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/redis/upgrade.html#upgrading-a-redis-version