### PR TITLE
MOP-106 Upgrading DB instance type to t4g 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/rds.tf
@@ -10,7 +10,8 @@ module "manage_offences_rds" {
   infrastructure_support      = var.infrastructure_support
   rds_family                  = var.rds_family
   allow_major_version_upgrade = "false"
-  db_instance_class           = "db.t3.small"
+  db_instance_class           = "db.t4g.micro"
+  db_max_allocated_storage    = "500"
   db_engine_version           = "14"
 
   db_password_rotated_date = "13-02-2023"


### PR DESCRIPTION
Steps 1 and 2 from https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-to-a-new-major-database-version

Step 1: Skip pipeline
Step 2: Change instance type