### PR TITLE
Increase max pods in CLA-UAT environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/03-resourcequota.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: laa-cla-backend-uat
 spec:
   hard:
-    pods: "50"
+    pods: "100"


### PR DESCRIPTION
Because we are hitting the limit now we are running an extra environment, and there are lots of jobs during deployment. Hitting the limit on most deploys now.