### PR TITLE
Add service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-hello-world-mat-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-hello-world-mat-dev/resources/serviceaccount.tf
@@ -1,0 +1,12 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}


### PR DESCRIPTION
I'm working my way through this guide:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#add-a-service-account-to-your-namespace

I skipped the github actions part as I don't think I need that right now - I'm just trying to familiarise myself with the platform