### PR TITLE
New CAS3 test URL

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/06-certificates.yaml
@@ -24,6 +24,7 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - temporary-accommodation-test.hmpps.service.justice.gov.uk
+    - transitional-accommodation-test.hmpps.service.justice.gov.uk
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
The service has been renamed from temporary to transitional. We need to keep the old urls working.
