### PR TITLE
chore: 🤖 upgrade serviceaccount modules to latest

### DIFF
--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module/resources/serviceaccount.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ap-firebreak-superset/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ap-firebreak-superset/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=skip-secret-env"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-demo/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-demo/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"
@@ -76,7 +76,7 @@ module "circleci-sa" {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "manage-intelligence-ga"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "manage-intelligence-ga"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"
@@ -76,7 +76,7 @@ module "circleci-sa" {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "hmpps-portfolio-management"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"
@@ -76,7 +76,7 @@ module "circleci-sa" {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "hmpps-portfolio-management"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-moj-forms-adapter-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-moj-forms-adapter-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-development/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-development/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount-github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-prd/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-prd/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount-github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount-github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-tst/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-tst/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount-github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "manage-intelligence-ga"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/poornima-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/poornima-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster


### PR DESCRIPTION
This PR upgrades service accounts for users who are actually setting the `github_environments` variable, because of this there are lots of secrets deleted.

```
 grep "github_environments " **/*.tf  |  grep -v "#" | grep -v data-platform-app | grep "serviceaccount"|  awk '{print $1}' | sed 's/.$//' | xargs -I % gsed -i 's/serviceaccount?ref=.*"/serviceaccount?ref=1.0.0"/g' %
 ```
 
This command gets all the files with github_env defined, exclude commented-out lines and exclude data platform apps, only include service account files and upgrade the module version