### PR TITLE
chore: Allow CircleCI access to CSC service monitors

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-dev/05-serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-dev/05-serviceaccount-circleci.yaml
@@ -31,6 +31,7 @@ rules:
       - "monitoring.coreos.com"
     resources:
       - "prometheusrules"
+      - "servicemonitors"
     verbs:
       - "*"
 


### PR DESCRIPTION
Allow CircleCI access to CSC service monitors

[MAP-10]

[MAP-10]: https://dsdmoj.atlassian.net/browse/MAP-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ