### PR TITLE
DCES-Revert Team Name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-prod/resources/variables.tf
@@ -33,7 +33,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "laa-dces-team"
+  default     = "laa-crime-apps-team"
 }
 
 variable "environment" {


### PR DESCRIPTION
Reverting back to crime-apps as dces-team will require overhead.