### PR TITLE
Rotate secrets to prepare to go live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/api-auth-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/api-auth-secrets.tf
@@ -4,15 +4,15 @@ locals {
   datastore_api_consumers = {
     "crime_apply" = {
       namespace  = "laa-apply-for-criminal-legal-aid-production"
-      rotated_at = "2023-04-25"
+      rotated_at = "2023-07-13"
     }
     "crime_review" = {
       namespace  = "laa-review-criminal-legal-aid-production"
-      rotated_at = "2023-04-25"
+      rotated_at = "2023-07-13"
     }
     "maat_adapter" = {
       namespace  = "laa-crime-applications-adaptor-prod"
-      rotated_at = "2023-04-27"
+      rotated_at = "2023-07-13"
     }
   }
 }


### PR DESCRIPTION
Note, this is not a security incident. We are pre-emptively rotating the secrets as we plan to go live with the service in the coming few days, and to ensure our rotation mechanism and services relying on these secrets behave as expected.