### PR TITLE
Add opensearch secret for data platform datahub

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/opensearch.tf
@@ -40,3 +40,15 @@ module "opensearch" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
+# Output the proxy URL
+resource "kubernetes_secret" "opensearch" {
+  metadata {
+    name      = "${var.team_name}-opensearch-proxy-url"
+    namespace = var.namespace
+  }
+
+  data = {
+    proxy_url = module.opensearch.proxy_url
+  }
+}


### PR DESCRIPTION
Didn't output the open search proxy url to a secret initially so adding in here