### PR TITLE
CCCD-DEV Create rds read-replica k8s secret

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
@@ -38,7 +38,7 @@ module "read_replica" {
   db_backup_retention_period = 0
 }
 
-resource "kubernetes_secret" "read-replica" {
+resource "kubernetes_secret" "read_replica" {
   count = 1
 
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
@@ -38,7 +38,7 @@ module "read_replica" {
   db_backup_retention_period = 0
 }
 
-resource "kubernetes_secret" "read_replica" {
+resource "kubernetes_secret" "read-replica" {
   count = 1
 
   metadata {
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "read_replica" {
   # The database_username, database_password, database_name values are same as the source RDS instance.
   # Uncomment if count > 0 as in on. if count < 0 then it's off
   data = {
-    rds_instance_endpoint = module.read_replica.rds_instance_endpoint
+    rds-instance-endpoint = module.read-replica.rds-instance-endpoint
     # rds_instance_address  = module.read_replica.rds_instance_address
     # access_key_id         = module.read_replica.access_key_id
     # secret_access_key     = module.read_replica.secret_access_key

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
@@ -39,7 +39,7 @@ module "read_replica" {
 }
 
 resource "kubernetes_secret" "read_replica" {
-  count = 0
+  count = 1
 
   metadata {
     name      = "rds-postgresql-read-replica-output"
@@ -48,10 +48,10 @@ resource "kubernetes_secret" "read_replica" {
 
   # The database_username, database_password, database_name values are same as the source RDS instance.
   # Uncomment if count > 0 as in on. if count < 0 then it's off
-  # data = {
-  #   rds_instance_endpoint = module.read_replica.rds_instance_endpoint
-  #   rds_instance_address  = module.read_replica.rds_instance_address
-  #   access_key_id         = module.read_replica.access_key_id
-  #   secret_access_key     = module.read_replica.secret_access_key
-  # }
+  data = {
+    rds_instance_endpoint = module.read_replica.rds_instance_endpoint
+    # rds_instance_address  = module.read_replica.rds_instance_address
+    # access_key_id         = module.read_replica.access_key_id
+    # secret_access_key     = module.read_replica.secret_access_key
+  }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "read_replica" {
   # The database_username, database_password, database_name values are same as the source RDS instance.
   # Uncomment if count > 0 as in on. if count < 0 then it's off
   data = {
-    rds-instance-endpoint = module.read-replica.rds-instance-endpoint
+    rds_instance_endpoint = module.read_replica.rds_instance_endpoint
     # rds_instance_address  = module.read_replica.rds_instance_address
     # access_key_id         = module.read_replica.access_key_id
     # secret_access_key     = module.read_replica.secret_access_key

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "read_replica" {
   # The database_username, database_password, database_name values are same as the source RDS instance.
   # Uncomment if count > 0 as in on. if count < 0 then it's off
   data = {
-    rds_instance_endpoint = module.read_replica.rds_instance_endpoint
+    rds_instance_endpoint = module.read_replica[0].rds_instance_endpoint
     # rds_instance_address  = module.read_replica.rds_instance_address
     # access_key_id         = module.read_replica.access_key_id
     # secret_access_key     = module.read_replica.secret_access_key


### PR DESCRIPTION
For CCCD Dev

Create rds read replica secret called `read-replica`
Return the `rds-instance-endpoint` so that it can be used to create a port-forward on demand (non-persistent) manually.