### PR TITLE
EL-882: Keep staging RDS instance online overnight

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-staging/resources/rds.tf
@@ -47,7 +47,7 @@ module "rds" {
   allow_major_version_upgrade = "false"
 
   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
-  enable_rds_auto_start_stop  = true
+  enable_rds_auto_start_stop  = false
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Temporarily re-enable RDS overnight until we can come up with an elegant way of silencing Pingdom alerts 10pm - 6pm on Staging