### PR TITLE
Add namespace to fb-editor-web ecr module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -491,6 +491,7 @@ module "ecr-repo-fb-editor-web" {
   oidc_providers = ["circleci"]
 
   github_repositories = ["fb-editor"]
+  namespace = var.namespace
 }
 
 resource "kubernetes_secret" "ecr-repo-fb-editor-web" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/variables.tf
@@ -34,3 +34,7 @@ variable "github_token" {
   default     = ""
 }
 
+variable "namespace" {
+  default = "formbuilder-repos"
+}
+


### PR DESCRIPTION
Missed the namespace out, using the var so that it will generate a configmap in formbuilder-repos