### PR TITLE
🚑 Add `ingressTemplate` to Data Platform's HTTP01 resolver

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/07-issuer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/07-issuer.yaml
@@ -19,7 +19,6 @@ spec:
                 # Considerations: We are hardcoding the template name to be "cm-acme-http-solver" to comply with GateKeeper
                 # however, this might cause a clash if we're processing multiple cert-manager HTTP01 challenges at the same time
                 # a solution to this is maybe Cloud Platform exlude our namespace from GateKeeper for `k8sexternaldnsweight`
-                name: cm-acme-http-solver
                 annotations:
                   external-dns.alpha.kubernetes.io/set-identifier: cm-acme-http-solver-data-platform-production-green
                   external-dns.alpha.kubernetes.io/aws-weight: "100"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/07-issuer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/07-issuer.yaml
@@ -14,3 +14,12 @@ spec:
       - http01:
           ingress:
             ingressClassName: default
+            ingressTemplate:
+              metadata:
+                # Considerations: We are hardcoding the template name to be "cm-acme-http-solver" to comply with GateKeeper
+                # however, this might cause a clash if we're processing multiple cert-manager HTTP01 challenges at the same time
+                # a solution to this is maybe Cloud Platform exlude our namespace from GateKeeper for `k8sexternaldnsweight`
+                name: cm-acme-http-solver
+                annotations:
+                  external-dns.alpha.kubernetes.io/set-identifier: cm-acme-http-solver-data-platform-production-green
+                  external-dns.alpha.kubernetes.io/aws-weight: "100"


### PR DESCRIPTION
Trying to consume our HTTP01 resolver failed, we aren't seeing certificates created, due to

```
Warning   PresentError         challenge/assets-tls-1-3027398620-3333557501   Error presenting challenge: admission webhook "validation.gatekeeper.sh" denied the request: [k8sexternaldnsweight] ...
```
and 
```
$ kubectl --namespace data-platform-production get challenges.acme.cert-manager.io assets-tls-1-3027398620-3333557501 --output yaml
...
status:
  presented: false
  processing: true
  reason: "admission webhook \"validation.gatekeeper.sh\" denied the request: [k8sexternaldnsweight]
    \nPlease add valid AWS weight annotation e.g. external-dns.alpha.kubernetes.io/aws-weight:
    '100'\n[k8sexternaldnsidentifier] \nPlease add valid external-dns set-identifier
    annotation for ingress data-platform-production/cm-acme-http-solver-c2mrj, remember:
    <ingress-name>-<ns>-${clusterColor}"
  state: pending
```
