### PR TITLE
laa-hmrc-assure-staging: remove rds minor version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/rds-postgresql.tf
@@ -24,7 +24,7 @@ module "rds" {
   db_instance_class           = "db.t4g.small"
   rds_family                  = "postgres14"
   allow_minor_version_upgrade = "true"
-  allow_major_version_upgrade = "false"
+  allow_major_version_upgrade = "true"
   #
   # Team Note: could be useful but since we are likely to be using overnight
   # scheduled jobs we are not enabling on non UAT environments for now.


### PR DESCRIPTION
After updating to v14.10 we don't want to lock at this version so removing the minor version to allow future auto minor updates, also allow major version updates in line with our other non-production environments