### PR TITLE
Replicate the DNS r53 records for production CaseTracker as currently…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/route53.tf
@@ -12,6 +12,27 @@ resource "aws_route53_zone" "casetracker_route53_zone" {
   }
 }
 
+resource "aws_route53_record" "aws_route53_record_prod_1" {
+  name    = "casetracker.justice.gov.uk."
+  zone_id = aws_route53_zone.casetracker_route53_zone.zone_id
+  type    = "A"
+  alias {
+    zone_id                = "ZHURV8PSTC4K8"
+    name                   = "dualstack.civil-loadb-qvbu457dp1b-1835055660.eu-west-2.elb.amazonaws.com."
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "aws_route53_record_cname_1" {
+  name    = "_490401529e094a46111033e0656c3ee9.casetracker.justice.gov.uk."
+  zone_id = aws_route53_zone.casetracker_route53_zone.zone_id
+  type    = "CNAME"
+  ttl     = 60
+  records = [
+    "_aacbc806a088e7cdff9935f0c9958e9e.auiqqraehs.acm-validations.aws."
+  ]
+}
+
 resource "kubernetes_secret" "casetracker_route53_zone_sec" {
   metadata {
     name      = "casetracker-route53-zone-output"


### PR DESCRIPTION
… in DSD AWS account. This will create the new NS records inside Cloud Platform