### PR TITLE
CDPS-401 - Update request default to 100m CPU on the profile

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-prod/02-limitrange.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: LimitRange
 metadata:
@@ -6,10 +5,10 @@ metadata:
   namespace: hmpps-prisoner-profile-prod
 spec:
   limits:
-    - default:
-        cpu: 2000m
-        memory: 1024Mi
-      defaultRequest:
-        cpu: 10m
-        memory: 512Mi
-      type: Container
+  - default:
+      cpu: 2000m
+      memory: 1024Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 512Mi
+    type: Container


### PR DESCRIPTION
This is part one of 2 for the profile where we need to resize the minimum CPU request size for prod profile. there will be another PR to cover the HPA settings, which we will set there.