### PR TITLE
Refactor Kubernetes secrets in dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
@@ -1,6 +1,6 @@
-resource "kubernetes_secret" "services" {
+resource "kubernetes_secret" "aws_services" {
   metadata {
-    name      = "services"
+    name      = "aws-services"
     namespace = var.namespace
   }
 
@@ -38,21 +38,20 @@ resource "kubernetes_secret" "services" {
   ]
 }
 
-resource "kubernetes_secret" "certificates" {
+resource "kubernetes_secret" "client_certificate_auth" {
   metadata {
-    name      = "certificates"
+    name      = "client-certificate-auth"
     namespace = var.namespace
   }
 
-  # Certificates and keys used for mutual TLS are uploaded manually.
   data = {
     "ca.crt" = aws_api_gateway_client_certificate.api_gateway_client.pem_encoded_certificate
   }
 }
 
-resource "kubernetes_secret" "consumers" {
+resource "kubernetes_secret" "consumer_api_keys" {
   metadata {
-    name      = "consumers"
+    name      = "consumer-api-keys"
     namespace = var.namespace
   }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
@@ -35,14 +35,15 @@ module "truststore_s3_bucket" {
 EOF
 }
 
-data "github_repository_file" "truststore" {
-  repository = "ministryofjustice/hmpps-integration-api"
-  file       = "temporary_certificates/dev-truststore.pem"
+data "kubernetes_secret" "truststore" {
+  metadata {
+    name = "mutual-tls-auth"
+    namespace = var.namespace
+  }
 }
 
 resource "aws_s3_object" "truststore" {
   bucket  = module.truststore_s3_bucket.bucket_name
   key     = "dev-truststore.pem"
-  content = data.github_repository_file.truststore.content
+  content = data.kubernetes_secret.truststore.data["truststore-public-key"]
 }
-


### PR DESCRIPTION
This is because Kubernetes secrets that we updated manually that were managed by Terraform were being over-written when the pipeline ran following infrastructure changes. We now store these Kubernetes secrets separately to prevent this issue.

We have also moved our truststore public key (for mutual TLS) out of GitHub and into a Kubernetes secret, to remove the dependency on GitHub.