### PR TITLE
CAS Pingdom checks are made via the health-kick service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
@@ -4,13 +4,13 @@ provider "pingdom" {
 resource "pingdom_check" "hmpps-approved-premises-ui" {
   type                     = "http"
   name                     = "HMPPS - approved-premises/CAS1 - Production"
-  host                     = "approved-premises.hmpps.service.justice.gov.uk"
+  host                     = "health-kick.prison.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   integrationids           = [130656, 130657]
   notifyagainevery         = 0
-  url                      = "/health"
+  url                      = "/https/approved-premises.hmpps.service.justice.gov.uk/health"
   encryption               = true
   port                     = 443
   tags                     = "businessunit_hmpps,application_approved-premises,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"
@@ -20,13 +20,13 @@ resource "pingdom_check" "hmpps-approved-premises-ui" {
 resource "pingdom_check" "hmpps-temporary-accommodation-ui" {
   type                     = "http"
   name                     = "HMPPS - temporary-accommodation/CAS3 - Production"
-  host                     = "temporary-accommodation.hmpps.service.justice.gov.uk"
+  host                     = "health-kick.prison.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   integrationids           = [130657]
   notifyagainevery         = 0
-  url                      = "/health"
+  url                      = "/https/temporary-accommodation.hmpps.service.justice.gov.uk/health"
   encryption               = true
   port                     = 443
   tags                     = "businessunit_hmpps,application_temporary-accommodation,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"
@@ -36,13 +36,13 @@ resource "pingdom_check" "hmpps-temporary-accommodation-ui" {
 resource "pingdom_check" "hmpps-approved-premises-api" {
   type                     = "http"
   name                     = "HMPPS - approved-premises-api - Production"
-  host                     = "approved-premises-api.hmpps.service.justice.gov.uk"
+  host                     = "health-kick.prison.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   integrationids           = [130656, 130657]
   notifyagainevery         = 0
-  url                      = "/health_check"
+  url                      = "/https/approved-premises-api.hmpps.service.justice.gov.uk/health_check"
   encryption               = true
   port                     = 443
   tags                     = "businessunit_hmpps,application_approved-premises-api,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"


### PR DESCRIPTION
Pingdom is currently unable to detect the CAS services as they aren’t publicly accessible services.

We think there’s two options:

1. Go via the health-kick service which has existing permission to access the health check pages of our service and is used by other services[1]
2. Add all Pingdom IP addresses into each services helm allowlist [2]

On the one hand we are dependant on health-check service being available, on the other we have to maintain a long list of Pingdom IP addresses which could become out of date. Both can generate false positives. On balance we think the health-kick service is worth a go given it’s used by other services already.

[1] https://github.com/ministryofjustice/cloud-platform-environments/blob/6114e5cc0d24d6afc1f2b62c66c496283a9baf3a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/pingdom.tf#L7
[2] https://github.com/ministryofjustice/hmpps-assessments-api/blob/main/helm_deploy/hmpps-assessments-api/values.yaml#L65

(We think there's room to update the Pingdom docs to remind folks that we likely need to figure out firewalling and perhaps to recommend an option such as the health-kick service.)