### PR TITLE
Update ECR module to use long-lived credentials in prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/ecr.tf
@@ -2,4 +2,7 @@ module "ecr_credentials" {
   source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
+  oidc_providers = ["circleci"]
+  github_repositories = [var.github_repo_name]
+  namespace = var.namespace
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/variables.tf
@@ -53,6 +53,11 @@ variable "github_token" {
   default     = ""
 }
 
+variable "github_repo_name" {
+  description = "Main GitHub repository name"
+  default     = "hmpps-integration-api"
+}
+
 variable "base_domain" {
   default = "hmpps.service.justice.gov.uk"
 }


### PR DESCRIPTION
## Context

We need to stop using long term credentials and move to using short lived credentials for ecr as notified by cloud platform. Pr raised as per the following [guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-circleci).

## Changes proposed in this PR

- Added attributes to ecr to enable short term credentials