### PR TITLE
Add production Pingdom check with Slack alert for CAS2

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/pingdom.tf
@@ -17,6 +17,22 @@ resource "pingdom_check" "hmpps-approved-premises-ui" {
   probefilters             = "region:EU"
 }
 
+resource "pingdom_check" "hmpps-community-accommodation-tier-2-ui" {
+  type                     = "http"
+  name                     = "HMPPS - short-term-accommodation-cas-2/CAS2 - Production"
+  host                     = "health-kick.prison.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  integrationids           = [133623]
+  notifyagainevery         = 0
+  url                      = "/https/short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/health"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_hmpps,application_short-term-accommodation-cas-2,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_cas-dev"
+  probefilters             = "region:EU"
+}
+
 resource "pingdom_check" "hmpps-temporary-accommodation-ui" {
   type                     = "http"
   name                     = "HMPPS - transitional-accommodation/CAS3 - Production"


### PR DESCRIPTION
We copy the other CAS frontend health checks.

The CAS2 health check endpoint can be viewed https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk/health

[We've requested out Slack integration ID here](https://github.com/ministryofjustice/cloud-platform/issues/5201#issuecomment-1908636973).