### PR TITLE
Add lawcom s3 bucket policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -12,10 +12,10 @@ module "irsa" {
   # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
-    s3 = module.s3_bucket.irsa_policy_arn
+    s3 = module.s3_bucket.irsa_policy_arn,
     s3_lawcom = module.aws_iam_policy.tacticalproducts_lawcom_s3_policy.irsa_policy_arn,
     ecr = module.ecr_credentials.irsa_policy_arn,
-    ecr2 = module.ecr_feed_parser.irsa_policy_arn,
+    ecr2 = module.ecr_feed_parser.irsa_policy_arn
   }
 
   data "aws_iam_policy_document" "tacticalproducts_lawcom_s3_policy" {
@@ -39,17 +39,17 @@ module "irsa" {
   }
 
   resource "aws_iam_policy" "tacticalproducts_lawcom_s3_policy" {
-  name   = "tacticalproducts_lawcom_s3_policy"
-  policy = data.aws_iam_policy_document.tacticalproducts_lawcom_s3_policy.json
+    name   = "tacticalproducts_lawcom_s3_policy"
+    policy = data.aws_iam_policy_document.tacticalproducts_lawcom_s3_policy.json
 
-  tags = {
-    business_unit          = var.business_unit
-    application            = var.application
-    is_production          = var.is_production
-    team_name              = var.team_name
-    environment_name       = var.environment
-    infrastructure_support = var.infrastructure_support
-    }
+    tags = {
+      business_unit          = var.business_unit
+      application            = var.application
+      is_production          = var.is_production
+      team_name              = var.team_name
+      environment_name       = var.environment
+      infrastructure_support = var.infrastructure_support
+      }
   }
 
   resource "kubernetes_secret" "lawcom_aws_secret" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -13,7 +13,7 @@ module "irsa" {
     # provide an output called `irsa_policy_arn` that can be used.
     role_policy_arns = {
       s3 = module.s3_bucket.irsa_policy_arn,
-      s3_lawcom = aws_iam_policy.tacticalproducts_lawcom_s3_policy.irsa_policy_arn,
+      s3_lawcom = aws_iam_policy.tacticalproducts_lawcom_s3_policy.arn,
       ecr = module.ecr_credentials.irsa_policy_arn,
       ecr2 = module.ecr_feed_parser.irsa_policy_arn
     }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -13,9 +13,9 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     s3 = module.s3_bucket.irsa_policy_arn
-    s3_lawcom = aws_iam_policy.tacticalproducts_lawcom_s3_policy.arn,
+    s3_lawcom = module.aws_iam_policy.tacticalproducts_lawcom_s3_policy.irsa_policy_arn,
     ecr = module.ecr_credentials.irsa_policy_arn,
-    ecr2 = module.ecr_feed_parser.irsa_policy_arn,
+    ecr2 = module.ecr_feed_parser.irsa_policy_arn,§
   }
 
   data "aws_iam_policy_document" "tacticalproducts_lawcom_s3_policy" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -1,21 +1,30 @@
 module "irsa" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+    source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
 
-  # EKS configuration
-  eks_cluster_name = var.eks_cluster_name
+    # EKS configuration
+    eks_cluster_name = var.eks_cluster_name
 
-  # IRSA configuration
-  service_account_name = "hale-platform-dev-service"
-  namespace            = var.namespace # this is also used as a tag
+    # IRSA configuration
+    service_account_name = "hale-platform-dev-service"
+    namespace            = var.namespace # this is also used as a tag
 
-  # Attach the approprate policies using a key => value map
-  # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
-  # provide an output called `irsa_policy_arn` that can be used.
-  role_policy_arns = {
-    s3 = module.s3_bucket.irsa_policy_arn,
-    s3_lawcom = module.aws_iam_policy.tacticalproducts_lawcom_s3_policy.irsa_policy_arn,
-    ecr = module.ecr_credentials.irsa_policy_arn,
-    ecr2 = module.ecr_feed_parser.irsa_policy_arn
+    # Attach the approprate policies using a key => value map
+    # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
+    # provide an output called `irsa_policy_arn` that can be used.
+    role_policy_arns = {
+      s3 = module.s3_bucket.irsa_policy_arn,
+      s3_lawcom = module.aws_iam_policy.tacticalproducts_lawcom_s3_policy.irsa_policy_arn,
+      ecr = module.ecr_credentials.irsa_policy_arn,
+      ecr2 = module.ecr_feed_parser.irsa_policy_arn
+    }
+
+    # Tags
+    business_unit          = var.business_unit
+    application            = var.application
+    is_production          = var.is_production
+    team_name              = var.team_name
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
   }
 
   data "aws_iam_policy_document" "tacticalproducts_lawcom_s3_policy" {
@@ -23,6 +32,9 @@ module "irsa" {
     statement {
       actions = [
         "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
       ]
       resources = [
         "arn:aws:s3:::lawcom-prod-storage-11jsxou24uy7q",
@@ -30,7 +42,11 @@ module "irsa" {
     }
     statement {
       actions = [
-        "s3:*",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+
       ]
       resources = [
         "arn:aws:s3:::lawcom-prod-storage-11jsxou24uy7q/*"
@@ -62,12 +78,3 @@ module "irsa" {
       bucket_arn = "arn:aws:s3:::lawcom-prod-storage-11jsxou24uy7q"
     }
   }
-
-  # Tags
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  team_name              = var.team_name
-  environment_name       = var.environment
-  infrastructure_support = var.infrastructure_support
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -13,8 +13,54 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     s3 = module.s3_bucket.irsa_policy_arn
+    s3_lawcom = aws_iam_policy.tacticalproducts_lawcom_s3_policy.arn,
     ecr = module.ecr_credentials.irsa_policy_arn,
     ecr2 = module.ecr_feed_parser.irsa_policy_arn,
+  }
+
+  data "aws_iam_policy_document" "tacticalproducts_lawcom_s3_policy" {
+    # Provide list of permissions and target AWS account resources to allow access to
+    statement {
+      actions = [
+        "s3:ListBucket",
+      ]
+      resources = [
+        "arn:aws:s3:::lawcom-prod-storage-11jsxou24uy7q",
+     ]
+    }
+    statement {
+      actions = [
+        "s3:*",
+      ]
+      resources = [
+        "arn:aws:s3:::lawcom-prod-storage-11jsxou24uy7q/*"
+      ]
+    }
+  }
+
+  resource "aws_iam_policy" "tacticalproducts_lawcom_s3_policy" {
+  name   = "tacticalproducts_lawcom_s3_policy"
+  policy = data.aws_iam_policy_document.tacticalproducts_lawcom_s3_policy.json
+
+  tags = {
+    business_unit          = var.business_unit
+    application            = var.application
+    is_production          = var.is_production
+    team_name              = var.team_name
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+    }
+  }
+
+  resource "kubernetes_secret" "lawcom_aws_secret" {
+    metadata {
+    name      = "lawcom-prod-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+      bucket_arn = "arn:aws:s3:::lawcom-prod-storage-11jsxou24uy7q"
+    }
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -15,7 +15,7 @@ module "irsa" {
     s3 = module.s3_bucket.irsa_policy_arn
     s3_lawcom = module.aws_iam_policy.tacticalproducts_lawcom_s3_policy.irsa_policy_arn,
     ecr = module.ecr_credentials.irsa_policy_arn,
-    ecr2 = module.ecr_feed_parser.irsa_policy_arn,§
+    ecr2 = module.ecr_feed_parser.irsa_policy_arn,
   }
 
   data "aws_iam_policy_document" "tacticalproducts_lawcom_s3_policy" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/irsa.tf
@@ -13,7 +13,7 @@ module "irsa" {
     # provide an output called `irsa_policy_arn` that can be used.
     role_policy_arns = {
       s3 = module.s3_bucket.irsa_policy_arn,
-      s3_lawcom = module.aws_iam_policy.tacticalproducts_lawcom_s3_policy.irsa_policy_arn,
+      s3_lawcom = aws_iam_policy.tacticalproducts_lawcom_s3_policy.irsa_policy_arn,
       ecr = module.ecr_credentials.irsa_policy_arn,
       ecr2 = module.ecr_feed_parser.irsa_policy_arn
     }


### PR DESCRIPTION
Allow access to an s3 bucket in another aws account so that I can run `aws s3 sync` and transfer the contents of this old bucket to our new CloudPlatform bucket.