### PR TITLE
fix: 🐛 rds version for c100 appication

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
@@ -15,7 +15,7 @@ module "rds-instance" {
   team_name              = var.team_name
   db_engine_version      = var.db_engine_version
   db_instance_class	     = var.db_instance_class
-  allow_major_version_upgrade = "true"
+  allow_minor_version_upgrade = "false"
   rds_family             = var.db_engine_family
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/variables.tf
@@ -33,7 +33,7 @@ variable "repo_name" {
 # Database 
 
 variable "db_engine_version" {
-  default = "14.4"
+  default = "14.7"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
aws has upgraded the minor version but the application has also pinned the postgres version causing `apply-live` pipeline failures.

This updates the pin and sets `allow_minor_upgrade_version = "false"`