### PR TITLE
Remove ECR protection from case info dashboard

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/bold-case-information-dashboard-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/bold-case-information-dashboard-dev/resources/ecr.tf
@@ -4,8 +4,10 @@
  * releases page of this repository.
  *
  */
-module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
+
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=6.0.0"
+  deletion_protection = false
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/bold-case-information-dashboard-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/bold-case-information-dashboard-dev/resources/ecr.tf
@@ -5,8 +5,8 @@
  *
  */
 
-module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=6.0.0"
+module "ecr_credentials" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
   deletion_protection = false
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"


### PR DESCRIPTION
Set the deletion protection flag to false for the bold-case-information-dashboard-dev environment in preparation for deletion.

Preparing to delete this namespace as the data platform team will be taking over our deployment. 