### PR TITLE
Use smaller redis instance for laa-status-dashboard-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/elasticache.tf
@@ -11,7 +11,7 @@ module "elasticache_redis" {
 
   engine_version        = "7.0"
   parameter_group_name  = "default.redis7"
-  node_type             = "cache.m4.xlarge"
+  node_type             = "cache.t4g.small"
   number_cache_clusters = "2"
 
   providers = {


### PR DESCRIPTION
Might need to bump it up in the future