### PR TITLE
LNP-563: 🔧  raise spec of content hub staging to match development.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/02-limitrange.yaml
@@ -7,23 +7,10 @@ metadata:
 # These are the normal settings for staging.
 spec:
   limits:
-  - default:
-      cpu: 360m
-      memory: 1024Mi
-    defaultRequest:
-      cpu: 10m
-      memory: 512Mi
-    type: Container
-
-# These are the settings to flex staging up to match production.
-# These should only be used when setting staging up for load testing, so it accurately
-# matches production and therefore is an accurate prediction of prod behaviour.
-#spec:
-#  limits:
-#    - default:
-#        cpu: 1000m
-#        memory: 2048Mi
-#      defaultRequest:
-#        cpu: 10m
-#        memory: 1024Mi
-#      type: Container
+    - default:
+        cpu: 1000m
+        memory: 2048Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 1024Mi
+      type: Container


### PR DESCRIPTION
We had some strange behaviour where bulk updates of content that worked on dev failed subsequently on staging.
This PR is to bring staging up to the spec of dev.