### PR TITLE
Remove autoscaling label used in API group

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
@@ -19,10 +19,11 @@ module "serviceaccount" {
 
   serviceaccount_rules = [
     {
-      api_groups = ["autoscaling"]
+      api_groups = [""]
       resources = [
         "pods/portforward",
         "deployment",
+        "secrets",
         "services",
         "pods",
         "serviceaccounts",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
@@ -29,7 +29,6 @@ module "serviceaccount" {
         "serviceaccounts",
         "configmaps",
         "persistentvolumeclaims",
-        "hpa",
         "horizontalpodautoscalers",
       ]
       verbs = [


### PR DESCRIPTION
Having "autoscaling" in the group API seemed to introduce an issue with the elements in the resource list, specifically secrets.