### PR TITLE
Remove bucket policy no longer needed

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/s3.tf
@@ -56,23 +56,6 @@ module "s3_bucket" {
     aws = aws.london
   }
 
-  bucket_policy = <<EOF
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Principal": "*",
-              "Action": "s3:GetObject",
-              "Resource": [
-                "$${bucket_arn}/uploads/*",
-                "$${bucket_arn}/feed-parser/*"
-            ]
-          }
-      ]
-  }
-  EOF
-  
 }
 
 resource "kubernetes_secret" "s3_bucket" {
@@ -86,4 +69,3 @@ resource "kubernetes_secret" "s3_bucket" {
     bucket_name = module.s3_bucket.bucket_name
   }
 }
-


### PR DESCRIPTION
We were able to manually remove `List` from the bucket root so this is no longer needed.