### PR TITLE
RR-573 - Remove the cert for the CIAG UI from the hmpps-education-employment-dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/06-certificate.yaml
@@ -28,19 +28,6 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: hmpps-ciag-careers-induction-ui-dev-cert
-  namespace: hmpps-education-employment-dev
-spec:
-  secretName: hmpps-ciag-careers-induction-ui-cert
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
-    - ciag-induction-dev.hmpps.service.justice.gov.uk
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
   name: hmpps-ciag-careers-induction-api-dev-cert
   namespace: hmpps-education-employment-dev
 spec:


### PR DESCRIPTION
Remove the cert for the CIAG UI from the hmpps-education-employment-dev namespace