### PR TITLE
laa-assure-hmrc-data-production: remove unusable hosted zone

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/certificate.yaml
@@ -1,19 +1,6 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: assure-hmrc-data-certificate
-  namespace: laa-assure-hmrc-data-production
-spec:
-  secretName: assure-hmrc-data-tls-certificate
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
-  - assure-hmrc-data.service.justice.gov.uk
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
   name: check-clients-details-using-hmrc-data-certificate
   namespace: laa-assure-hmrc-data-production
 spec:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/route53.tf
@@ -1,18 +1,3 @@
-resource "aws_route53_zone" "assure_hmrc_data_route53_zone" {
-  name = "assure-hmrc-data.service.justice.gov.uk"
-
-  tags = {
-    team_name              = var.team_name
-    business-unit          = var.business_unit
-    application            = var.application
-    is-production          = var.is_production
-    environment-name       = var.environment
-    owner                  = var.team_name
-    infrastructure-support = var.infrastructure_support
-    namespace              = var.namespace
-  }
-}
-
 resource "aws_route53_zone" "check_clients_details_using_hmrc_data_route53_zone" {
   name = "check-clients-details-using-hmrc-data.service.justice.gov.uk"
 
@@ -35,8 +20,7 @@ resource "kubernetes_secret" "assure_hmrc_data_route_53_zone_sec" {
   }
 
   data = {
-    old_zone_id = aws_route53_zone.assure_hmrc_data_route53_zone.zone_id
-    new_zone_id = aws_route53_zone.check_clients_details_using_hmrc_data_route53_zone.zone_id
+    zone_id = aws_route53_zone.check_clients_details_using_hmrc_data_route53_zone.zone_id
   }
 }
 


### PR DESCRIPTION
Remove unusable hosted zone and certificate

Due to AzureAD authentication redirect URL issues it
is unnecessarily complex to ensure redirecting to the
the correct hosted zone/custom domain, so removing the
superfluous, older one, is simplest.
