### PR TITLE
[laa-apply-for-legalaid-uat] Add configmaps permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
@@ -15,6 +15,7 @@ rules:
       - ""
     resources:
       - "pods/portforward"
+      - "configmaps"
       - "deployment"
       - "secrets"
       - "services"


### PR DESCRIPTION
Add configmaps permissions

Allow circleci service account to query configmaps resources

Currently A UAT branch that is attempting to install bitnami/redis
is errororing due to lack of permissions

```sh
Deploying CIRCLE_SHA1: b24b35edcf6c7d522378eb78b05afc27d9c9d54c under release name: 'apply-ap-4499-remove-redis-namespace'...
Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with update: could not get information about the resource: configmaps "apply-ap-4499-remove-redis-namespace-configuration" is forbidden: User "system:serviceaccount:**************************:circleci" cannot get resource "configmaps" in API group "" in the namespace "**************************"

Exited with code exit status 1
```
