### PR TITLE
SLM-338 update SLM DB version to 15.5 for send-legal-mail-to-prisons-dev namespace.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
@@ -11,12 +11,12 @@ module "slmtp_api_rds" {
   enable_rds_auto_start_stop = true
 
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade   = false
+  prepare_for_major_upgrade   = true
   db_instance_class           = "db.t4g.micro"
   db_max_allocated_storage    = "500"
   db_engine                   = "postgres"
-  rds_family                  = "postgres14"
-  db_engine_version           = "14.10"
+  rds_family                  = "postgres15"
+  db_engine_version           = "15.5"
   db_password_rotated_date    = "2023-03-22"
 
   providers = {


### PR DESCRIPTION
SLM-338 update Send Legal Mail DB version to 15.5 for send-legal-mail-to-prisons-dev namespace.