### PR TITLE
Add DPS tech team to BOLD CID

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/bold-case-information-dashboard-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/bold-case-information-dashboard-dev/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:bold-rr-ops-team"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
Adding the DPS tech team to the BOLD case information dashboard so that the HMPPS Auth team can manage our credentials.