### PR TITLE
Provide access to our ECR repositories via the service pod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -13,7 +13,8 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     s3 = module.s3_bucket.irsa_policy_arn
-    ecr = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    ecr = module.ecr_credentials.irsa_policy_arn,
+    ecr2 = module.ecr_feed_parser.irsa_policy_arn,
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -13,6 +13,7 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     s3 = module.s3_bucket.irsa_policy_arn
+    ecr = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
   }
 
   # Tags


### PR DESCRIPTION
Currently running `aws ecr list-images --repository-name jotw-content-devs/hale-platform-dev-feed-parser-ecr` inside our namespaces' service pod we get a permissions error:
```An error occurred (AccessDeniedException) when calling the ListImages operation: User: arn:aws:sts::754256621582:assumed-role/cloud-platform-irsa-1d5cba8b376d92aa-live/botocore-session-1692802205 is not authorized to perform: ecr:ListImages on resource: arn:aws:ecr:eu-west-2:754256621582:repository/jotw-content-devs/hale-platform-dev-feed-parser-ecr because no identity-based policy allows the ecr:ListImages action```

By adding the IRSA policy to our two ECR modules I'm hoping this gives us access.