### PR TITLE
laa-hmrc-assure-production: remove rds minor version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/rds-postgresql.tf
@@ -20,7 +20,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # Database configuration
-  db_engine_version           = "14.10"
+  db_engine_version           = "14"
   db_instance_class           = "db.t4g.small"
   rds_family                  = "postgres14"
   allow_minor_version_upgrade = "true"


### PR DESCRIPTION
After updating to v14.10 we don't want to lock at this version so removing the minor version to allow future auto minor updates