### PR TITLE
DPR2-311: limit replication slot WAL size to a small value

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -49,7 +49,12 @@ module "rds" {
       name         = "wal_sender_timeout"
       value        = "0"
       apply_method = "immediate"
-    }
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
   ]
 
   # Tags


### PR DESCRIPTION
Allows us to test the effect on the DMS when the replication slot gets too far behind