### PR TITLE
Generate a configmap for fb-builder

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -327,6 +327,10 @@ module "ecr-repo-fb-builder" {
   scan_on_push     = var.scan_on_push
   lifecycle_policy = var.lifecycle_policy
 
+  oidc_providers = ["circleci"]
+
+  github_repositories = ["fb-builder"]
+  namespace = var.namespace
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
`fb-builder` is a custom image that lives in an ECR repository we access using static creds then build our components from that docker context.

Adding these values to this ECR module should generate a configmap I can use to pull a role arn, and use that to pull the build image as described here https://circleci.com/docs/pull-an-image-from-aws-ecr-with-oidc/ - replacing our static ECR credentials used to pull this image.