### PR TITLE
New CAS3 preprod URL

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/06-certificates.yaml
@@ -24,6 +24,7 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - temporary-accommodation-preprod.hmpps.service.justice.gov.uk
+    - transitional-accommodation-preprod.hmpps.service.justice.gov.uk
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
The service has been renamed from temporary to transitional. We need to keep the old urls working.