### PR TITLE
Migrate certificatedbailiffs.justice.gov.uk production site

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/route53.tf
@@ -22,24 +22,3 @@ resource "kubernetes_secret" "certbailiff_route53_zone_sec" {
     zone_id = aws_route53_zone.certbailiff_route53_zone.zone_id
   }
 }
-
-resource "aws_route53_record" "aws_route53_record_prod_1" {
-  name    = "certificatedbailiffs.justice.gov.uk."
-  zone_id = aws_route53_zone.certbailiff_route53_zone.zone_id
-  type    = "A"
-  alias {
-    zone_id                = "ZHURV8PSTC4K8"
-    name                   = "certi-LoadB-Q2S48NUAQSC6-1478330638.eu-west-2.elb.amazonaws.com."
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "aws_route53_record_cname_1" {
-  name    = "_5cf8079a9b824596abdbbcb00d30073c.certificatedbailiffs.justice.gov.uk."
-  zone_id = aws_route53_zone.certbailiff_route53_zone.zone_id
-  type    = "CNAME"
-  ttl     = 60
-  records = [
-    "_121059a8dce2ffbcf7aee539544f7f7e.htgdxnmnnj.acm-validations.aws."
-  ]
-}


### PR DESCRIPTION
Remove the A and CNAME records which were pointing to the old service in tacticalproducts AWS

This will make the service live in Cloud Platform