### PR TITLE
Add Pingdom to laa-status-dashboard-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/pingdom.tf
@@ -1,0 +1,18 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "laa-status-dashboard-production-healthcheck" {
+  type                     = "http"
+  name                     = "LAA Status Dashboard - Production"
+  host                     = "laa-status-dashboard.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 2
+  notifyagainevery         = 0
+  url                      = "/ping"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_${var.business_unit},application_${var.namespace},component_ping,isproduction_${var.is_production},environment_production,infrastructuresupport_${var.team_name}"
+  probefilters             = "region:EU"
+  integrationids           = [129414]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.20.0"
     }
+    pingdom = {
+      source  = "DrFaust92/pingdom"
+      version = "~> 1.3.1"
+    }
   }
 }


### PR DESCRIPTION
Preparing this even if laa-status-dashboard.service.justice.gov.uk hasn't been created yet.