### PR TITLE
CFE-Civil: Add all Civil Apply namespaces to CFE-Civil

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/04-networkpolicy.yaml
@@ -43,3 +43,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               cloud-platform.justice.gov.uk/namespace: laa-apply-for-legalaid-production
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: laa-apply-for-legalaid-staging
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: laa-apply-for-legalaid-uat


### PR DESCRIPTION
Once the service is cutover we will rely on a stable environment. This should allow all Civil Apply namespaces to call CFE-Civil production using internal routing for speed enhancements