### PR TITLE
Create S3 bucket to backup client certificates Dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/iam.tf
@@ -22,6 +22,30 @@ data "aws_iam_policy_document" "api_gateway" {
       "${element(split("/", aws_api_gateway_rest_api.api_gateway.arn), 0)}/*",
     ]
   }
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      module.certificate_backup.bucket_arn
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectAcl"
+    ]
+
+    resources = [
+      "${module.certificate_backup.bucket_arn}/*"
+    ]
+  }
 }
 
 resource "aws_iam_user_policy" "api_gateway_policy" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
@@ -47,3 +47,43 @@ resource "aws_s3_object" "truststore" {
   key     = "dev-truststore.pem"
   content = data.kubernetes_secret.truststore.data["truststore-public-key"]
 }
+
+module "certificate_backup" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.1.0"
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+  bucket_name            = "${var.application}-certificates-backup"
+  versioning             = true
+
+  providers = {
+    aws = aws.london_without_default_tags
+  }
+
+  bucket_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowBucketAccess",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_user.api_gateway_user.name}"
+      },
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:GetObjectVersion"
+      ],
+      "Resource": [
+        "$${bucket_arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
Our CA and client certificates and private keys are stored in K8s secrets. For backup we will also store them in a version enabled, encrypted S3 bucket. An existing IAM user that has access to the API Gateway (for debugging) will also have access to this bucket.