### PR TITLE
CCCD-DEV Update the max allocated storage of the read replica

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds_read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds_read_replica.tf
@@ -26,6 +26,7 @@ module "read_replica" {
   rds_family        = "postgres13"
   db_instance_class = "db.t4g.micro"
   db_allocated_storage = "60"
+  db_max_allocated_storage = "500"
   allow_major_version_upgrade = "true"
   db_parameter                = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
   # It is mandatory to set the below values to create read replica instance

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds_read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/rds_read_replica.tf
@@ -25,7 +25,7 @@ module "read_replica" {
   db_engine_version = "13"
   rds_family        = "postgres13"
   db_instance_class = "db.t4g.micro"
-  db_allocated_storage        = "50"
+  db_allocated_storage = "60"
   allow_major_version_upgrade = "true"
   db_parameter                = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
   # It is mandatory to set the below values to create read replica instance


### PR DESCRIPTION
Update the max allocated storage size of the read replica by 10 percent.

This fixes an issue with the read replica deployment that says:
`InvalidParameterCombination: The maximum allocated storage must be increased by at least 10 percent.`
