### PR TITLE
Update repo name for new CCQ UAT namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-uat/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-uat/00-namespace.yaml
@@ -12,7 +12,7 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "laa-ccq-team"
     cloud-platform.justice.gov.uk/application: "Check if your client qualifies for legal aid"
     cloud-platform.justice.gov.uk/owner: "Check Client Qualifies: eligibility@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-check-client-qualifies"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-estimate-financial-eligibility-for-legal-aid"
     cloud-platform.justice.gov.uk/team-name: "check-client-qualifies"
     cloud-platform.justice.gov.uk/review-after: ""
     cloud-platform.justice.gov.uk/runbook: “https://dsdmoj.atlassian.net/wiki/spaces/laagetaccess/pages/4405724996/CCQ+Runbook“

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-uat/resources/variables.tf
@@ -57,7 +57,7 @@ variable "github_token" {
 
 variable "repo_name" {
   description = "The name of github repo"
-  default     = "laa-check-client-qualifies"
+  default     = "laa-estimate-financial-eligibility-for-legal-aid"
 }
 
 variable "eks_cluster_name" {


### PR DESCRIPTION
We accidentally broke the pipeline by using a new repo name for our new CCQ UAT namespace.

We haven't yet renamed our existing repo to this new name, so we are setting the repo name back to our existing repo name to fix the pipeline build.