### PR TITLE
CICA RDS Staging allocation

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
@@ -13,7 +13,7 @@ module "rds" {
   db_engine                  = "postgres"
   db_engine_version          = "14.3"
   db_instance_class          = "db.t4g.micro"
-  db_allocated_storage       = "5"
+  db_allocated_storage       = "500"
   db_name                    = "datacaptureservice"
   db_backup_retention_period = var.db_backup_retention_period
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
@@ -13,7 +13,7 @@ module "rds" {
   db_engine                  = "postgres"
   db_engine_version          = "14.3"
   db_instance_class          = "db.t4g.micro"
-  db_allocated_storage       = "500"
+  db_allocated_storage       = "50"
   db_name                    = "datacaptureservice"
   db_backup_retention_period = var.db_backup_retention_period
 


### PR DESCRIPTION
Terraform wasn't happy about the size of the RDS database being 5gb - increasing to 50gb, any further seems unnecessary as it's a small amount of data being stored.