### PR TITLE
Enable oidc provider as Github

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
@@ -9,6 +9,9 @@ module "ecr-repo" {
   repo_name = var.repo_name
 
   github_repositories = [var.repo_name]
+
+  # enable the oidc implementation for GitHub
+  oidc_providers = ["github"]
 }
 
 resource "kubernetes_secret" "ecr-repo" {


### PR DESCRIPTION
Migration to short lived credentials, as per https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#deprecating-long-lived-credentials-for-container-repositories