### PR TITLE
Add localhost domain for track-a-query-development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -44,10 +44,6 @@ resource "kubernetes_secret" "track_a_query_s3" {
   }
 
   data = {
-    access_key_id     = module.track_a_query_s3.access_key_id
-    secret_access_key = module.track_a_query_s3.secret_access_key
-    bucket_arn        = module.track_a_query_s3.bucket_arn
     bucket_name       = module.track_a_query_s3.bucket_name
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -44,6 +44,6 @@ resource "kubernetes_secret" "track_a_query_s3" {
   }
 
   data = {
-    bucket_name       = module.track_a_query_s3.bucket_name
+    bucket_name = module.track_a_query_s3.bucket_name
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/s3.tf
@@ -19,7 +19,7 @@ module "track_a_query_s3" {
       allowed_methods = ["GET", "POST", "PUT"]
       allowed_origins = [
         "https://development.track-a-query.service.justice.gov.uk",
-        "https://track-a-query-development.apps.live-1.cloud-platform.service.justice.gov.uk",
+        "http://localhost:3000"
       ]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000


### PR DESCRIPTION
- Removes long lived keys
- Removes old live1 domain
- Adds localhost domain so bucket can be used from local environment