### PR TITLE
[laa assure hmrc data uat] Add s3 lifecycle rule

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -12,6 +12,24 @@ module "s3_bucket" {
   providers = {
     aws = aws.london
   }
+
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "expire sensitive data files"
+
+      noncurrent_version_expiration = [
+        {
+          days = 32
+        },
+      ]
+      expiration = [
+        {
+          days = 32
+        },
+      ]
+    }
+  ]
 }
 
 resource "kubernetes_secret" "s3_bucket" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -20,12 +20,12 @@ module "s3_bucket" {
 
       noncurrent_version_expiration = [
         {
-          days = 32
+          days = 1
         },
       ]
       expiration = [
         {
-          days = 32
+          days = 1
         },
       ]
     }


### PR DESCRIPTION
[laa-assure-hmrc-data-uat] Add `lifecycle_rule` to expire all s3 bucket objects after 32 days

The app purges files containing sensitive data 1 month (exactly)
from creation. This is an additional insurance that we are in
compliance with our GDPR requirements.
