### PR TITLE
AP-4178: Add ECR lifecycle policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/ecr.tf
@@ -31,18 +31,18 @@ module "ecr_credentials" {
   # Lifecycle_policy provides a way to automate the cleaning up of your container images by expiring images based on age or count.
   # To apply multiple rules, combined them in one policy JSON.
   # https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_examples.html
-
+  */
   lifecycle_policy = <<EOF
 {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "Expire untagged images older than 14 days",
+            "description": "Expire untagged images older than 7 days",
             "selection": {
                 "tagStatus": "untagged",
                 "countType": "sinceImagePushed",
                 "countUnit": "days",
-                "countNumber": 14
+                "countNumber": 7
             },
             "action": {
                 "type": "expire"
@@ -50,12 +50,13 @@ module "ecr_credentials" {
         },
         {
             "rulePriority": 2,
-            "description": "Keep last 30 dev and staging images",
+            "description": "Expire images tagged with 'latest' older than 180 days",
             "selection": {
                 "tagStatus": "tagged",
-                "tagPrefixList": ["dev", "staging"],
-                "countType": "imageCountMoreThan",
-                "countNumber": 30
+                "tagPrefixList": ["latest"],
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 180
             },
             "action": {
                 "type": "expire"
@@ -63,11 +64,11 @@ module "ecr_credentials" {
         },
         {
             "rulePriority": 3,
-            "description": "Keep the newest 100 images and mark the rest for expiration",
+            "description": "Keep the newest 50 images and mark the rest for expiration",
             "selection": {
                 "tagStatus": "any",
                 "countType": "imageCountMoreThan",
-                "countNumber": 100
+                "countNumber": 50
             },
             "action": {
                 "type": "expire"
@@ -76,10 +77,7 @@ module "ecr_credentials" {
     ]
 }
 EOF
-*/
-
 }
-
 
 resource "kubernetes_secret" "ecr_credentials" {
   metadata {


### PR DESCRIPTION
AP-4178: Add ECR lifecycle policy

With the advent of short lived credentials, including
a principle of least privilege, the existing code repo's
script and CI based removal of "old" ECR images will
become unusable. In addition the old approach is discouraged in 
favour of [ECR life cycle policies](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters)

reference: [Assure PR](https://github.com/ministryofjustice/laa-assure-hmrc-data/pull/340)
