### PR TITLE
CTSKF-333 - UAT Set DB for update

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
@@ -17,8 +17,10 @@ module "lcdui_rds" {
   infrastructure-support      = var.infrastructure_support
   db_allocated_storage        = "10"
   db_instance_class           = "db.t3.small"
-  db_engine_version           = "11"
-  rds_family                  = "postgres11"
+  prepare_for_major_upgrade   = true
+  db_engine                   = "postgres"
+  db_engine_version           = "14.4"
+  rds_family                  = "postgres14"
   allow_major_version_upgrade = "true"
 
 


### PR DESCRIPTION
## Description

As per the email sent out around Postgres 11 deprecation we are upgrading our database version. 

## Changes

- added `prepare_for_major_upgrade`
- added `db_engine`
- changed `db_engine_version` from 11 -> 14.4 (we are on 11.16 so this is the latest version we can use as per [this documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion))
- changed `rds_family` from postgres11 to postgres14 

All done as per [the user guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-to-a-new-major-database-version) - point 5