### PR TITLE
CCQ PROD add route53 terraform file

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "eligibility_team_route53_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.github_owner
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "eligibility_team_route53_zone" {
+  metadata {
+    name      = "example-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id   = aws_route53_zone.eligibility_team_route53_zone.zone_id
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/variables.tf
@@ -54,3 +54,7 @@ variable "github_token" {
   description = "Required by the Github Terraform provider"
   default     = ""
 }
+
+variable "domain" {
+  default = "check-your-client-qualifies-for-legal-aid.service.gov.uk"
+}


### PR DESCRIPTION
The CCQ service has passed private beta and will be going live on gov.uk, this is to create the DNS for nameservers for use with the new domain.