### PR TITLE
Add new service accounts using terraform module to formbuilder-saas-test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
@@ -1,0 +1,32 @@
+locals {
+  sa_name = "circleci-formbuilder-saas-test"
+}
+
+resource "kubernetes_service_account" "circleci_formbuilder_saas_test_service_account" {
+  metadata {
+    name      = local.sa_name
+    namespace = var.namespace
+  }
+
+  secret {
+    name = "${local.sa_name}-token"
+  }
+
+  automount_service_account_token = true
+}
+
+resource "kubernetes_secret_v1" "circleci_formbuilder_saas_test_service_account_token" {
+  metadata {
+    name      = "circleci_formbuilder_saas_test_service_account_token"
+    namespace = var.namespace
+    annotations = {
+      "kubernetes.io/service-account.name" = local.sa_name
+    }
+  }
+
+  type = "kubernetes.io/service-account-token"
+
+  depends_on = [
+    kubernetes_service_account.circleci_formbuilder_saas_test_service_account
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/fb-av-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/fb-av-service-account.tf
@@ -1,0 +1,32 @@
+locals {
+  sa_name = "formbuilder-av-saas-test"
+}
+
+resource "kubernetes_service_account" "formbuilder_av_saas_test_service_account" {
+  metadata {
+    name      = local.sa_name
+    namespace = var.namespace
+  }
+
+  secret {
+    name = "${local.sa_name}-token"
+  }
+
+  automount_service_account_token = true
+}
+
+resource "kubernetes_secret_v1" "formbuilder_av_saas_test_service_token" {
+  metadata {
+    name      = "formbuilder_av_saas_test_service_token"
+    namespace = var.namespace
+    annotations = {
+      "kubernetes.io/service-account.name" = local.sa_name
+    }
+  }
+
+  type = "kubernetes.io/service-account-token"
+
+  depends_on = [
+    kubernetes_service_account.formbuilder_av_saas_test_service_account
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
@@ -30,3 +30,37 @@ resource "kubernetes_secret" "metadata-api-rds-instance" {
     url = "postgres://${module.metadata-api-rds-instance.database_username}:${module.metadata-api-rds-instance.database_password}@${module.metadata-api-rds-instance.rds_instance_endpoint}/${module.metadata-api-rds-instance.database_name}"
   }
 }
+
+locals {
+  sa_name = "formbuilder-metadata-api-test"
+}
+
+
+resource "kubernetes_service_account" "metadata_api_service_account" {
+  metadata {
+    name      = local.sa_name
+    namespace = var.namespace
+  }
+
+  secret {
+    name = "${local.sa_name}-token"
+  }
+
+  automount_service_account_token = true
+}
+
+resource "kubernetes_secret_v1" "metadata_api_service_account_token" {
+  metadata {
+    name      = "metadata_api_service_account_token"
+    namespace = var.namespace
+    annotations = {
+      "kubernetes.io/service-account.name" = local.sa_name
+    }
+  }
+
+  type = "kubernetes.io/service-account-token"
+
+  depends_on = [
+    kubernetes_service_account.metadata_api_service_account
+  ]
+}


### PR DESCRIPTION
We're migrating our service accounts from the old yaml style because they no longer auto generate a token.

We have already migrated the service accounts we needed to use short lived IAM tokens, these should only be used for circle ci deployments.