### PR TITLE
LNP-272: 🔍  add opensearch module to prisoner content hub dev environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/opensearch.tf
@@ -1,6 +1,6 @@
 # Configure an S3 bucket for Snapshot Management
 module "s3_opensearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.9.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.0.0"
 
   # Tags
   business_unit          = var.business_unit
@@ -8,7 +8,7 @@ module "s3_opensearch" {
   is_production          = var.is_production
   team_name              = var.team_name
   namespace              = var.namespace
-  environment_name       = var.environment
+  environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/opensearch.tf
@@ -1,0 +1,57 @@
+# Configure an S3 bucket for Snapshot Management
+module "s3_opensearch" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.9.0"
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+# Create the domain
+module "opensearch" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-opensearch?ref=1.2.0"
+
+  # VPC/EKS configuration
+  vpc_name         = var.vpc_name
+  eks_cluster_name = var.eks_cluster_name
+
+  # Cluster configuration
+  engine_version      = "OpenSearch_2.7"
+  snapshot_bucket_arn = module.s3_opensearch.bucket_arn
+
+  # Non-production cluster configuration
+  cluster_config = {
+    instance_count = 2
+    instance_type  = "t3.small.search"
+  }
+
+  ebs_options = {
+    volume_size = 10
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+}
+
+# Output the proxy URL
+resource "kubernetes_secret" "opensearch" {
+  metadata {
+    name      = "${var.team_name}-opensearch-proxy-url"
+    namespace = var.namespace
+  }
+
+  data = {
+    proxy_url = module.opensearch.proxy_url
+  }
+}


### PR DESCRIPTION
This will enable us to test pointing Drupal at OpenSearch instead of ElasticSearch.