### PR TITLE
Add RDS IRSA Policy to Service Account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/irsa.tf
@@ -22,7 +22,12 @@ module "irsa" {
   eks_cluster_name = var.eks_cluster_name
   service_account_name = "hmpps-community-accommodation-api-service-account"
   namespace = var.namespace
-  role_policy_arns = local.sns_policies
+  role_policy_arns = merge(
+    {
+      rds = module.rds.irsa_policy_arn
+    },
+    local.sns_policies
+  )
   business_unit = var.business_unit
   application = var.application
   is_production = var.is_production


### PR DESCRIPTION
This adds the RDS policy to the service account used in our service pod, so we can create manual RDS snapshots.