### PR TITLE
feat(Go): Adding ES cluster to dev env

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/jacksapp-dev/resources/elasticsearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/jacksapp-dev/resources/elasticsearch.tf
@@ -1,0 +1,21 @@
+module "jacksapp_es" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticsearch?ref=4.2.0"
+  eks_cluster_name       = var.eks_cluster_name
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  namespace              = var.namespace
+
+  elasticsearch-domain            = "jacksapp-es"
+  encryption_at_rest              = true
+  node_to_node_encryption_enabled = true
+  domain_endpoint_enforce_https   = true
+
+  # change the elasticsearch version as you see fit.
+  elasticsearch_version = "7.10"
+
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/jacksapp-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/jacksapp-dev/resources/variables.tf
@@ -2,6 +2,8 @@
 variable "vpc_name" {
 }
 
+variable "eks_cluster_name" {
+}
 
 variable "kubernetes_cluster" {
 }


### PR DESCRIPTION
This cluster will be used to test the elasticsearch api for scripting movement between storage to move the manual step of having to do one at a time from the console
