### PR TITLE
Update prod db instance to db.m6g.xlarge

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
@@ -11,7 +11,7 @@ module "hmpps_interventions_postgres14" {
 
   rds_family                  = "postgres14"
   db_engine_version           = "14"
-  db_instance_class           = "db.m5.xlarge"
+  db_instance_class           = "db.m6g.xlarge"
   db_allocated_storage        = 20
   allow_major_version_upgrade = "false"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
@@ -11,7 +11,7 @@ module "hmpps_interventions_postgres14" {
 
   rds_family                  = "postgres14"
   db_engine_version           = "14"
-  db_instance_class           = "db.m5.large"
+  db_instance_class           = "db.m5.xlarge"
   db_allocated_storage        = 20
   allow_major_version_upgrade = "false"
 


### PR DESCRIPTION
We have seen our DB usage hitting 100% and it takes long time to get DB connection. Hence we are changing db instance in production to db.m5.xlarge.