### PR TITLE
Civil Apply: Update permissions for github action service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
@@ -78,6 +78,7 @@ variable "serviceaccount_rules" {
         "services",
         "pods",
         "HorizontalPodAutoscaler",
+        "configmaps",
       ]
       verbs = [
         "patch",


### PR DESCRIPTION
A clean up job has started to fail with
```
Failed to delete release: [configmaps "apply-helm-delete-failures-redis-health" is forbidden: User "system:serviceaccount:***:github-actions" cannot delete resource "configmaps" in API group "" in the namespace "***"
```

So this PR adds the configmaps into the "" resource group that already has delete permissions