### PR TITLE
Add new production dns in preparation for migration of casetracker.ju…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: casetracker-justice-app-cert
+  namespace: civil-appeal-case-tracker-prod
+spec:
+  secretName: casetracker-justice-app-secret
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+      - casetracker.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/route53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_zone" "casetracker_route53_zone" {
+  name = "casetracker.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "casetracker_route53_zone_sec" {
+  metadata {
+    name      = "casetracker-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.casetracker_route53_zone.zone_id
+  }
+}


### PR DESCRIPTION
Add new production dns in preparation for migration of casetracker.justice.gov.uk from tacticalproducts AWS account to CP