### PR TITLE
Update CAS3 pingdom check url

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
@@ -19,14 +19,14 @@ resource "pingdom_check" "hmpps-approved-premises-ui" {
 
 resource "pingdom_check" "hmpps-temporary-accommodation-ui" {
   type                     = "http"
-  name                     = "HMPPS - temporary-accommodation/CAS3 - Production"
+  name                     = "HMPPS - transitional-accommodation/CAS3 - Production"
   host                     = "health-kick.prison.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   integrationids           = [130657]
   notifyagainevery         = 0
-  url                      = "/https/temporary-accommodation.hmpps.service.justice.gov.uk/health"
+  url                      = "/https/transitional-accommodation.hmpps.service.justice.gov.uk/health"
   encryption               = true
   port                     = 443
   tags                     = "businessunit_hmpps,application_temporary-accommodation,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"


### PR DESCRIPTION
We’ve recently redirected from temporary-x to transitional-x so the 301 is preventing the healthy state.