### PR TITLE
Correct `aqa` team name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-dev/00-namespace.yaml
@@ -11,5 +11,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "aqa-website"
     cloud-platform.justice.gov.uk/owner: "AQA Corporate Group: asd-aqa-group@justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/aqa_website"
-    cloud-platform.justice.gov.uk/team-name: "https://github.com/orgs/moj-analytical-services/teams/aqa-website-admin"
+    cloud-platform.justice.gov.uk/team-name: "aqa-website-admin"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: data-platform-app-aqa-website-dev
 subjects:
   - kind: Group
-    name: "github:https://github.com/orgs/moj-analytical-services/teams/aqa-website-admin"
+    name: "github:aqa-website-admin"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: github:analytics-hq

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-dev/resources/variables.tf
@@ -29,7 +29,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "https://github.com/orgs/moj-analytical-services/teams/aqa-website-admin"
+  default     = "aqa-website-admin"
 }
 
 variable "environment" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-prod/00-namespace.yaml
@@ -11,5 +11,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "aqa-website"
     cloud-platform.justice.gov.uk/owner: "AQA Corporate Group: asd-aqa-group@justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/aqa_website"
-    cloud-platform.justice.gov.uk/team-name: "https://github.com/orgs/moj-analytical-services/teams/aqa-website-admin"
+    cloud-platform.justice.gov.uk/team-name: "aqa-website-admin"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-prod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: data-platform-app-aqa-website-prod
 subjects:
   - kind: Group
-    name: "github:https://github.com/orgs/moj-analytical-services/teams/aqa-website-admin"
+    name: "github:aqa-website-admin"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: github:analytics-hq

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-prod/resources/variables.tf
@@ -29,7 +29,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "https://github.com/orgs/moj-analytical-services/teams/aqa-website-admin"
+  default     = "aqa-website-admin"
 }
 
 variable "environment" {


### PR DESCRIPTION
This change is preventing pipelines from running correctly ([dev](https://github.com/ministryofjustice/cloud-platform-environments/pull/15402) + [prod](https://github.com/ministryofjustice/cloud-platform-environments/pull/15403)) previous PRs have failed in Concourse and this seeks to resolve that. 