### PR TITLE
laa-civil-apply-staging: remove rds minor version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/rds.tf
@@ -17,7 +17,7 @@ module "apply-for-legal-aid-rds" {
   infrastructure_support   = "apply-for-civil-legal-aid@digital.justice.gov.uk"
 
   # Database configuration
-  db_engine_version           = "14.10"
+  db_engine_version           = "14"
   db_instance_class           = "db.t4g.small"
   rds_family                  = "postgres14"
   db_name                     = "apply_for_legal_aid_staging"


### PR DESCRIPTION
After updating to v14.10 we don't want to lock at this version so removing the minor version to allow future auto minor updates