### PR TITLE
Changing team responsible for sentence plan dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/00-namespace.yaml
@@ -8,8 +8,8 @@ metadata:
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
-    cloud-platform.justice.gov.uk/slack-channel: "probation-integration-team"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps-sentence-plan-notifications"
     cloud-platform.justice.gov.uk/application: "Sentence Plan"
-    cloud-platform.justice.gov.uk/owner: "probation-integration: probation-integration-team@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/team-name: "probation-integration"
+    cloud-platform.justice.gov.uk/owner: "hmpps-sentence-planning: sentence-plan-team@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-sentence-planning"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-sentence-plan,https://github.com/ministryofjustice/hmpps-sentence-plan-ui"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-sentence-plan-dev
 subjects:
   - kind: Group
-    name: "github:probation-integration"
+    name: "github:hmpps-sentence-planning"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:dps-tech" # for credentials rotation

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/variables.tf
@@ -29,7 +29,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "probation-integration"
+  default     = "hmpps-sentence-planning"
 }
 
 variable "environment" {
@@ -41,7 +41,7 @@ variable "environment" {
 variable "infrastructure_support" {
   description = "Email address of the team responsible this service"
   type        = string
-  default     = "probation-integration-team@digital.justice.gov.uk"
+  default     = "sentence-plan-team@digital.justice.gov.uk"
 }
 
 variable "is_production" {


### PR DESCRIPTION
The sentence plan repos and namespace have been handed over from probabtion-integration to the hmpps-sentence-planning team