### PR TITLE
Revert "AP-4321: remove old, unused ecr repo for clamav"

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
@@ -102,8 +102,9 @@ resource "kubernetes_secret" "ecr_credentials" {
 module "ecr-repo-clamav" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
 
-  team_name = "laa-apply-for-legal-aid"
-  repo_name = "clamav"
+  team_name           = "laa-apply-for-legal-aid"
+  repo_name           = "clamav"
+  deletion_protection = false
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
@@ -98,3 +98,29 @@ resource "kubernetes_secret" "ecr_credentials" {
     secret_access_key = module.ecr_credentials.secret_access_key
   }
 }
+
+module "ecr-repo-clamav" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
+
+  team_name = "laa-apply-for-legal-aid"
+  repo_name = "clamav"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "ecr-repo-clamav" {
+  metadata {
+    name      = "ecr-repo-clamav"
+    namespace = "laa-apply-for-legalaid-production"
+  }
+
+  data = {
+    repo_arn          = module.ecr-repo-clamav.repo_arn
+    repo_url          = module.ecr-repo-clamav.repo_url
+    access_key_id     = module.ecr-repo-clamav.access_key_id
+    secret_access_key = module.ecr-repo-clamav.secret_access_key
+  }
+}
+


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-environments#14563 and disable deletion_protection. Subsequent PR to remove/destroy the repo should then remove all images.