### PR TITLE
Add shared secret to formbuilder-platform-test-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/shared-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/shared-secrets.tf
@@ -1,0 +1,10 @@
+resource "kubernetes_secret" "formbuilder_platform_test_dev" {
+  metadata {
+    name      = "service-metadata-test-production-policy-arns"
+    namespace = "formbuilder-saas-test"
+  }
+
+  data = {
+    service_metadata_bucket_irsa = module.service-metadata-s3-bucket.irsa_policy_arn
+  }
+}


### PR DESCRIPTION
This will be used to apply the bucket arn to the service account in the saas-test namespace (saas-test publishes forms to test-dev and test-production from one service account, access will follow in next PR)