### PR TITLE
abundant-namespace-dev: remove ElastiCache access keys

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/elasticache.tf
@@ -30,8 +30,6 @@ resource "kubernetes_secret" "test_ec_cluster" {
     primary_endpoint_address = module.test_ec_cluster.primary_endpoint_address
     member_clusters          = jsonencode(module.test_ec_cluster.member_clusters)
     auth_token               = module.test_ec_cluster.auth_token
-    access_key_id            = module.test_ec_cluster.access_key_id
-    secret_access_key        = module.test_ec_cluster.secret_access_key
     replication_group_id     = module.test_ec_cluster.replication_group_id
   }
 }


### PR DESCRIPTION
As part of ministryofjustice/cloud-platform#4586.

These are unused.