### PR TITLE
Add route53 for help-with-child-arrangements-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/route53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = "helpwithchildarrangements.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
+  }
+}


### PR DESCRIPTION
The route53 config for this zone currently exists in a different namespace - https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/fj-cait-production/resources/route53.tf

This namespace is no longer required as the application has been replatformed, so the route53 config needs to be moved.