### PR TITLE
Upgrade redis node type formbuilder-platform-live-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
@@ -11,6 +11,7 @@ module "service-token-cache-elasticache" {
   business-unit          = var.business_unit
   engine_version         = "7.0"
   parameter_group_name   = "default.redis7"
+  node_type              = "cache.t4g.medium"
   namespace              = var.namespace
 
   providers = {


### PR DESCRIPTION
Gone for t4g.medium as this is a live/user facing env and higher traffic than our dev envs, it's live-dev as it's for form owners to publish and test their forms privately.