### PR TITLE
VB-2572 STAGING - Orchestration service, Update SQS/SNS queue updates…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/irsa.tf
@@ -3,8 +3,8 @@
 # This information is used to collect the IAM policies which are used by the IRSA module.
 locals {
   sqs_queues = {
-    "Digital-Prison-Services-dev-hmpps_prison_visits_event_queue" = "hmpps-domain-events-dev",
-    "Digital-Prison-Services-dev-hmpps_prison_visits_event_dlq" = "hmpps-domain-events-dev",
+    "book-a-prison-visit-staging-hmpps_prison_visits_event_queue" = "visit-someone-in-prison-backend-svc-staging",
+    "book-a-prison-visit-staging-hmpps_prison_visits_event_dlq" = "visit-someone-in-prison-backend-svc-staging",
   }
   sns_topics = {
     "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/irsa.tf
@@ -3,8 +3,8 @@
 # This information is used to collect the IAM policies which are used by the IRSA module.
 locals {
   sqs_queues = {
-    "book-a-prison-visit-staging-hmpps_prison_visits_event_queue" = "visit-someone-in-prison-backend-svc-staging",
-    "book-a-prison-visit-staging-hmpps_prison_visits_event_dlq" = "visit-someone-in-prison-backend-svc-staging",
+    "book-a-prison-visit-staging-hmpps_prison_visits_event_queue" = var.namespace,
+    "book-a-prison-visit-staging-hmpps_prison_visits_event_dlq" = var.namespace,
   }
   sns_topics = {
     "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/irsa.tf
@@ -3,8 +3,8 @@
 # This information is used to collect the IAM policies which are used by the IRSA module.
 locals {
   sqs_queues = {
-    "book-a-prison-visit-staging-hmpps_prison_visits_event_queue" = var.namespace,
-    "book-a-prison-visit-staging-hmpps_prison_visits_event_dlq" = var.namespace,
+    "Book-A-Prison-Visit-staging-hmpps_prison_visits_event_queue" = var.namespace,
+    "Book-A-Prison-Visit-staging-hmpps_prison_visits_event_dlq" = var.namespace,
   }
   sns_topics = {
     "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev",


### PR DESCRIPTION
Change Orchestration service to use IRSA

Prior to this PR were only using SNS in VSiP for posting domain events with IRSA, we did not cover listening on hmpps_prison_visits_event queue the orchestration service they are in the same name space (VSiP, orchestration).

Had to alter to point to SQS queue in same name space as domaine events for staging does not exist