### PR TITLE
Create new API key for consumer in Preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/locals.tf
@@ -10,5 +10,5 @@ locals {
     GithubTeam             = var.team_name
   }
 
-  clients = ["emile", "ting", "april", "heartbeat"]
+  clients = ["emile", "ctrlo", "heartbeat"]
 }


### PR DESCRIPTION
## Context

This PR is for updating the consumer list for preprod. Including ctrlo will generate an API Gateway API key that can be shared.

## Changes proposed in this PR
- Removed former consumers of preprod
- Added ctrlo to consumer list