### PR TITLE
Change CAS Test Elasticache to t4g.micro

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/elasticache.tf
@@ -12,7 +12,7 @@ module "elasticache_redis" {
   team_name              = var.team_name
   business-unit          = var.business_unit
   number_cache_clusters  = var.number_cache_clusters
-  node_type              = "cache.t3.micro"
+  node_type              = "cache.t4g.micro"
   engine_version         = "7.0"
   parameter_group_name   = "default.redis7"
   namespace              = var.namespace


### PR DESCRIPTION
The engine update to 7 looks to be complete https://github.com/ministryofjustice/cloud-platform-environments/pull/12509

Now the engine version has been updated to 7 and deployed, we can update our instance to a t4g for efficiency.