### PR TITLE
Civil Apply: Update permissions for github action service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
@@ -79,6 +79,7 @@ variable "serviceaccount_rules" {
         "pods",
         "HorizontalPodAutoscaler",
         "configmaps",
+        "serviceaccounts",
       ]
       verbs = [
         "patch",


### PR DESCRIPTION
A clean up job has started to fail with unable to delete `serviceaccounts`

So this PR adds the serviceaccounts into the "" resource group that already has delete permissions