### PR TITLE
Adds team slug to default provider default_tags.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-dev/resources/main.tf
@@ -10,6 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
+      GithubTeam = "laa-aws-infrastructure"
     }
   }
 }


### PR DESCRIPTION
Adds team github slug to default provider so all resources created are visible.