### PR TITLE
[SI-476] Create a serviceaccount pod for debugging SQS DLQ issue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/serviceaccount.tf
@@ -1,0 +1,10 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/SI-476

We have unresolved alerts around messages in the DLQ:

<img width="585" alt="Screenshot 2023-10-26 at 11 21 07" src="https://github.com/ministryofjustice/cloud-platform-environments/assets/6329541/56739afa-c299-4d70-a0de-a673ba533305">

I am trying to get access to AWS to see these messages. 

I am following this guide:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/using-cloud-platform-service-pod.html#using-the-cloud-platform-service-pod

We already have this config:

https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/irsa.tf