### PR TITLE
CCCD-DEV Add a secrets manager resource and store the rds_instance_endpoint secret

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
@@ -5,7 +5,7 @@ module "secrets_manager" {
   business_unit          = var.business_unit
   is_production          = var.is_production
   namespace              = var.namespace
-  environment_name       = var.environment_name
+  environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
   eks_cluster_name       = var.eks_cluster_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
@@ -5,7 +5,7 @@ module "secrets_manager" {
   business_unit          = var.business_unit
   is_production          = var.is_production
   namespace              = var.namespace
-  environment_name       = var.environment
+  environment_name       = var.environment_name
   infrastructure_support = var.infrastructure_support
   eks_cluster_name       = var.eks_cluster_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
@@ -1,5 +1,5 @@
 module "secrets_manager" {
-  source = "../"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.0"
   team_name              = var.team_name
   application            = var.application
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
@@ -1,0 +1,19 @@
+module "secrets_manager" {
+  source = "../"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "read_replica" = {
+      description             = "This is the RDS read replica rds_instance_endpoint",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "rds_instance_endpoint"
+    },
+  }
+}


### PR DESCRIPTION
This is to hold the rds `read_replica` secret which will contain the cccd-dev's read replica `rds_instance_endpoint` secret key/value

This will then be used to manually create temporary port-forward pods to the read replica database and not the primary database