### PR TITLE
LCAM 878 Added configuration for ccp test client creds in secrets manager

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/main.tf
@@ -5,16 +5,34 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "github" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/secret.tf
@@ -1,0 +1,44 @@
+module "secrets_manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.0"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "maat_api_oauth_client_id" = {
+      description             = "MAAT API oauth client ID for CCP Test",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "maat-api-oauth-client-id"
+    },
+    "maat_api_oauth_client_secret" = {
+      description             = "MAAT API oauth client secret for CCP Test",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "maat-api-oauth-client-secret"
+    },
+    "cda_oauth_client_id" = {
+      description             = "Court Data API oauth client ID for CCP Test",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "cda-oauth-client-id"
+    },
+    "cda_oauth_client_secret" = {
+      description             = "Court Data API oauth client secret for CCP Test",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "cda-oauth-client-secret"
+    },
+    "evidence_oauth_client_id" = {
+      description             = "Evidence Service oauth client ID for CCP Test",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "evidence-oauth-client-id"
+    },
+    "evidence_oauth_client_secret" = {
+      description             = "Evidence Service oauth client secret for CCP Test",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "evidence-oauth-client-secret"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/variables.tf
@@ -23,7 +23,7 @@ variable "business_unit" {
 
 variable "team_name" {
   description = "The name of your development team"
-  default     = "crime-apps"
+  default     = "laa-crime-apps-team"
 }
 
 variable "environment" {


### PR DESCRIPTION
**NOTE: PR includes a team_name change, so will manually need to arrange for the current ECR to be emptied of images in order for it to be deleted and recreated with the new name.**