### PR TITLE
NN-5273 need list bucket to get the correct error response

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/s3.tf
@@ -28,7 +28,6 @@ module "analytical_platform_s3_bucket" {
   environment-name       = var.environment
   infrastructure-support = var.infrastructure_support
   namespace              = var.namespace
-  bucket_policy          = data.aws_iam_policy_document.bucket-policy.json
 
   providers = {
     aws = aws.london
@@ -41,7 +40,7 @@ data "aws_iam_policy_document" "bucket-policy" {
       "s3:ListBucket",
     ]
     resources = [
-      "arn:aws:s3:::cloud-platform-403569db5b294899ffe32e696b1c4ab1"
+      module.analytical_platform_s3_bucket.bucket_arn
     ]
   }
   statement {
@@ -49,7 +48,7 @@ data "aws_iam_policy_document" "bucket-policy" {
       "s3:GetObject"
     ]
     resources = [
-      "arn:aws:s3:::cloud-platform-403569db5b294899ffe32e696b1c4ab1/*"
+      "${module.analytical_platform_s3_bucket.bucket_arn}/*"
     ]
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/s3.tf
@@ -38,6 +38,14 @@ module "analytical_platform_s3_bucket" {
 data "aws_iam_policy_document" "bucket-policy" {
   statement {
     actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::cloud-platform-403569db5b294899ffe32e696b1c4ab1"
+    ]
+  }
+  statement {
+    actions = [
       "s3:GetObject"
     ]
     resources = [


### PR DESCRIPTION
If you have the s3:ListBucket permission on the bucket, Amazon S3 will return an HTTP status code 404 (“no such key”) error.
If you don’t have the s3:ListBucket permission, Amazon S3 will return an HTTP status code 403 (“access denied”) error.

Expecting a 404, but getting a 403 and the above suggests it due to missing permission.  