### PR TITLE
CCCD-DEV Update the RBAC role for port-forwarding

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/05-rbac-dart-read-only.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/05-rbac-dart-read-only.yaml
@@ -4,7 +4,10 @@ metadata:
   name: cccd-dev-dart-team
   namespace: cccd-dev
 rules:
-- apiGroups: [""] # "" indicates the core API group
+- apiGroups: [""]
   resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/portforward"] # allows port forwarding on a pod
   resourceNames: ["port-forward-pod"]
-  verbs: ["get"]
+  verbs: ["create"]


### PR DESCRIPTION
Allow the a moj github team to do port-forwarding on a specific pod

This is a proof of concept test, to see if we can give RDS access to the data and reporting team in laa digital

This follows the principle of least privilege