### PR TITLE
Add certificate for development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-dev/06-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: justice-gov-uk-dev-cert
+  namespace: justice-gov-uk-dev
+spec:
+  secretName: justice-gov-uk-dev-cert-secret
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - dev.justice.gov.uk


### PR DESCRIPTION
Use `dev.justice.gov.uk` to target the development application.