### PR TITLE
CDPS-459 and CDPS-393 - update limit ranges for HPA use

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-prod/02-limitrange.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: LimitRange
 metadata:
@@ -6,10 +5,10 @@ metadata:
   namespace: hmpps-digital-prison-services-prod
 spec:
   limits:
-    - default:
-        cpu: 2000m
-        memory: 1024Mi
-      defaultRequest:
-        cpu: 10m
-        memory: 512Mi
-      type: Container
+  - default:
+      cpu: 2000m
+      memory: 1024Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 512Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-prod/02-limitrange.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: LimitRange
 metadata:
@@ -6,10 +5,10 @@ metadata:
   namespace: hmpps-micro-frontend-components-prod
 spec:
   limits:
-    - default:
-        cpu: 2000m
-        memory: 1024Mi
-      defaultRequest:
-        cpu: 10m
-        memory: 512Mi
-      type: Container
+  - default:
+      cpu: 2000m
+      memory: 1024Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 512Mi
+    type: Container


### PR DESCRIPTION
following on from #17635 update defaultRequests for Homepage and MFE Services to 100m. this is to support HPA use.