### PR TITLE
Move circleci service account to use the sa module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
@@ -2,31 +2,14 @@ locals {
   circleci_sa_name = "circleci-terraform-formbuilder-saas-test"
 }
 
-resource "kubernetes_service_account" "circleci_formbuilder_saas_test_service_account" {
-  metadata {
-    name      = local.circleci_sa_name
-    namespace = var.namespace
-  }
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
-  secret {
-    name = "${local.circleci_sa_name}-token"
-  }
+  namespace           = var.namespace
+  kubernetes_cluster  = var.kubernetes_cluster
+  serviceaccount_name = locals.circleci_sa_name
 
-  automount_service_account_token = true
-}
-
-resource "kubernetes_secret_v1" "circleci_formbuilder_saas_test_service_account_token" {
-  metadata {
-    name      = "${local.circleci_sa_name}-token"
-    namespace = var.namespace
-    annotations = {
-      "kubernetes.io/service-account.name" = local.circleci_sa_name
-    }
-  }
-
-  type = "kubernetes.io/service-account-token"
-
-  depends_on = [
-    kubernetes_service_account.circleci_formbuilder_saas_test_service_account
-  ]
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["fb-editor", "fb-metadata-api", "fb-av"]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
@@ -1,13 +1,9 @@
-locals {
-  circleci_sa_name = "circleci-terraform-formbuilder-saas-test"
-}
-
 module "serviceaccount" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
-  serviceaccount_name = locals.circleci_sa_name
+  serviceaccount_name = "circleci-terraform-formbuilder-saas-test"
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/variables.tf
@@ -44,3 +44,8 @@ variable "github_token" {
 }
 
 variable "eks_cluster_name" {}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}


### PR DESCRIPTION
We're migrating from old yaml service accounts used by circleci to deploy, trying to add a new service account alongside the old one using the module so I can verify the token it generates will work with our pipelines.

Note: The resource service account I am replacing is not the service account currently in use, it was another experiment! The currently-used service account is untouched in this PR.