### PR TITLE
Change CAS prod Elasticache to t4g.small

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/elasticache.tf
@@ -12,7 +12,7 @@ module "elasticache_redis" {
   team_name              = var.team_name
   business-unit          = var.business_unit
   number_cache_clusters  = var.number_cache_clusters
-  node_type              = "cache.t3.small"
+  node_type              = "cache.t4g.small"
   engine_version         = "7.0"
   parameter_group_name   = "default.redis7"
   namespace              = var.namespace


### PR DESCRIPTION
The redis 7 engine update looks to have successfully completed: https://github.com/ministryofjustice/cloud-platform-environments/pull/12508

Now the engine version has been updated to 7 and deployed, we can update our instance to a t4g for efficiency.

