### PR TITLE
🔥 content hub staging s3 changes now it is no longer used as a sync source.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/s3.tf
@@ -25,51 +25,6 @@ module "drupal_content_storage" {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "AllowHubDevelopmentS3Sync",
-      "Effect": "Allow",
-      "Principal": {
-          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-8f67b39c6e3bd0e7ca18f73b97b39938"
-      },
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "$${bucket_arn}",
-        "$${bucket_arn}/*"
-      ]
-    },
-    {
-      "Sid": "AllowHubDevelopmentS3SyncTemp",
-      "Effect": "Allow",
-      "Principal": {
-          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-8f67b39c6e3bd0e7ca18f73b97b39938"
-      },
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "$${bucket_arn}",
-        "$${bucket_arn}/*"
-      ]
-    },
-    {
-      "Sid": "AllowHubProductionS3SyncTemp",
-      "Effect": "Allow",
-      "Principal": {
-          "AWS": "arn:aws:iam::754256621582:user/system/s3-bucket-user/s3-bucket-user-ee432bcfffe38a157f08669a6d4b7740"
-      },
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "$${bucket_arn}",
-        "$${bucket_arn}/*"
-      ]
-    },
-    {
       "Sid": "AllowListBucketVersions",
       "Effect": "Allow",
       "Principal": {
@@ -131,31 +86,5 @@ resource "kubernetes_secret" "drupal_content_storage_secret" {
     secret_access_key = module.drupal_content_storage.secret_access_key
     bucket_arn        = module.drupal_content_storage.bucket_arn
     bucket_name       = module.drupal_content_storage.bucket_name
-  }
-}
-
-# Temporarily output S3 bucket info to production and development namespaces.
-# We are moving prod S3 from eu-west-1 to eu-west-2. Rather than sync the whole 500GB
-# across regions, we are going to sync prod eu-west-2 from staging, which is already in
-# eu-west-2 and is largely already sync'd with prod eu-west-1.
-# NOTE: We only share the bucket name.  We never share access keys.
-resource "kubernetes_secret" "drupal_content_storage_output_staging_temp" {
-  metadata {
-    name      = "drupal-s3-output-temp"
-    namespace = "prisoner-content-hub-production"
-  }
-
-  data = {
-    bucket_name = module.drupal_content_storage.bucket_name
-  }
-}
-resource "kubernetes_secret" "drupal_content_storage_output_development_temp" {
-  metadata {
-    name      = "drupal-s3-output-temp"
-    namespace = "prisoner-content-hub-development"
-  }
-
-  data = {
-    bucket_name = module.drupal_content_storage.bucket_name
   }
 }


### PR DESCRIPTION
🔥  remove bucket_policy entries that facilitated using content hub staging as a sync source. 

🔥 also remove export of staging s3 bucket name as k8s secret to other environments. That was only used to sync.