### PR TITLE
update perms for cross iam role for athena access

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/resources/cross-iam-role-sa.tf
@@ -14,9 +14,13 @@ data "aws_iam_policy_document" "bold_rr_ops_test_ap_policy" {
       "s3:ListBucket",
       "s3:GetObject",
       "s3:GetObjectAcl",
+      "glue:GetDatabase",
+      "glue:GetTable",
+      "glue:GetPartitions"
     ]
     resources = [
       "arn:aws:s3:::mojap-bold-rr-ops",
+      "arn:aws:glue:eu-west-2:*:database/bold_rr_ops_test/mtcars",
     ]
   }
 }


### PR DESCRIPTION
Updated the cross-iam-role to have:

```
      "glue:GetDatabase",
      "glue:GetTable",
      "glue:GetPartitions"
```
    
So that CP app can reference the following Glue Catalog Table: `arn:aws:glue:eu-west-2:*:database/bold_rr_ops_test/mtcars`