### PR TITLE
adding explicit redis snapshot window

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-dev/resources/elasticache.tf
@@ -16,6 +16,7 @@ module "mercury_submit_elasticache_redis" {
   engine_version         = "7.0"
   parameter_group_name   = "default.redis7"
   maintenance_window     = "sun:23:00-mon:01:00"
+  snapshot_window        = "02:00-05:00"
   namespace              = var.namespace
 
   providers = {


### PR DESCRIPTION
Error on previous terraform apply saying maintenance window and snapshot window cannot overlap