### PR TITLE
Civil Apply Staging: Post DB upgrade tidy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -16,13 +16,11 @@ module "apply-for-legal-aid-rds" {
   environment-name         = "staging"
   infrastructure-support   = "apply-for-civil-legal-aid@digital.justice.gov.uk"
   db_engine                = "postgres"
-  db_engine_version        = "14.7"
-  db_instance_class        = "db.t3.large"
+  db_engine_version        = "14"
+  db_instance_class        = "db.t4g.small"
   db_name                  = "apply_for_legal_aid_staging"
   rds_family               = "postgres14"
   db_max_allocated_storage = "500"
-
-  prepare_for_major_upgrade = true
 
   snapshot_identifier = "rds:cloud-platform-464651662c253592-2022-03-03-05-40"
 


### PR DESCRIPTION
* Revert db_engine_version to just `14`
* Downsize instance class to t4g.small
* Remove the prepare_for_major_upgrade flag