### PR TITLE
Add a service account for nettest namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/nettest/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/nettest/resources/serviceaccount.tf
@@ -1,0 +1,10 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.8.1"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["modernisation-platform-cp-network-test"]
+}


### PR DESCRIPTION
This is to enable deployments via github actions from the modernisation-platform-cp-network-test repository.