### PR TITLE
Create a new API key for MAPPS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
@@ -10,5 +10,5 @@ locals {
     GithubTeam             = var.team_name
   }
 
-  clients = ["emile", "ting", "april", "matt"]
+  clients = ["emile", "ting", "april", "matt", "mapps"]
 }


### PR DESCRIPTION
Each client we specify as a local gets an API key auto generated. This will be stored in a Kubernetes secret.