### PR TITLE
AP-4297: Add ECR lifecycle policy to legal-framework-api-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/ecr.tf
@@ -6,6 +6,57 @@ module "ecr-repo" {
   oidc_providers      = ["circleci"]
   github_repositories = [var.repo_name]
   namespace           = var.namespace
+
+  /*
+  # Lifecycle_policy provides a way to automate the cleaning up of your container images by expiring images based on age or count.
+  # To apply multiple rules, combined them in one policy JSON.
+  # https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_examples.html
+  */
+  lifecycle_policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images older than 7 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 7
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Expire images tagged with 'latest' older than 180 days",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["latest"],
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 180
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 3,
+            "description": "Keep the newest 25 images and mark the rest for expiration",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 25
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
 }
 
 resource "kubernetes_secret" "ecr-repo" {


### PR DESCRIPTION
Add ECR lifecycle policy to legal-framework-api-uat

Remove need for scripted deletion of images using long lived
credentials.
