### PR TITLE
Add network policy and service monitor for prometheus

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/04-networkpolicy.yaml
@@ -25,3 +25,20 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: laa-apply-for-criminal-legal-aid-production
+spec:
+  podSelector:
+    matchLabels:
+      app: apply-for-criminal-legal-aid-web-production
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/05-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/05-servicemonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metrics-service-monitor
+  namespace: laa-apply-for-criminal-legal-aid-production
+spec:
+  selector:
+    matchLabels:
+      app: apply-for-criminal-legal-aid-web-production
+  endpoints:
+  - port: metrics
+    interval: 15s


### PR DESCRIPTION
In order to enable prometheus metrics scraping from our production namespace.