### PR TITLE
Remove Old Hale Platform Dev ECR Access Credentials

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/ecr.tf
@@ -50,8 +50,6 @@ module "ecr_credentials" {
 
   github_actions_secret_ecr_name       = var.github_actions_secret_ecr_name
   github_actions_secret_ecr_url        = var.github_actions_secret_ecr_url
-  github_actions_secret_ecr_access_key = var.github_actions_secret_ecr_access_key
-  github_actions_secret_ecr_secret_key = var.github_actions_secret_ecr_secret_key
 }
 
 resource "kubernetes_secret" "ecr_credentials" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/variables.tf
@@ -88,13 +88,3 @@ variable "github_actions_secret_ecr_url" {
   description = "The name of the github actions secret containing the ECR URL"
   default     = "ECR_URL"
 }
-
-variable "github_actions_secret_ecr_access_key" {
-  description = "The name of the github actions secret containing the ECR AWS access key"
-  default     = "ECR_AWS_ACCESS_KEY_ID_DEV"
-}
-
-variable "github_actions_secret_ecr_secret_key" {
-  description = "The name of the github actions secret containing the ECR AWS secret key"
-  default     = "ECR_AWS_SECRET_ACCESS_KEY_DEV"
-}


### PR DESCRIPTION
Now uses short lived credentials.