### PR TITLE
PIC-3407: Add hmpps-document-management-dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-document-management-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "dev"
+    pod-security.kubernetes.io/audit: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps-document-management"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "farsight-alerts"
+    cloud-platform.justice.gov.uk/application: "HMPPS Document Management"
+    cloud-platform.justice.gov.uk/owner: "Digital Prison Services: dps-hmpps@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-document-management-api.git"
+    cloud-platform.justice.gov.uk/team-name: "farsight-devs"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/01-rbac.yaml
@@ -1,0 +1,17 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-document-management-dev-admin
+  namespace: hmpps-document-management-dev
+subjects:
+  - kind: Group
+    name: "github:farsight-devs"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/02-limitrange.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-document-management-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1024Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 128Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-document-management-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-document-management-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-document-management-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/05-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-document-management-api-dev-cert
+  namespace: hmpps-document-management-dev
+spec:
+  secretName: hmpps-document-management-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - document-api-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/irsa.tf
@@ -1,0 +1,47 @@
+# Add the names of the SQS queues & SNS topics which the app needs permissions to access.
+# The value of each item should be the namespace where the queue or topic was created.
+# This information is used to collect the IAM policies which are used by the IRSA module.
+locals {
+  # The names of the queues used and the namespace which created them
+  sqs_queues = {
+    "Digital-Prison-Services-dev-hmpps_audit_queue" = "hmpps-audit-dev",
+  }
+
+  # The names of the SNS topics used and the namespace which created them
+  sns_topics = {
+    "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev"
+  }
+
+  sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
+  sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
+}
+
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0" # use the latest release
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "hmpps-document-management-api"
+  role_policy_arns = merge(local.sqs_policies, local.sns_policies)
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace # this is also used to attach your service account to your namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
+  for_each = local.sqs_queues
+  name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
+}
+
+data "aws_ssm_parameter" "irsa_policy_arns_sns" {
+  for_each = local.sns_topics
+  name     = "/${each.value}/sns/${each.key}/irsa-policy-arn"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/rds-postgresql.tf
@@ -1,0 +1,38 @@
+module "rds_postgres" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # Database configuration
+  db_engine                  = "postgres"
+  db_engine_version          = "15"
+  rds_family                 = "postgres15"
+  db_instance_class          = "db.t4g.micro"
+  db_max_allocated_storage   = "500"
+  enable_rds_auto_start_stop = true
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "rds_postgres" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds_postgres.rds_instance_endpoint
+    database_name         = module.rds_postgres.database_name
+    database_username     = module.rds_postgres.database_username
+    database_password     = module.rds_postgres.database_password
+    rds_instance_address  = module.rds_postgres.rds_instance_address
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/s3.tf
@@ -1,0 +1,26 @@
+module "s3" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.1.0" # use the latest release
+
+  # S3 configuration
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "s3" {
+  metadata {
+    name      = "s3-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.s3.bucket_arn
+    bucket_name = module.s3.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/serviceaccount.tf
@@ -1,0 +1,10 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/variables.tf
@@ -1,0 +1,67 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "hmpps-document-management"
+}
+
+variable "namespace" {
+  default = "hmpps-document-management-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "farsight-devs"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "dev"
+}
+
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "dps-hmpps@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "hmpps-document-management"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+
+variable "rds_family" {
+  default = "postgres14"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/versions.tf
@@ -1,0 +1,18 @@
+
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.39.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
Adds a new hmpps-document-management-dev namespace for the HMPPS Document Management API project. This project will prove out an electronic document storage service used initially by the products in the Legacy team. The service is intended to be available across HMPPS as a centralised document management facility and/or templated supporting per service reuse.

Reasons for each module:

- irsa - publish audit events when documents are uploaded/replaced/viewed
- rds-postgres - store document metadata
- s3 - document storage