### PR TITLE
DPR2-311: Increase storage to allow db to restart for troubleshooting.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -19,7 +19,7 @@ module "rds" {
   allow_minor_version_upgrade  = true
   allow_major_version_upgrade  = true
   performance_insights_enabled = false
-  db_max_allocated_storage     = "500"
+  db_max_allocated_storage     = "700"
   enable_rds_auto_start_stop   = true
 
   # PostgreSQL specifics

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -19,6 +19,7 @@ module "rds" {
   allow_minor_version_upgrade  = true
   allow_major_version_upgrade  = true
   performance_insights_enabled = false
+  db_allocated_storage         = "600"
   db_max_allocated_storage     = "700"
   enable_rds_auto_start_stop   = true
 


### PR DESCRIPTION
The DB is in "Storage-full" state an so we cannot start it. This PR bumps db_max_allocated_storage so we can start it for investigation/troubleshooting of the underlying issue