### PR TITLE
Remove ECR protection from ops-pilot-test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ops-pilot-test/resources/ecr.tf
@@ -6,6 +6,7 @@
  */
 module "ecr_credentials" {
   source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
+  deletion_protection = false
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 


### PR DESCRIPTION
In preparation for removing the ops-pilot-test namespace, remove the ECR deletion protection.