### PR TITLE
[CRIMAPP-297] Add missing IRSA policy role (LAA Criminal Applications Datastore Production)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/irsa.tf
@@ -13,6 +13,7 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     rds = module.rds.irsa_policy_arn
+    s3  = module.s3_bucket.irsa_policy_arn    
     sns = module.application-events-sns-topic.irsa_policy_arn
     sqs = module.application-events-dlq.irsa_policy_arn
   }


### PR DESCRIPTION
Adds missing IRSA role for use of S3 in production