### PR TITLE
Update Hale Platform Dev github secret names to work with new git action

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/variables.tf
@@ -61,32 +61,32 @@ variable "github_token" {
 
 variable "github_actions_secret_kube_cluster" {
   description = "The name of the github actions secret containing the kubernetes cluster name"
-  default     = "KUBE_CLUSTER_DEV"
+  default     = "KUBE_CLUSTER"
 }
 
 variable "github_actions_secret_kube_namespace" {
   description = "The name of the github actions secret containing the kubernetes namespace name"
-  default     = "KUBE_NAMESPACE_DEV"
+  default     = "KUBE_NAMESPACE"
 }
 
 variable "github_actions_secret_kube_cert" {
   description = "The name of the github actions secret containing the serviceaccount ca.crt"
-  default     = "KUBE_CERT_DEV"
+  default     = "KUBE_CERT"
 }
 
 variable "github_actions_secret_kube_token" {
   description = "The name of the github actions secret containing the serviceaccount token"
-  default     = "KUBE_TOKEN_DEV"
+  default     = "KUBE_TOKEN"
 }
 
 variable "github_actions_secret_ecr_name" {
   description = "The name of the github actions secret containing the ECR name"
-  default     = "ECR_NAME_DEV"
+  default     = "ECR_NAME"
 }
 
 variable "github_actions_secret_ecr_url" {
   description = "The name of the github actions secret containing the ECR URL"
-  default     = "ECR_URL_DEV"
+  default     = "ECR_URL"
 }
 
 variable "github_actions_secret_ecr_access_key" {


### PR DESCRIPTION
New git action works with secrets depending on environment so we dont need 'Dev' at end of the name