### PR TITLE
rename `supported-accommodation` to `community-accommodation-tier-2`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/00-namespace.yaml
@@ -12,5 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
     cloud-platform.justice.gov.uk/application: "Community Accommodation"
     cloud-platform.justice.gov.uk/owner: "Community Accommodation: cas3@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git,https://github.com/ministryofjustice/hmpps-supported-accommodation-ui"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git,https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui"
     cloud-platform.justice.gov.uk/team-name: "hmpps-community-accommodation"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/06-certificates.yaml
@@ -41,12 +41,12 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: hmpps-supported-accommodation-dev-cert
+  name: hmpps-community-accommodation-tier-2-dev-cert
   namespace: hmpps-community-accommodation-dev
 spec:
-  secretName: hmpps-supported-accommodation-dev-cert
+  secretName: hmpps-community-accommodation-tier-2-dev-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - supported-accommodation-dev.hmpps.service.justice.gov.uk
+    - community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
The user-facing name for this service will primarily be CAS-2 (Community Accommodation Service Tier 2) - although the other tiers have secondary names (`temporary-accommodation` and `approved-premises`) the long-term goal is to bring everything under the CAS banner.