### PR TITLE
SAA-1014: Activities preprod - linking the service account to a token secret (for bootstrap)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/05-serviceaccount-circleci.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: circleci
   namespace: hmpps-activities-management-preprod
+secrets:
+- name: circleci-token
 
 ---
 apiVersion: v1


### PR DESCRIPTION
This PR implements the link between a secret holding the service account token and the service account, to replicate the pre V1.24 behaviour which automatically created a secret with the SA token in it.

This is required for the current version of bootstrap to work - though its being looked at, with other potential ways to obtain the circleci-token. 