### PR TITLE
RR-2 - Renamed certificate dns names

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/06-certificate.yaml
@@ -10,7 +10,7 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - hmpps-education-and-work-plan-api-dev.hmpps.service.justice.gov.uk
+    - learningandworkprogress-api-dev.hmpps.service.justice.gov.uk
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -23,4 +23,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    -  hmpps-education-and-work-plan-dev.hmpps.service.justice.gov.uk
+    -  learning-and-work-progress-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This PR renames the DNS names for the Education And Work Plan namespace UI and APIs

The previous DNS name for the API was slightly too long in `dev` (and would be even longer as and when we get to `preprod`

Given that our service has been renamed anyway to "Learning and work progress", I've taken the opportunity to rename our DNS names accordingly, as well as dropping the `hmpps-` prefix from the domain names.

The worst case combination for us is the `-api` in `-preprod`. Even with this new name the proposed name for preprod would have been too long!; so for the API I've opted to remove the hyphens; which makes our longest name:
```
learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk
```
(as and when we get to preprod)