### PR TITLE
MAP-323: Set ownership correctly for UoF

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/00-namespace.yaml
@@ -9,8 +9,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "use-of-force"
-    cloud-platform.justice.gov.uk/owner: "Digital Prison Services: dps-hmpps@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "moveaprisoner@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/use-of-force.git"
-    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
-    cloud-platform.justice.gov.uk/slack-channel: "dps_shared"
-    cloud-platform.justice.gov.uk/team-name: "dps-shared"
+    cloud-platform.justice.gov.uk/slack-channel: "move-a-prisoner-digital"
+    cloud-platform.justice.gov.uk/team-name: "Move a Prisoner"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/variables.tf
@@ -38,6 +38,11 @@ variable "is_production" {
   default = "false"
 }
 
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "move-a-prisoner-digital"
+}
+
 variable "number_cache_clusters" {
   default = "2"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/00-namespace.yaml
@@ -9,8 +9,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "use-of-force"
-    cloud-platform.justice.gov.uk/owner: "Digital Prison Services: dps-hmpps@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "moveaprisoner@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/use-of-force.git"
-    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
-    cloud-platform.justice.gov.uk/slack-channel: "dps_shared"
-    cloud-platform.justice.gov.uk/team-name: "dps-shared"
+    cloud-platform.justice.gov.uk/slack-channel: "move-a-prisoner-digital"
+    cloud-platform.justice.gov.uk/team-name: "Move a Prisoner"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/variables.tf
@@ -21,7 +21,7 @@ variable "business_unit" {
 
 variable "team_name" {
   description = "The name of your development team"
-  default     = "Digital Prison Services/New Nomis"
+  default     = "Move a Prisoner"
 }
 
 variable "environment-name" {
@@ -36,6 +36,11 @@ variable "infrastructure_support" {
 
 variable "is_production" {
   default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "move-a-prisoner-digital"
 }
 
 variable "number_cache_clusters" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/00-namespace.yaml
@@ -9,8 +9,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/application: "use-of-force"
-    cloud-platform.justice.gov.uk/owner: "Digital Prison Services: dps-hmpps@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "moveaprisoner@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/use-of-force.git"
-    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts"
-    cloud-platform.justice.gov.uk/slack-channel: "dps_shared"
-    cloud-platform.justice.gov.uk/team-name: "dps-shared"
+    cloud-platform.justice.gov.uk/slack-channel: "move-a-prisoner-digital"
+    cloud-platform.justice.gov.uk/team-name: "Move a Prisoner"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/variables.tf
@@ -42,6 +42,11 @@ variable "is_production" {
   default = "true"
 }
 
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "move-a-prisoner-digital"
+}
+
 variable "number_cache_clusters" {
   default = "3"
 }


### PR DESCRIPTION
The dps-shared Slack channel is no more. I have updated UoF so that it has the correct ownership details and slack channel.