### PR TITLE
Add slack channel to pingdom alert

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mikebell-test/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mikebell-test/resources/pingdom.tf
@@ -15,6 +15,6 @@ resource "pingdom_check" "mikebell-test-check" {
   port                     = 443
   tags                     = "businessunit_platforms,application_mikebell_test,component_healthcheck,isproduction_false,environment_development,infrastructuresupport_platforms"
   probefilters             = "region:EU"
-  integrationids           = ["C015JL16L8Z"]
+  integrationids           = [132557]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mikebell-test/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mikebell-test/resources/pingdom.tf
@@ -6,7 +6,7 @@ resource "pingdom_check" "mikebell-test-check" {
   type                     = "http"
   name                     = "mikebell-test"
   host                     = "mikebell-test.apps.live.cloud-platform.service.justice.gov.uk"
-  resolution               = 5
+  resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
@@ -15,5 +15,6 @@ resource "pingdom_check" "mikebell-test-check" {
   port                     = 443
   tags                     = "businessunit_platforms,application_mikebell_test,component_healthcheck,isproduction_false,environment_development,infrastructuresupport_platforms"
   probefilters             = "region:EU"
+  integrationids           = ["C015JL16L8Z"]
 }
 


### PR DESCRIPTION
Adds the `#cloud-platform-test` channel to the pingdom alert.