### PR TITLE
Increase prod memory limit

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2000Mi
     defaultRequest:
       cpu: 200m
       memory: 600Mi


### PR DESCRIPTION
Pods are hitting OOMKILLED with current memory capacity. Looking at Grafana, they seem to spike around 1.5Mi but I have increased the limit to 2000Mi with some buffer room.