### PR TITLE
Adds ingress/egress for 10.200.0.0/20 on tcp 1521.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-sandbox-admin/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-sandbox-admin/resources/rds.tf
@@ -79,6 +79,24 @@ resource "aws_security_group_rule" "ruleb" {
   security_group_id = aws_security_group.rds.id
 }
 
+resource "aws_security_group_rule" "rule3" {
+  cidr_blocks       = ["10.200.0.0/20"]
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 1521
+  to_port           = 1521
+  security_group_id = aws_security_group.rds.id
+}
+
+resource "aws_security_group_rule" "rule4" {
+  cidr_blocks       = ["10.200.0.0/20"]
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 1521
+  to_port           = 1521
+  security_group_id = aws_security_group.rds.id
+}
+
 
 
 resource "kubernetes_secret" "rds-instance" {


### PR DESCRIPTION
Adds additional rules for ingress & egress from laa shared services non-prod so we can test the new transit gateway routes without impacting the current acess.