### PR TITLE
[laa-apply-for-legalaid-uat] Add serviceaccount permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
@@ -18,6 +18,7 @@ rules:
       - "deployment"
       - "secrets"
       - "services"
+      - "serviceaccounts"
       - "pods"
       - "HorizontalPodAutoscaler"
     verbs:


### PR DESCRIPTION
Add serviceaccount intropection permissions

Allow circleci service account to query serviceaccounts resources

Currently A UAT branch that is attempting to install bitnami/redis
is errororing as follows

```sh
Deploying CIRCLE_SHA1: b24b35edcf6c7d522378eb78b05afc27d9c9d54c under release name: 'apply-ap-4499-remove-redis-namespace'...
Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with
update: could not get information about the resource: serviceaccounts "apply-ap-4499-remove-redis-namespace" is
forbidden: User "system:serviceaccount:**************************:circleci" cannot get resource "serviceaccounts" in API group "" in
the namespace "**************************"

Exited with code exit status 1
```

[example](https://app.circleci.com/pipelines/github/ministryofjustice/laa-apply-for-legal-aid/24495/workflows/8c207fff-c33b-43ea-8d46-69687a51de49/jobs/127753)
