### PR TITLE
Add CORS Rule to laa-fala-staging S3 Bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
@@ -12,6 +12,15 @@ module "s3" {
   providers = {
     aws = aws.london
   }
+  cors_rule = [
+  {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["https://*.apps.live-1.cloud-platform.service.justice.gov.uk", "https://staging.find-legal-advice.justice.gov.uk"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+]
 }
 
 module "cla_fala_static_files_bucket" {


### PR DESCRIPTION
Adds a CORS rule to the S3 Bucket of `laa-fala-staging` allowing incoming get requests from additional domains.