### PR TITLE
assess-dev-crm4: cleanup up after postgres major upgrade

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-dev-crm4/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-dev-crm4/resources/rds-postgresql.tf
@@ -12,8 +12,8 @@ module "rds" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = true
-  prepare_for_major_upgrade = true
+  allow_major_version_upgrade  = false
+  prepare_for_major_upgrade = false
   
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
@@ -22,7 +22,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16"
+  db_engine_version = "16.1"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
 


### PR DESCRIPTION
Cleanup after major postgress upgrade

Unset flags and specify engine version (for completeness).  Will remove SKIP file
in subsequent commit to be safe.
