### PR TITLE
Set throttle request limit on API GW Preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/api_gateway.tf
@@ -153,6 +153,10 @@ resource "aws_api_gateway_usage_plan" "default" {
     api_id = aws_api_gateway_rest_api.api_gateway.id
     stage  = aws_api_gateway_stage.main.stage_name
   }
+
+  throttle_settings {
+    rate_limit = 5
+  }
 }
 
 resource "aws_api_gateway_usage_plan_key" "clients" {


### PR DESCRIPTION
Additional safety mechanism to allow a maximum of 5 requests per second on API Gateway. This will be more than enough for our expected load.

Should prevent accidental DOS from one of our consumers from a runaway script (worst case scenario that hopefully never happens).