### PR TITLE
Set hale platform dev ecr to generate short lived credentials

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/ecr.tf
@@ -17,6 +17,9 @@ module "ecr_credentials" {
   scan_on_push = "false"
   */
 
+  # enable the oidc implementation for GitHub
+  oidc_providers = ["github"]
+
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in
   # github actions CI/CD pipelines


### PR DESCRIPTION
We are testing moving from long-lived to short-lived credentials. 
Once the new secrets have been generated we can rewrite our git action so it pushes using the new method.
Keeping current secrets in the ecr config  until we have the new method working.