### PR TITLE
Bring legacy apps domain under Cloud Platform Management

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/outputs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/outputs.tf
@@ -1,9 +1,9 @@
 output "alpha_zone_name_servers" {
-  value       = try(aws_route53_zone.default[0].name_servers, [])
+  value       = try(aws_route53_zone.data_platform_apps_alpha_route53_zone.name_servers, [])
   description = "Alpha Route53 DNS Zone Name Servers"
 }
 
 output "alpha_fqdn" {
-  value       = join("", aws_route53_zone.default.*.name)
+  value       = join("", aws_route53_zone.data_platform_apps_alpha_route53_zone.*.name)
   description = "Alpha Fully-qualified domain name"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/outputs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/outputs.tf
@@ -1,0 +1,9 @@
+output "alpha_zone_name_servers" {
+  value       = try(aws_route53_zone.default[0].name_servers, [])
+  description = "Alpha Route53 DNS Zone Name Servers"
+}
+
+output "alpha_fqdn" {
+  value       = join("", aws_route53_zone.default.*.name)
+  description = "Alpha Fully-qualified domain name"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/outputs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/outputs.tf
@@ -2,8 +2,3 @@ output "alpha_zone_name_servers" {
   value       = try(aws_route53_zone.data_platform_apps_alpha_route53_zone.name_servers, [])
   description = "Alpha Route53 DNS Zone Name Servers"
 }
-
-output "alpha_fqdn" {
-  value       = join("", aws_route53_zone.data_platform_apps_alpha_route53_zone.*.name)
-  description = "Alpha Fully-qualified domain name"
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/route53.tf
@@ -11,6 +11,19 @@ resource "aws_route53_zone" "data_platform_production_route53_zone" {
   }
 }
 
+resource "aws_route53_zone" "data_platform_apps_alpha_route53_zone" {
+  name = "apps.alpha.mojanalytics.xyz"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
 /* Delegating to data-platform-development */
 resource "aws_route53_record" "data_platform_development_zone" {
   zone_id = aws_route53_zone.data_platform_production_route53_zone.zone_id


### PR DESCRIPTION
We would like to set up redirection for migrated apps from old domain to the new fqdn. As such, we want to bring the old zone under CP management. 