### PR TITLE
MAP-269: Change BaSM API Redis maxmemory-policy to noeviction (preprod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
@@ -10,7 +10,7 @@ module "redis-elasticache" {
   business_unit           = var.business_unit
   team_name               = var.team_name
   engine_version          = "7.0"
-  parameter_group_name    = "default.redis7"
+  parameter_group_name    = aws_elasticache_parameter_group.basm_api_redis.name
   namespace               = var.namespace
   snapshot_window         = var.backup_window
   maintenance_window      = var.maintenance_window
@@ -33,5 +33,16 @@ resource "kubernetes_secret" "redis-elasticache" {
     auth_token               = module.redis-elasticache.auth_token
     url                      = "rediss://:${module.redis-elasticache.auth_token}@${module.redis-elasticache.primary_endpoint_address}:6379"
     replication_group_id     = module.redis-elasticache.replication_group_id
+  }
+}
+
+resource "aws_elasticache_parameter_group" "basm_api_redis" {
+  name   = "basm-api-redis-parameter-group-preprod"
+  family = "redis7"
+
+  # Prevent Redis from evicting Sidekiq data
+  parameter {
+    name  = "maxmemory-policy"
+    value = "noeviction"
   }
 }


### PR DESCRIPTION
We noticed this warning in the logs of one of the Sidekiq pods:

```
WARNING: Your Redis instance will evict Sidekiq data under heavy load.
The 'noeviction' maxmemory policy is recommended (current policy: 'volatile-lru').
See: https://github.com/sidekiq/sidekiq/wiki/Using-Redis#memory
```

This could be the reason that we have had notifications go missing at times, so we have followed the recommendation.

This PR updates preprod.