### PR TITLE
laa-court-data-ui-dev Remove DiskSpace-Threshold-Reached alert

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/prometheus.yaml
@@ -39,13 +39,6 @@ spec:
       annotations:
         message: laa-court-data-ui-dev An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-court-data-ui-dev),type:phrase,value:laa-court-data-ui-dev),query:(match:(log_processed.kubernetes_namespace:(query:laa-court-data-ui-dev,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="laa-court-data-ui-dev"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-court-data-ui-dev"})
-      for: 1m
-      labels:
-        severity: laa-court-data-ui-preprod
-      annotations:
-        message: laa-court-data-ui-dev Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
       expr: ruby_http_request_duration_seconds{namespace="laa-court-data-ui-dev"} > 30
       for: 1m


### PR DESCRIPTION
Remove DiskSpace-Threshold-Reached alert from laa-court-data-ui-dev

This is because this alert query is no longer supported