### PR TITLE
LFA-staging: Remove the postgres version lock

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # Database configuration
-  db_engine_version = "14.4"
+  db_engine_version = "14"
   db_instance_class = "db.t4g.small"
   rds_family = "postgres14"
   allow_major_version_upgrade = "true"


### PR DESCRIPTION
This was added during the 11 > 14 upgrade and is preventing minor system updates