### PR TITLE
Remove secrets label from resource list

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
@@ -23,7 +23,6 @@ module "serviceaccount" {
       resources = [
         "pods/portforward",
         "deployment",
-        "secrets",
         "services",
         "pods",
         "serviceaccounts",


### PR DESCRIPTION
Remove secrets label from service account resource list as it seems to be producing an [error](https://github.com/ministryofjustice/hale-platform/actions/runs/5626229760/job/15287282222). 