### PR TITLE
Try to fix Education and Work Plan dev certificates 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/06-certificate.yaml
@@ -10,7 +10,10 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    - plp-api-dev.hmpps.service.justice.gov.uk
     - learningandworkprogress-api-dev.hmpps.service.justice.gov.uk
+    - learning-and-work-progress-api-dev.hmpps.service.justice.gov.uk
+    - education-and-work-plan-api-dev.hmpps.service.justice.gov.uk
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -23,4 +26,6 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    -  plp-dev.hmpps.service.justice.gov.uk
     -  learning-and-work-progress-dev.hmpps.service.justice.gov.uk
+    -  education-and-work-plan-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Try to fix Education and Work Plan `dev` certificates by using a shorter CN, with a series of longer SANs

This is in relation to this slack conversation: https://mojdt.slack.com/archives/C57UPMZLY/p1694184747281519

We've had discussions in the past about using a short CN with a series of shorter SANs because our service name is long and in one case our primary name would exceed the 64 character limit (`learning-and-work-progress-api-preprod.hmpps.service.justice.gov.uk`).
We worked around this at the time by shortening it to `learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk` (which is exactly 64 characters)

We currently have a problem with `dev`, and whilst its longest CN is below 64 characters (`learningandworkprogress-api-dev.hmpps.service.justice.gov.uk`), trying to use a short CN and a series of longer SANs feels like a reasonable thing to try. If nothing else it will at least re-create the TF certificate resource so might fix the problem anyway just by re-creating it 🤷 

I've set the CN to `plp-......` because PLP is actually the original project/team name, and is still a term that is used (Personal Learning Plans), so it at least relevant to the service and team.

If this works for `dev` I will raise another PR to make the same changes in `preprod` and `prod`
