### PR TITLE
fix: 🐛 pinned rds version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-production/resources/rds.tf
@@ -18,7 +18,7 @@ module "check-financial-eligibility-rds" {
   db_engine                 = "postgres"
 
   # specified as latest version that can be upgraded from 11.16
-  db_engine_version         = "14.4"
+  db_engine_version         = "14.7"
 
   db_name                   = "check_financial_eligibility_production"
   db_parameter              = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
@@ -26,6 +26,7 @@ module "check-financial-eligibility-rds" {
   deletion_protection       = true
   db_instance_class         = "db.t4g.small"
   db_max_allocated_storage  = "500"
+  allow_minor_version_upgrade = "false"
   prepare_for_major_upgrade = false
 
   providers = {


### PR DESCRIPTION
`allow_minor_version_upgrade` defaults to true, aws has upgraded the db but the version is pinned in tf. tf tries to downgrade the version and throws an error.

- update the db pin
- turn off minor upgrades