### PR TITLE
🆙 Upgrade postgres db to mitigate CVE-2023-5869

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-metadata-poc/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-metadata-poc/resources/rds.tf
@@ -5,11 +5,12 @@ module "rds" {
   vpc_name = var.vpc_name
 
   # Database configuration
-  db_engine                = "postgres"
-  db_engine_version        = "15"
-  rds_family               = "postgres15"
-  db_instance_class        = "db.t4g.micro"
-  db_max_allocated_storage = "500"
+  db_engine                   = "postgres"
+  db_engine_version           = "15"
+  rds_family                  = "postgres15"
+  db_instance_class           = "db.t4g.micro"
+  db_max_allocated_storage    = "500"
+  allow_minor_version_upgrade = "true"
 
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4004
- To enable automatic updates and get the latest minor release of PostgresDB to mitigate CVE-2023-5869

## ♻️ What's changed

- Added `allow_minor_version_upgrade = "true"` to rds configuration
