### PR TITLE
AP-4295: Add circleci ECR oidc provider for laa-hmrc-interface-service-api

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/ecr.tf
@@ -1,13 +1,11 @@
 module "ecr-repo" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
 
-  team_name = var.team_name
-  repo_name = "${var.namespace}-ecr"
-
-  # Uncomment and provide repository names to create github actions secrets
-  # containing the ECR name, AWS access key, and AWS secret key, for use in
-  # github actions CI/CD pipelines
-  # github_repositories = ["my-repo"]
+  team_name           = var.team_name
+  repo_name           = "${var.namespace}-ecr"
+  oidc_providers      = ["circleci"]
+  github_repositories = [var.repo_name]
+  namespace           = var.namespace
 }
 
 resource "kubernetes_secret" "ecr-repo" {


### PR DESCRIPTION
Enable short lived credentials for circleci ECR push and pull
