### PR TITLE
DCES-Report-Service Monitoring Change

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-dev/04-networkpolicy.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: laa-dces-report-service-dev
+      app: laa-dces-report-service
   policyTypes:
     - Ingress
   ingress:


### PR DESCRIPTION
Removing -dev suffix for allow-prometheus-scraping network policy. 