### PR TITLE
Hale platform staging var names

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/variables.tf
@@ -61,40 +61,30 @@ variable "github_token" {
 
 variable "github_actions_secret_kube_cluster" {
   description = "The name of the github actions secret containing the kubernetes cluster name"
-  default     = "KUBE_CLUSTER_STAGING"
+  default     = "KUBE_CLUSTER"
 }
 
 variable "github_actions_secret_kube_namespace" {
   description = "The name of the github actions secret containing the kubernetes namespace name"
-  default     = "KUBE_NAMESPACE_STAGING"
+  default     = "KUBE_NAMESPACE"
 }
 
 variable "github_actions_secret_kube_cert" {
   description = "The name of the github actions secret containing the serviceaccount ca.crt"
-  default     = "KUBE_CERT_STAGING"
+  default     = "KUBE_CERT"
 }
 
 variable "github_actions_secret_kube_token" {
   description = "The name of the github actions secret containing the serviceaccount token"
-  default     = "KUBE_TOKEN_STAGING"
+  default     = "KUBE_TOKEN"
 }
 
 variable "github_actions_secret_ecr_name" {
   description = "The name of the github actions secret containing the ECR name"
-  default     = "ECR_NAME_STAGING"
+  default     = "ECR_NAME"
 }
 
 variable "github_actions_secret_ecr_url" {
   description = "The name of the github actions secret containing the ECR URL"
-  default     = "ECR_URL_STAGING"
-}
-
-variable "github_actions_secret_ecr_access_key" {
-  description = "The name of the github actions secret containing the ECR AWS access key"
-  default     = "ECR_AWS_ACCESS_KEY_ID_STAGING"
-}
-
-variable "github_actions_secret_ecr_secret_key" {
-  description = "The name of the github actions secret containing the ECR AWS secret key"
-  default     = "ECR_AWS_SECRET_ACCESS_KEY_STAGING"
+  default     = "ECR_URL"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/variables.tf
@@ -88,3 +88,13 @@ variable "github_actions_secret_ecr_url" {
   description = "The name of the github actions secret containing the ECR URL"
   default     = "ECR_URL"
 }
+
+variable "github_actions_secret_ecr_access_key" {
+  description = "The name of the github actions secret containing the ECR AWS access key"
+  default     = "ECR_AWS_ACCESS_KEY_ID_STAGING"
+}
+
+variable "github_actions_secret_ecr_secret_key" {
+  description = "The name of the github actions secret containing the ECR AWS secret key"
+  default     = "ECR_AWS_SECRET_ACCESS_KEY_STAGING"
+}


### PR DESCRIPTION
Rename variables so they can be generic and the same deploy code can be used for each env