### PR TITLE
Add namespace to get credentials in configmap

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/ecr.tf
@@ -8,7 +8,7 @@ module "contact-moj_ecr_credentials" {
   source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
   repo_name = "contact-moj-ecr"
   team_name = var.team_name
-
+  namespace = var.namespace
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
Missed this from the guide when adding oidc provider.