### PR TITLE
Remove newlines from API Gateway CloudWatch logs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -178,7 +178,7 @@ resource "aws_api_gateway_stage" "main" {
 
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.api_gateway_access_logs.arn
-    format          = "$context.extendedRequestId $context.identity.sourceIp $context.identity.clientCert.subjectDN [$context.requestTime] \"$context.httpMethod $context.resourcePath \" \nHttpCode: $context.status \nLength:$context.responseLength"
+    format          = "$context.extendedRequestId $context.identity.sourceIp $context.identity.clientCert.subjectDN [$context.requestTime] \"$context.httpMethod $context.resourcePath\" HttpCode: $context.status Length: $context.responseLength"
   }
 
   depends_on = [aws_cloudwatch_log_group.api_gateway_access_logs]


### PR DESCRIPTION
This should fix the error: `BadRequestException: Access Log format must be single line, new line character is allowed only at end of the format`.

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/5639