### PR TITLE
Upgrade hmcts-adapter-prod to postgres 14.4

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
@@ -14,6 +14,7 @@ module "hmcts-complaints-adapter-rds-instance" {
   rds_family           = "postgres14"
   db_instance_class    = "db.t3.medium"
   db_allocated_storage = "100"
+  prepare_for_major_upgrade = true
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
@@ -10,8 +10,8 @@ module "hmcts-complaints-adapter-rds-instance" {
   infrastructure-support     = var.infrastructure_support
   team_name                  = var.team_name
 
-  db_engine_version    = "11"
-  rds_family           = "postgres11"
+  db_engine_version    = "14.4"
+  rds_family           = "postgres14"
   db_instance_class    = "db.t3.medium"
   db_allocated_storage = "100"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -14,6 +14,7 @@ module "hmcts-complaints-adapter-rds-instance" {
   rds_family                 = "postgres14"
   db_instance_class          = "db.t4g.micro"
   db_max_allocated_storage   = "500" # maximum storage for autoscaling
+  prepare_for_major_upgrade  = true
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -14,7 +14,6 @@ module "hmcts-complaints-adapter-rds-instance" {
   rds_family                 = "postgres14"
   db_instance_class          = "db.t4g.micro"
   db_max_allocated_storage   = "500" # maximum storage for autoscaling
-  prepare_for_major_upgrade  = true
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
The prod instance is already on a t3.medium so should support 14.4, which is our max upgrade going from 11.16