### PR TITLE
Remove # from slack name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bold-case-info-dashboard-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bold-case-info-dashboard-dev/resources/variables.tf
@@ -53,7 +53,7 @@ variable "is_production" {
 variable "slack_channel" {
   description = "Slack channel name for your team, if we need to contact you about this service"
   type        = string
-  default     = "#ask-bold-case-info-dashboard"
+  default     = "ask-bold-case-info-dashboard"
 }
 
 variable "github_owner" {


### PR DESCRIPTION
Apologies for this error, minor PR to correct Slack name in `.../variables.tf`. This was breaking `apply-live`. 