### PR TITLE
laa-apply-for-legalaid-namespaces: Remove prom rules using `container_fs_usage_bytes`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/05-prometheus.yaml
@@ -53,20 +53,6 @@ spec:
         severity: apply-for-legal-aid-prod
       annotations:
         message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-production"} / 1024 / 1024 > 150
-      for: 1m
-      labels:
-        severity: apply-for-legal-aid-prod
-      annotations:
-        message: Container disk space usage is more than 150Mb
-    - alert: DiskSpace-Threshold-NotReported
-      expr: absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-production"})
-      for: 3m
-      labels:
-        severity: apply-for-legal-aid-prod
-      annotations:
-        message: Container disk space usage is not reported
     - alert: Long-Request
       expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production", controller!~"providers/bank_statements|v1/bank_statements|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
       for: 1m

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/05-prometheus.yaml
@@ -53,20 +53,6 @@ spec:
         severity: apply-for-legal-aid-staging
       annotations:
         message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-staging"} / 1024 / 1024 > 150
-      for: 1m
-      labels:
-        severity: apply-for-legal-aid-staging
-      annotations:
-        message: Container disk space usage is more than 150Mb
-    - alert: DiskSpace-Threshold-NotReported
-      expr: absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-staging"})
-      for: 3m
-      labels:
-        severity: apply-for-legal-aid-staging
-      annotations:
-        message: Container disk space usage is not reported
     - alert: Long-Request
       expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller!~"providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
       for: 1m

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
@@ -53,20 +53,6 @@ spec:
         severity: apply-for-legal-aid-uat
       annotations:
         message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-uat"} / 1024 / 1024 > 150
-      for: 1m
-      labels:
-        severity: apply-for-legal-aid-uat
-      annotations:
-        message: Container disk space usage is more than 150Mb
-    - alert: DiskSpace-Threshold-NotReported
-      expr: absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-uat"})
-      for: 3m
-      labels:
-        severity: apply-for-legal-aid-uat
-      annotations:
-        message: Container disk space usage is not reported
     - alert: Long-Request
       expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-uat", controller!~"providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
       for: 1m


### PR DESCRIPTION
Remove prom rules using `container_fs_usage_bytes`

This metric is no longer available as of k8s version 1.24,
dockershim to containerd change, and is resulting in daily
or twice daily alerting in the channels for no good reason.

References:

[migrating from dockershim, known issues](https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-removal-affects-you/#known-issues)
[Related CP Issue](https://github.com/ministryofjustice/cloud-platform/issues/4672)
