### PR TITLE
Temporarily remove read replica rds

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
@@ -8,39 +8,6 @@
 # IMP NOTE: Updating to module version 5.3, existing database password will be rotated.
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
-module "cla_backend_rds_postgres_14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.0"
-  vpc_name               = var.vpc_name
-  team_name              = var.team_name
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  namespace              = var.namespace
-  environment_name       = var.environment-name
-  infrastructure_support = var.infrastructure_support
-
-  # It is mandatory to set the below values to create read replica instance
-  db_name = null # "db_name": conflicts with replicate_source_db
-
-  # Set the db_identifier of the source db
-  replicate_source_db = module.cla_backend_rds_postgres_14.db_identifier
-
-  # Set to true. No backups or snapshots are created for read replica
-  skip_final_snapshot        = "true"
-  db_backup_retention_period = 0
-
-  # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11, postgres14
-  # Pick the one that defines the postgres version the best
-  rds_family        = "postgres14"
-  db_engine_version = "14"
-  db_instance_class = "db.t4g.small"
-
-  providers = {
-    # Can be either "aws.london" or "aws.ireland"
-    aws = aws.london
-  }
-}
-
 module "cla_backend_rds_postgres_14" {
   source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.0"
   vpc_name      = var.vpc_name
@@ -100,7 +67,5 @@ resource "kubernetes_secret" "cla_backend_rds_postgres_14" {
     user              = module.cla_backend_rds_postgres_14.database_username
     password          = module.cla_backend_rds_postgres_14.database_password
     db_identifier     = module.cla_backend_rds_postgres_14.db_identifier
-    replica_host      = module.cla_backend_rds_postgres_14_replica.rds_instance_address
-    replica_endpoint  = module.cla_backend_rds_postgres_14_replica.rds_instance_endpoint
   }
 }


### PR DESCRIPTION
Temporarily removes the read replica RDS so it can be re-created and attached to the restored source RDS.