### PR TITLE
Correct CAS API health_check endpoint

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
@@ -42,7 +42,7 @@ resource "pingdom_check" "hmpps-approved-premises-api" {
   sendnotificationwhendown = 6
   integrationids           = [130656, 130657]
   notifyagainevery         = 0
-  url                      = "/https/approved-premises-api.hmpps.service.justice.gov.uk/health_check"
+  url                      = "/https/approved-premises-api.hmpps.service.justice.gov.uk/health"
   encryption               = true
   port                     = 443
   tags                     = "businessunit_hmpps,application_approved-premises-api,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"


### PR DESCRIPTION
This seems to have been originally misconfigured and was only surfaced when this fix to the health kick service[1] was made. It appears like a 200 was returned to by health-kick even though the path didn't resolve in a healthy response.

You can test out that this path resolves by visiting the api in dev (which is more easily accessible when on an MoJ device): https://health-kick.prison.service.justice.gov.uk/https/approved-premises-api-dev.hmpps.service.justice.gov.uk/health

[1]  https://github.com/ministryofjustice/health-kick/pull/58