### PR TITLE
Add service pod to cjs-dashboard-demo

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/servicepod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/servicepod.tf
@@ -10,7 +10,7 @@ module "irsa_servicepod" {
 
   # Attach the approprate policies using a key => value map
   role_policy_arns = {
-    ecr  = module.ecr.irsa_policy_arn
+    ecr  = module.ecr_credentials.irsa_policy_arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/servicepod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/servicepod.tf
@@ -1,0 +1,30 @@
+module "irsa_servicepod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "${var.namespace}-servicepod-sa"
+  namespace            = var.namespace
+
+  # Attach the approprate policies using a key => value map
+  role_policy_arns = {
+    ecr  = module.ecr.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.0.0"
+
+  namespace            = var.namespace
+  service_account_name = "${var.namespace}-servicepod-sa"
+}


### PR DESCRIPTION
This PR adds a service pod and the required IRSA configuration to the CJS dashboard demo environment.

One question about the PR -  we already have an IRSA module set up in the `cross-iam-role-sa.tf` file, which we use to handle cross-account access to an S3 bucket on the Analytical Platform. Rather than setting up a second IRSA as I have done here, would it be better to reuse the existing one?