### PR TITLE
[DPR2-122] Service account module version bump

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.9.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster


### PR DESCRIPTION
Bump service account module version in order to fix the following CircleCI failure:

```
Error: rendered manifests contain a resource that already exists. Unable to continue with install: could not get information about the resource: networkpolicies.networking.k8s.io "**************************-ui-dev-monitoring" is forbidden: User "system:serviceaccount:**************************:circleci" cannot get resource "networkpolicies" in API group "networking.k8s.io" in the namespace "**************************"
```