### PR TITLE
CAS dev upgrade redis instance

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/elasticache.tf
@@ -12,7 +12,7 @@ module "elasticache_redis" {
   team_name              = var.team_name
   business-unit          = var.business_unit
   number_cache_clusters  = var.number_cache_clusters
-  node_type              = "cache.t2.small"
+  node_type              = "cache.t4g.micro"
   engine_version         = "7.0"
   parameter_group_name   = "default.redis7"
   namespace              = var.namespace


### PR DESCRIPTION
Upgrade redis type to cache.t4g.micro

Now that we've updated to Redis 7 we can change to a new instance type that should be more cost effective https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/redis/create.html#table-of-instance-types