### PR TITLE
cross IAM role to access AP s3 bucket from CP app

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
@@ -11,15 +11,15 @@ data "aws_iam_policy_document" "cjs_dashboard_demo_ap_policy" {
       "s3:ListBucket",
     ]
     resources = [
-      "arn:aws:s3:::alpha-cjs-scorecard",
+      "arn:aws:s3:::mojap-alpha-cjs-scorecard",
     ]
   }
   statement {
     actions = [
-      "s3:*",
+      "s3:GetObject",
     ]
     resources = [
-      "arn:aws:s3:::alpha-cjs-scorecard/data_processed/*"
+      "arn:aws:s3:::mojap-alpha-cjs-scorecard/*"
     ]
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
@@ -1,0 +1,82 @@
+module "irsa" {
+  source           = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=1.1.0"
+  namespace        = var.namespace
+  eks_cluster_name = var.eks_cluster_name
+  role_policy_arns = [aws_iam_policy.cjs_dashboard_demo_ap_policy.arn]
+}
+data "aws_iam_policy_document" "cjs_dashboard_demo_ap_policy" {
+  # Provide list of permissions and target AWS account resources to allow access to
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::alpha-cjs-scorecard",
+    ]
+  }
+  statement {
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "arn:aws:s3:::alpha-cjs-scorecard/data_processed/*"
+    ]
+  }
+}
+resource "aws_iam_policy" "cjs_dashboard_demo_ap_policy" {
+  name   = "cjs_dashboard_demo_ap_policy"
+  policy = data.aws_iam_policy_document.cjs_dashboard_demo_ap_policy.json
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "irsa-output"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.aws_iam_role_name
+    serviceaccount = module.irsa.service_account_name.name
+    rolearn        = module.irsa.aws_iam_role_arn
+  }
+}
+
+resource "random_id" "cjs-dashboard-demo-ap-id" {
+  byte_length = 16
+}
+
+resource "aws_iam_user" "cjs_dashboard_demo_ap_user" {
+  name = "ap-s3-user-${random_id.cjs-dashboard-demo-ap-id.hex}"
+  path = "/system/manage-offences-api-ap-s3-bucket-user/"
+}
+
+resource "aws_iam_access_key" "cjs_dashboard_demo_ap_user" {
+  user = aws_iam_user.cjs_dashboard_demo_ap_user.name
+}
+
+resource "aws_iam_user_policy" "cjs_dashboard_demo_ap_policy" {
+  name   = "${var.namespace}-ap-s3"
+  policy = data.aws_iam_policy_document.cjs_dashboard_demo_ap_policy.json
+  user   = aws_iam_user.cjs_dashboard_demo_ap_user.name
+}
+
+resource "kubernetes_secret" "ap_aws_secret" {
+  metadata {
+    name      = "cjs-dashboard-demo-ap-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn         = "arn:aws:s3:::alpha-cjs-scorecard"
+    user_arn           = aws_iam_user.cjs_dashboard_demo_ap_user.arn
+    access_key_id      = aws_iam_access_key.cjs_dashboard_demo_ap_user.id
+    secret_access_key  = aws_iam_access_key.cjs_dashboard_demo_ap_user.secret
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
@@ -1,5 +1,5 @@
 module "irsa" {
-  source           = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=1.1.0"
+  source           = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
   namespace        = var.namespace
   eks_cluster_name = var.eks_cluster_name
   role_policy_arns = [aws_iam_policy.cjs_dashboard_demo_ap_policy.arn]
@@ -54,7 +54,7 @@ resource "random_id" "cjs-dashboard-demo-ap-id" {
 
 resource "aws_iam_user" "cjs_dashboard_demo_ap_user" {
   name = "ap-s3-user-${random_id.cjs-dashboard-demo-ap-id.hex}"
-  path = "/system/manage-offences-api-ap-s3-bucket-user/"
+  path = "/system/cjs-dashboard-demo-ap-s3-bucket-user/"
 }
 
 resource "aws_iam_access_key" "cjs_dashboard_demo_ap_user" {
@@ -74,7 +74,7 @@ resource "kubernetes_secret" "ap_aws_secret" {
   }
 
   data = {
-    bucket_arn         = "arn:aws:s3:::alpha-cjs-scorecard"
+    bucket_arn         = "arn:aws:s3:::mojap-alpha-cjs-scorecard"
     user_arn           = aws_iam_user.cjs_dashboard_demo_ap_user.arn
     access_key_id      = aws_iam_access_key.cjs_dashboard_demo_ap_user.id
     secret_access_key  = aws_iam_access_key.cjs_dashboard_demo_ap_user.secret

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
@@ -9,7 +9,7 @@ module "irsa" {
   environment_name       = var.environment
   team_name              = var.team_name
   infrastructure_support = var.infrastructure_support
-  role_policy_arns = [aws_iam_policy.cjs_dashboard_demo_ap_policy.arn]
+  role_policy_arns       = {s3 = aws_iam_policy.cjs_dashboard_demo_ap_policy.arn}
 }
 data "aws_iam_policy_document" "cjs_dashboard_demo_ap_policy" {
   # Provide list of permissions and target AWS account resources to allow access to
@@ -49,9 +49,9 @@ resource "kubernetes_secret" "irsa" {
     namespace = var.namespace
   }
   data = {
-    role           = module.irsa.aws_iam_role_name
-    serviceaccount = module.irsa.service_account_name.name
-    rolearn        = module.irsa.aws_iam_role_arn
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+    #rolearn        = module.irsa.aws_iam_role_arn
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/cross-iam-role-sa.tf
@@ -2,6 +2,13 @@ module "irsa" {
   source           = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
   namespace        = var.namespace
   eks_cluster_name = var.eks_cluster_name
+  business_unit          = var.business_unit
+  application            = var.application
+  service_account_name   = "${var.namespace}-sa"
+  is_production          = var.is_production
+  environment_name       = var.environment
+  team_name              = var.team_name
+  infrastructure_support = var.infrastructure_support
   role_policy_arns = [aws_iam_policy.cjs_dashboard_demo_ap_policy.arn]
 }
 data "aws_iam_policy_document" "cjs_dashboard_demo_ap_policy" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/variables.tf
@@ -94,3 +94,7 @@ variable "github_actions_secret_ecr_secret_key" {
   description = "The name of the github actions secret containing the ECR AWS secret key"
   default     = "ECR_AWS_SECRET_ACCESS_KEY_DEMO"
 }
+
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/versions.tf
@@ -14,5 +14,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.20.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5.1"
+    }
   }
 }


### PR DESCRIPTION
The changes made are meant to allow the cjs-dashboard-demo application in CP to access data in an S3 bucket in AP.

I have tried to implement the changes based on work recently done by Yasin Mustafa on another CP application. Link to the thread for Yasin's work here: https://mojdt.slack.com/archives/C57UPMZLY/p1681892544708609