### PR TITLE
Add Disclosure checker AlertManager hooks to Slack

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/05-alerts.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/05-alerts.yaml
@@ -1,13 +1,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: disclosure-checker-alerts
   namespace: disclosure-checker-production
   labels:
-    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-disclosure-checker
 spec:
   groups:
-    - name: disclosure-checker
+    - name: application-rules
       rules:
         - alert: KubePodCrashLooping
           annotations:
@@ -17,77 +17,39 @@ spec:
             rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"disclosure-checker-production"}[5m]) * 600 > 2
           for: 4m
           labels:
-            severity: cdpt-disclosure-checker
-        - alert: KubeJobFailed
-          annotations:
-            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete
-            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
-          expr: |-
-            kube_job_status_failed{job="kube-state-metrics", namespace="disclosure-checker-production"} > 0
-          for: 4m
-          labels:
-            severity: cdpt-disclosure-checker
-        - alert: FailedDelayedJobs
-          annotations:
-            message: Failed Delayed Job in {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})
-            runbook_url: https://ministryofjustice.github.io/fb-guide-and-runbook/troubleshooting/find-a-failed-submission/#delayed-job-failures
-          expr: |-
-            avg(delayed_jobs_failed{namespace="disclosure-checker-production"}) > 0
-          for: 1m
-          labels:
-            severity: cdpt-disclosure-checker
+            severity: central-digital-product-team
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
               matched the expected number of replicas for longer than an hour.
-            runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
           expr: |-
             kube_deployment_spec_replicas{namespace="disclosure-checker-production", job="kube-state-metrics"}
               !=
             kube_deployment_status_replicas_available{namespace="disclosure-checker-production", job="kube-state-metrics"}
           for: 1h
           labels:
-            severity: cdpt-disclosure-checker
+            severity: central-digital-product-team
         - alert: KubePodNotReady
           annotations:
             message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
               state for longer than an hour.
-            runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubepodnotready
           expr: sum by (namespace, pod) (kube_pod_status_phase{namespace="disclosure-checker-production", job="kube-state-metrics",
             phase=~"Pending|Unknown"}) > 0
           for: 1h
           labels:
-            severity: cdpt-disclosure-checker
-        - alert: KubeJobCompletion
-          annotations:
-            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
-              than 30mins to complete.
-            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
-          expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics", namespace="disclosure-checker-production"}  >
-            0
-          for: 30m
-          labels:
-            severity: cdpt-disclosure-checker
-        - alert: KubeCronJobRunning
-          annotations:
-            message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
-              than 30mins to complete.
-            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
-          expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="disclosure-checker-production"} > 3600
-          for: 30m
-          labels:
-            severity: cdpt-disclosure-checker
+            severity: central-digital-product-team
         - alert: SlowResponses
           annotations:
             message: ingress {{ $labels.ingress }} is serving slow responses over 5 seconds
-            runbook_url: https://example.com/
           expr: |-
             avg(rate(nginx_ingress_controller_request_duration_seconds_sum{exported_namespace = "disclosure-checker-production"}[5m])
             /
             rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = "disclosure-checker-production"}[5m]) > 0) by (ingress) > 5
           for: 1m
           labels:
-            severity: cdpt-disclosure-checker
+            severity: central-digital-product-team
         - alert: KubeNamespaceQuotaNearing
           annotations:
             message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
@@ -95,8 +57,8 @@ spec:
           expr: |-
             100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace="disclosure-checker-production"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{job="kube-state-metrics", type="hard", namespace="disclosure-checker-production"} > 0)
+            (kube_resourcequota{job="kube-state-metrics", type="hard", namespace="disclosure-checker-producton"} > 0)
               > 80
           for: 5m
           labels:
-            severity: cdpt-disclosure-checker
+            severity: central-digital-product-team

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/05-alerts.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/05-alerts.yaml
@@ -1,0 +1,102 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: disclosure-checker-alerts
+  namespace: disclosure-checker-production
+  labels:
+    prometheus: cloud-platform
+spec:
+  groups:
+    - name: disclosure-checker
+      rules:
+        - alert: KubePodCrashLooping
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+          expr: |-
+            rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"disclosure-checker-production"}[5m]) * 600 > 2
+          for: 4m
+          labels:
+            severity: cdpt-disclosure-checker
+        - alert: KubeJobFailed
+          annotations:
+            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
+          expr: |-
+            kube_job_status_failed{job="kube-state-metrics", namespace="disclosure-checker-production"} > 0
+          for: 4m
+          labels:
+            severity: cdpt-disclosure-checker
+        - alert: FailedDelayedJobs
+          annotations:
+            message: Failed Delayed Job in {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})
+            runbook_url: https://ministryofjustice.github.io/fb-guide-and-runbook/troubleshooting/find-a-failed-submission/#delayed-job-failures
+          expr: |-
+            avg(delayed_jobs_failed{namespace="disclosure-checker-production"}) > 0
+          for: 1m
+          labels:
+            severity: cdpt-disclosure-checker
+        - alert: KubeDeploymentReplicasMismatch
+          annotations:
+            message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+              matched the expected number of replicas for longer than an hour.
+            runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
+          expr: |-
+            kube_deployment_spec_replicas{namespace="disclosure-checker-production", job="kube-state-metrics"}
+              !=
+            kube_deployment_status_replicas_available{namespace="disclosure-checker-production", job="kube-state-metrics"}
+          for: 1h
+          labels:
+            severity: cdpt-disclosure-checker
+        - alert: KubePodNotReady
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+              state for longer than an hour.
+            runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
+          expr: sum by (namespace, pod) (kube_pod_status_phase{namespace="disclosure-checker-production", job="kube-state-metrics",
+            phase=~"Pending|Unknown"}) > 0
+          for: 1h
+          labels:
+            severity: cdpt-disclosure-checker
+        - alert: KubeJobCompletion
+          annotations:
+            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+              than 30mins to complete.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+          expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics", namespace="disclosure-checker-production"}  >
+            0
+          for: 30m
+          labels:
+            severity: cdpt-disclosure-checker
+        - alert: KubeCronJobRunning
+          annotations:
+            message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+              than 30mins to complete.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
+          expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="disclosure-checker-production"} > 3600
+          for: 30m
+          labels:
+            severity: cdpt-disclosure-checker
+        - alert: SlowResponses
+          annotations:
+            message: ingress {{ $labels.ingress }} is serving slow responses over 5 seconds
+            runbook_url: https://example.com/
+          expr: |-
+            avg(rate(nginx_ingress_controller_request_duration_seconds_sum{exported_namespace = "disclosure-checker-production"}[5m])
+            /
+            rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = "disclosure-checker-production"}[5m]) > 0) by (ingress) > 5
+          for: 1m
+          labels:
+            severity: cdpt-disclosure-checker
+        - alert: KubeNamespaceQuotaNearing
+          annotations:
+            message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+          expr: |-
+            100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace="disclosure-checker-production"}
+              / ignoring(instance, job, type)
+            (kube_resourcequota{job="kube-state-metrics", type="hard", namespace="disclosure-checker-production"} > 0)
+              > 80
+          for: 5m
+          labels:
+            severity: cdpt-disclosure-checker

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/secrets.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: slackwebhook
+type: Opaque
+data:
+  aws_access_key_id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+  aws_secret_access_key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/secrets.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/secrets.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: slackwebhook
-type: Opaque
-data:
-  aws_access_key_id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-  aws_secret_access_key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Add alert manager hooks to Slack. 

As per the steps from https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#create-a-slack-webhook-and-amend-alertmanager