### PR TITLE
Refresh api keys in prod for current consumers

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/locals.tf
@@ -10,5 +10,5 @@ locals {
     GithubTeam             = var.team_name
   }
 
-  clients = ["emile", "ting", "april", "heartbeat"]
+  clients = ["emile", "ctrlo", "heartbeat"]
 }


### PR DESCRIPTION
## Context

This PR is for updating the consumer list for prod. Including ctrlo will generate an API Gateway API key that can be shared.

## Changes proposed in this PR
- Removed former consumers of prod
- Added ctrlo to consumer list