### PR TITLE
Justice Gov UK Archiver init

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: justice-gov-uk-archiver-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-intranet"
+    cloud-platform.justice.gov.uk/application: "Justice Website Archiver"
+    cloud-platform.justice.gov.uk/owner: "Central Digital: central-digital-product-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/justice-webiste-archive"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"
+    cloud-platform.justice.gov.uk/review-after: "2023-10-01"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: justice-gov-uk-archiver-dev-admin
+  namespace: justice-gov-uk-archiver-dev
+subjects:
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: justice-gov-uk-archiver-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: justice-gov-uk-archiver-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: justice-gov-uk-archiver-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: justice-gov-uk-archiver-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/ecr.tf
@@ -1,0 +1,38 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+
+  /*
+    By default scan_on_push is set to true. When this is enabled then all images pushed to the repo are scanned for any security
+    / software vulnerabilities in your image and the results can be viewed in the console. For further details, please see:
+    https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html
+    To disable 'scan_on_push', set it to false as below:
+  scan_on_push = "false"
+  */
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  github_repositories = ["intranet-archive"]
+}
+
+resource "kubernetes_secret" "ecr_credentials" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.ecr_credentials.access_key_id
+    secret_access_key = module.ecr_credentials.secret_access_key
+    repo_arn          = module.ecr_credentials.repo_arn
+    repo_url          = module.ecr_credentials.repo_url
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      GithubTeam = "central-digital-product-team"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/s3.tf
@@ -1,0 +1,27 @@
+module "s3_bucket" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.8.2"
+  team_name              = var.team_name
+  business-unit          = var.business_unit
+  application            = var.application
+  is-production          = var.is_production
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  namespace              = var.namespace
+  providers              = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "s3_bucket" {
+  metadata {
+    name      = "s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    access_key_id     = module.s3_bucket.access_key_id
+    secret_access_key = module.s3_bucket.secret_access_key
+    bucket_arn        = module.s3_bucket.bucket_arn
+    bucket_name       = module.s3_bucket.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/serviceaccount.tf
@@ -1,0 +1,9 @@
+
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.8.2"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = ["justice-website-archive"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/variables.tf
@@ -1,0 +1,53 @@
+variable "vpc_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Justice Gov UK Archive"
+}
+
+variable "namespace" {
+  default = "justice-gov-uk-archiver-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HQ"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "central-digital-product-team"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "central-digital-product-team@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "cdpt-intranet"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-archiver-dev/resources/versions.tf
@@ -1,0 +1,18 @@
+
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.64.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.20.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.23.0"
+    }
+  }
+}


### PR DESCRIPTION
A new environment to bring in our archive process application for https://www.justice.gov.uk/

An empty Cloudfront template file is included, as this will need to be configured to set up a distribution that can serve the archive from an S3 bucket. This resource is not directly needed to begin the archiving process. Development of this template however is underway.