### PR TITLE
EL-1101: prevent e-mail spoofing (CCQ)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/route53.tf
@@ -25,3 +25,32 @@ resource "kubernetes_secret" "eligibility_team_route53_zone" {
   }
 }
 
+resource "aws_route53_record" "eligibility_team_route53_txt_spf_record" {
+  zone_id = aws_route53_zone.eligibility_team_route53_zone.zone_id
+  name    = "https://check-your-client-qualifies-for-legal-aid.service.gov.uk"
+  type    = "TXT"
+  records = ["v=spf1 -all"]
+}
+
+resource "aws_route53_record" "eligibility_team_route53_txt_dmarc_record" {
+  zone_id = aws_route53_zone.eligibility_team_route53_zone.zone_id
+  name    = "_dmarc"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:eligibility@justice.gov.uk"]
+}
+
+resource "aws_route53_record" "eligibility_team_route53_txt_dkim_record" {
+  zone_id = "aws_route53_zone.eligibility_team_route53_zone.zone_id"
+  name    = "*._domainkey"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DKIM1; p="]
+}
+
+resource "aws_route53_record" "eligibility_team_route53_mx_record" {
+  zone_id  = aws_route53_zone.eligibility_team_route53_zone.zone_id
+  type     = "MX"
+  priority = 0
+  value    = "."
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-estimate-financial-eligibility-for-legal-aid-production/resources/route53.tf
@@ -47,10 +47,3 @@ resource "aws_route53_record" "eligibility_team_route53_txt_dkim_record" {
   ttl     = 300
   records = ["v=DKIM1; p="]
 }
-
-resource "aws_route53_record" "eligibility_team_route53_mx_record" {
-  zone_id  = aws_route53_zone.eligibility_team_route53_zone.zone_id
-  type     = "MX"
-  priority = 0
-  value    = "."
-}


### PR DESCRIPTION
Have added DNS records to prevent email spoofing of our production domain, following this [guidance](https://www.gov.uk/guidance/protect-domains-that-dont-send-email). Ideally would like a thorough review, as I may have missed something 

I could not create a valid null MX record. 