### PR TITLE
Added new dns address to cert for CEMO service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/06-certificate.yaml
@@ -13,3 +13,4 @@ spec:
     - electronic-monitoring-dev.hmpps.service.justice.gov.uk
     - api.electronic-monitoring-dev.hmpps.service.justice.gov.uk
     - architecture.electronic-monitoring-dev.hmpps.service.justice.gov.uk
+    - hmpps-create-electronic-monitoring-order-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
New dns address: **hmpps-create-electronic-monitoring-order-dev.hmpps.service.justice.gov.uk**

For service: [Create Electronic Monitoring Order](https://github.com/ministryofjustice/hmpps-create-electronic-monitoring-order)