### PR TITLE
Fix Education and Work Plan preprod certificates 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/06-certificate.yaml
@@ -10,7 +10,10 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    - plp-api-preprod.hmpps.service.justice.gov.uk
     - learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk
+    - learning-and-work-progress-api-preprod.hmpps.service.justice.gov.uk
+    - education-and-work-plan-api-preprod.hmpps.service.justice.gov.uk
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -23,4 +26,6 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    -  plp-preprod.hmpps.service.justice.gov.uk
     -  learning-and-work-progress-preprod.hmpps.service.justice.gov.uk
+    -  education-and-work-plan-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Fix Education and Work Plan preprod certificates by using a shorter CN, with a series of longer SANs

This PR is the same change we have just made and proved in `dev` via [this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/16415)



