### PR TITLE
FUM-staging migrate to short lived credentials

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-staging/resources/ecr.tf
@@ -1,0 +1,36 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.2.0"
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  # enable the oidc implementation for Github
+  oidc_providers = ["github"]
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  github_repositories = ["find-unclaimed-court-money"]
+  github_actions_prefix = "staging"
+
+}
+
+
+resource "kubernetes_secret" "ecr_credentials" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.ecr_credentials.access_key_id
+    secret_access_key = module.ecr_credentials.secret_access_key
+    repo_arn          = module.ecr_credentials.repo_arn
+    repo_url          = module.ecr_credentials.repo_url
+  }
+}


### PR DESCRIPTION
As per - https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#deprecating-long-lived-credentials-for-container-repositories