### PR TITLE
setting rds postgresql work_mem back to 4Mb for testing

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/rds-aurora.tf
@@ -42,7 +42,7 @@ resource "aws_db_parameter_group" "default" {
   }
   parameter {
     name  = "work_mem"
-    value = 131072
+    value = 4096
   }
 }
 


### PR DESCRIPTION
Setting work_mem to 4MB, to carry out some testing of its effectiveness