### PR TITLE
CFE: set ECR deletion_protection to false

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-financial-eligibility-uat/resources/ecr.tf
@@ -4,6 +4,8 @@ module "ecr-repo-check-financial-eligibility-service" {
   team_name = "laa-apply-for-legal-aid"
   repo_name = "check-financial-eligibility-service"
 
+  deletion_protection = false
+
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
We are about to start decommissioning this service and, following the steps on https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/cleaning-up.html are turning off deletion protection