### PR TITLE
Remove apply pipeline skip namespace - send-legal-mail-to-prisons-dev 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,1 +1,0 @@
---skip namespace for db instance upgrade


### PR DESCRIPTION
Remove apply pipeline skip namespace file after upgrading database instance for send-legal-mail-to-prisons-dev namespace.