### PR TITLE
 claim-criminal-injuries-dev add tempus queue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -5,7 +5,7 @@ module "claim-criminal-injuries-tempus-queue" {
   fifo_queue             = false
   team_name              = var.team_name
   business-unit          = var.business_unit
-  tempus                 = var.tempus
+  application            = var.application
   is-production          = var.is_production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure_support
@@ -86,7 +86,7 @@ module "claim-criminal-injuries-tempus-dlq" {
   fifo_queue             = false
   team_name              = var.team_name
   business-unit          = var.business_unit
-  tempus            = var.tempus
+  application            = var.application
   is-production          = var.is_production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure_support

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -26,6 +26,9 @@ module "claim-criminal-injuries-tempus-queue" {
 
 data "aws_ssm_parameter" "cica_dev_account_id" {
   name = "/claim-criminal-injuries-compensation-dev/cica-dev-account-id"
+  depends_on = [
+    aws_ssm_parameter.cica_dev_account_id,
+  ]
 }
 
 resource "aws_sqs_queue_policy" "claim-criminal-injuries-tempus-queue-policy" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -79,7 +79,6 @@ resource "aws_sqs_queue_policy" "claim-criminal-injuries-tempus-queue-policy" {
   EOF
 }
 
-
 module "claim-criminal-injuries-tempus-dlq" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.11.0"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -1,5 +1,5 @@
 module "claim-criminal-injuries-tempus-queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.11.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.11.0"
 
   sqs_name               = "claim-criminal-injuries-tempus-queue"
   fifo_queue             = false

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -81,7 +81,7 @@ resource "aws_sqs_queue_policy" "claim-criminal-injuries-tempus-queue-policy" {
 
 
 module "claim-criminal-injuries-tempus-dlq" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.10.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.11.0"
 
   sqs_name               = "claim-criminal-injuries-tempus-dead-letter-queue"
   fifo_queue             = false

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -54,7 +54,7 @@ resource "aws_sqs_queue_policy" "claim-criminal-injuries-tempus-queue-policy" {
       {
         "Sid": "claim-criminal-injuries-tempus-queue-allow-app-service",
         "Effect": "Allow",
-        "Principal": {"AWS": "${data.aws_ssm_parameter.cica_dev_acct_id.value}"},
+        "Principal": {"AWS": "${data.aws_ssm_parameter.cica_dev_account_id.value}"},
         "Action": [
           "sqs:DeleteMessage",
           "sqs:ReceiveMessage",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -1,5 +1,5 @@
 module "claim-criminal-injuries-tempus-queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.10.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.11.1"
 
   sqs_name               = "claim-criminal-injuries-tempus-queue"
   fifo_queue             = false
@@ -13,7 +13,7 @@ module "claim-criminal-injuries-tempus-queue" {
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = module.claim-criminal-injuries-tempus-dlq.sqs_arn
-    maxReceiveCount     = 1
+    maxReceiveCount     = 3
   })
 
   # Set encrypt_sqs_kms = "true", to enable SSE for SQS using KMS key.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -1,0 +1,175 @@
+module "claim-criminal-injuries-tempus-queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.10.1"
+
+  sqs_name               = "claim-criminal-injuries-tempus-queue"
+  fifo_queue             = false
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  tempus            = var.tempus
+  is-production          = var.is_production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure_support
+  namespace              = var.namespace
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.claim-criminal-injuries-tempus-dlq.sqs_arn
+    maxReceiveCount     = 1
+  })
+
+  # Set encrypt_sqs_kms = "true", to enable SSE for SQS using KMS key.
+  encrypt_sqs_kms = "true"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+data "aws_ssm_parameter" "cica_dev_account_id" {
+  name = "cica_dev_account_id"
+}
+
+resource "aws_sqs_queue_policy" "claim-criminal-injuries-tempus-queue-policy" {
+  queue_url = module.claim-criminal-injuries-tempus-queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "claim-criminal-injuries-tempus-queue-access-policy",
+    "Statement": [
+      {
+        "Sid": "claim-criminal-injuries-tempus-queue-allow-dcs",
+        "Effect": "Allow",
+        "Principal": {"AWS": "*"},
+        "Action": "sqs:SendMessage",
+        "Resource": "${module.claim-criminal-injuries-tempus-queue.sqs_arn}",
+        "Condition": {
+          "ArnEquals": {
+            "aws:SourceArn": [
+              "${aws_iam_user.app_service.arn}",
+              "${aws_iam_user.redrive_service.arn}"
+            ]
+          }
+        }
+      },
+      {
+        "Sid": "claim-criminal-injuries-tempus-queue-allow-app-service",
+        "Effect": "Allow",
+        "Principal": {"AWS": "${data.aws_ssm_parameter.cica_dev_acct_id.value}"},
+        "Action": [
+          "sqs:DeleteMessage",
+          "sqs:ReceiveMessage",
+          "sqs:GetQueueAttributes"
+        ],
+        "Resource": "${module.claim-criminal-injuries-tempus-queue.sqs_arn}",
+      },
+      {
+        "Sid": "AlwaysEncrypted",
+        "Effect": "Deny",
+        "Principal": {"AWS": "*"},
+        "Action": "sqs:*",
+        "Resource": "${module.claim-criminal-injuries-tempus-queue.sqs_arn}",
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false"
+          }
+        }
+      }
+    ]
+  }
+  EOF
+}
+
+
+module "claim-criminal-injuries-tempus-dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.10.1"
+
+  sqs_name               = "claim-criminal-injuries-tempus-dead-letter-queue"
+  fifo_queue             = false
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  tempus            = var.tempus
+  is-production          = var.is_production
+  environment-name       = var.environment-name
+  infrastructure-support = var.infrastructure_support
+  namespace              = var.namespace
+
+  # Set encrypt_sqs_kms = "true", to enable SSE for SQS using KMS key.
+  encrypt_sqs_kms = "true"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "claim-criminal-injuries-tempus-dlq-policy" {
+  queue_url = module.claim-criminal-injuries-tempus-dlq.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "claim-criminal-injuries-tempus-queue-dlq-policy",
+    "Statement": [
+      {
+        "Sid": "claim-criminal-injuries-tempus-dlq-allow-redrive-service",
+        "Effect": "Allow",
+        "Principal": {"AWS": "*"},
+        "Action": [
+          "sqs:GetQueueAttributes",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage"
+        ],
+        "Resource": "${module.claim-criminal-injuries-tempus-dlq.sqs_arn}",
+        "Condition": {
+          "ArnNotEquals": {
+            "aws:SourceArn": [
+              "${aws_iam_user.redrive_service.arn}"
+            ]
+          }
+        }
+      },
+      {
+        "Sid": "AlwaysEncrypted",
+        "Effect": "Deny",
+        "Principal": {"AWS": "*"},
+        "Action": "sqs:*",
+        "Resource": "${module.claim-criminal-injuries-tempus-dlq.sqs_arn}",
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false"
+          }
+        }
+      }
+    ]
+  }
+  EOF
+}
+
+resource "kubernetes_secret" "claim-criminal-injuries-tempus-sqs" {
+  metadata {
+    name      = "tempus-sqs"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.claim-criminal-injuries-tempus-queue.access_key_id
+    secret_access_key = module.claim-criminal-injuries-tempus-queue.secret_access_key
+    sqs_id            = module.claim-criminal-injuries-tempus-queue.sqs_id
+    sqs_arn           = module.claim-criminal-injuries-tempus-queue.sqs_arn
+    sqs_name          = module.claim-criminal-injuries-tempus-queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "claim-criminal-injuries-tempus-dlq" {
+  metadata {
+    name      = "tempus-dlq"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.claim-criminal-injuries-tempus-dlq.access_key_id
+    secret_access_key = module.claim-criminal-injuries-tempus-dlq.secret_access_key
+    sqs_id            = module.claim-criminal-injuries-tempus-dlq.sqs_id
+    sqs_arn           = module.claim-criminal-injuries-tempus-dlq.sqs_arn
+    sqs_name          = module.claim-criminal-injuries-tempus-dlq.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -5,7 +5,7 @@ module "claim-criminal-injuries-tempus-queue" {
   fifo_queue             = false
   team_name              = var.team_name
   business-unit          = var.business_unit
-  tempus            = var.tempus
+  tempus                 = var.tempus
   is-production          = var.is_production
   environment-name       = var.environment-name
   infrastructure-support = var.infrastructure_support

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/claim-criminal-injuries-tempus-queue.tf
@@ -25,7 +25,7 @@ module "claim-criminal-injuries-tempus-queue" {
 }
 
 data "aws_ssm_parameter" "cica_dev_account_id" {
-  name = "cica_dev_account_id"
+  name = "/claim-criminal-injuries-compensation-dev/cica-dev-account-id"
 }
 
 resource "aws_sqs_queue_policy" "claim-criminal-injuries-tempus-queue-policy" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/route53.tf
@@ -69,3 +69,11 @@ resource "aws_route53_record" "data_platform_pagerduty_status_page_mail_dkim2" {
   ttl     = "300"
   records = ["pdt2.domainkey.u31181182.wl183.sendgrid.net."]
 }
+
+resource "aws_route53_record" "data_platform_rapid_dev_zone" {
+  zone_id = aws_route53_zone.data_platform_production_route53_zone.zone_id
+  name    = "rapid.dev.data-platform.service.justice.gov.uk"
+  type    = "NS"
+  ttl     = "600"
+  records = ["ns-1638.awsdns-12.co.uk.", "ns-93.awsdns-11.com.", "ns-1512.awsdns-61.org.", "ns-588.awsdns-09.net."]
+}


### PR DESCRIPTION
The SSM Parameter is to be overwritten by an MoJ CP team member to avoid putting account IDs in the public repository. As discussed with Jake.