### PR TITLE
Add access to allow autoscaling to our pods

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
@@ -29,7 +29,8 @@ module "serviceaccount" {
         "serviceaccounts",
         "configmaps",
         "persistentvolumeclaims",
-
+        "hpa",
+        "horizontalpodautoscalers",
       ]
       verbs = [
         "update",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
@@ -19,7 +19,7 @@ module "serviceaccount" {
 
   serviceaccount_rules = [
     {
-      api_groups = [""]
+      api_groups = ["autoscaling"]
       resources = [
         "pods/portforward",
         "deployment",


### PR DESCRIPTION
Provide access to run a autoscaling of our pods as we get the current [error message](https://github.com/ministryofjustice/hale-platform/actions/runs/5626229760/job/15283374004):
forbidden: User "system:serviceaccount:***:cd-serviceaccount" cannot get resource "horizontalpodautoscalers"