### PR TITLE
Remove client for HMPPS Integration API in dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
@@ -10,5 +10,5 @@ locals {
     GithubTeam             = var.team_name
   }
 
-  clients = ["emile", "ting", "april", "matt", "mapps", "heartbeat"]
+  clients = ["emile", "ting", "april", "mapps", "heartbeat"]
 }


### PR DESCRIPTION
This client is no longer required and will therefore remove the API key, update API Gateway and update our Kubernetes secret for API keys.