### PR TITLE
add short version of CAS2 preprod domain name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/06-certificates.yaml
@@ -50,5 +50,5 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk
+    - cas2-preprod.hmpps.service.justice.gov.uk
     - community-accommodation-tier-2-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
The existing domain name is over 64 characters and causing the certificate to error. This follows process used elsewhere such as https://github.com/ministryofjustice/cloud-platform-environments/blob/83728051db55cbe97100ee60e5609e096d14f2b8/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/05-certificates.yml#L27

and following a conversation here https://mojdt.slack.com/archives/C69NWE339/p1697642282015629 