### PR TITLE
🚑 Add GitHub Pages validation

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/observability-platform-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/observability-platform-production/resources/route53.tf
@@ -11,6 +11,14 @@ resource "aws_route53_zone" "observability_platform_service_justice_gov_uk" {
   }
 }
 
+resource "aws_route53_record" "github_pages_verification" {
+  zone_id = aws_route53_zone.observability_platform_service_justice_gov_uk.zone_id
+  name    = "_github-pages-challenge-ministryofjustice.observability-platform.service.service.justice.gov.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["87d36fcc49f1fb1ff0a853223ed685"]
+}
+
 resource "aws_route53_record" "github_pages" {
   zone_id = aws_route53_zone.observability_platform_service_justice_gov_uk.zone_id
   name    = "observability-platform.service.justice.gov.uk"


### PR DESCRIPTION
This pull request:

- Adds GitHub Pages validation for observability-platform.service.service.justice.gov.uk

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>