### PR TITLE
NON-303: Non-associations `preprod`: Shutdown RDS during non-working hours

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/rds.tf
@@ -9,6 +9,8 @@ module "dps_rds" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 
+  enable_rds_auto_start_stop = true
+
   db_instance_class           = "db.t4g.small"
   rds_family                  = "postgres15"
   db_engine_version           = "15"


### PR DESCRIPTION
Stop RDS instance during non-working hours to save money.

See CP user guide:

> [...] temporarily stop your database at 10PM and restart it at 6AM UTC
> (11PM and 7AM BST).

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/create.html#non-production