### PR TITLE
[laa-assure-hmrc-data-uat] Add aws_s3_bucket_lifecycle_configuration to expire all s3 objects

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -14,7 +14,7 @@ module "s3_bucket" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_config" {
-  bucket = s3_bucket.bucket.id
+  bucket = aws_s3_bucket.bucket.id
 
   rule {
     id = "expire sensitive data"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -14,7 +14,7 @@ module "s3_bucket" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_config" {
-  bucket = module.aws_s3_bucket.bucket_name
+  bucket = module.aws_s3_bucket.bucket.id
 
   rule {
     id = "expire sensitive data"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -1,5 +1,4 @@
 module "s3_bucket" {
-
   source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.8.2"
   team_name              = var.team_name
   business-unit          = var.business_unit
@@ -11,6 +10,20 @@ module "s3_bucket" {
 
   providers = {
     aws = aws.london
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_config" {
+  bucket = s3_bucket.bucket.id
+
+  rule {
+    id = "expire sensitive data"
+
+    expiration {
+      days = 1
+    }
+
+    status = "Enabled"
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -14,7 +14,7 @@ module "s3_bucket" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_config" {
-  bucket = aws_s3_bucket.bucket.id
+  bucket = module.aws_s3_bucket.bucket_name
 
   rule {
     id = "expire sensitive data"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -14,7 +14,7 @@ module "s3_bucket" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_config" {
-  bucket = module.s3_bucket.bucket.id
+  bucket = module.s3_bucket.bucket_name
 
   rule {
     id = "expire sensitive data"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -14,7 +14,7 @@ module "s3_bucket" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_config" {
-  bucket = module.aws_s3_bucket.bucket.id
+  bucket = module.s3_bucket.bucket.id
 
   rule {
     id = "expire sensitive data"


### PR DESCRIPTION
[laa-assure-hmrc-data-uat] Add `aws_s3_bucket_lifecycle_configuration` to expire all s3 bucket objects after 32 days

The app purges files containing sensitive data 1 month (exactly)
from creation. This is an additional insurance that we are in
compliance with our GDPR requirements.