### PR TITLE
:wrench: Add a github action scaleset

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/github-actions-controller.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-github-runners-poc/resources/github-actions-controller.tf
@@ -9,3 +9,21 @@ resource "helm_release" "actions_scale_set_controller" {
     value = "0.7.0"
   }
 }
+
+
+resource "helm_release" "operations_engineering_runners" {
+  name       = "operations-engineering-private-runners"
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart      = "gha-runner-scale-set"
+  namespace  = "operations-engineering-github-runners-poc"
+
+  set {
+    name  = "githubConfigUrl"
+    value = "https://github.com/ministryofjustice"
+  }
+
+  set {
+    name  = "githubConfigSecret"
+    value = "poc-classic-token"
+  }
+}


### PR DESCRIPTION
This commit connects to https://github.com/ministryofjustice/operations-engineering/issues/3759 and relates to the requirement to self-host GitHub actions local runners on the Cloud Platform.
