### PR TITLE
Adjust memory limit to stop OOM error on deploy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2000Mi
     defaultRequest:
       cpu: 200m
       memory: 600Mi


### PR DESCRIPTION
When deploying more than one pod, we are coming close to, or hitting our memory limits and on some pods getting an OOMKILLED message. This results in pods spinning up with half of the files they require. We have tested on prod and setting this new limit fixes the issue.