### PR TITLE
Bump db engine version in tf to match the actual version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -10,7 +10,7 @@ module "hmcts-complaints-adapter-rds-instance" {
   infrastructure-support     = var.infrastructure_support
   team_name                  = var.team_name
 
-  db_engine_version          = "14.4"
+  db_engine_version          = "14.7"
   rds_family                 = "postgres14"
   db_instance_class          = "db.t4g.micro"
   db_max_allocated_storage   = "500" # maximum storage for autoscaling


### PR DESCRIPTION
This is because the minor_version_upgrade is set to true and aws managed the upgrades. This is to retrofit the terraform code.