### PR TITLE
Add access to prometheus rules to service account in cccd-dev-lgfs namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/serviceaccount-circleci.yaml
@@ -31,9 +31,11 @@ rules:
       - "extensions"
       - "apps"
       - "networking.k8s.io"
+      - "monitoring.coreos.com"
     resources:
       - "deployments"
       - "ingresses"
+      - "prometheusrules"
     verbs:
       - "get"
       - "list"


### PR DESCRIPTION
In order to allow our CircleCI service account to update prometheus rules in our app, this gives the account access to `prometheusrules` resources in the `monitoring.coreos.com` API group.