### PR TITLE
🔧  test enabling versioning on prisoner content hub dev s3 bucket to …

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -45,6 +45,8 @@ module "drupal_content_storage_2" {
   
 */
 
+  versioning = true
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london


### PR DESCRIPTION
…see if that accounts for the new log messages occurring on image upload.

Whilst moving prod s3 from eu-west-1 to eu-west-2 we also turned off versioning.

Whilst end user functionality is not impeded, new log messages are being raised in dev and prod where versioning was turned off. Such errors are not generated on staging, which has not been affected by the recent changes.

This PR is to turn versioning back on on dev to see if that accounts for the new log messages.