### PR TITLE
Add CAS production checks for availability with Pingdom

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
@@ -1,0 +1,50 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "hmpps-approved-premises-ui" {
+  type                     = "http"
+  name                     = "HMPPS - approved-premises/CAS1 - Production"
+  host                     = "approved-premises.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  integrationids           = [130656, 130657]
+  notifyagainevery         = 0
+  url                      = "/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_hmpps,application_approved-premises,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"
+  probefilters             = "region:EU"
+}
+
+resource "pingdom_check" "hmpps-temporary-accommodation-ui" {
+  type                     = "http"
+  name                     = "HMPPS - temporary-accommodation/CAS3 - Production"
+  host                     = "temporary-accommodation.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  integrationids           = [130657]
+  notifyagainevery         = 0
+  url                      = "/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_hmpps,application_temporary-accommodation,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"
+  probefilters             = "region:EU"
+}
+
+resource "pingdom_check" "hmpps-approved-premises-api" {
+  type                     = "http"
+  name                     = "HMPPS - approved-premises-api - Production"
+  host                     = "approved-premises-api.hmpps.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  integrationids           = [130656, 130657]
+  notifyagainevery         = 0
+  url                      = "/health_check"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_hmpps,application_approved-premises-api,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"
+  probefilters             = "region:EU"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/versions.tf
@@ -14,6 +14,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.20.0"
     }
+    pingdom = {
+      source  = "DrFaust92/pingdom"
+      version = "~> 1.3.1"
+    }
   }
 }
-


### PR DESCRIPTION
We follow the CP documentation to create a basic health check for each production service[1].

We try to follow the tagging documentation as best we can[2]

Slack integrations requested here[3]

[1] https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-pingdom-checks.html#create-a-pingdom-check
[2] https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html#tags-you-should-use
[3] https://github.com/ministryofjustice/cloud-platform/issues/4665