### PR TITLE
EL-1078: Allow CCQ access to pull CFE ECR images

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/ecr.tf
@@ -13,7 +13,7 @@ module "ecr_credentials" {
   oidc_providers = ["circleci"]
 
   # REQUIRED: GitHub repositories that push to this container repository
-  github_repositories = ["cfe-civil"]
+  github_repositories = ["cfe-civil", "laa-estimate-financial-eligibility-for-legal-aid"]
 
   # OPTIONAL: GitHub environments, to create variables as actions variables in your environments
   # github_environments = ["production"]


### PR DESCRIPTION
So that CCQ's CI can use short-lived credentials to pull down a CFE ECR image.