### PR TITLE
Add production namespace for replatforming

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: help-with-child-arrangements-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-child-arrangements-information-tool"
+    cloud-platform.justice.gov.uk/application: "Help with child arrangements"
+    cloud-platform.justice.gov.uk/owner: "Central Digital Product Team: central-digital-product-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/help-with-child-arrangements"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/00-namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: help-with-child-arrangements-production
   labels:
-    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
     pod-security.kubernetes.io/enforce: restricted
   annotations:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: help-with-child-arrangements-production-admin
+  namespace: help-with-child-arrangements-production
+subjects:
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: help-with-child-arrangements-production
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: help-with-child-arrangements-production
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: help-with-child-arrangements-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: help-with-child-arrangements-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: help-with-child-arrangements-production-cert
+  namespace: help-with-child-arrangements-production
+spec:
+  secretName: help-with-child-arrangements-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - helpwithchildarrangements.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/bypass-psp-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/bypass-psp-rbac.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: temp-bypass-psp
+  namespace: help-with-child-arrangements-production
+  labels:
+subjects:
+  - kind: Group
+    name: "system:authenticated"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: psp:0-super-privileged
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/serviceaccount.tf
@@ -1,0 +1,11 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["help-with-child-arrangements"]
+  github_environments = ["production"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/variables.tf
@@ -1,0 +1,69 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Help with child arrangements"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "help-with-child-arrangements-production"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HQ"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "central-digital-product-team"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "central-digital-product-team@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "true"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "cdpt-child-arrangements-information-tool"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.39.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/versions.tf
@@ -9,9 +9,5 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.39.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.23.0"
-    }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/versions.tf
@@ -10,9 +10,5 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.39.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.23.0"
-    }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.39.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
   }
 }


### PR DESCRIPTION
This will soon replace an existing service - https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-production