### PR TITLE
INC-1235: Incentives `dev`: Shutdown RDS during non-working hours

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/rds.tf
@@ -9,6 +9,8 @@ module "dps_rds" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 
+  enable_rds_auto_start_stop = true
+
   prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.small"
   rds_family                  = "postgres15"


### PR DESCRIPTION
Stop RDS instance during non-working hours to save money.

See CP user guide:

> [...] temporarily stop your database at 10PM and restart it at 6AM UTC
> (11PM and 7AM BST).

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/create.html#non-production