### PR TITLE
Adds Egress Sec Group Rule for oracle RDS.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-sandbox-admin/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-sandbox-admin/resources/rds.tf
@@ -70,6 +70,15 @@ resource "aws_security_group_rule" "rule" {
   security_group_id = aws_security_group.rds.id
 }
 
+resource "aws_security_group_rule" "ruleb" {
+  cidr_blocks       = ["10.200.0.0/20"]
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 1521
+  to_port           = 1521
+  security_group_id = aws_security_group.rds.id
+}
+
 
 
 resource "kubernetes_secret" "rds-instance" {


### PR DESCRIPTION
As per title. This adds egress to the LAA Landing Zone's Shared Services VPC for access to the DB via workspaces.