### PR TITLE
RR-411 - Add `farsight-devs` to `hmpps-education-employment-dev`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/00-namespace.yaml
@@ -14,5 +14,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Education & Employment services"
     cloud-platform.justice.gov.uk/owner: "Education Skills Work Employment: managing.eswe@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-education-employment-ui.git"
-    cloud-platform.justice.gov.uk/team-name: "education-skills-work-employment"
+    cloud-platform.justice.gov.uk/team-name: "education-skills-work-employment, farsight-devs"
     cloud-platform.justice.gov.uk/review-after: ""


### PR DESCRIPTION
Add the `farsight-devs` GH team to the `hmpps-education-employment-dev` namespace