### PR TITLE
data-platform-app-*: trigger build

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmcts-ccpt-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmcts-ccpt-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmcts-ccpt-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmcts-ccpt-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmpps-hr-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmpps-hr-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmpps-hr-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmpps-hr-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-document-manager-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-document-manager-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-document-manager-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-document-manager-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-search-tool-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-search-tool-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-search-tool-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-search-tool-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-intel-app-homepage-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-intel-app-homepage-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-intel-app-homepage-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-intel-app-homepage-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-interventions-deploy-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-interventions-deploy-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-interventions-deploy-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-interventions-deploy-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-invoice-nlp-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-invoice-nlp-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-invoice-nlp-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-invoice-nlp-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-jdl-visulizer-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-jdl-visulizer-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-jdl-visulizer-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-jdl-visulizer-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-reviews-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-reviews-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-reviews-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-reviews-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-wm2-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-wm2-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-wm2-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-wm2-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-legal-aid-tools-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-legal-aid-tools-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-legal-aid-tools-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-legal-aid-tools-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ltc-capabilites-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ltc-capabilites-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ltc-capabilites-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ltc-capabilites-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-matrix-booking-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-matrix-booking-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-matrix-booking-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-matrix-booking-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mlp-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mlp-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mlp-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mlp-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mmp-web-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mmp-web-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mmp-web-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mmp-web-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-model-redevelopment-website-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-model-redevelopment-website-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-model-redevelopment-website-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-model-redevelopment-website-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-moj-officehub-locator-webapp-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-moj-officehub-locator-webapp-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-moj-officehub-locator-webapp-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-moj-officehub-locator-webapp-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-lpa-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-lpa-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-lpa-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-lpa-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-mi-dashdemo-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-mi-dashdemo-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-mi-dashdemo-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-mi-dashdemo-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pay-gap-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pay-gap-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pay-gap-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pay-gap-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-data-self-serve-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-data-self-serve-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-data-self-serve-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-data-self-serve-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-engagement-prediction-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-engagement-prediction-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-engagement-prediction-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-engagement-prediction-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-prediction-tool-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-prediction-tool-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-prediction-tool-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-prediction-tool-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pfg-dash-moj-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pfg-dash-moj-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pfg-dash-moj-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pfg-dash-moj-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pi-form-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pi-form-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pi-form-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pi-form-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-network-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-network-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-network-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-network-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-visitor-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-visitor-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-visitor-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-visitor-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prisons-ready-reckoner-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prisons-ready-reckoner-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prisons-ready-reckoner-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prisons-ready-reckoner-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-mi-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-mi-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-mi-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-mi-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-staffing-model-dash-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-staffing-model-dash-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-staffing-model-dash-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-staffing-model-dash-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-regime-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-regime-dashboard-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-regime-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-regime-dashboard-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-remuneration-tool-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-remuneration-tool-app-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-remuneration-tool-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-remuneration-tool-app-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-safety-diagnostic-tool-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-safety-diagnostic-tool-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-safety-diagnostic-tool-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-safety-diagnostic-tool-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-sat-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-sat-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-sat-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-sat-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-statistics-explorer-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-statistics-explorer-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-statistics-explorer-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-statistics-explorer-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-stats-web-analytics-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-stats-web-analytics-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-stats-web-analytics-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-stats-web-analytics-prod/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+trigger build


### PR DESCRIPTION
Triggers a build as the apply pipeline failed on the [previous PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/14953) due to a variable issue. The offending namespaces were fixed in #14981.