### PR TITLE
SAA-853 activities domain event secrets DEV

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-activities-management.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-activities-management.tf
@@ -92,7 +92,7 @@ resource "aws_sns_topic_subscription" "activities_domain_events_subscription" {
 resource "kubernetes_secret" "activities_domain_events_queue" {
   metadata {
     name      = "activities-domain-events-sqs-instance-output"
-    namespace = "activities-api-dev"
+    namespace = "hmpps-activities-management-dev"
   }
 
   data = {
@@ -107,7 +107,7 @@ resource "kubernetes_secret" "activities_domain_events_queue" {
 resource "kubernetes_secret" "activities_dlq" {
   metadata {
     name      = "activities-domain-events-sqs-dl-instance-output"
-    namespace = "activities-api-dev"
+    namespace = "hmpps-activities-management-dev"
   }
 
   data = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/variables.tf
@@ -22,9 +22,9 @@ variable "team_name" {
 variable "additional_topic_clients" {
   description = "Create a dedicated access key and store it in a secret named 'hmpps-domain-events-topic' in each of the below namespaces."
   default = [
-    "activities-api-dev",
     "calculate-release-dates-api-dev",
     "court-probation-dev",
+    "hmss-activities-management-dev",
     "hmpps-adjustments-dev",
     "hmpps-assessments-dev",
     "hmpps-community-accommodation-dev",


### PR DESCRIPTION
Moving domain events queue secrets from old activities API namespace to the new, combined namespace `hmpps-activities-management-dev` 