### PR TITLE
Remove throttling settings from API Gateway in Dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -154,11 +154,6 @@ resource "aws_api_gateway_usage_plan" "default" {
     api_id = aws_api_gateway_rest_api.api_gateway.id
     stage  = aws_api_gateway_stage.main.stage_name
   }
-
-  throttle_settings {
-    burst_limit = 50
-    rate_limit  = 100
-  }
 }
 
 resource "aws_api_gateway_usage_plan_key" "clients" {


### PR DESCRIPTION
There is AWS Shield for any major DDOS attacks.
Second level of defense will happen at the NGINX level. The throttle settings at API Gateway level are "best effort" and didn't work quite as expected when testing requests per second.