### PR TITLE
Share bucket arn across namespaces

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/json-output-attachments-s3.tf
@@ -53,6 +53,37 @@ EOF
   ]
 }
 
+module "json-output-attachments-s3-irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  eks_cluster_name = var.eks_cluster_name
+
+  service_account_name = "json-output-attachments-irsa-${var.environment-name}"
+  namespace            = var.namespace # this is also used as a tag
+
+  role_policy_arns = {
+    jsonS3       = module.json-output-attachments-s3-bucket.irsa_policy_arn
+  }
+
+  team_name              = var.team_name
+  business_unit          = "transformed-department"
+  application            = "formbuilderuserfilestore"
+  is_production          = var.is_production
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "json-output-attachments-s3-bucket-cross-namespace" {
+  metadata {
+    name      = "json-output-s3-arn"
+    namespace = "formbuilder-saas-test"
+  }
+
+  data = {
+    s3_policy_arn = module.json-output-attachments-s3-irsa.irsa_policy_arn
+  }
+}
+
 resource "kubernetes_secret" "json-output-attachments-s3-bucket" {
   metadata {
     name      = "json-output-attachments-s3-bucket-${var.environment-name}"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
@@ -18,6 +18,33 @@ module "editor-rds-instance" {
   }
 }
 
+module "editor-json-output-s3-irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  eks_cluster_name = var.eks_cluster_name
+
+  service_account_name = "formbuilder-editor-test" # match existing service account defined in editor-service-account.yaml
+  namespace            = var.namespace # this is also used as a tag
+
+  role_policy_arns = {
+    jsonS3 = data.kubernetes_secret.json-output-s3-secret.data.json-output-s3-arn
+  }
+
+  team_name              = var.team_name
+  business_unit          = "transformed-department"
+  application            = "formbuilder-editor"
+  is_production          = var.is_production
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+}
+
+data "kubernetes_secret" "json-output-s3-secret" {
+  metadata {
+    name      = "json-output-s3-arn"
+    namespace = var.namespace
+  }
+}
+
 resource "kubernetes_secret" "editor-rds-instance" {
   metadata {
     name      = "rds-instance-formbuilder-editor-${var.environment_name}"


### PR DESCRIPTION
The goal is to add access to the `json-output-s3-bucket` defined in f`ormbuilder-platform-test-dev` to the service account for the editor, `formbuilder-editor-test` which is defined in editor-service-account.yaml in the namespace `formbuilder-saas-test`.

Currently access is shared by exporting access key id and secret key in a kubernetes secret and injecting them via pipeline environment, this should replace that method by sharing a secret containing the arn to assume across namespaces and adding that iam role to the existing editor service account.