### PR TITLE
Civil Apply UAT: Update circle ci service account permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/serviceaccount-circleci.yaml
@@ -22,6 +22,7 @@ rules:
       - "serviceaccounts"
       - "pods"
       - "HorizontalPodAutoscaler"
+      - "persistentvolumeclaims"
     verbs:
       - "patch"
       - "get"


### PR DESCRIPTION
Include persistentvolumeclaims so that circle can delete UAT pvcs when a branch is torn down