### PR TITLE
Limit rbac cluster role to view in production namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/01-rbac.yaml
@@ -9,5 +9,5 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: admin
+  name: view
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
We are assuming this will not break anything, but can't see any other teams doing this.

Is this the correct approach?

We want to limit access to the production namespace so resources can't be easily removed or edited/applied in the CLI with `kubectl`. Still resources are applied via deploy pipeline (service account will have write access).