### PR TITLE
Add servicemonitors to circleCI resources - send-legal-mail-to-prisons-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/05-serviceaccount-circleci.yaml
@@ -31,6 +31,7 @@ rules:
       - "monitoring.coreos.com"
     resources:
       - "prometheusrules"
+      - "servicemonitors"
     verbs:
       - "*"
 


### PR DESCRIPTION
Add servicemonitors to circleCI resources (send-legal-mail-to-prisons-preprod) as a fix for failing build - https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-send-legal-mail-staff-ui/101/workflows/22dc3a2b-a726-45cc-a845-c000d2ae21c7/jobs/574