### PR TITLE
:closed_lock_with_key: Add github-runner role and rolebinding

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/01-rbac.yaml
@@ -1,3 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gha-runner-scale-set-controller
+  namespace: operations-engineering-github-runners-poc
+rules:
+  - apiGroups: ["actions.github.com"]
+    resources:
+      [
+        "autoscalingrunnersets",
+        "autoscalingrunnersets/finalizers",
+        "autoscalingrunnersets/status",
+        "ephemeralrunnersets",
+        "ephemeralrunnersets/status",
+        "ephemeralrunnersets/finalizers",
+        "ephemeralrunners",
+        "ephemeralrunners/finalizers",
+        "ephemeralrunners/status",
+        "autoscalinglisteners",
+      ]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -10,4 +33,19 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: operations-engineering-github-runners-poc
+  namespace: operations-engineering-github-runners-poc
+subjects:
+  - kind: Group
+    name: "github:operations-engineering"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: gha-runner-scale-set-controller
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This change will allow Operations Engineering staff to make changes to the github runner controller customer resources.
