### PR TITLE
Share secret with assess non standard mags dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev/resources/shared-s3-secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev/resources/shared-s3-secret.tf
@@ -1,0 +1,10 @@
+resource "kubernetes_secret" "claim-nsm-s3-secret" {
+  metadata {
+    name      = "s3-policy-arns"
+    namespace = "laa-assess-non-standard-magistrate-fee-dev"
+  }
+
+  data = {
+    service_metadata_bucket_irsa = module.s3_bucket.irsa_policy_arn
+  }
+}


### PR DESCRIPTION
Creates a secret in the laa-assess-non-standard-magistrate-fee-dev environment to share IRSA policy to access the shared S3 bucket.