### PR TITLE
Add lifecycle rule to laa-cla-backend-uat S3 Bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
@@ -14,6 +14,20 @@ module "cla_backend_private_reports_bucket" {
     aws = aws.london
   }
 
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "Remove reports after 2 years"
+      prefix  = "exports/"
+
+      expiration = [
+        {
+          days = 730
+        },
+      ]
+    }
+  ]
+
 }
 
 module "cla_backend_deleted_objects_bucket" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/s3.tf
@@ -25,6 +25,12 @@ module "cla_backend_private_reports_bucket" {
           days = 730
         },
       ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 730
+        },
+      ]
     }
   ]
 


### PR DESCRIPTION
Adds a lifecycle rule to the `laa-cla-backend-uat` S3 Bucket to expire entries that are over 2 years old.