### PR TITLE
CCQ PROD remove domain duplicated from old NS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/variables.tf
@@ -54,7 +54,3 @@ variable "github_token" {
   description = "Required by the Github Terraform provider"
   default     = ""
 }
-
-variable "domain" {
-  default = "check-your-client-qualifies-for-legal-aid.service.gov.uk"
-}


### PR DESCRIPTION
The domain removed here also exists in our old namespace `laa-estimate-financial....-production`
deleting from here as it appears to be interfering with A records being created