### PR TITLE
LEP-429 Give Eligibility Platform team access CLA UAT environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:laa-get-access"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:laa-eligibility-platform"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
This is temporary, for the purpose of developing the integration of CLA with Eligibility Platform