### PR TITLE
DPR2-311: Increase max_slot_wal_keep_size

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -52,7 +52,7 @@ module "rds" {
     },
     {
       name         = "max_slot_wal_keep_size"
-      value        = "1024"
+      value        = "40000"
       apply_method = "immediate"
     },
   ]


### PR DESCRIPTION
Increase max_slot_wal_keep_size to give over 2 days grace where the task can be disconnected before DMS task has to be restarted from scratch (at current loads). This will prevent the DB from running out of disk space when the DMS is disconnected for long periods but also gives us a grace period where we can resume it.