### PR TITLE
Added ingress Network Policy to laa-govuk-notify-orchestrator-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-staging/04-networkpolicy.yaml
@@ -25,3 +25,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: laa-cla-backend-staging
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: laa-cla-public-staging


### PR DESCRIPTION
- Adds ingress Network Policy from `laa-cla-backend-staging` and `laa-cla-public-staging`.