### PR TITLE
Remove client for HMPPS Integration API in pre-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/locals.tf
@@ -10,5 +10,5 @@ locals {
     GithubTeam             = var.team_name
   }
 
-  clients = ["emile", "ting", "april", "matt", "heartbeat"]
+  clients = ["emile", "ting", "april", "heartbeat"]
 }


### PR DESCRIPTION
This client is no longer required and will therefore remove the API key, update API Gateway and update our Kubernetes secret for API keys.