### PR TITLE
APIGW key IDs as K8s secrets and proxy to backend

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -115,7 +115,8 @@ resource "aws_api_gateway_integration" "proxy_http_proxy" {
   uri                     = "${var.cloud_platform_integration_api_url}/{proxy}"
 
   request_parameters = {
-    "integration.request.path.proxy" = "method.request.path.proxy"
+    "integration.request.path.proxy" = "method.request.path.proxy",
+    "integration.request.header.api-key-id" = "context.identity.apiKeyId"
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
@@ -48,7 +48,11 @@ resource "kubernetes_secret" "consumer_api_keys" {
   }
 
   data = {
-    for client in local.clients : client => aws_api_gateway_api_key.clients[client].value
+    for client in local.clients :
+      client => jsonencode({
+        "key" = aws_api_gateway_api_key.clients[client].value,
+        "id" = aws_api_gateway_api_key.clients[client].id
+      })
   }
 }
 


### PR DESCRIPTION
These API key IDs will be used to distinguish between consumers of our API and to authorise endpoints.