### PR TITLE
VB-1874/2 rename grafana dashboards (All visits namespaces)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/07-grafandashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/07-grafandashboard.yaml
@@ -2021,7 +2021,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "help-with-prison-visits-dev",
+      "title": "Visits - HWPV - Dev",
       "uid": "d164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/07-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/07-grafanadashboard.yaml
@@ -2021,7 +2021,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "help-with-prison-visits-preprod",
+      "title": "Visits - HWPV - PreProd",
       "uid": "e164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/07-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/07-grafanadashboard.yaml
@@ -2021,7 +2021,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "help-with-prison-visits-prod",
+      "title": "Visits - HWPV - Prod",
       "uid": "s164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/07-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/07-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "prison-visits-booking-dev",
+      "title": "Visits - PVB - Dev",
       "uid": "f164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/05-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/05-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "prison-visits-booking-production",
+      "title": "Visits - PVB - Prod",
       "uid": "g164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/05-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/05-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "prison-visits-booking-staging",
+      "title": "Visits - PVB - PreProd (staging)",
       "uid": "h164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/07-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/07-grafanadashboard.yaml
@@ -2021,7 +2021,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "send-legal-mail-to-prisons-dev",
+      "title": "Visits - SLM - Dev",
       "uid": "i164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/07-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/07-grafanadashboard.yaml
@@ -2021,7 +2021,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "send-legal-mail-to-prisons-preprod",
+      "title": "Visits - SLM - PreProd",
       "uid": "j164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/07-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/07-grafanadashboard.yaml
@@ -2021,7 +2021,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "send-legal-mail-to-prisons-prod",
+      "title": "Visits - SLM - Prod",
       "uid": "k164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/10-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/10-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "visit-someone-in-prison-backend-svc-dev",
+      "title": "Visits - VSIP Backend - Dev",
       "uid": "c164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/10-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/10-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "visit-someone-in-prison-backend-svc-preprod",
+      "title": "Visits - VSIP Backend - PreProd",
       "uid": "l164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/09-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/09-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "visit-someone-in-prison-backend-svc-prod",
+      "title": "Visits - VSIP Backend - Prod",
       "uid": "m164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/10-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/10-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "visit-someone-in-prison-backend-svc-staging",
+      "title": "Visits - VSIP Backend - Staging",
       "uid": "n164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/09-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/09-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "visit-someone-in-prison-frontend-svc-dev",
+      "title": "Visits - VSIP Frontend - Dev",
       "uid": "o164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/09-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/09-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "visit-someone-in-prison-frontend-svc-preprod",
+      "title": "Visits - VSIP Frontend - PreProd",
       "uid": "p164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/09-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/09-grafanadashboard.yaml
@@ -2028,7 +2028,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "visit-someone-in-prison-frontend-svc-prod",
+      "title": "Visits - VSIP Frontend - Prod",
       "uid": "q164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/09-grafanadashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/09-grafanadashboard.yaml
@@ -2020,7 +2020,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "visit-someone-in-prison-frontend-svc-staging",
+      "title": "Visits - VSIP Frontend - Staging",
       "uid": "r164a7f0339f99e89cea5cb47e9be617",
       "version": 1,
       "weekStart": ""


### PR DESCRIPTION
## Description
Update all Grafana dashboard titles in the visits namespaces 

Uses the 'Visits' prefix followed by our 'known by' abbreviation and environment