### PR TITLE
Removed deletion_protection from laa-govuk-notify-orchestation-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-dev/resources/ecr.tf
@@ -68,4 +68,5 @@ module "ecr" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
Removed the deletion_protection argument from the ECR Module in the laa-govuk-notify-orchestation-dev namespace in preparation to delete and remake the namespace.