### PR TITLE
Enable API Gateway Cloudwatch logging on hmpps-integration-api-development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -222,7 +222,7 @@ resource "kubernetes_secret" "api_gateway_logs" {
   }
 
   data = {
-    "access_log_url" = "https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.api_gateway.id}/${aws_api_gateway_deployment.development.stage_name}"
+    "access_log_url" = "https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/${aws_cloudwatch_log_group.api_gateway_access_logs.name}"
   }
 
   depends_on = [

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/api_gateway.tf
@@ -211,7 +211,7 @@ resource "aws_api_gateway_stage" "development" {
 }
 
 resource "aws_cloudwatch_log_group" "api_gateway_access_logs" {
-  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.api_gateway.id}/${aws_api_gateway_deployment.development.stage_name}"
+  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.api_gateway.id}/${var.namespace}"
   retention_in_days = 7
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-development/resources/iam.tf
@@ -81,3 +81,27 @@ resource "aws_iam_role_policy" "api_gw_s3" {
 }
 EOF
 }
+
+data "aws_iam_policy_document" "cloudwatch" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+      "logs:GetLogEvents",
+      "logs:FilterLogEvents",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cloudwatch" {
+  name   = "${var.namespace}-default"
+  role   = aws_iam_role.api_gateway_role.id
+  policy = data.aws_iam_policy_document.cloudwatch.json
+}


### PR DESCRIPTION
- Enable access logs for API Gateway. 
- Store log group URL within Kubernetes secret for easy access. _Temporary solution until API Gateway is a supported module_
- Allow API Gateway to perform Cloudwatch actions
