### PR TITLE
[legal-framework-api-uat] Add persistentvolumeclaims privilege

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/variables.tf
@@ -80,6 +80,7 @@ variable "serviceaccount_rules" {
         "services",
         "pods",
         "HorizontalPodAutoscaler",
+        "persistentvolumeclaims",
       ]
       verbs = [
         "patch",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/serviceaccount-circleci.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/serviceaccount-circleci.yaml
@@ -19,6 +19,7 @@ rules:
       - "secrets"
       - "services"
       - "pods"
+      - "persistentvolumeclaims"
     verbs:
       - "patch"
       - "get"


### PR DESCRIPTION
Add privileges for persistentvolumeclaims so that github actions and circleci can delete UAT pvcs when a branch is torn down