### PR TITLE
Add Lifecycle Rule to S3 Bucket of laa-cla-backend-training

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/s3.tf
@@ -14,6 +14,26 @@ module "cla_backend_private_reports_bucket" {
     aws = aws.london
   }
 
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "Remove reports after 2 years"
+      prefix  = "exports/"
+
+      expiration = [
+        {
+          days = 730
+        },
+      ]
+
+      noncurrent_version_expiration = [
+        {
+          days = 730
+        },
+      ]
+    }
+  ]
+
 }
 
 module "cla_backend_deleted_objects_bucket" {


### PR DESCRIPTION
Adds lifecycle rule to the S3 Bucket, removing any extract reports created over 2 years ago.