### PR TITLE
:sparkles: Add GitHub actions local runners controller

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/github-actions-controller.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/github-actions-controller.tf
@@ -1,6 +1,6 @@
 resource "helm_release" "actions_scale_set_controller" {
   name       = "actions-runner-controller"
-  repository = "https://ghcr.io/actions/actions-runner-controller-charts"
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts"
   chart      = "gha-runner-scale-set-controller"
   namespace  = "operations-engineering-github-runners-poc"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/github-actions-controller.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/github-actions-controller.tf
@@ -1,0 +1,11 @@
+resource "helm_release" "actions_scale_set_controller" {
+  name       = "actions-runner-controller"
+  repository = "https://actions-runner-controller.github.io/actions-runner-controller"
+  chart      = "gha-runner-scale-set-controller"
+  namespace  = "operations-engineering-github-runners-poc"
+
+  set {
+    name  = "image.tag"
+    value = "0.7.0"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/github-actions-controller.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/github-actions-controller.tf
@@ -1,6 +1,6 @@
 resource "helm_release" "actions_scale_set_controller" {
   name       = "actions-runner-controller"
-  repository = "https://actions-runner-controller.github.io/actions-runner-controller"
+  repository = "https://ghcr.io/actions/actions-runner-controller-charts"
   chart      = "gha-runner-scale-set-controller"
   namespace  = "operations-engineering-github-runners-poc"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/main.tf
@@ -44,3 +44,4 @@ provider "github" {
 }
 
 provider "kubernetes" {}
+provider "helm" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.11.0"
+    }
   }
 }


### PR DESCRIPTION
Why:
This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/3759, please see here for the user story associated.

What:
This PR introduces the GitHub Actions Runner Controller using Helm. The addition is intended to enhance our CI/CD pipeline capabilities by enabling the use of self-hosted runners for GitHub Actions.

Key Points:
- The Helm chart is sourced from the official actions-runner-controller repository.
- The instructions set out [here](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/quickstart-for-actions-runner-controller) outline required resources deploy the controller on our behalf. 
- Operations Engineering would maintain the controller, but we need don't have the ability to Install the required clusterroles and clusterrolebindings.

Value:
The Ministry of Justice are allocated a hard limit of 50 hours per month for private repositories. By merging this PR we should be able to create ephemeral local runners inside of Cloud Platform.

Please review the changes and provide any feedback or necessary adjustments. Your insights are greatly valued to ensure a smooth and secure integration.
