### PR TITLE
PI-1226 Grant IRSA policy to GitHub Actions service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/iam.tf
@@ -25,7 +25,7 @@ locals {
     module.tier-to-delius-dlq,
     module.tier-to-delius-queue,
     module.unpaid-work-and-delius-dlq,
-    module.unpaid-work-and-delius-dlq,
+    module.unpaid-work-and-delius-queue,
     module.workforce-allocations-to-delius-dlq,
     module.workforce-allocations-to-delius-queue,
   ]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/serviceaccount.tf
@@ -1,13 +1,48 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.8.1"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+  application            = var.application
+  business_unit          = var.business_unit
+  eks_cluster_name       = var.eks_cluster_name
+  environment_name       = var.environment_name
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
 
-  namespace                            = var.namespace
-  kubernetes_cluster                   = var.kubernetes_cluster
-  serviceaccount_rules                 = var.serviceaccount_rules
-  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
-  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
-  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
-  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  service_account_name = "cd-serviceaccount"
+  role_policy_arns     = { sqs = aws_iam_policy.irsa_policy.arn }
+}
+
+resource "kubernetes_role" "github_actions_role" {
+  metadata {
+    name      = "serviceaccount-role"
+    namespace = var.namespace
+  }
+  dynamic "rule" {
+    for_each = var.serviceaccount_rules
+    content {
+      api_groups = rule.value.api_groups
+      resources  = rule.value.resources
+      verbs      = rule.value.verbs
+    }
+  }
+}
+
+resource "kubernetes_role_binding" "github-actions-rolebinding" {
+  metadata {
+    name      = "serviceaccount-rolebinding"
+    namespace = var.namespace
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.github_actions_role.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = module.serviceaccount.service_account.name
+    namespace = var.namespace
+  }
 }
 
 data "kubernetes_service_account" "service_account" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/variables.tf
@@ -88,15 +88,8 @@ variable "serviceaccount_rules" {
   default = [
     {
       api_groups = [""]
-      resources  = ["pods/log"]
-      verbs      = ["get"]
-    },
-    {
-      api_groups = [""]
       resources = [
         "pods/portforward",
-        "pods/exec",
-        "pods/attach",
         "deployment",
         "secrets",
         "services",


### PR DESCRIPTION
Trying this out to see if we can use IRSA directly on the CI/CD service account, instead of granting permissions to start pods.