### PR TITLE
Major upgrade!

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -12,6 +12,8 @@ module "hmcts-complaints-adapter-rds-instance" {
 
   db_engine_version          = "14"
   rds_family                 = "postgres14"
+  db_instance_class          = "db.t3.small"
+  prepare_for_major_upgrade  = true
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
Set major upgrade flag and migrate to a t3 instance type as the old type does not support the upgrade to Postgres 14