### PR TITLE
Fix CAS test deployment by using compatible elasticache node

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/elasticache.tf
@@ -12,7 +12,7 @@ module "elasticache_redis" {
   team_name              = var.team_name
   business-unit          = var.business_unit
   number_cache_clusters  = var.number_cache_clusters
-  node_type              = "cache.t4g.micro"
+  node_type              = "cache.t3.micro"
   engine_version         = "7.0"
   parameter_group_name   = "default.redis7"
   namespace              = var.namespace


### PR DESCRIPTION
We tried deploying the redis engine upgrade to 7 at the same time as changing the node type. These need to be in two steps to get through deployment.

We'll move to t4g.micro later as a second operation.