### PR TITLE
AP-4293: Add new ECR repo with lifecycle policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
@@ -1,7 +1,9 @@
+# TODO: delete "ecr-repo-applyforlegalaid-service" module once images
+# being pushed/pulled to/from new ECR repo
 module "ecr-repo-applyforlegalaid-service" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
 
-  team_name = "laa-apply-for-legal-aid"
+  team_name = var.team_name
   repo_name = "applyforlegalaid-service"
 
   providers = {
@@ -12,7 +14,7 @@ module "ecr-repo-applyforlegalaid-service" {
 resource "kubernetes_secret" "ecr-repo-applyforlegalaid-service" {
   metadata {
     name      = "ecr-repo-applyforlegalaid-service"
-    namespace = "laa-apply-for-legalaid-production"
+    namespace = var.namespace
   }
 
   data = {
@@ -20,6 +22,80 @@ resource "kubernetes_secret" "ecr-repo-applyforlegalaid-service" {
     repo_url          = module.ecr-repo-applyforlegalaid-service.repo_url
     access_key_id     = module.ecr-repo-applyforlegalaid-service.access_key_id
     secret_access_key = module.ecr-repo-applyforlegalaid-service.secret_access_key
+  }
+}
+
+module "ecr_credentials" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
+
+  team_name           = var.team_name
+  repo_name           = "${var.namespace}-ecr"
+  oidc_providers      = ["circleci"]
+  github_repositories = [var.repo_name]
+  namespace           = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+
+  lifecycle_policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images older than 7 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 7
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Expire images tagged with 'latest' older than 180 days",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["latest"],
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 180
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 3,
+            "description": "Keep the newest 50 images and mark the rest for expiration",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 50
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}
+
+resource "kubernetes_secret" "ecr_credentials" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_arn          = module.ecr_credentials.repo_arn
+    repo_url          = module.ecr_credentials.repo_url
+    access_key_id     = module.ecr_credentials.access_key_id
+    secret_access_key = module.ecr_credentials.secret_access_key
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/variables.tf
@@ -10,6 +10,11 @@ variable "namespace" {
   default = "laa-apply-for-legalaid-production"
 }
 
+variable "repo_name" {
+  description = "The name of github repo"
+  default     = "laa-apply-for-legal-aid"
+}
+
 variable "application" {
   description = "Name of Application you are deploying"
   default     = "laa-apply-for-legalaid"


### PR DESCRIPTION
Add new ECR repo with oidc provider and lifecyle policy

To replace the old inconsistently named ECR repo
with consistently named one that implements oidc
for circleci and has a lifecycle policy - to facilitate
migration to IRSA.

THe old ECR repo will be deleted once we have been using
the new for a few days successfully.
