### PR TITLE
Enable method settings logs for API Gateway

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -223,5 +223,6 @@ resource "aws_api_gateway_method_settings" "all" {
   settings {
     metrics_enabled = true
     logging_level   = "INFO"
+    data_trace_enabled = true
   }
 }


### PR DESCRIPTION
Set data_trace_enabled to true in the aws_api_gateway_method_settings resource. Suspect this resource is overwriting the custom access logs specified in the aws_api_gateway_stage, which disables logging.