### PR TITLE
Upgrade postgres minor version to 14.10 for laa-court-data-ui-staging [STAGING] 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/rds.tf
@@ -16,7 +16,7 @@ module "lcdui_rds" {
   environment_name            = var.environment-name
   infrastructure_support      = var.infrastructure_support
   db_allocated_storage        = "10"
-  db_instance_class           = "db.t4g.small"
+  db_instance_class           = "db.t3.small"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "14.10"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/rds.tf
@@ -16,7 +16,7 @@ module "lcdui_rds" {
   environment_name            = var.environment-name
   infrastructure_support      = var.infrastructure_support
   db_allocated_storage        = "10"
-  db_instance_class           = "db.t3.small"
+  db_instance_class           = "db.t4g.small"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "14.7"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/rds.tf
@@ -19,7 +19,7 @@ module "lcdui_rds" {
   db_instance_class           = "db.t4g.small"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "14.7"
+  db_engine_version           = "14.10"
   rds_family                  = "postgres14"
   allow_major_version_upgrade = "true"
 


### PR DESCRIPTION
For `laa-court-data-ui-staging`:

Upgrade the postgres version to 14.10. This is due to PostGres no longer supporting the minor version of 14.7 after march of this year