### PR TITLE
CCCD-STAGING - Set the RDS to use an older snapshot temporarily

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-staging/resources/rds.tf
@@ -22,7 +22,7 @@ module "cccd_rds" {
   allow_major_version_upgrade = "true"
   db_parameter                = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
 
-  snapshot_identifier = "rds:cloud-platform-7c41317651c21a33-2023-11-01-04-22"
+  snapshot_identifier = "cloud-platform-7c41317651c21a33-finalsnapshot"
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Following this CP guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rds-snapshots.html#restoring-live-services-from-an-rds-db-snapshot

CC: @jakemulley 

Next steps:

4. Contact the Cloud Platform team about the restore, providing the db-instance-identifier and the PR raised.

5. **Before the PR can be merged**, the Cloud Platform team have to:

- pause the [Apply Pipeline](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apply-pipeline.html), and
- rename the DB Instance via the AWS console