### PR TITLE
Rotate CAS preprod elasticache auth token

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/elasticache.tf
@@ -17,6 +17,8 @@ module "elasticache_redis" {
   parameter_group_name   = "default.redis7"
   namespace              = var.namespace
 
+  auth_token_rotated_date = "2023-04-25"
+
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rotate-tokens-keys.html#aws-rds-db-password

- We are on the latest elasticache cluster module of 6.1.0