### PR TITLE
🔥  remove old dev s3 bucket reference in prod bucket policy for content hub. That old dev bucket has been deleted.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3-old.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/s3-old.tf
@@ -32,21 +32,6 @@ module "drupal_content_storage" {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "AllowHubDevelopmentS3Sync",
-      "Effect": "Allow",
-      "Principal": {
-          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-8f67b39c6e3bd0e7ca18f73b97b39938"
-      },
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "$${bucket_arn}",
-        "$${bucket_arn}/*"
-      ]
-    },
-    {
       "Sid": "AllowHubProductionS3SyncNew",
       "Effect": "Allow",
       "Principal": {


### PR DESCRIPTION
See https://github.com/ministryofjustice/cloud-platform-environments/pull/13204 for removal of the s3 bucket in question.