### PR TITLE
CCCD-DEV Add a new RBAC role for testing purposes

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/05-rbac-dart-read-only.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/05-rbac-dart-read-only.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cccd-dev-dart-team
+  namespace: cccd-dev
+subjects:
+  - kind: Group
+    name: "github:cccd-abdi-test"
+    apiGroup: rbac.authorization.k8s.io
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  resourceNames: ["port-forward-pod"]
+  verbs: ["get"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/05-rbac-dart-read-only.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/05-rbac-dart-read-only.yaml
@@ -3,10 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cccd-dev-dart-team
   namespace: cccd-dev
-subjects:
-  - kind: Group
-    name: "github:cccd-abdi-test"
-    apiGroup: rbac.authorization.k8s.io
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/06-rbac-role-bind-dart-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/06-rbac-role-bind-dart-team.yaml
@@ -2,7 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods
-  namespace: default
+  namespace: cccd-dev
 subjects:
 - kind: Group
   name: "github:cccd-abdi-test"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/06-rbac-role-bind-dart-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/06-rbac-role-bind-dart-team.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-pods
+  namespace: default
+subjects:
+  - kind: Group
+    name: "github:cccd-abdi-test"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  # "roleRef" specifies the binding to a Role / ClusterRole
+  kind: Role #this must be Role or ClusterRole
+  name: cccd-dev-dart-team # this must match the name of the Role or ClusterRole you wish to bind to
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/06-rbac-role-bind-dart-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/06-rbac-role-bind-dart-team.yaml
@@ -4,9 +4,9 @@ metadata:
   name: read-pods
   namespace: default
 subjects:
-  - kind: Group
-    name: "github:cccd-abdi-test"
-    apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:cccd-abdi-test"
+  apiGroup: rbac.authorization.k8s.io
 roleRef:
   # "roleRef" specifies the binding to a Role / ClusterRole
   kind: Role #this must be Role or ClusterRole


### PR DESCRIPTION
Add a read only RBAC role for a temporary github team.

this is to test whether we can give a data reporting team pod proxy access to our rds database using kubectl.

This is only temporary whilst i do a proof of concept that we can limit kubectl access to our resources