### PR TITLE
Add service monitor for laa-status-dashboard-development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scraping
+  namespace: laa-status-dashboard-development
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/05-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/05-servicemonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: service-monitor-development
+spec:
+  selector:
+    matchLabels:
+      app: laa-status-dashboard-development
+  endpoints:
+  - port: https
+    interval: 30s


### PR DESCRIPTION
In order to get application metrics into Prometheus.