### PR TITLE
Hale platform staging deployment updates

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/ecr.tf
@@ -9,6 +9,25 @@ module "ecr_credentials" {
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 
+  lifecycle_policy = <<EOF
+  {
+    "rules": [
+      {
+        "rulePriority": 1,
+        "description": "Keep the newest 100 images and mark the rest for expiration",
+        "selection": {
+          "tagStatus": "any",
+          "countType": "imageCountMoreThan",
+          "countNumber": 100
+        },
+        "action": {
+          "type": "expire"
+        }
+      }
+    ]
+  }
+  EOF  
+
   /*
     By default scan_on_push is set to true. When this is enabled then all images pushed to the repo are scanned for any security
     / software vulnerabilities in your image and the results can be viewed in the console. For further details, please see:
@@ -16,6 +35,9 @@ module "ecr_credentials" {
     To disable 'scan_on_push', set it to false as below:
   scan_on_push = "false"
   */
+
+  # enable the oidc implementation for GitHub
+  oidc_providers = ["github"]
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/ecr.tf
@@ -48,6 +48,11 @@ module "ecr_credentials" {
   # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets
   github_environments = ["Staging"]
 
+  # OPTIONAL:
+  # set this if you use one GitHub repository to push to multiple container repositories
+  # this ensures the variable key used in the workflow is unique
+  github_actions_prefix = "staging"
+
   github_actions_secret_ecr_name       = var.github_actions_secret_ecr_name
   github_actions_secret_ecr_url        = var.github_actions_secret_ecr_url
   github_actions_secret_ecr_access_key = var.github_actions_secret_ecr_access_key

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/irsa.tf
@@ -1,0 +1,25 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "hale-platform-staging-service"
+  namespace            = var.namespace # this is also used as a tag
+
+  # Attach the approprate policies using a key => value map
+  # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
+  # provide an output called `irsa_policy_arn` that can be used.
+  role_policy_arns = {
+    s3  = module.s3_bucket.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/variables.tf
@@ -31,6 +31,10 @@ variable "environment" {
   default     = "staging"
 }
 
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}
+
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "wordpress@digital.justice.gov.uk"


### PR DESCRIPTION
- Adds lifecycle policy to ecr
- enables the oidc implementation for ecr so we can use short-lived credentials
- creates irsa - used by s3
- Leave ECR AccessKey variables for now till we are happy finished testing short lived credentials