### PR TITLE
LASB-1919: Enabled RDS auto start-stop for CDA in UAT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds-instance.tf
@@ -13,6 +13,7 @@ module "court_data_adaptor_rds" {
   db_engine_version      = "14"
 
   allow_major_version_upgrade = "true"
+  enable_rds_auto_start_stop  = true
   db_instance_class           = "db.t3.small"
 
   providers = {


### PR DESCRIPTION
- [x] LASB-1919: Enabled RDS auto start-stop for laa-court-data-adaptor-uat.