### PR TITLE
New CAS 3 dev URL

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/06-certificates.yaml
@@ -24,6 +24,7 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - temporary-accommodation-dev.hmpps.service.justice.gov.uk
+    - transitional-accommodation-dev.hmpps.service.justice.gov.uk
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
The service has been renamed from temporary to transitional. We need to keep the old urls working.

We'll be adding this to all other namespaces.

Is this all that's needed?