### PR TITLE
HMRC Interface Production - Revert enable_rds_auto_start_stop

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/rds.tf
@@ -20,7 +20,7 @@ module "rds" {
   rds_family                  = "postgres14"
   allow_minor_version_upgrade = "true"
   allow_major_version_upgrade = "false"
-  enable_rds_auto_start_stop  = true
+  enable_rds_auto_start_stop  = false
   deletion_protection         = true
 
   providers = {


### PR DESCRIPTION
Probably shouldn't turn prod off overnight! 🤦‍♂️ 