### PR TITLE
CPR-124 add secret for slack webhook

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/secret.tf
@@ -1,6 +1,6 @@
 
 module "secrets_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=1.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.2"
   team_name              = var.team_name
   application            = var.application
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/secret.tf
@@ -1,0 +1,20 @@
+
+module "secrets_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=1.2.0"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "slack-webhook" = {
+      description             = "Slack Webhook",   # Required
+      recovery_window_in_days = 7,               # Required
+      k8s_secret_name         = "slack-webhook" # The name of the secret in k8s and must only contain lowercase alphanumeric characters, dots and dashes
+    },
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/variables.tf
@@ -67,3 +67,7 @@ variable "github_token" {
   description = "Required by the GitHub Terraform provider"
   default     = ""
 }
+
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster"
+}


### PR DESCRIPTION
I have created this directly in the production environment. Do I need it in any other environments as well?

I am following https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#create-a-slack-webhook-and-amend-alertmanager