### PR TITLE
Add TLS cert for Welsh subdomain - victim and witnesses

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/07-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/07-certificates.yaml
@@ -391,6 +391,19 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: cym.victimandwitnessinformation.org.uk
+  namespace: hale-platform-prod
+spec:
+  secretName: victimandwitnessinformation-cym-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - cym.victimandwitnessinformation.org.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: victimscode.org.uk
   namespace: hale-platform-prod
 spec:


### PR DESCRIPTION
Add cym.victimandwitnessinformation.org.uk to handle the Welsh language site to the parent site victimandwitnessinformation.org.uk