### PR TITLE
Civil Apply Production: Increase instance class size

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
@@ -17,9 +17,12 @@ module "apply-for-legal-aid-rds" {
   infrastructure-support = "apply-for-civil-legal-aid@digital.justice.gov.uk"
   db_engine              = "postgres"
   db_engine_version      = "11"
+  db_instance_class      = "db.t3.large"
   db_name                = "apply_for_legal_aid_production"
   rds_family             = "postgres11"
   deletion_protection    = true
+
+  prepare_for_major_upgrade = true
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
This is to help with the upgrade to v14 of postgres so we have added the prepare_for_major_upgrade = true flag too

This will be merged by the Civil Apply team out of hours to avoid disruptive downtime