### PR TITLE
:fire: Remove IAM access key id and secret

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering/resources/dynamodb-ap-gh-collab-repo.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering/resources/dynamodb-ap-gh-collab-repo.tf
@@ -23,7 +23,5 @@ resource "kubernetes_secret" "ap_gh_collab_repo_tf_state_lock" {
   data = {
     table_name        = module.ap_gh_collab_repo_tf_state_lock.table_name
     table_arn         = module.ap_gh_collab_repo_tf_state_lock.table_arn
-    access_key_id     = module.ap_gh_collab_repo_tf_state_lock.access_key_id
-    secret_access_key = module.ap_gh_collab_repo_tf_state_lock.secret_access_key
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering/resources/s3-ap-gh-collab-repo.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering/resources/s3-ap-gh-collab-repo.tf
@@ -22,8 +22,6 @@ resource "kubernetes_secret" "ap_gh_collab_repo_s3_bucket" {
   }
 
   data = {
-    access_key_id     = module.ap_gh_collab_repo_s3_bucket.access_key_id
-    secret_access_key = module.ap_gh_collab_repo_s3_bucket.secret_access_key
     bucket_arn        = module.ap_gh_collab_repo_s3_bucket.bucket_arn
   }
 }


### PR DESCRIPTION
This isn't actually used. We actually use the IAM user created in another file.
