### PR TITLE
laa-fee-calculator-ui-dev Initiate short lived ecr credentials for the DEV Environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-ui-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-ui-dev/resources/ecr.tf
@@ -17,6 +17,13 @@ module "ecr_credentials" {
   scan_on_push = "false"
   */
 
+  # enable the oidc implementation for CircleCI
+  oidc_providers = ["circleci"]
+
+  # set your namespace name to create a ConfigMap
+  # of credentials you need in CircleCI
+  namespace = var.namespace
+
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in
   # github actions CI/CD pipelines

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-ui-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-ui-dev/resources/ecr.tf
@@ -17,17 +17,17 @@ module "ecr_credentials" {
   scan_on_push = "false"
   */
 
-  # enable the oidc implementation for CircleCI
-  oidc_providers = ["circleci"]
-
-  # set your namespace name to create a ConfigMap
-  # of credentials you need in CircleCI
-  namespace = var.namespace
+  # enable the oidc implementation for GitHub
+  oidc_providers = ["github"]
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in
   # github actions CI/CD pipelines
   github_repositories = ["laa-fee-calculator-user-interface"]
+
+  # set this if you use one GitHub repository to push to multiple container repositories
+  # this ensures the variable key used in the workflow is unique
+  github_actions_prefix = "dev"
 
   # list of github environments, to create the ECR secrets as environment secrets
   # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets


### PR DESCRIPTION
[Following the cloud platform user guide for migrating to short-lived credentials for GithubActions](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-github-actions)

- Enable oidc implementation of GitHub Actions via the ECR resource configuration file
- Set a namespace in the ecr resource config
