### PR TITLE
Increase throttling limit on API Gateway in Dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -156,7 +156,8 @@ resource "aws_api_gateway_usage_plan" "default" {
   }
 
   throttle_settings {
-    rate_limit = 5
+    burst_limit = 50
+    rate_limit  = 100
   }
 }
 


### PR DESCRIPTION
Currently seeing 429 Too many requests errors from very few requests. It doesn't seem that "rate_limit" is restricting requests per second as suggested by the AWS documentation.

Increase this limit and add burst_limit for concurrent requests. Future performance testing may force us to revisit this figure.