### PR TITLE
Pde 2191 migrate data

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/analytical-platform-access.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/analytical-platform-access.tf
@@ -61,12 +61,12 @@ resource "aws_iam_user_policy" "pathfinder_ap_policy" {
 
 resource "kubernetes_secret" "ap_aws_secret" {
   metadata {
-    name      = "s3://moj-reg-dev/landing/hmpps-pathfinder-dev/"
+    name      = "pathfinder-analytical-platform-reporting-s3-bucket"
     namespace = var.namespace
   }
 
   data = {
-    destination_bucket = "s3://hmpps-${var.namespace}-landing"
+    destination_bucket = "s3://moj-reg-dev/landing/hmpps-pathfinder-dev/"
     user_arn           = aws_iam_user.pathfinder_ap_user.arn
     access_key_id      = aws_iam_access_key.pathfinder_ap_user.id
     secret_access_key  = aws_iam_access_key.pathfinder_ap_user.secret

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/analytical-platform-access.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/analytical-platform-access.tf
@@ -34,8 +34,8 @@ data "aws_iam_policy_document" "pathfinder_ap_access" {
     ]
 
     resources = [
-      "arn:aws:s3:::hmpps-${var.namespace}-landing/*",
-      "arn:aws:s3:::hmpps-${var.namespace}-landing/"
+      "arn:aws:s3:::moj-reg-dev/landing/hmpps-pathfinder-dev/*",
+      "arn:aws:s3:::moj-reg-dev/landing/hmpps-pathfinder-dev/"
     ]
   }
 }
@@ -61,7 +61,7 @@ resource "aws_iam_user_policy" "pathfinder_ap_policy" {
 
 resource "kubernetes_secret" "ap_aws_secret" {
   metadata {
-    name      = "pathfinder-analytical-platform-reporting-s3-bucket"
+    name      = "s3://moj-reg-dev/landing/hmpps-pathfinder-dev/"
     namespace = var.namespace
   }
 


### PR DESCRIPTION
Data Extractor will need to move data into another bucket. Hence the policy changes. 


Reason for change:

A new architecture is being implemented to reduce the number of S3 Buckets being used. 