### PR TITLE
NN-5784 increase tokens in preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-preprod/resources/rds.tf
@@ -15,7 +15,7 @@ module "ma_rds" {
   rds_family                  = "postgres15"
   db_password_rotated_date    = "15-02-2023"
   prepare_for_major_upgrade   = false
-  db_allocated_storage        = "1000"
+  db_allocated_storage        = "2000"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
Ran out of tokens this monday, during a slightly slower run.  Issue faced in prod is the app will still need to work after the migration, so need a far greater amount of tokens to avoid throttling during, or after the migration within a 24 hour window