### PR TITLE
laa-crime-application-store-dev - bump to latest minor version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/resources/rds-postgresql.tf
@@ -20,7 +20,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.7"
+  db_engine_version = "14.10"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.micro"
 


### PR DESCRIPTION
Bump PG instance to latest minor version to prep for major version 