### PR TITLE
CCQ PROD add route53

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/route53.tf
@@ -1,0 +1,50 @@
+resource "aws_route53_zone" "eligibility_team_route53_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.github_owner
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "eligibility_team_route53_zone" {
+  metadata {
+    name      = "eligibility-team-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id   = aws_route53_zone.eligibility_team_route53_zone.zone_id
+    nameservers = join(", ", aws_route53_zone.eligibility_team_route53_zone.name_servers)
+  }
+}
+
+resource "aws_route53_record" "eligibility_team_route53_txt_spf_record_2" {
+  zone_id = aws_route53_zone.eligibility_team_route53_zone.zone_id
+  name    = "check-your-client-qualifies-for-legal-aid.service.gov.uk"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 -all"]
+}
+
+resource "aws_route53_record" "eligibility_team_route53_txt_dmarc_record" {
+  zone_id = aws_route53_zone.eligibility_team_route53_zone.zone_id
+  name    = "_dmarc"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:eligibility@justice.gov.uk"]
+}
+
+resource "aws_route53_record" "eligibility_team_route53_txt_dkim_record" {
+  zone_id = aws_route53_zone.eligibility_team_route53_zone.zone_id
+  name    = "*._domainkey"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DKIM1; p="]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/variables.tf
@@ -58,3 +58,7 @@ variable "github_token" {
 variable "eks_cluster_name" {
   description = "The name of the eks cluster to retrieve the OIDC information"
 }
+
+variable "domain" {
+  default = "check-your-client-qualifies-for-legal-aid.service.gov.uk"
+}


### PR DESCRIPTION
The CCQ service has recently transferred to a new namespace `laa-check-client-qualifies-production`

This PR recreates the route53 hosted zone that is being deleted from the old namespace

There is a [linked PR ](https://github.com/ministryofjustice/cloud-platform-environments/pull/17850)that removes the associated route53 hosted zone from the old namespace `laa-estimate-financial-eligibility-for-legal-aid-production`

There is a support ticket for Cloud Platform Team to transfer the Hosted Zone 'state'
https://github.com/ministryofjustice/cloud-platform/issues/5036