### PR TITLE
Change prod hash key to name to meet new structure

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-prod/resources/dynamodb.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-prod/resources/dynamodb.tf
@@ -9,7 +9,7 @@ module "opseng_reports" {
   is-production          = "true"
   namespace              = var.namespace
 
-  hash_key                    = "filename"
+  hash_key                    = "name"
   enable_autoscaler           = "true"
   autoscale_max_read_capacity = "100"
 }


### PR DESCRIPTION
Operations Engineering is changing the way we store repository information in reports namespaces. This enables us to perform a more efficient lookup of key values when querying.
