### PR TITLE
switching conftest namespace check to fail on non-passing checks

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -16,4 +16,3 @@ jobs:
 
       - name: Run Conftest 
         run: conftest test namespaces/live.cloud-platform.service.justice.gov.uk/ --ignore $IGNORE_LIST
-        continue-on-error: true


### PR DESCRIPTION
This PR enables our conftest action, so that namespaces with missing required annotations and labels ([see here for rego policies](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/policy/namespace.rego)) will fail this check.