### PR TITLE
Civil-Apply: update prometheus rules... again

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/05-prometheus.yaml
@@ -54,21 +54,21 @@ spec:
       annotations:
         message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
     - alert: Long-Request
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-production", controller!~"providers/bank_statements|v1/bank_statements|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-production", controller!~"providers/bank_statements|v1/bank_statements|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
       for: 1m
       labels:
         severity: apply-for-legal-aid-prod
       annotations:
         message: Request is taking more than 2 seconds
     - alert: "Long-Request: file_uploads"
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-production", controller="providers/bank_statements|v1/bank_statements|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-production", controller="providers/bank_statements|v1/bank_statements|providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
       for: 1m
       labels:
         severity: apply-for-legal-aid-prod
       annotations:
         message: File upload request is taking more than 10 seconds    
     - alert: "Long-Request: means_summaries"
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-production", controller="providers/means_summaries"} > 5
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-production", controller="providers/means_summaries"} > 5
       for: 1m
       labels:
         severity: apply-for-legal-aid-prod

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/05-prometheus.yaml
@@ -54,21 +54,21 @@ spec:
       annotations:
         message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
     - alert: Long-Request
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-staging", controller!~"providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller!~"providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
       for: 1m
       labels:
         severity: apply-for-legal-aid-staging
       annotations:
         message: Request is taking more than 2 seconds
     - alert: "Long-Request: file_uploads"
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-staging", controller="providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller="providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
       for: 1m
       labels:
         severity: apply-for-legal-aid-staging
       annotations:
         message: File upload request is taking more than 10 seconds    
     - alert: "Long-Request: means_summaries"
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-staging", controller="providers/means_summaries"} > 5
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-staging", controller="providers/means_summaries"} > 5
       for: 1m
       labels:
         severity: apply-for-legal-aid-staging

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
@@ -54,21 +54,21 @@ spec:
       annotations:
         message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
     - alert: Long-Request
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-uat", controller!~"providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-uat", controller!~"providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/means_summaries|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 2
       for: 1m
       labels:
         severity: apply-for-legal-aid-uat
       annotations:
         message: Request is taking more than 2 seconds
     - alert: "Long-Request: file_uploads"
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-uat", controller="providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-uat", controller="providers/application_merits_task/statement_of_cases|v1/statement_of_cases|providers/uploaded_evidence_collections|v1/uploaded_evidence_collections"} > 10
       for: 1m
       labels:
         severity: apply-for-legal-aid-uat
       annotations:
         message: File upload request is taking more than 10 seconds    
     - alert: "Long-Request: means_summaries"
-      expr: ruby_http_request_duration_seconds_count{namespace="laa-apply-for-legalaid-uat", controller="providers/means_summaries"} > 5
+      expr: ruby_http_request_duration_seconds{namespace="laa-apply-for-legalaid-uat", controller="providers/means_summaries"} > 5
       for: 1m
       labels:
         severity: apply-for-legal-aid-uat


### PR DESCRIPTION
These had the erroneus, count, keyword added to the end of the search query, subsequently they kept increasing!

This should revert the checks to report as expected