### PR TITLE
Add versioning to truststore

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -11,6 +11,7 @@ resource "aws_api_gateway_domain_name" "api_gateway_fqdn" {
 
   mutual_tls_authentication {
     truststore_uri = "s3://${module.truststore_s3_bucket.bucket_name}/${aws_s3_object.truststore.id}"
+    truststore_version = aws_s3_object.truststore.version_id
   }
 
   depends_on = [aws_acm_certificate_validation.api_gateway_custom_hostname]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
@@ -7,6 +7,7 @@ module "truststore_s3_bucket" {
   environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
   namespace              = var.namespace
+  versioning             = true
 
   providers = {
     aws = aws.london_without_default_tags


### PR DESCRIPTION
Enable versioning for S3 bucket that holds our truststore.pem for mTLS with API Gateway, and then use latest version.

We realised that API Gateway is using an old version of our truststore.pem and does not update it upon updating the file in S3. Versioning needs to be enabled to do so.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_domain_name#truststore_uri