### PR TITLE
MAP-16: Use separate certs for CSC UI and API (prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/06-certificate.yaml
@@ -11,4 +11,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - cell-allocation-api.prison.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-change-someones-cell-cert
+  namespace: hmpps-prisoner-cell-allocation-prod
+spec:
+  secretName: hmpps-change-someones-cell-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
     - change-someones-cell.prison.service.justice.gov.uk


### PR DESCRIPTION
Use separate certs for CSC UI and API (preprod)