### PR TITLE
Civil Apply Production: Update long running prometheus rules

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/05-prometheus.yaml
@@ -68,14 +68,14 @@ spec:
       annotations:
         message: Container disk space usage is not reported
     - alert: Long-Request
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller!~"providers/bank_statements_controller|v1/bank_statements_controller|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller!~"providers/bank_statements|v1/bank_statements|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
       for: 1m
       labels:
         severity: apply-for-legal-aid-prod
       annotations:
         message: Request is taking more than 2 seconds
     - alert: "Long-Request: file_uploads"
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller="providers/bank_statements_controller|v1/bank_statements_controller|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller="providers/bank_statements|v1/bank_statements|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
       for: 1m
       labels:
         severity: apply-for-legal-aid-prod


### PR DESCRIPTION
We had shifted v1/bank_statements_controller into the 10 second window as file uploads regularly exceed 2 seconds and we, and users, are fine with it.  This is now being shown in the logs as v1/bank_statements so this updates the rule to prevent false positives in the alerts channel