### PR TITLE
Update contact details for ops-pilot-test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/00-namespace.yaml
@@ -7,9 +7,9 @@ metadata:
     cloud-platform.justice.gov.uk/environment-name: "test"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
-    cloud-platform.justice.gov.uk/slack-channel: "ask-bold-rr-ops"
+    cloud-platform.justice.gov.uk/slack-channel: "ask-bold-case-info-dashboard"
     cloud-platform.justice.gov.uk/application: "Operational pilot prototype"
-    cloud-platform.justice.gov.uk/owner: "BOLD Reducing Reoffending Operational Pilot: william.martin@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "BOLD Case Information Dashboard: CaseInformationDashboard@justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/bold-rr-ops-test"
     cloud-platform.justice.gov.uk/team-name: "bold-rr-ops-team"
     cloud-platform.justice.gov.uk/review-after: "2023-06-16"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/resources/variables.tf
@@ -53,7 +53,7 @@ variable "is_production" {
 variable "slack_channel" {
   description = "Slack channel name for your team, if we need to contact you about this service"
   type        = string
-  default     = "ask-bold-case-info-dashboard""
+  default     = "ask-bold-case-info-dashboard"
 }
 
 variable "github_owner" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/resources/variables.tf
@@ -41,7 +41,7 @@ variable "environment" {
 variable "infrastructure_support" {
   description = "Email address of the team responsible this service"
   type        = string
-  default     = "william.martin@digital.justice.gov.uk"
+  default     = "CaseInformationDashboard@justice.gov.uk"
 }
 
 variable "is_production" {
@@ -53,7 +53,7 @@ variable "is_production" {
 variable "slack_channel" {
   description = "Slack channel name for your team, if we need to contact you about this service"
   type        = string
-  default     = "ask-bold-rr-ops"
+  default     = "ask-bold-case-info-dashboard""
 }
 
 variable "github_owner" {


### PR DESCRIPTION
We've got a new team inbox and renamed Slack channel to match; just updating the contact details to match.