### PR TITLE
Update API Gateway execution log settings in Dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -203,12 +203,16 @@ resource "aws_api_gateway_stage" "main" {
     })
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   depends_on = [aws_cloudwatch_log_group.api_gateway_access_logs]
 }
 
 resource "aws_cloudwatch_log_group" "api_gateway_access_logs" {
-  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.api_gateway.id}/${var.namespace}"
-  retention_in_days = 7
+  name              = "API-Gateway-Execution-Logs_${var.namespace}"
+  retention_in_days = 60
 }
 
 resource "aws_api_gateway_method_settings" "all" {


### PR DESCRIPTION
Currently we're not getting any logs for API Gateway. Rebuild the log group, and give it a predictable name so it can be documented. Also bump the retention policy to 2 months instead of 2 weeks for debugging older issues.