### PR TITLE
Add secrets to circleCI resources send-legal-mail-to-prisons-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/05-serviceaccount-circleci.yaml
@@ -32,6 +32,7 @@ rules:
     resources:
       - "prometheusrules"
       - "servicemonitors"
+      - "secrets"
     verbs:
       - "*"
 


### PR DESCRIPTION
Add secrets to circleCI resources send-legal-mail-to-prisons-preprod as a fix for failing build - https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-send-legal-mail-staff-ui/105/workflows/03c71810-3652-4edf-88d7-fc78f7c6521e/jobs/609

Needs to read secrets from namespace to run smoke tests.