### PR TITLE
LGA-2576 enable OIDC for circleci

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
@@ -1,5 +1,4 @@
 module "ecr-repo" {
-
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
 
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
@@ -1,6 +1,6 @@
 module "ecr-repo" {
 
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
@@ -12,7 +12,7 @@ module "ecr-repo" {
   oidc_providers = ["circleci"]
 
   # specify which GitHub repository your CircleCI job runs from
-  github_repositories = [repo_name]
+  github_repositories = [var.repo_name]
 }
 
 resource "kubernetes_secret" "ecr-repo" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
@@ -1,4 +1,5 @@
 module "ecr-repo" {
+
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.0"
 
   team_name = var.team_name
@@ -7,6 +8,12 @@ module "ecr-repo" {
   providers = {
     aws = aws.london
   }
+
+  # enable the oidc implementation for CircleCI
+  oidc_providers = ["circleci"]
+
+  # specify which GitHub repository your CircleCI job runs from
+  github_repositories = [repo_name]
 }
 
 resource "kubernetes_secret" "ecr-repo" {


### PR DESCRIPTION
PR to allow laa-cla-backend to use short lived credentials for pushing docker image using circleci. Note that only one ecr module for all namespaces.

[Following these instructions](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-circleci)
