### PR TITLE
SAA-1431 increase available memory to the activites production PODs to help the PODs from running out of memory.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/02-limitrange.yaml
@@ -8,8 +8,8 @@ spec:
   limits:
     - default:
         cpu: 2000m
-        memory: 1024Mi
+        memory: 2048Mi
       defaultRequest:
-        cpu: 10m
-        memory: 512Mi
+        cpu: 100m
+        memory: 1024Mi
       type: Container


### PR DESCRIPTION
We are seeing POD of memory errors in the production Activities and Appointments DPS service.

This change increases the available memory to the production PODs in an attempt to alleviate that.