### PR TITLE
Increase default CPU and memory usage

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 1000m
       memory: 1000Mi
     defaultRequest:
-      cpu: 10m
-      memory: 100Mi
+      cpu: 200m
+      memory: 600Mi
     type: Container


### PR DESCRIPTION
We are continuously exceeding the current default compute limits which makes setting HPA settings difficult. Changing these so that we are within usage limits means we can set thresholds on HPA.