### PR TITLE
HMRC Assure UAT - update RDS minor version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/rds-postgresql.tf
@@ -23,34 +23,13 @@ module "rds" {
   # enable performance insights
   performance_insights_enabled = true
 
-  # change the postgres version as you see fit.
-  db_engine_version = "14"
-
-  # change the instance class as you see fit.
-  db_instance_class = "db.t4g.small"
-
-  # rds_family should be one of: postgres10, postgres11, postgres12, postgres13, postgres14
-  # Pick the one that defines the postgres version the best
-  rds_family = "postgres14"
-
-  # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate).
-  # You will need to specify "pending-reboot" here, as default is set to "immediate".
-  # db_parameter = [
-  #   {
-  #     name         = "rds.force_ssl"
-  #     value        = "0"
-  #     apply_method = "pending-reboot"
-  #   }
-  # ]
-
-  # use "allow_major_version_upgrade" when upgrading the major version of an engine
-  allow_major_version_upgrade = "false"
-
-  # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
-  enable_rds_auto_start_stop = true
-
-  # This will rotate the db password. Update the value to the current date.
-  # db_password_rotated_date  = "dd-mm-yyyy"
+  # Database configuration
+  db_engine_version           = "14.10"
+  db_instance_class           = "db.t4g.small"
+  rds_family                  = "postgres14"
+  allow_minor_version_upgrade = "true"
+  allow_major_version_upgrade = "true"
+  enable_rds_auto_start_stop  = true
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Update minor version to 14.10 and rationalise the DB config block to be easier to read and similar to
other rds instances maintained by this team