### PR TITLE
offender-management-production: Upgrade DB engine version to 14.7

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
@@ -7,20 +7,21 @@
 module "allocation-rds" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.19.0"
 
-  vpc_name               = var.vpc_name
-  db_instance_class      = "db.m5.large"
-  team_name              = "offender-management"
-  business-unit          = "HMPPS"
-  application            = "offender-management-allocation-manager"
-  is-production          = "true"
-  namespace              = var.namespace
-  environment-name       = "production"
-  infrastructure-support = "manage-pom-cases@digital.justice.gov.uk"
-  db_engine              = "postgres"
-  db_engine_version      = "14.7"
-  rds_family             = "postgres14"
-  db_name                = "allocations"
-  db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
+  vpc_name                    = var.vpc_name
+  db_instance_class           = "db.m5.large"
+  team_name                   = "offender-management"
+  business-unit               = "HMPPS"
+  application                 = "offender-management-allocation-manager"
+  is-production               = "true"
+  namespace                   = var.namespace
+  environment-name            = "production"
+  infrastructure-support      = "manage-pom-cases@digital.justice.gov.uk"
+  db_engine                   = "postgres"
+  db_engine_version           = "14.7"
+  rds_family                  = "postgres14"
+  allow_minor_version_upgrade = "false"
+  db_name                     = "allocations"
+  db_parameter                = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
 
   db_password_rotated_date = "2023-04-05T11:31:27Z"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
@@ -17,7 +17,7 @@ module "allocation-rds" {
   environment-name       = "production"
   infrastructure-support = "manage-pom-cases@digital.justice.gov.uk"
   db_engine              = "postgres"
-  db_engine_version      = "14.3"
+  db_engine_version      = "14.7"
   rds_family             = "postgres14"
   db_name                = "allocations"
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]


### PR DESCRIPTION
The actual DB engine version is 14.7 even though we configured 14.3 - update the TF to match reality and disable minor version upgrades in the future