### PR TITLE
laa-asure-hmrc-data-staging: remove certificate for old hosted zone

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/certificate.yaml
@@ -1,19 +1,6 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: assure-hmrc-data-certificate
-  namespace: laa-assure-hmrc-data-staging
-spec:
-  secretName: assure-hmrc-data-tls-certificate
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
-  - staging.assure-hmrc-data.service.justice.gov.uk
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
   name: check-clients-details-using-hmrc-data-certificate
   namespace: laa-assure-hmrc-data-staging
 spec:


### PR DESCRIPTION
Remove certificate for old hosted zone