### PR TITLE
EMP-3: Update MSSQL engine used in PROD RDS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
@@ -19,11 +19,11 @@ module "rds_mssql" {
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # SQL Server specifics
-  db_engine            = "sqlserver-ex"
-  db_engine_version    = "15.00.4236.7.v1"
-  rds_family           = "sqlserver-ex-15.0"
+  db_engine            = "sqlserver-web"
+  db_engine_version    = "15.00.4345.5.v1"
+  rds_family           = "sqlserver-web-15.0"
   db_instance_class    = "db.t3.small"
-  db_allocated_storage = 200 # minimum of 20GiB for SQL Server
+  db_allocated_storage = 500 # minimum of 20GiB for SQL Server
   option_group_name    = aws_db_option_group.sqlserver_backup_rds_option_group.name
 
   # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).


### PR DESCRIPTION
Update MSSQL engine used in PROD RDS to -web, was -ex
Also, an additional increase in size now that we are starting the real data migration 