### PR TITLE
Switched ingress & egress from/to laa-development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-sandbox-admin/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-sandbox-admin/resources/rds.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "rds" {
 }
 
 resource "aws_security_group_rule" "rule" {
-  cidr_blocks       = ["10.200.0.0/20"]
+  cidr_blocks       = ["10.202.0.0/20"]
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 1521
@@ -71,7 +71,7 @@ resource "aws_security_group_rule" "rule" {
 }
 
 resource "aws_security_group_rule" "ruleb" {
-  cidr_blocks       = ["10.200.0.0/20"]
+  cidr_blocks       = ["10.202.0.0/20"]
   type              = "egress"
   protocol          = "tcp"
   from_port         = 1521


### PR DESCRIPTION
As per title, this changes the ingress/egress rule to cover access from laa-development's VPC. This is due to laa-shared-services not having any routing connection to Cloud Platform.