### PR TITLE
Update SQS permissions for CCCD-DEV

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
@@ -61,7 +61,7 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
           "Effect": "Allow",
           "Principal": {"AWS": "*"},
           "Resource": "${module.claims_for_ccr.sqs_arn}",
-          "Action": "SQS:SendMessage",
+          "Action": "sqs:*",
           "Condition":
             {
               "ArnEquals":
@@ -119,7 +119,7 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
           "Effect": "Allow",
           "Principal": {"AWS": "*"},
           "Resource": "${module.claims_for_cclf.sqs_arn}",
-          "Action": "SQS:SendMessage",
+          "Action": "sqs:*",
           "Condition":
             {
               "ArnEquals":


### PR DESCRIPTION
Update permissions to allow all actions on SQS in dev

This is so that we can test cross account SQS access with the LAA Landing zone