### PR TITLE
Add CAS2 frontend to CAS production namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/00-namespace.yaml
@@ -13,5 +13,5 @@ metadata:
     cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts"
     cloud-platform.justice.gov.uk/application: "Community Accommodation"
     cloud-platform.justice.gov.uk/owner: "Community Accommodation: cas3@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git,https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui.git"
     cloud-platform.justice.gov.uk/team-name: "hmpps-community-accommodation"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/06-certificates.yaml
@@ -38,3 +38,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - approved-premises-api.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-community-accommodation-tier-2-prod-cert
+  namespace: hmpps-community-accommodation-prod
+spec:
+  secretName: hmpps-community-accommodation-tier-2-prod-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - short-term-accommodation-cas-2.hmpps.service.justice.gov.uk


### PR DESCRIPTION
We’re now ready to launch into prod so we repeat the steps we took when launching pre-prod[1].

[1] https://github.com/ministryofjustice/cloud-platform-environments/pull/17070