### PR TITLE
EL-941: Update CCQ production alert rules

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/05-prometheus-custom-rules.yaml
@@ -11,7 +11,7 @@ spec:
       rules:
         - alert: CcqProduction5xxIngressResponses
           expr: |-
-            avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="laa-estimate-financial-eligibility-for-legal-aid-production", status=~"5.*"}[1m]) * 60 > 0) by (ingress)
+            sum by (ingress)(nginx_ingress_controller_requests{exported_namespace="laa-estimate-financial-eligibility-for-legal-aid-production",status="500"}) - sum by (ingress)(nginx_ingress_controller_requests{exported_namespace="laa-estimate-financial-eligibility-for-legal-aid-production",status="500"} offset 2m) > 0
           labels:
             severity: laa-estimate-eligibility-production
           annotations:


### PR DESCRIPTION
The previous rule was only firing if we had non-zero values for 2 consecutive data points.