### PR TITLE
AP-4065: Add lifecycle policy with 32 day expiration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/s3.tf
@@ -14,6 +14,20 @@ module "s3_bucket" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_config" {
+  bucket = module.s3_bucket.bucket_name
+
+  rule {
+    id = "expire sensitive data"
+
+    expiration {
+      days = 32
+    }
+
+    status = "Enabled"
+  }
+}
+
 resource "kubernetes_secret" "s3_bucket" {
   metadata {
     name      = "s3-bucket-output"


### PR DESCRIPTION
AP-4065: Add lifecycle policy with 32 day expiration

Fallback for app code that purges sensitive data
after 1 month. 32 days chosen deliberately to
be one day over longest month to avoid potential
problems with app code attempting to purge keys
that no longer exist.
