### PR TITLE
Need access to modify cronjobs, but missed batch from the api group list

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
@@ -35,7 +35,8 @@ module "serviceaccount" {
         "extensions",
         "apps",
         "monitoring.coreos.com",
-        "networking.k8s.io"
+        "networking.k8s.io",
+        "batch"
       ]
       resources = [
         "deployments",


### PR DESCRIPTION
The token needs to create cronjobs, but had forgot batch from the api group list, even though cronjob resources were already listed.