### PR TITLE
Conftest checks

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -1,0 +1,19 @@
+name: conftest
+on: [pull_request]
+
+jobs:
+  conftest:
+    env:
+      # GH repo env var string containing files / dirs to ignore which cannot be parsed by conftest
+      IGNORE_LIST: ${{ vars.CONFTEST_IGNORE_LIST }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Setup conftest
+        uses: princespaghetti/setup-conftest@v1.1.18
+
+      - name: Run Conftest 
+        run: conftest test namespaces/live.cloud-platform.service.justice.gov.uk/ --ignore $IGNORE_LIST
+        continue-on-error: true

--- a/policy/namespace.rego
+++ b/policy/namespace.rego
@@ -76,3 +76,11 @@ deny[msg] {
   not has_cp_label("environment-name")
   msg := "Namespace must have environment-name label"
 }
+
+# Deny namespace if no psa audit restricted label is provided. To update when we move to enforce.
+
+deny[msg] {
+  input.kind == "Namespace"
+  not input.metadata.labels["pod-security.kubernetes.io/audit"] == "restricted"
+  msg := "Namespace must have label 'pod-security.kubernetes.io/audit: restricted'"
+}


### PR DESCRIPTION
This PR  enables conftest testing for all namespace rego annotation checks and adds PSA label checks.

GH Action currently set to continue-on-error, this will be disabled once PSA switches from audit to enforce mode.