### PR TITLE
Add permissions to new service account module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
@@ -8,4 +8,71 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["fb-editor", "fb-metadata-api", "fb-av"]
+
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods"
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch"
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "monitoring.coreos.com",
+        "networking.k8s.io"
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "statefulsets",
+        "poddisruptionbudgets",
+        "networkpolicies",
+        "servicemonitors"
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch"
+      ]
+    },
+    {
+      api_groups = [
+        "autoscaling"
+      ]
+      resources = [
+        "hpa",
+        "horizontalpodautoscalers"
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Using the [existing service account](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/05-circleci-service-account.yaml) as s guide for what permissions need to be added 