### PR TITLE
Stop exporting `money-to-prisoners-test` RDS & S3 access key into k8s secret

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/irsa.tf
@@ -27,14 +27,14 @@ resource "aws_iam_policy" "analytical-platform" {
 }
 
 data "aws_iam_policy_document" "analytical-platform" {
-  # Allows direct put access to a test-only S3 bucket in "mojdsd" AWS account
+  # Allows direct put access to subpath of terraformed S3 bucket for mimicking Analytical Platform
   statement {
     actions = [
       "s3:PutObject",
       "s3:PutObjectAcl",
     ]
     resources = [
-      "arn:aws:s3:::money-to-prisoners-testing/cp/*",
+      "${module.s3.bucket_arn}/faux-ap/*",
     ]
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -43,7 +43,5 @@ resource "kubernetes_secret" "rds" {
     database_password     = module.rds.database_password
     rds_instance_address  = module.rds.rds_instance_address
     rds_instance_port     = module.rds.rds_instance_port
-    access_key_id         = module.rds.access_key_id
-    secret_access_key     = module.rds.secret_access_key
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/s3.tf
@@ -46,9 +46,7 @@ resource "kubernetes_secret" "s3" {
   }
 
   data = {
-    bucket_arn        = module.s3.bucket_arn
-    bucket_name       = module.s3.bucket_name
-    access_key_id     = module.s3.access_key_id
-    secret_access_key = module.s3.secret_access_key
+    bucket_arn  = module.s3.bucket_arn
+    bucket_name = module.s3.bucket_name
   }
 }


### PR DESCRIPTION
… in preparation for when the long-lived access key will not be available