### PR TITLE
Send mTLS subject distinguished name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -116,7 +116,7 @@ resource "aws_api_gateway_integration" "proxy_http_proxy" {
 
   request_parameters = {
     "integration.request.path.proxy" = "method.request.path.proxy",
-    "integration.request.header.api-key-id" = "context.identity.apiKeyId"
+    "integration.request.header.subject-distinguished-name" = "context.identity.clientCert.subjectDN"
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/kubernetes_secrets.tf
@@ -49,10 +49,7 @@ resource "kubernetes_secret" "consumer_api_keys" {
 
   data = {
     for client in local.clients :
-      client => jsonencode({
-        "key" = aws_api_gateway_api_key.clients[client].value,
-        "id" = aws_api_gateway_api_key.clients[client].id
-      })
+      client => aws_api_gateway_api_key.clients[client].value
   }
 }
 


### PR DESCRIPTION
We will use the distinguished name from the client certificate to implement authorisation instead of API key IDs.

This is more flexible as we don't need to keep an internal mapping between key IDs and endpoints.