### PR TITLE
AP-4065: Amend lifecyle policy to 32 days

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/s3.tf
@@ -20,7 +20,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_config" {
     id = "expire sensitive data"
 
     expiration {
-      days = 1
+      days = 32
     }
 
     status = "Enabled"


### PR DESCRIPTION
AP-4065: Amend lifecyle policy to 32 days

Fallback app code that purges sensitive data
after 1 month. 32 days chosen deliberatley to
be one day over longest month to avoid potential
problems with app code attempting to purge keys
that no longer exist.
