### PR TITLE
Bump Cloud Platform ECR credentials module production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/ecr.tf
@@ -1,8 +1,17 @@
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=6.1.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
   oidc_providers = ["circleci"]
   github_repositories = [var.github_repo_name]
   namespace = var.namespace
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  business_unit = var.business_unit
+  application = var.application
+
+  providers = {
+    aws = aws.london_without_default_tags
+  }
 }


### PR DESCRIPTION
Also remove default tags from this module as it leads to duplicated tags.