### PR TITLE
NIT-994 pipeline for installing helm charts

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfrsco-poc/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfrsco-poc/resources/serviceaccount.tf
@@ -1,7 +1,8 @@
 module "serviceaccount" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
-  namespace           = var.namespace
-  kubernetes_cluster  = var.kubernetes_cluster
-  github_repositories = ["hmpps-delius-alfresco-poc"]
+  namespace            = var.namespace
+  kubernetes_cluster   = var.kubernetes_cluster
+  github_repositories  = ["hmpps-delius-alfresco-poc"]
+  serviceaccount_rules = var.serviceaccount_rules
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfrsco-poc/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfrsco-poc/resources/variables.tf
@@ -136,6 +136,18 @@ variable "serviceaccount_rules" {
     },
     {
       api_groups = [
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "prometheusrules",
+        "servicemonitors",
+      ]
+      verbs = [
+        "*",
+      ]
+    },
+    {
+      api_groups = [
         "autoscaling",
       ]
       resources = [

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfrsco-poc/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfrsco-poc/resources/variables.tf
@@ -71,3 +71,85 @@ variable "github_token" {
 variable "eks_cluster_name" {
   description = "The name of the EKS cluster"
 }
+
+variable "serviceaccount_rules" {
+  description = "The capabilities of this serviceaccount"
+
+  type = list(object({
+    api_groups = list(string),
+    resources  = list(string),
+    verbs      = list(string)
+  }))
+
+  # See the docs at https://github.com/ministryofjustice/cloud-platform-terraform-serviceaccount
+  default = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+        "replicationcontrollers",
+        "persistentvolumeclaims",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "policy",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "poddisruptionbudgets",
+        "networkpolicies",
+        "daemonsets",
+        "statefulsets",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "autoscaling",
+      ]
+      resources = [
+        "horizontalpodautoscalers",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
+}


### PR DESCRIPTION
This is to fix the following errors in github workflows when trying to deploy or get resources:
```
Error from server (Forbidden): replicationcontrollers is forbidden: User "system:serviceaccount:***:cd-serviceaccount" cannot list resource "replicationcontrollers" in API group "" in the namespace "***"
Error from server (Forbidden): daemonsets.apps is forbidden: User "system:serviceaccount:***:cd-serviceaccount" cannot list resource "daemonsets" in API group "apps" in the namespace "***"
Error from server (Forbidden): statefulsets.apps is forbidden: User "system:serviceaccount:***:cd-serviceaccount" cannot list resource "statefulsets" in API group "apps" in the namespace "***"
Error from server (Forbidden): horizontalpodautoscalers.autoscaling is forbidden: User "system:serviceaccount:***:cd-serviceaccount" cannot list resource "horizontalpodautoscalers" in API group "autoscaling" in the namespace "***"
Error: UPGRADE FAILED: could not get information about the resource: persistentvolumeclaims "activemq-default-pvc" is forbidden: User "system:serviceaccount:***:cd-serviceaccount" cannot get resource "persistentvolumeclaims" in API group "" in the namespace "***"
```