### PR TITLE
[laa-apply-for-legalaid-uat] Enable deletion of persistent volume claims

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/variables.tf
@@ -80,6 +80,7 @@ variable "serviceaccount_rules" {
         "HorizontalPodAutoscaler",
         "configmaps",
         "serviceaccounts",
+        "persistentvolumeclaims",
       ]
       verbs = [
         "patch",


### PR DESCRIPTION
Enable deletion of persistent volume claims

We use postgres and redis helm charts with associated
PVCs. They need to be deleted when the UAT branch's
deployment is "uninstalled" on close and merge of
branches.
