### PR TITLE
SAA-767 domain events for activities prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-activities-management.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/hmpps-activities-management.tf
@@ -1,0 +1,121 @@
+module "activities_domain_events_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.11.0"
+
+  environment-name          = var.environment-name
+  team_name                 = var.team_name
+  infrastructure-support    = var.infrastructure_support
+  application               = var.application
+  sqs_name                  = "activities_domain_events_queue"
+  encrypt_sqs_kms           = "true"
+  message_retention_seconds = 1209600
+  namespace                 = var.namespace
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.activities_domain_events_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+
+EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "activities_domain_events_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=4.11.0"
+
+  environment-name       = var.environment-name
+  team_name              = var.team_name
+  infrastructure-support = var.infrastructure_support
+  application            = var.application
+  sqs_name               = "activities_domain_events_dl"
+  encrypt_sqs_kms        = "true"
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "activities_domain_events_queue_policy" {
+  queue_url = module.activities_domain_events_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.activities_domain_events_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.activities_domain_events_queue.sqs_arn}",
+          "Action": "SQS:SendMessage",
+          "Condition":
+                      {
+                        "ArnEquals":
+                          {
+                            "aws:SourceArn": "${module.hmpps-domain-events.topic_arn}"
+                          }
+                        }
+        }
+      ]
+  }
+
+EOF
+
+}
+
+resource "aws_sns_topic_subscription" "activities_domain_events_subscription" {
+  provider      = aws.london
+  topic_arn     = module.hmpps-domain-events.topic_arn
+  protocol      = "sqs"
+  endpoint      = module.activities_domain_events_queue.sqs_arn
+  filter_policy = jsonencode({
+    eventType = [
+      "prison-offender-events.prisoner.released",
+      "prison-offender-events.prisoner.received",
+      "prison-offender-events.prisoner.merged",
+      "prison-offender-events.prisoner.cell.move",
+      "prison-offender-events.prisoner.non-association-detail.changed",
+      "prison-offender-events.prisoner.activities-changed",
+      "prison-offender-events.prisoner.appointments-changed",
+      "incentives.iep-review.inserted",
+      "incentives.iep-review.updated",
+      "incentives.iep-review.deleted"
+    ]
+  })
+
+}
+
+resource "kubernetes_secret" "activities_domain_events_queue" {
+  metadata {
+    name      = "activities-domain-events-sqs-instance-output"
+    namespace = "hmpps-activities-management-prod"
+  }
+
+  data = {
+    access_key_id     = module.activities_domain_events_queue.access_key_id
+    secret_access_key = module.activities_domain_events_queue.secret_access_key
+    sqs_queue_url     = module.activities_domain_events_queue.sqs_id
+    sqs_queue_arn     = module.activities_domain_events_queue.sqs_arn
+    sqs_queue_name    = module.activities_domain_events_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "activities_dlq" {
+  metadata {
+    name      = "activities-domain-events-sqs-dl-instance-output"
+    namespace = "hmpps-activities-management-prod"
+  }
+
+  data = {
+    access_key_id     = module.activities_domain_events_dead_letter_queue.access_key_id
+    secret_access_key = module.activities_domain_events_dead_letter_queue.secret_access_key
+    sqs_queue_url     = module.activities_domain_events_dead_letter_queue.sqs_id
+    sqs_queue_arn     = module.activities_domain_events_dead_letter_queue.sqs_arn
+    sqs_queue_name    = module.activities_domain_events_dead_letter_queue.sqs_name
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/outputs-to-ssm-parameters.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/outputs-to-ssm-parameters.tf
@@ -6,6 +6,8 @@ locals {
     (module.cvl_domain_events_dead_letter_queue.sqs_name)                           = module.cvl_domain_events_dead_letter_queue.irsa_policy_arn,
     (module.curious_queue.sqs_name)                                                 = module.curious_queue.irsa_policy_arn,
     (module.curious_dead_letter_queue.sqs_name)                                     = module.curious_dead_letter_queue.irsa_policy_arn,
+    (module.activities_domain_events_queue.sqs_name)                                = module.activities_domain_events_queue.irsa_policy_arn,
+    (module.activities_domain_events_dead_letter_queue.sqs_name)                    = module.activities_domain_events_dead_letter_queue.irsa_policy_arn,
     (module.hmpps_domain_event_logger_queue.sqs_name)                               = module.hmpps_domain_event_logger_queue.irsa_policy_arn,
     (module.hmpps_domain_event_logger_dead_letter_queue.sqs_name)                   = module.hmpps_domain_event_logger_dead_letter_queue.irsa_policy_arn,
     (module.keyworker_api_queue.sqs_name)                                           = module.keyworker_api_queue.irsa_policy_arn,

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/variables.tf
@@ -26,6 +26,7 @@ variable "additional_topic_clients" {
   default = [
     "calculate-release-dates-api-prod",
     "court-probation-prod",
+    "hmpps-activities-management-prod",
     "hmpps-adjustments-prod",
     "hmpps-assessments-prod",
     "hmpps-community-accommodation-prod",


### PR DESCRIPTION
Will create a subscription and queue to the HMPPS domain event topic and add secrets into the production namespace for activities management.