### PR TITLE
cccd-dev-lgfs: Rename SQS role_policy_arn to SNS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/irsa.tf
@@ -13,7 +13,7 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     s3  = module.cccd_s3_bucket.irsa_policy_arn
-    sqs_submitted = module.cccd_claims_submitted.irsa_policy_arn
+    sns_submitted = module.cccd_claims_submitted.irsa_policy_arn
     sqs_ccr = module.claims_for_ccr.irsa_policy_arn
     sqs_cclf = module.claims_for_cclf.irsa_policy_arn
     sqs_responses = module.responses_for_cccd.irsa_policy_arn
@@ -21,7 +21,6 @@ module "irsa" {
     sqs_cclf_dlq = module.cclf_dead_letter_queue.irsa_policy_arn
     sqs_respons_dlq = module.cccd_response_dead_letter_queue.irsa_policy_arn
     rds = module.cccd_rds.irsa_policy_arn
-    # TODO sns?
   }
 
   # Tags


### PR DESCRIPTION
One `role_policy_arn` in our `irsa.tf` was incorrectly described as being for SQS when it is actually for SNS. For clarity, fix the label (and remove the related TODO comment).