### PR TITLE
RR-573 - Remove the cert for the CIAG UI from the hmpps-education-employment-preprod namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/06-certificate.yaml
@@ -28,19 +28,6 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: hmpps-ciag-careers-induction-ui-preprod-cert
-  namespace: hmpps-education-employment-preprod
-spec:
-  secretName: hmpps-ciag-careers-induction-ui-cert
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
-    - ciag-induction-preprod.hmpps.service.justice.gov.uk
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
   name: hmpps-ciag-careers-induction-api-preprod-cert
   namespace: hmpps-education-employment-preprod
 spec:


### PR DESCRIPTION
Remove the cert for the CIAG UI from the hmpps-education-employment-preprod namespace