### PR TITLE
RR-279 - Add serviceaccount rules to circleci SA

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-circleci.tf
@@ -68,5 +68,5 @@ module "serviceaccount" {
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
-  serviceaccount_rules = locals.sa_rules
+  serviceaccount_rules = local.sa_rules
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-circleci.tf
@@ -69,5 +69,4 @@ module "serviceaccount" {
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   serviceaccount_rules = locals.sa_rules
-  ]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-circleci.tf
@@ -1,7 +1,73 @@
+locals {
+  sa_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "policy",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "poddisruptionbudgets",
+        "networkpolicies"
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "prometheusrules",
+        "servicemonitors"
+      ]
+      verbs = [
+        "*",
+      ]
+    },
+  ]
+}
+
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
-  namespace           = var.namespace
-  kubernetes_cluster  = var.kubernetes_cluster
-  serviceaccount_name = "circleci"
-  role_name           = "circleci"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  namespace            = var.namespace
+  kubernetes_cluster   = var.kubernetes_cluster
+  serviceaccount_name  = "circleci"
+  role_name            = "circleci"
+  serviceaccount_rules = locals.sa_rules
+  ]
 }


### PR DESCRIPTION
Add serviceaccount rules to circleci SA; specifically `networkpolicies` and `servicemonitors` as these are missing from the [serviceaccount module](https://github.com/ministryofjustice/cloud-platform-terraform-serviceaccount/blob/main/variables.tf#L20)
