### PR TITLE
nscc-dev-crm4:turn off prepare_for_major_upgrade

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev-crm4/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev-crm4/resources/rds-postgresql.tf
@@ -13,7 +13,7 @@ module "rds" {
   # RDS configuration
   allow_minor_version_upgrade  = true
   allow_major_version_upgrade  = true
-  prepare_for_major_upgrade = true
+  prepare_for_major_upgrade = false
 
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"


### PR DESCRIPTION
Following guide note

> Note: If you need to upgrade major versions more than once, e.g. from Postgres 12 to 14, and then 14 to 16, you must turn off prepare_for_major_upgrade (step 6) after each upgrade and then turn it back on (step 5). Otherwise, any upgrade after the first will fail.

