### PR TITLE
MAP-323: Set ownership correctly for BVL dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/00-namespace.yaml
@@ -8,9 +8,8 @@ metadata:
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
-    cloud-platform.justice.gov.uk/slack-channel: "dps-shared"
-    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
+    cloud-platform.justice.gov.uk/slack-channel: "move-a-prisoner-digital"
     cloud-platform.justice.gov.uk/application: "HMPPS Book video link"
-    cloud-platform.justice.gov.uk/owner: "DPS Shared: dps-hmpps@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "moveaprisoner@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-book-video-link.git"
-    cloud-platform.justice.gov.uk/team-name: "dps-shared"
+    cloud-platform.justice.gov.uk/team-name: "Move a Prisoner"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/variables.tf
@@ -20,7 +20,7 @@ variable "business_unit" {
 
 variable "team_name" {
   description = "The name of your development team"
-  default     = "dps-shared"
+  default     = "Move a Prisoner"
 }
 
 variable "environment-name" {
@@ -39,7 +39,7 @@ variable "is_production" {
 
 variable "slack_channel" {
   description = "Team slack channel to use if we need to contact your team"
-  default     = "dps-shared"
+  default     = "move-a-prisoner-digital"
 }
 
 variable "number_cache_clusters" {


### PR DESCRIPTION
The dps-shared Slack channel is no more. I have updated BVL dev so that it has the correct ownership details and slack channel.