### PR TITLE
🐛 set the metadata.name for the kubernetes secret for the new S3 dev …

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -221,7 +221,7 @@ EOF
 
 resource "kubernetes_secret" "drupal_content_storage_2_secret" {
   metadata {
-    name      = "drupal-s3"
+    name      = "drupal-s3-2"
     namespace = var.namespace
   }
 


### PR DESCRIPTION
…bucket to be different to the old one, as terraform will refuse to apply it if they match.