### PR TITLE
Upgrade to postgres v14

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/rds.tf
@@ -15,14 +15,14 @@ module "rds" {
 
   # change the postgres version as you see fit.
   db_engine         = "postgres"
-  db_engine_version = "15"
+  db_engine_version = "14"
 
   # change the instance class as you see fit.
   db_instance_class        = "db.t4g.micro"
   db_max_allocated_storage = "500"
 
   # Pick the one that defines the postgres version the best
-  rds_family = "postgres15"
+  rds_family = "postgres14"
 
   # use "prepare_for_major_upgrade" when upgrading the major version of an engine
   prepare_for_major_upgrade = true


### PR DESCRIPTION
Upgrade to v15 failed as upgrading from v13 -> v15 is too high a jump. Amends [previous change ](https://github.com/ministryofjustice/cloud-platform-environments/pull/12542) to upgrade to v14 instead. 