### PR TITLE
LASB-2404 - Amend irsa.tf

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sqstesting-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sqstesting-dev/resources/irsa.tf
@@ -5,7 +5,7 @@ module "irsa" {
   eks_cluster_name = var.eks_cluster_name
 
   # IRSA configuration
-  service_account_name = var.application
+  service_account_name = var.namespace
   namespace            = var.namespace # this is also used as a tag
 
   # Attach the approprate policies using a key => value map


### PR DESCRIPTION
Amend service_account_name to use var.namespace to avoid whitespace issue with var.application.