### PR TITLE
Add certificate for new Certificated Bailiffs production site

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: certbailiff-justice-app-cert
+  namespace: certificated-bailiffs-prod
+spec:
+  secretName: certbailiff-justice-app-secret
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+      - certificatedbailiffs.justice.gov.uk


### PR DESCRIPTION
New production cert for certificatedbailiffs.justice.gov.uk in preparation for migration from tacticalproducts AWS account