### PR TITLE
LAA-HMRC-Interface Production - update RDS minor version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/rds.tf
@@ -8,23 +8,20 @@ module "rds" {
   is_production = var.is_production
   namespace     = var.namespace
 
-  # enable performance insights
-  performance_insights_enabled = true
-
-  # change the postgres version as you see fit.
-  db_engine_version      = "14"
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 
-  # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
-  # Pick the one that defines the postgres version the best
-  rds_family = "postgres14"
+  # enable performance insights
+  performance_insights_enabled = true
 
-  # use "allow_major_version_upgrade" when upgrading the major version of an engine
-  allow_major_version_upgrade = "false"
+  # Database configuration
+  db_engine_version           = "14.10"
   db_instance_class           = "db.t4g.small"
-
-  deletion_protection = true
+  rds_family                  = "postgres14"
+  allow_minor_version_upgrade = "true"
+  allow_major_version_upgrade = "false"
+  enable_rds_auto_start_stop  = true
+  deletion_protection         = true
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Update minor version to 14.10 and rationalise the DB config block to be easier to read and similar to
other rds instances maintained by this team