### PR TITLE
Capitalise CCCD github repo name in ecr.tf

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/ecr.tf
@@ -9,7 +9,7 @@ module "cccd_ecr_credentials" {
   }
 
   oidc_providers      = ["circleci"]
-  github_repositories = ["claim-for-crown-court-defence"]
+  github_repositories = ["Claim-for-Crown-Court-Defence"]
   namespace           = var.namespace
 }
 


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-environments/pull/14134 enabled short-lived ECR credentials for CCCD, however CircleCI is failing at the `Generate shortlived AWS Keys using CircleCI OIDC token.` stage with the error

```An error occurred (AccessDenied) when calling the AssumeRoleWithWebIdentity operation: Not authorized to perform sts:AssumeRoleWithWebIdentity```

I'm not clear why this is happening but on reviewing the config I noticed that the `github_repositories` attribute is all lower case while in GitHub (and therefore CircleCI) it is in title-case. To try and resolve the failure this corrects the capitalisation.