### PR TITLE
Increase cpu, memory req and limits for canary-app

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/application.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/application.tf
@@ -3,7 +3,7 @@ resource "helm_release" "cloud_platform_canary" {
   namespace  = "cloud-platform-canary-app-eks"
   repository = "https://stefanprodan.github.io/podinfo"
   chart      = "podinfo"
-  version    = "6.1.7"
+  version    = "6.5.2"
 
   values = [templatefile("${path.module}/values.yaml", {
     external_dns  = "cloud-platform-canary-app-podinfo-cloud-platform-canary-app-eks-green"
@@ -17,7 +17,7 @@ resource "helm_release" "cloud_platform_modsec_canary" {
   namespace  = "cloud-platform-canary-app-eks"
   repository = "https://stefanprodan.github.io/podinfo"
   chart      = "podinfo"
-  version    = "6.1.7"
+  version    = "6.5.2"
 
   values = [templatefile("${path.module}/values.yaml", {
     external_dns  = "cloud-platform-canary-app-modsec-podinfo-cloud-platform-canary-app-eks-green"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/values.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/values.yaml
@@ -23,8 +23,8 @@ ingress:
 
 resources:
   limits:
-    cpu: 4m
-    memory: 32Mi
+    cpu: 100m
+    memory: 100Mi
   requests:
-    cpu: 2m
+    cpu: 40m
     memory: 16Mi


### PR DESCRIPTION
- The app has been alerting on high priority for service down
- The pod was exiting with exitCode:137 which lead to investigating towards cpu and memory
- Grafana screenshot showing CPU utlization over limits 
<img width="1769" alt="Screenshot 2023-10-15 at 11 25 17" src="https://github.com/ministryofjustice/cloud-platform-environments/assets/51324851/f9dab690-de08-4e94-a2db-50969e7c4402">


