### PR TITLE
CMR547-854: correct namespace for shared secret)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev-crm4/resources/shared-s3-secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev-crm4/resources/shared-s3-secret.tf
@@ -1,12 +1,12 @@
 resource "kubernetes_secret" "claim-nsm-s3-secret" {
   metadata {
     name      = "s3-policy-arns"
-    namespace = var.namespace
+    namespace = "laa-assess-non-standard-magistrate-fee-dev-crm4"
   }
 
   data = {
     service_metadata_bucket_irsa = module.s3_bucket.irsa_policy_arn
-    bucket_arn  = module.s3_bucket.bucket_arn
-    bucket_name = module.s3_bucket.bucket_name
+    bucket_arn                   = module.s3_bucket.bucket_arn
+    bucket_name                  = module.s3_bucket.bucket_name
   }
 }


### PR DESCRIPTION
CMR547-854: correct namespace for shared secret

This secret needs to generated in a different namespace
that requires access to the same s3 bucket.
