### PR TITLE
LASB-1919: Enabled RDS auto start-stop for court data adaptor DEV.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
@@ -14,7 +14,6 @@ module "court_data_adaptor_rds" {
   db_engine_version           = "14"
   db_instance_class           = "db.t3.small"
   allow_major_version_upgrade = "true"
-   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
   enable_rds_auto_start_stop  = true
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
@@ -14,6 +14,8 @@ module "court_data_adaptor_rds" {
   db_engine_version           = "14"
   db_instance_class           = "db.t3.small"
   allow_major_version_upgrade = "true"
+   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
+  enable_rds_auto_start_stop  = true
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
- [x] Enable the RDS auto start-stop functionality for `laa-court-data-adaptor-dev`.