### PR TITLE
CCQ PROD display nameservers as a list

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/route53.tf
@@ -21,7 +21,7 @@ resource "kubernetes_secret" "eligibility_team_route53_zone" {
 
   data = {
     zone_id   = aws_route53_zone.eligibility_team_route53_zone.zone_id
-    nameservers = join("\n", aws_route53_zone.eligibility_team_route53_zone.name_servers)
+    nameservers = join(", ", aws_route53_zone.eligibility_team_route53_zone.name_servers)
   }
 }
 


### PR DESCRIPTION
the nameserver list is currently obtained using:
`nameservers = join("\n", aws_route53_zone.eligibility_team_route53_zone.name_servers)`
the output is something like this:
`ns-11.awsdns-11.org\nns-22.awsdns-22.co.uk\nns-33.awsdns-33.com\nns-44.awsdns-44.net`
This PR is to make the nameservers a more readable list with out the `/n`