### PR TITLE
CCCD-DEV Update replicate_source_db value to db_identifier

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds_read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds_read_replica.tf
@@ -35,7 +35,7 @@ module "read_replica" {
 
   # Set the db_identifier of the source db
   # replicate_source_db = module.rds.db_identifier
-  replicate_source_db = module.cccd_rds.rds_instance_address
+  replicate_source_db = module.cccd_rds.db_identifier
 
   # Set to true. No backups or snapshots are created for read replica
   skip_final_snapshot        = "true"


### PR DESCRIPTION
Fix incorrect configuration of read-replica for the cccd dev environment.

Update the value of `replicate_source_db` to `module.cccd_rds.db_identifier`