### PR TITLE
Add oidc config for github actions ecr - staging datastore

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/ecr.tf
@@ -4,6 +4,9 @@ module "ecr-repo" {
   team_name = var.team_name
   repo_name = var.repo_name
 
+  # enable the oidc implementation for GitHub
+  oidc_providers = ["github"]
+
   github_repositories = [var.repo_name]
 
   lifecycle_policy = <<EOF


### PR DESCRIPTION
Adds github oidc config to ecr.tf to enable short lived creds in github actions for crime apply datastore staging namespace.
