### PR TITLE
[DPR-636] Fake DPS Service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-dpr-fake-dps-service
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "ask_dpr"
+    cloud-platform.justice.gov.uk/application: "Digital Prison Reporting Fake DPS Service"
+    cloud-platform.justice.gov.uk/owner: "Digital Prison Reporting: digitalprisonreporting@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-dpr-fake-dps-service"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-digital-prison-reporting"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/01-rbac.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-dpr-fake-dps-service-admin
+  namespace: hmpps-dpr-fake-dps-service
+subjects:
+  - kind: Group
+    name: "github:hmpps-digital-prison-reporting"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-dpr-fake-dps-service
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-dpr-fake-dps-service
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-dpr-fake-dps-service
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-dpr-fake-dps-service
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/05-certificates.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-certificate
+  namespace: hmpps-dpr-fake-dps-service
+spec:
+  secretName: hmpps-dpr-fake-dps-service-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - hmpps-dpr-fake-dps-service.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/api-token.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/api-token.tf
@@ -1,0 +1,15 @@
+resource "random_password" "api_token" {
+  length  = 16
+  special = false
+}
+
+resource "kubernetes_secret" "api_token" {
+  metadata {
+    name      = "api-token"
+    namespace = var.namespace
+  }
+
+  data = {
+    session_secret = random_password.api_token.result
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}
+
+provider "random" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -22,6 +22,28 @@ module "rds" {
   db_engine_version = "14.7"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.micro"
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "immediate"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_keep_size"
+      value        = "64"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_wal_keep_size"
+      value        = "64"
+      apply_method = "immediate"
+    }
+  ]
 
   # Tags
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -1,0 +1,61 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.19.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = false
+  db_max_allocated_storage     = "500"
+  enable_rds_auto_start_stop   = true
+
+  # PostgreSQL specifics
+  db_engine         = "postgres"
+  db_engine_version = "14.7"
+  rds_family        = "postgres14"
+  db_instance_class = "db.t4g.micro"
+
+  # Tags
+  application            = var.application
+  business-unit          = var.business_unit
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
+  is-production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+    access_key_id         = module.rds.access_key_id
+    secret_access_key     = module.rds.secret_access_key
+  }
+}
+
+# Configmap to store non-sensitive data related to the RDS instance
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/serviceaccount.tf
@@ -1,0 +1,11 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+
+  namespace           = var.namespace
+  kubernetes_cluster  = var.kubernetes_cluster
+  serviceaccount_name = "circleci"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/variables.tf
@@ -1,0 +1,69 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Digital Prison Reporting Fake DPS Service"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "hmpps-dpr-fake-dps-service"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "hmpps-digital-prison-reporting"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "digitalprisonreporting@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "ask_dpr"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.64.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.23.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.20.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5.1"
+    }
+  }
+}


### PR DESCRIPTION
Implements a namespace to support a fake DPS service to be used initially as a PoC, and later for system testing.