### PR TITLE
[DPR2-44] RDS 'major' version upgrade fix

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -17,14 +17,14 @@ module "rds" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = false
+  allow_major_version_upgrade  = true
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   enable_rds_auto_start_stop   = true
 
   # PostgreSQL specifics
   db_engine              = "postgres"
-  db_engine_version      = "14.10"
+  db_engine_version      = "14.9"
   rds_family             = "postgres14"
   db_instance_class      = "db.t4g.micro"
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]


### PR DESCRIPTION
Fixes:
- AWS considers 14.7 -> 14.10 to be a major version upgrade.
- 14.10 isn't supported yet.