### PR TITLE
Remove sendnotificationwhendown attribute from CCCD production pingdom.tf

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/pingdom.tf
@@ -8,7 +8,6 @@ resource "pingdom_check" "claim-crown-court-defence-production" {
   host                     = "claim-crown-court-defence.service.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
-  sendnotificationwhendown = 6
   notifyagainevery         = 0
   url                      = "/ping"
   encryption               = true


### PR DESCRIPTION
Removes the `sendnotificationwhendown` attribute from `pingdom.tf` so that we receive alerts of downtime sooner.