### PR TITLE
SAA-853: Activities DEV namespace typo.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/variables.tf
@@ -24,7 +24,7 @@ variable "additional_topic_clients" {
   default = [
     "calculate-release-dates-api-dev",
     "court-probation-dev",
-    "hmss-activities-management-dev",
+    "hmpps-activities-management-dev",
     "hmpps-adjustments-dev",
     "hmpps-assessments-dev",
     "hmpps-community-accommodation-dev",


### PR DESCRIPTION
Typo in new namespace name corrected for domain event topic secret.
Sorry Tom, there was a small typo that I missed in previous PR. 