### PR TITLE
Tfsec improvements

### DIFF
--- a/.github/workflows/devsec-scan.yaml
+++ b/.github/workflows/devsec-scan.yaml
@@ -1,14 +1,8 @@
-name: devsec
-
-# on:
-#   schedule:
-#     - cron: '0 * * * *'
+name: devsec-scan
 
 on:
-  push:
-    branches: [ tfsec-improvements ]
-  pull_request:
-  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
 
 jobs:
   devsec:

--- a/.github/workflows/devsec-scan.yaml
+++ b/.github/workflows/devsec-scan.yaml
@@ -2,7 +2,7 @@ name: devsec-scan
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */4 * * 1-5'
 
 jobs:
   devsec:

--- a/.github/workflows/devsec-scheduled.yaml
+++ b/.github/workflows/devsec-scheduled.yaml
@@ -1,0 +1,26 @@
+name: devsec
+
+# on:
+#   schedule:
+#     - cron: '0 * * * *'
+
+on:
+  push:
+    branches: [ tfsec-improvements ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  devsec:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/tfsec-sarif-action@v0.1.4
+        with:
+          tfsec_args: --force-all-dirs --soft-fail -m=HIGH -e=github-repositories-private,github-branch_protections-require_signed_commits,github-actions-no-plain-text-action-secrets,aws-iam-no-policy-wildcards,aws-ecr-enforce-immutable-repository,aws-rds-enable-performance-insights-encryption,aws-s3-encryption-customer-key,aws-sqs-enable-queue-encryption
+          sarif_file: tfsec.sarif
+      - uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: tfsec.sarif

--- a/.github/workflows/terraform-tools.yml
+++ b/.github/workflows/terraform-tools.yml
@@ -2,7 +2,7 @@ name: terraform-tools
 
 on:
   push:
-    branches: [ tfsec-improvements ]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/terraform-tools.yml
+++ b/.github/workflows/terraform-tools.yml
@@ -2,7 +2,7 @@ name: terraform-tools
 
 on:
   push:
-    branches: [ main ]
+    branches: [ tfsec-improvements ]
   pull_request:
   workflow_dispatch:
 
@@ -26,14 +26,11 @@ jobs:
               cp -r $file .tfsec | true
            done
            ls .tfsec -latr
-      - uses: aquasecurity/tfsec-sarif-action@v0.1.4
+      - uses: aquasecurity/tfsec-action@v1.0.3
         with:
           working_directory: .tfsec
-          tfsec_args: --force-all-dirs --soft-fail -m=HIGH -e=github-repositories-private,github-branch_protections-require_signed_commits,github-actions-no-plain-text-action-secrets,aws-iam-no-policy-wildcards,aws-ecr-enforce-immutable-repository,aws-rds-enable-performance-insights-encryption,aws-s3-encryption-customer-key,aws-sqs-enable-queue-encryption
-          sarif_file: tfsec.sarif
-      - uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: tfsec.sarif
+          soft_fail: true
+          additional_args: --force-all-dirs -m=HIGH -e=github-repositories-private,github-branch_protections-require_signed_commits,github-actions-no-plain-text-action-secrets,aws-iam-no-policy-wildcards,aws-ecr-enforce-immutable-repository,aws-rds-enable-performance-insights-encryption,aws-s3-encryption-customer-key,aws-sqs-enable-queue-encryption
   tflint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As we changed the tfsec to changed-files, it closed all the security-alerts. We have to bring it back so it is open and visible to security team.

* Run tfscan for changed files and display the results - currently set to soft-fail set to TRUE. This can be changed.

* Adding scheduled tfscan for full code and upload SARIF file security team.

There is a plan to integrate checkov and scan all possible configs used across this repo.