### PR TITLE
PI-1733: Added probation service to prod auth namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/04-networkpolicy.yaml
@@ -50,3 +50,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               cloud-platform.justice.gov.uk/namespace: token-verification-api-prod
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: hmpps-probation-integration-services-prod


### PR DESCRIPTION
The probation integration team would like to switch to internal URLS for hmpps auth for prod. The internal IPs for the following clients will also need to be added to the allowlist:

    "CLIENT_ID": "approved-premises-and-delius-integration-1",
    "CLIENT_ID": "cas2-and-delius-1",
    "CLIENT_ID": "cas3-and-delius-1",
    "CLIENT_ID": "create-and-vary-a-licence-and-delius-1",
    "CLIENT_ID": "custody-key-dates-and-delius-1",
    "CLIENT_ID": "make-recall-decisions-and-delius-2",
    "CLIENT_ID": "manage-offences-and-delius-1",
    "CLIENT_ID": "manage-pom-cases-and-delius-1",
    "CLIENT_ID": "opd-and-delius-1",
    "CLIENT_ID": "pre-sentence-service-delius-client-1",
    "CLIENT_ID": "prison-case-notes-to-probation-client-1",
    "CLIENT_ID": "prison-custody-status-to-delius-client-1",
    "CLIENT_ID": "prison-identifier-and-delius-1",
    "CLIENT_ID": "refer-and-monitor-and-delius",
    "CLIENT_ID": "tier-to-delius-1",
    "CLIENT_ID": "unpaid-work-and-delius-1",
    "CLIENT_ID": "hmpps-allocations-delius-client-1",