### PR TITLE
Increase the autoscale_max_read_capacity to fix ProvisionedThroughputExceededException

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/dynamodb.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/dynamodb.tf
@@ -14,7 +14,7 @@ module "cloud_platform_reports_dynamodb" {
   enable_autoscaler = "true"
 
   # autoscaling maximums
-  autoscale_max_read_capacity = 50
+  autoscale_max_read_capacity = 100
 }
 
 resource "kubernetes_secret" "cloud_platform_reports_dynamodb" {


### PR DESCRIPTION
Fixes: HOODAW app flapping with errror ```2023-11-08 15:08:17 - Aws::DynamoDB::Errors::ProvisionedThroughputExceededException - The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.:```