### PR TITLE
Increase requested compute resource

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 1000Mi
     defaultRequest:
-      cpu: 10m
-      memory: 100Mi
+      cpu: 200m
+      memory: 600Mi
     type: Container


### PR DESCRIPTION
Our production application continuously goes over the default requested amount of both CPU and memory. This makes it difficult to configure our HPA correctly. I've increased both CPU and memory to hopefully cover what is needed.