### PR TITLE
Added ingress network policy to laa-govuk-notify-orchestrator-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-production/04-networkpolicy.yaml
@@ -25,3 +25,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: laa-cla-backend-production
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: laa-cla-public-production


### PR DESCRIPTION
- Adds ingress Network Policy from `laa-cla-backend-production` and `laa-cla-public-production`.