### PR TITLE
CCCD-DEV Add an RBAC role and binding for the DART team

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/05-rbac-dart-read-only.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/05-rbac-dart-read-only.yaml
@@ -1,0 +1,13 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cccd-dev-dart-team
+  namespace: cccd-dev
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/portforward"] # allows port forwarding on a pod
+  resourceNames: ["port-forward-pod"]
+  verbs: ["create"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/06-rbac-role-bind-dart-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/06-rbac-role-bind-dart-team.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-pods
+  namespace: cccd-dev
+subjects:
+- kind: Group
+  name: "github:laa-data-and-reporting"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  # "roleRef" specifies the binding to a Role / ClusterRole
+  kind: Role #this must be Role or ClusterRole
+  name: cccd-dev-dart-team # this must match the name of the Role or ClusterRole you wish to bind to
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
For the CCCD dev database:

- Add an RBAC role to have read only access to the port-forward-pod
- Bind this role to the DART team / MI reporting team so that they have the ability to use the `port-forward-pod` to connect to the read replica database without having further access privileges to our namespace: This practices the principle of least privilege as they'll only have read access to the pod.