### PR TITLE
EL-941: Add custom prometheus alerts for CCQ production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/05-prometheus-custom-rules.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-estimate-financial-eligibility-for-legal-aid-production
+  labels:
+    role: alert-rules
+  name: prometheus-custom-rules-ccq
+spec:
+  groups:
+    - name: application-rules
+      rules:
+        - alert: CcqProduction5xxIngressResponses
+          expr: |-
+            avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="laa-estimate-financial-eligibility-for-legal-aid-production", status=~"5.*"}[1m]) * 60 > 0) by (ingress)
+          labels:
+            severity: laa-estimate-eligibility-production
+          annotations:
+            message: Ingress {{ $labels.exported_namespace }}/{{ $labels.ingress }} is serving 5xx responses.
+            runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/LE/pages/4405724996/CCQ+Runbook
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/djtEK4abc/ccq-ingress-check-if-your-client-qualifies-for-legal-aid?orgId=1&var-namespace=laa-estimate-financial-eligibility-for-legal-aid-production

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/05-prometheus-custom-rules.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:


### PR DESCRIPTION
Adding this alert to the repo as per [guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#advisory-note-1-if-prometheus-gets-re-installed) in case prometheus is ever re-installed