### PR TITLE
Remove APPLY_PIPELINE_SKIP_THIS_NAMESPACE from namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,1 +1,0 @@
---skip visit-someone-in-prison-backend-svc-staging namespace for DB upgrade


### PR DESCRIPTION
Remove APPLY_PIPELINE_SKIP_THIS_NAMESPACE from visit-someone-in-prison-backend-svc-staging namepsace