### PR TITLE
SAA-1014: Activities preprod namespace - explicit creation of secret for service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/05-serviceaccount-circleci.yaml
@@ -5,7 +5,7 @@ metadata:
   name: circleci
   namespace: hmpps-activities-management-preprod
 
---
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/05-serviceaccount-circleci.yaml
@@ -5,6 +5,16 @@ metadata:
   name: circleci
   namespace: hmpps-activities-management-preprod
 
+--
+apiVersion: v1
+kind: Secret
+metadata:
+  name: circleci-token
+  namespace: hmpps-activities-management-preprod
+  annotations:
+    kubernetes.io/service-account.name: circleci
+type: kubernetes.io/service-account-token
+
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This is related to the conversation here - https://mojdt.slack.com/archives/C57UPMZLY/p1689928407472739
As of K8s v1.24 service accounts do not implicitly create a secret in the namespace - this must now be created explicitly.
I'll get this in and check that the bootstrap process (which configures circle CI deployments into CP, amongst other things) works ok with it.