### PR TITLE
update namespace template with psa audit restricted label

### DIFF
--- a/namespace-resources-cli-template/00-namespace.yaml
+++ b/namespace-resources-cli-template/00-namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Namespace }}
+  name: { { .Namespace } }
   labels:
     cloud-platform.justice.gov.uk/is-production: "{{ .IsProduction }}"
     cloud-platform.justice.gov.uk/environment-name: "{{ .Environment }}"

--- a/namespace-resources-cli-template/00-namespace.yaml
+++ b/namespace-resources-cli-template/00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cloud-platform.justice.gov.uk/is-production: "{{ .IsProduction }}"
     cloud-platform.justice.gov.uk/environment-name: "{{ .Environment }}"
+    pod-security.kubernetes.io/audit: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "{{ .BusinessUnit }}"
     cloud-platform.justice.gov.uk/slack-channel: "{{ .SlackChannel }}"


### PR DESCRIPTION
This PR ensures that any new environments created include
`pod-security.kubernetes.io/audit: restricted` label.

Will be updated to `enforce` mode following period of PSA audit testing cluster wide.