### PR TITLE
Hale Platform Dev Prometheus Testing

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 100Mi
     defaultRequest:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
Modified memory limit from 1000 to 100 to trigger recently enabled prometheus rules to test notification functionality