### PR TITLE
VB-2573 PREPROD - Orchestration service, Update SQS/SNS queue updates…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/irsa.tf
@@ -1,8 +1,34 @@
-module "app-irsa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+# Add the names of the SQS/SNS which the app needs permissions to access.
+# The value of each item should be the namespace where the SQS/SNS was created.
+# This information is used to collect the IAM policies which are used by the IRSA module.
+locals {
+  sqs_queues = {
+    "Digital-Prison-Services-preprod-hmpps_prison_visits_event_queue" = "hmpps-domain-events-preprod",
+    "Digital-Prison-Services-preprod-hmpps_prison_visits_event_dlq" = "hmpps-domain-events-preprod",
+  }
+  sns_topics = {
+    "cloud-platform-Digital-Prison-Services-15b2b4a6af7714848baeaf5f41c85fcd" = "hmpps-domain-events-preprod",
+  }
+
+  sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
+  sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
+}
+
+data "aws_ssm_parameter" "irsa_policy_arns_sns" {
+  for_each = local.sns_topics
+  name     = "/${each.value}/sns/${each.key}/irsa-policy-arn"
+}
+
+data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
+  for_each = local.sqs_queues
+  name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
+}
+
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
   namespace            = var.namespace
   service_account_name = var.application
-  role_policy_arns     = { sns = data.aws_ssm_parameter.irsa_policy_arns_sns.value }
+  role_policy_arns     = merge(local.sqs_policies,local.sns_policies)
 
   # Tags
   business_unit          = var.business_unit
@@ -14,6 +40,3 @@ module "app-irsa" {
   eks_cluster_name       = var.eks_cluster_name
 }
 
-data "aws_ssm_parameter" "irsa_policy_arns_sns" {
-  name = "/hmpps-domain-events-preprod/sns/cloud-platform-Digital-Prison-Services-15b2b4a6af7714848baeaf5f41c85fcd/irsa-policy-arn"
-}


### PR DESCRIPTION
Change Orchestration service to use IRSA

Prior to this PR were only using SNS in VSiP for posting domain events with IRSA, we did not cover listening on hmpps_prison_visits_event queue the orchestration service they are in the same name space (VSiP, orchestration).