### PR TITLE
 Upgrade rds instance type to t4 for laa-court-data-ui [UAT]

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
@@ -16,7 +16,8 @@ module "lcdui_rds" {
   environment_name            = var.environment-name
   infrastructure_support      = var.infrastructure_support
   db_allocated_storage        = "10"
-  db_instance_class           = "db.t4g.small"
+  db_instance_class           = "db.t4g.micro"
+  db_max_allocated_storage    = "500"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "14.10"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/rds.tf
@@ -16,7 +16,7 @@ module "lcdui_rds" {
   environment_name            = var.environment-name
   infrastructure_support      = var.infrastructure_support
   db_allocated_storage        = "10"
-  db_instance_class           = "db.t3.small"
+  db_instance_class           = "db.t4g.small"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "14.10"


### PR DESCRIPTION
Upgrade the RDS instance type to t4g for `laa-court-data-ui-uat`