### PR TITLE
Add resources to laa-status-dashboard-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/ecr.tf
@@ -1,0 +1,80 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.1"
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  /*
+    By default scan_on_push is set to true. When this is enabled then all images pushed to the repo are scanned for any security
+    / software vulnerabilities in your image and the results can be viewed in the console. For further details, please see:
+    https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html
+    To disable 'scan_on_push', set it to false as below:
+  scan_on_push = "false"
+  */
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  github_repositories = ["laa-status-dashboard"]
+
+  # list of github environments, to create the ECR secrets as environment secrets
+  # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets
+  github_environments = ["staging"]
+
+  # Lifecycle_policy provides a way to automate the cleaning up of your container images by expiring images based on age or count.
+  # To apply multiple rules, combined them in one policy JSON.
+  # https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_examples.html
+
+  lifecycle_policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images older than 14 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 14
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Keep the newest 10 images and mark the rest for expiration",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 10
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+
+}
+
+
+resource "kubernetes_secret" "ecr_credentials" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.ecr_credentials.access_key_id
+    secret_access_key = module.ecr_credentials.secret_access_key
+    repo_arn          = module.ecr_credentials.repo_arn
+    repo_url          = module.ecr_credentials.repo_url
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/ecr.tf
@@ -5,9 +5,10 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.3"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
+  oidc_providers = ["github"]
 
   /*
     By default scan_on_push is set to true. When this is enabled then all images pushed to the repo are scanned for any security

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/elasticache.tf
@@ -1,0 +1,36 @@
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=6.1.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  namespace              = var.namespace
+
+  engine_version        = "7.0"
+  parameter_group_name  = "default.redis7"
+  node_type             = "cache.t4g.micro"
+  number_cache_clusters = "2"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    access_key_id            = module.elasticache_redis.access_key_id
+    secret_access_key        = module.elasticache_redis.secret_access_key
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    url                      = "rediss://${module.elasticache_redis.auth_token}@${module.elasticache_redis.primary_endpoint_address}:6379"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/rds-postgresql.tf
@@ -1,0 +1,60 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.18.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = true
+  db_max_allocated_storage     = "500"
+  enable_rds_auto_start_stop   = true
+  # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
+
+  # PostgreSQL specifics
+  db_engine         = "postgres"
+  db_engine_version = "15"
+  rds_family        = "postgres15"
+  db_instance_class = "db.t4g.micro"
+
+  # Tags
+  application            = var.application
+  business-unit          = var.business_unit
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  is-production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+  }
+}
+
+# Configmap to store non-sensitive data related to the RDS instance
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/serviceaccount.tf
@@ -1,0 +1,14 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.8.1"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["laa-status-dashboard"]
+
+  # list of github environments, to create the service account secrets as environment secrets
+  # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets
+  github_environments = ["staging"]
+}


### PR DESCRIPTION
Adding:

* RDS Postgres
* ECR
* Elasticache
* Service account

Notes:

I have added the `oidc_providers` because I was getting the following [in concourse](https://concourse.cloud-platform.service.justice.gov.uk/builds/21547043#L64527bb1:15:22):

```
Error: Invalid index

  on .terraform/modules/ecr_credentials/main.tf line 291, in resource "github_actions_secret" "role_to_assume":
 291:   plaintext_value = aws_iam_role.oidc["github"].arn
    ├────────────────
    │ aws_iam_role.oidc is object with no attributes

The given key does not identify an element in this collection value.
```