### PR TITLE
Fix typo in serviceaccounts

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-aws-microservice-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-aws-microservice-dev/resources/serviceaccount.tf
@@ -20,7 +20,7 @@ module "serviceaccount" {
         "services",
         "configmaps",
         "pods",
-        "serviceaccount",
+        "serviceaccounts",
       ]
       verbs = [
         "patch",


### PR DESCRIPTION
Add the missing "s" to allow the default service account to create other service accounts