### PR TITLE
Upgrade rds minor version for laa-court-data-ui [PROD]

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
@@ -19,7 +19,7 @@ module "lcdui_rds" {
   db_instance_class           = "db.t3.small"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "14.7"
+  db_engine_version           = "14.10"
   rds_family                  = "postgres14"
   allow_major_version_upgrade = "true"
 


### PR DESCRIPTION
Upgrade rds minor version for `laa-court-data-ui-prod`

- Update the postgresql minor version to 14.10 from 14.7

This is to mitigate many CVEs. Also, 14.7 will soon no longer be supported.