### PR TITLE
Upgrade RDS version for laa-court-data-ui-uat 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
@@ -16,7 +16,7 @@ module "lcdui_rds" {
   environment_name            = var.environment-name
   infrastructure_support      = var.infrastructure_support
   db_allocated_storage        = "10"
-  db_instance_class           = "db.t4g.small"
+  db_instance_class           = "db.t3.small"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "14.10"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
@@ -16,10 +16,10 @@ module "lcdui_rds" {
   environment_name            = var.environment-name
   infrastructure_support      = var.infrastructure_support
   db_allocated_storage        = "10"
-  db_instance_class           = "db.t3.small"
+  db_instance_class           = "db.t4g.small"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "14.7"
+  db_engine_version           = "14.10"
   rds_family                  = "postgres14"
   allow_major_version_upgrade = "true"
 


### PR DESCRIPTION
For `laa-court-data-ui-uat`:

1. Update the PostGres version to 14.10 as the minor version 14.7 will soon no longer be supported