### PR TITLE
VB-3380 - update prepare_for_major_upgrade to false after updating VSIP DB version to 14.10 for visit-someone-in-prison-backend-svc-preprod namespace.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -10,7 +10,7 @@ module "visit_scheduler_rds" {
   namespace              = var.namespace
 
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade   = true
+  prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "14.10"
   rds_family                  = "postgres14"


### PR DESCRIPTION
VB-3380 - update prepare_for_major_upgrade to false after updating VSIP DB version to 14.10 for visit-someone-in-prison-backend-svc-preprod namespace.