### PR TITLE
SLM-338 set prepare_for_major_upgrade to false post upgrade to 14.10

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
@@ -11,7 +11,7 @@ module "slmtp_api_rds" {
   enable_rds_auto_start_stop = true
 
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade   = true
+  prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.micro"
   db_max_allocated_storage    = "500"
   db_engine                   = "postgres"


### PR DESCRIPTION
SLM-338 set prepare_for_major_upgrade to false after updating Send Legal Mail DB version to 14.10 for send-legal-mail-to-prisons-dev namespace.