### PR TITLE
LASB-1778: Update CDA infrastructure support email.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/cp_local_queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/cp_local_queue.tf
@@ -5,7 +5,7 @@ module "cp_test_queue" {
   team_name                 = "crimeapps"
   application               = "crimeapps"
   sqs_name                  = "cp-test-queue"
-  infrastructure-support    = "example-team@digtal.justice.gov.uk"
+  infrastructure-support    = var.infrastructure_support
   encrypt_sqs_kms           = "false"
   message_retention_seconds = 1209600
   namespace                 = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
@@ -8,7 +8,7 @@ module "court_data_adaptor_rds" {
   is-production = "false"
 
   environment-name       = "dev"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
 
   rds_family                  = "postgres14"
   db_engine_version           = "14"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds.tf
@@ -16,7 +16,7 @@ module "laa_crime_apps_team_rds" {
   # change the postgres version as you see fit.
   db_engine_version      = "11"
   environment-name       = "development"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/variables.tf
@@ -28,7 +28,7 @@ variable "environment_name" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "crimeapps-laa@digital.justice.gov.uk"
+  default     = "laa-crime-apps@digital.justice.gov.uk"
 }
 
 variable "namespace" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds-instance.tf
@@ -8,7 +8,7 @@ module "court_data_adaptor_rds" {
   is-production = "true"
 
   environment-name       = "prod"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
   rds_family             = "postgres14"
   db_engine_version      = "14.3"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds.tf
@@ -16,7 +16,7 @@ module "laa_crime_apps_team_rds" {
   # change the postgres version as you see fit.
   db_engine_version      = "11"
   environment-name       = "production"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/variables.tf
@@ -28,7 +28,7 @@ variable "environment_name" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "crimeapps-laa@digital.justice.gov.uk"
+  default     = "laa-crime-apps@digital.justice.gov.uk"
 }
 
 variable "namespace" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds-instance.tf
@@ -8,7 +8,7 @@ module "court_data_adaptor_rds" {
   is-production = "false"
 
   environment-name       = "stage"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
   rds_family             = "postgres14"
   db_engine_version      = "14"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds.tf
@@ -16,7 +16,7 @@ module "laa_crime_apps_team_rds" {
   # change the postgres version as you see fit.
   db_engine_version      = "11"
   environment-name       = "staging"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/variables.tf
@@ -28,7 +28,7 @@ variable "environment_name" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "crimeapps-laa@digital.justice.gov.uk"
+  default     = "laa-crime-apps@digital.justice.gov.uk"
 }
 
 variable "namespace" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds-instance.tf
@@ -9,7 +9,7 @@ module "court_data_adaptor_rds" {
 
   db_engine_version      = "14"
   environment-name       = "test"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
   rds_family             = "postgres14"
 
   allow_major_version_upgrade = "true"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds.tf
@@ -16,7 +16,7 @@ module "laa_crime_apps_team_rds" {
   # change the postgres version as you see fit.
   db_engine_version      = "11"
   environment-name       = "test"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/variables.tf
@@ -28,7 +28,7 @@ variable "environment_name" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "crimeapps-laa@digital.justice.gov.uk"
+  default     = "laa-crime-apps@digital.justice.gov.uk"
 }
 
 variable "namespace" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds-instance.tf
@@ -8,7 +8,7 @@ module "court_data_adaptor_rds" {
   is-production = "false"
 
   environment-name       = "uat"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
   rds_family             = "postgres14"
   db_engine_version      = "14"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds.tf
@@ -16,7 +16,7 @@ module "laa_crime_apps_team_rds" {
   # change the postgres version as you see fit.
   db_engine_version      = "11"
   environment-name       = "uat"
-  infrastructure-support = "laa@digital.justice.gov.uk"
+  infrastructure-support = var.infrastructure_support
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/variables.tf
@@ -28,7 +28,7 @@ variable "environment_name" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "crimeapps-laa@digital.justice.gov.uk"
+  default     = "laa-crime-apps@digital.justice.gov.uk"
 }
 
 variable "namespace" {


### PR DESCRIPTION
- [x] Infrastructure support email for all `laa-court-data-adaptor` namespaces updated to `laa-crime-apps@digital.justice.gov.uk`