### PR TITLE
Allow content hub old prod s3 to sync to new dev and prod s3 buckets.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3-old.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3-old.tf
@@ -47,6 +47,21 @@ module "drupal_content_storage" {
       ]
     },
     {
+      "Sid": "AllowHubDevelopmentS3SyncNew",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-0da9568a0aa6b9444b6fb48e8d4f79cd"
+      },
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "$${bucket_arn}",
+        "$${bucket_arn}/*"
+      ]
+    },
+    {
       "Sid": "AllowHubStagingS3Sync",
       "Effect": "Allow",
       "Principal": {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3-old.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3-old.tf
@@ -47,6 +47,21 @@ module "drupal_content_storage" {
       ]
     },
     {
+      "Sid": "AllowHubProductionS3SyncNew",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-ee432bcfffe38a157f08669a6d4b7740"
+      },
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "$${bucket_arn}",
+        "$${bucket_arn}/*"
+      ]
+    },
+    {
       "Sid": "AllowHubDevelopmentS3SyncNew",
       "Effect": "Allow",
       "Principal": {


### PR DESCRIPTION
The new prod and dev s3 buckets have now been sync'd from staging so are largely in sync with prod.
However we want to start to sync the to the old prod bucket is still the bucket being used, so that they are kept up to date with all the very latest content changes made in the CMS so that we can cut ultimately cut over to the new buckets without loss of data.