### PR TITLE
Remove long-lived access credentials in Kubernetes secrets for dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
@@ -19,10 +19,6 @@ resource "kubernetes_secret" "aws_services" {
     })
 
     "s3" = jsonencode({
-      "access-credentials" = {
-        "access-key-id"     = module.truststore_s3_bucket.access_key_id
-        "secret-access-key" = module.truststore_s3_bucket.secret_access_key
-      }
       "bucket-arn"  = module.truststore_s3_bucket.bucket_arn
       "bucket-name" = module.truststore_s3_bucket.bucket_name
     })

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
@@ -14,10 +14,6 @@ resource "kubernetes_secret" "aws_services" {
     })
 
     "ecr" = jsonencode({
-      "access-credentials" = {
-        "access-key-id"     = module.ecr_credentials.access_key_id
-        "secret-access-key" = module.ecr_credentials.secret_access_key
-      }
       "repo-arn" = module.ecr_credentials.repo_arn
       "repo-url" = module.ecr_credentials.repo_url
     })


### PR DESCRIPTION
## Context

We use the Cloud Platform modules for ECR and S3. As long-lived access credentials are being deprecated for them, we need to remove them from our Kubernetes secret.

## Changes proposed in this PR

- Remove IAM access keys for ECR and S3 in our Kubernetes secret in dev.