### PR TITLE
[CRIMAP-63] Add s3 to laa-criminal-applications-datastore-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/s3.tf
@@ -1,0 +1,27 @@
+module "s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.1.0"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "s3_bucket" {
+  metadata {
+    name      = "s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.s3_bucket.bucket_arn
+    bucket_name = module.s3_bucket.bucket_name
+  }
+}


### PR DESCRIPTION
Adds S3 bucket for production use.

Replicates staging.

Ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-66