### PR TITLE
rds-aurora: deprecate access keys for non-production namespaces

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/aurora.tf
@@ -1,6 +1,6 @@
 module "aurora_db" {
   # always check the latest release in Github and set below
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=2.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=3.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -38,7 +38,5 @@ resource "kubernetes_secret" "aurora_db" {
     database_name               = module.aurora_db.database_name
     database_username           = module.aurora_db.database_username
     database_password           = module.aurora_db.database_password
-    access_key_id               = module.aurora_db.access_key_id
-    secret_access_key           = module.aurora_db.secret_access_key
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/rds-aurora.tf
@@ -1,5 +1,5 @@
 module "rds_aurora" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=2.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=3.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -11,7 +11,7 @@ module "rds_aurora" {
   instance_type  = "db.t4g.medium"
   replica_count  = 1
 
-  allow_major_version_upgrade  = true
+  allow_major_version_upgrade = true
 
   # Tags
   business_unit          = var.business_unit
@@ -50,8 +50,6 @@ resource "kubernetes_secret" "manage_intelligence_rds_aurora" {
     database_password                   = module.rds_aurora.database_password
     manage_intelligence_update_password = random_id.manage_intelligence_update_role_password.b64_url
     manage_intelligence_read_password   = random_id.manage_intelligence_read_role_password.b64_url
-    access_key_id                       = module.rds_aurora.access_key_id
-    secret_access_key                   = module.rds_aurora.secret_access_key
     url                                 = "postgres://${module.rds_aurora.database_username}:${module.rds_aurora.database_password}@${module.rds_aurora.rds_cluster_endpoint}/${module.rds_aurora.database_name}"
     reader_url                          = "postgres://${module.rds_aurora.database_username}:${module.rds_aurora.database_password}@${module.rds_aurora.rds_cluster_reader_endpoint}/${module.rds_aurora.database_name}"
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/rds-aurora.tf
@@ -1,5 +1,5 @@
 module "rds_aurora" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=2.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=3.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -43,7 +43,5 @@ resource "kubernetes_secret" "pcms_rds_aurora" {
     database_name               = module.rds_aurora.database_name
     database_username           = module.rds_aurora.database_username
     database_password           = module.rds_aurora.database_password
-    access_key_id               = module.rds_aurora.access_key_id
-    secret_access_key           = module.rds_aurora.secret_access_key
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/rds-aurora.tf
@@ -1,5 +1,5 @@
 module "rds_aurora" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=2.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=3.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -43,7 +43,5 @@ resource "kubernetes_secret" "pcms_rds_aurora" {
     database_name               = module.rds_aurora.database_name
     database_username           = module.rds_aurora.database_username
     database_password           = module.rds_aurora.database_password
-    access_key_id               = module.rds_aurora.access_key_id
-    secret_access_key           = module.rds_aurora.secret_access_key
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/rds-aurora.tf
@@ -1,5 +1,5 @@
 module "rds_aurora" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=2.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=3.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -50,8 +50,6 @@ resource "kubernetes_secret" "manage_intelligence_rds_aurora" {
     database_password                   = module.rds_aurora.database_password
     manage_intelligence_update_password = random_id.manage_intelligence_update_role_password.b64_url
     manage_intelligence_read_password   = random_id.manage_intelligence_read_role_password.b64_url
-    access_key_id                       = module.rds_aurora.access_key_id
-    secret_access_key                   = module.rds_aurora.secret_access_key
     url                                 = "postgres://${module.rds_aurora.database_username}:${module.rds_aurora.database_password}@${module.rds_aurora.rds_cluster_endpoint}/${module.rds_aurora.database_name}"
     reader_url                          = "postgres://${module.rds_aurora.database_username}:${module.rds_aurora.database_password}@${module.rds_aurora.rds_cluster_reader_endpoint}/${module.rds_aurora.database_name}"
   }


### PR DESCRIPTION
Related to [Deprecating long-lived credentials for modules](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/deprecating-long-lived-credentials.html) and ministryofjustice/cloud-platform#4546, ministryofjustice/cloud-platform#4372.

The use of RDS Aurora is not documented; though teams who use this (PCMS and IMS) have been made aware of this early removal.