### PR TITLE
Set repo name to try to work with existing fb-editor-web ecr repo

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/ecr.tf
@@ -2,7 +2,7 @@ module "ecr" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
 
   team_name = var.team_name
-  repo_name = "fb-editor-ecr"
+  repo_name = "fb-editor-web"
 
   oidc_providers = ["circleci"]
 


### PR DESCRIPTION
When pushing to ecr I get an EOF error which I think is because the repo names are mismatched, our old creds refer to `formbuilder/fb-editor-web` and the generated configmap refers to `formbuilder/fb-editor-ecr` so changing this to see if the credentials will work with the exist ecr repository