### PR TITLE
SLM-338 update prepare_for_major_upgrade to false - send-legal-mail-to-prisons-preprod namespace.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/rds.tf
@@ -10,7 +10,7 @@ module "slmtp_api_rds" {
   infrastructure_support = var.infrastructure_support
 
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade   = true
+  prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.micro"
   db_max_allocated_storage    = "500"
   db_engine                   = "postgres"


### PR DESCRIPTION
SLM-338 update prepare_for_major_upgrade to false after updating SLM DB version to 15.5 for send-legal-mail-to-prisons-preprod namespace.