### PR TITLE
Tweak ECR lifecycle policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/ecr.tf
@@ -11,11 +11,11 @@ module "ecr-repo" {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "Expire untagged images keeping newest 25",
+            "description": "Expire images keeping newest 200",
             "selection": {
-                "tagStatus": "untagged",
+                "tagStatus": "any",
                 "countType": "imageCountMoreThan",
-                "countNumber": 25
+                "countNumber": 200
             },
             "action": {
                 "type": "expire"


### PR DESCRIPTION
All our images are tagged one way or another, so in reality, `"tagStatus": "untagged"` was expiring nothing.
Changed to `"tagStatus": "any"` and increased total number of images to keep.