### PR TITLE
Revert "🔧  test enabling versioning on prisoner content hub dev s3 bucket to see if that accounts for the new log messages occurring on image upload."

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/s3.tf
@@ -45,8 +45,6 @@ module "drupal_content_storage_2" {
   
 */
 
-  versioning = true
-
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london


### PR DESCRIPTION
This reverts commit 35ff70fc81ab989a9685de5fc9dffcfd2f83e0fd.

Re-enabling versioning did not stop the new log messages being raised.