### PR TITLE
Revert "Limit rbac cluster role to view in production namespace (#14448)"

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/01-rbac.yaml
@@ -9,5 +9,5 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: view
+  name: admin
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
It didn't have the desired effect.

This reverts commit 048f474645866ab9ccbbb61841db544261858a49.