### PR TITLE
CTSKF-333 Prod - set prepare_for_major_upgrade to false

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
@@ -17,7 +17,7 @@ module "lcdui_rds" {
   infrastructure-support      = var.infrastructure_support
   db_allocated_storage        = "10"
   db_instance_class           = "db.t3.small"
-  prepare_for_major_upgrade   = true
+  prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "14.4"
   rds_family                  = "postgres14"


### PR DESCRIPTION
## Description

As per the email sent out around Postgres 11 deprecation we are upgrading our database version. 

## Changes

- Set `prepare_for_major_upgrade` to false

All done as per [the user guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-to-a-new-major-database-version) - point 6