### PR TITLE
Update Elasticache-Redis for the Accredited Programmes dev namespace & rotate secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/elasticache.tf
@@ -18,6 +18,7 @@ module "elasticache_redis" {
   engine_version        = "7.0"
   parameter_group_name  = "default.redis7"
 
+  auth_token_rotated_date = "2023-08-03"
   providers = {
     aws = aws.london
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/elasticache.tf
@@ -15,8 +15,8 @@ module "elasticache_redis" {
 
   number_cache_clusters = var.number_cache_clusters
   node_type             = "cache.t4g.small"
-  engine_version        = "6.x"
-  parameter_group_name  = "default.redis6.x"
+  engine_version        = "7.0"
+  parameter_group_name  = "default.redis7"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
We've been advised to update Elasticache-Redis to the latest version by the Cloud Platform team and to rotate secrets as part of the CircleCI incident remediation.

This PR does both, following instructions here:
1. https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/redis/upgrade.html#engine-version-and-parameter-groups
2. https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rotate-tokens-keys.html#aws-elasticache-auth-token

We've previously added a skip file in #15257 to tell the apply pipeline to skip this namespace.