### PR TITLE
AD-399 Update Decide Backend UAT Namespace 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-civil-legal-aid-backend-uat/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-civil-legal-aid-backend-uat/00-namespace.yaml
@@ -11,6 +11,6 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "laa-civil-decide"
     cloud-platform.justice.gov.uk/application: "API that allows creating and editing of civil legal aid decisions"
     cloud-platform.justice.gov.uk/owner: "Civil Decide: decide@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-decide-civil-legal-aid-backend.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-decide-civil-legal-aid-backend"
     cloud-platform.justice.gov.uk/team-name: "laa-decide"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-civil-legal-aid-backend-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-civil-legal-aid-backend-uat/resources/ecr.tf
@@ -15,7 +15,7 @@ module "ecr" {
   github_repositories = ["laa-decide-civil-legal-aid-backend"]
 
  # GitHub environments, to create variables as actions variables in your environments
-  github_environments = ["uat"]
+  # github_environments = ["uat"]
 
   # set this if you use one GitHub repository to push to multiple container repositories
   # this ensures the variable key used in the workflow is unique

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-civil-legal-aid-backend-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-civil-legal-aid-backend-uat/resources/serviceaccount.tf
@@ -8,5 +8,5 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  # github_repositories = ["laa-decide-civil-legal-aid-backend"]
+  github_repositories = ["laa-decide-civil-legal-aid-backend"]
 }


### PR DESCRIPTION
remove environment from ecr as does not yet exist in laa-decide-civil-legal-aid-backend