### PR TITLE
hosting-data-production, ky-first-cp-app-dev: bump cloud-platform-terraform-ecr-credentials to v6.0.0

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hosting-data-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hosting-data-production/resources/ecr.tf
@@ -1,10 +1,18 @@
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=6.0.0"
 
   repo_name = "hosting-data"
-  team_name = var.team_name
 
   github_actions_prefix = "prod"
   github_repositories   = ["hosting-data"]
   oidc_providers        = ["github"]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ky-first-cp-app-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ky-first-cp-app-dev/resources/ecr.tf
@@ -5,12 +5,10 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=6.0.0"
 
   # REQUIRED: Repository configuration
-  team_name = var.team_name
   repo_name = var.namespace
-  namespace = var.namespace
 
   # REQUIRED: OIDC providers to configure, either "github", "circleci", or both
   oidc_providers = ["github"]
@@ -69,4 +67,13 @@ module "ecr" {
     }
     EOF
   */
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ky-first-cp-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ky-first-cp-app-dev/resources/serviceaccount.tf
@@ -1,7 +1,7 @@
 module "serviceaccount" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
 
-  namespace = var.namespace
+  namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
 
   # Uncomment and provide repository names to create github actions secrets


### PR DESCRIPTION
Both of these namespaces/GitHub repositories already use OpenID Connect, so this removes their access keys.