### PR TITLE
NON-263: Secret to sync preprod DB (non-associations)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/rds.tf
@@ -38,3 +38,20 @@ resource "kubernetes_secret" "dps_rds" {
     url                   = "postgres://${module.dps_rds.database_username}:${module.dps_rds.database_password}@${module.dps_rds.rds_instance_endpoint}/${module.dps_rds.database_name}"
   }
 }
+
+# This places a secret for this preprod RDS instance in the production namespace,
+# this can then be used by a kubernetes job which will refresh the preprod data.
+resource "kubernetes_secret" "dps_rds_refresh_creds" {
+  metadata {
+    name      = "dps-rds-instance-output-preprod"
+    namespace = "hmpps-non-associations-prod"
+  }
+
+  data = {
+    rds_instance_endpoint = module.dps_rds.rds_instance_endpoint
+    database_name         = module.dps_rds.database_name
+    database_username     = module.dps_rds.database_username
+    database_password     = module.dps_rds.database_password
+    rds_instance_address  = module.dps_rds.rds_instance_address
+  }
+}


### PR DESCRIPTION
Created a secret in the `prod` namespace with the `preprod` DB credentials. This will be used to periodically sync the `preprod` database with the `prod` data.

See: `generic-service` helm chart documentation on Postgres database restore cronjob:

https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-service#prison-postgres-database-restore-cronjob