### PR TITLE
Remove A records pointing to old LB

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/brookhouse-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/brookhouse-route53.tf
@@ -22,31 +22,6 @@ resource "kubernetes_secret" "brookhouse_route53_zone_sec" {
   }
 }
 
-resource "aws_route53_record" "brookhouse_route53_a_record" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "brookhouseinquiry.org.uk"
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.brook-loadb-ubcen73kpkww-1507091893.eu-west-2.elb.amazonaws.com."
-    zone_id                = "ZHURV8PSTC4K8"
-    evaluate_target_health = false
-  }
-}
-
-
-resource "aws_route53_record" "brookhouse_route53_a_record_www" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "www.brookhouseinquiry.org.uk"
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.brook-loadb-ubcen73kpkww-1507091893.eu-west-2.elb.amazonaws.com."
-    zone_id                = "ZHURV8PSTC4K8"
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "brookhouse_route53_mx_record_mail" {
   zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
   name    = "brookhouseinquiry.org.uk"


### PR DESCRIPTION
Remove the A records for brookhouseinquiry.org.uk so that it deletes all A records pointing to our old load balancer. This then allows us to trigger a new A record pointing to the new CloudPlatform LB.