### PR TITLE
Rename the repo name for ap-rshiny-notesbook app

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ap-rshiny-notesbook-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ap-rshiny-notesbook-dev/00-namespace.yaml
@@ -10,6 +10,6 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "analytical-platform-team"
     cloud-platform.justice.gov.uk/application: "Rshiny notebook"
     cloud-platform.justice.gov.uk/owner: "Analytical Platform team: analytical-platform@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/ap-rshiny-notebook"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/ap-rshiny-notesbook"
     cloud-platform.justice.gov.uk/team-name: "analytics-hq"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ap-rshiny-notesbook-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ap-rshiny-notesbook-dev/resources/ecr.tf
@@ -6,7 +6,7 @@ module "ecr_credentials" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in
   # github actions CI/CD pipelines
-  github_repositories = ["ap-rshiny-notebook"]
+  github_repositories = ["ap-rshiny-notesbook"]
 
   # list of github environments, to create the ECR secrets as environment secrets
   # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ap-rshiny-notesbook-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ap-rshiny-notesbook-dev/resources/serviceaccount.tf
@@ -6,7 +6,7 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  github_repositories = ["ap-rshiny-notebook"]
+  github_repositories = ["ap-rshiny-notebooks"]
 
   github_environments = ["dev"]
 


### PR DESCRIPTION
found out the typo in the repo name which caused the mismatch between namespace's name and repo name 🤦‍♀️ . this PR is the rename the repo name