### PR TITLE
PR-1733 Change HMPPS Auth network policy for hmpps-probation-integration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/04-networkpolicy.yaml
@@ -50,3 +50,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               cloud-platform.justice.gov.uk/namespace: token-verification-api-dev
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: hmpps-probation-integration-services-dev

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/04-networkpolicy.yaml
@@ -65,3 +65,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               cloud-platform.justice.gov.uk/namespace: token-verification-api-preprod
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: hmpps-probation-integration-services-preprod

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/04-networkpolicy.yaml
@@ -50,3 +50,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               cloud-platform.justice.gov.uk/namespace: token-verification-api-prod
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: hmpps-probation-integration-services-prod


### PR DESCRIPTION
PR-1733 -  Change network policy to allow pods in the hmpps-probation-integration namespace to use internal urls