### PR TITLE
Add HMPPS Auth team to rbac

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bold-case-info-dashboard-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bold-case-info-dashboard-dev/01-rbac.yaml
@@ -10,6 +10,9 @@ subjects:
   - kind: Group
     name: github:analytics-hq
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
In line with [the request here](https://mojdt.slack.com/archives/C02S71KUBED/p1691742113287679?thread_ts=1691667201.530509&cid=C02S71KUBED), adding the HMPPS Auth team to the dev rbac file so they can manage our credentials. 