### PR TITLE
RR-2 - Corrected cert dns names

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/06-certificate.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: hmpps-education-and-work-plan-api-dev.prison.service.justice.gov.uk
+  name: hmpps-education-and-work-plan-api-dev.hmpps.service.justice.gov.uk
   namespace: hmpps-education-and-work-plan-dev
 spec:
   secretName:  hmpps-education-and-work-plan-api-cert
@@ -10,12 +10,12 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - hmpps-education-and-work-plan-api-dev.prison.service.justice.gov.uk
+    - hmpps-education-and-work-plan-api-dev.hmpps.service.justice.gov.uk
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name:  hmpps-education-and-work-plan-dev.prison.service.justice.gov.uk
+  name:  hmpps-education-and-work-plan-dev.hmpps.service.justice.gov.uk
   namespace: hmpps-education-and-work-plan-dev
 spec:
   secretName:  hmpps-education-and-work-plan-cert
@@ -23,4 +23,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    -  hmpps-education-and-work-plan-dev.prison.service.justice.gov.uk
+    -  hmpps-education-and-work-plan-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This PR corrects the domain name in the certificate names and dns names from `prison.service.justice.gov.uk` to `hmpps.service.justice.gov.uk` to match the ingress of the API and UI
(I'd blindly copy and pasted the certificate TF from another project! 🙄 )