### PR TITLE
CCCD-DEV Fix typo that failed naming conventions validations

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
@@ -10,7 +10,7 @@ module "secrets_manager" {
   eks_cluster_name       = var.eks_cluster_name
 
   secrets = {
-    "read_replica" = {
+    "read-replica" = {
       description             = "This is the RDS read replica rds_instance_endpoint / rds-instance-endpoint",
       recovery_window_in_days = 7
       k8s_secret_name         = "rds-instance-endpoint"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/secrets_manager.tf
@@ -11,9 +11,9 @@ module "secrets_manager" {
 
   secrets = {
     "read_replica" = {
-      description             = "This is the RDS read replica rds_instance_endpoint",
+      description             = "This is the RDS read replica rds_instance_endpoint / rds-instance-endpoint",
       recovery_window_in_days = 7
-      k8s_secret_name         = "rds_instance_endpoint"
+      k8s_secret_name         = "rds-instance-endpoint"
     },
   }
 }


### PR DESCRIPTION
Fix typo of kubernetes secret name to meet the naming standards

A previous [PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/16727) apply failed https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/9141

> The key to the secrets should only contain '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*') as this is used to create the actual kubernetes resource. 