### PR TITLE
hmpps-activities-management-preprod -- 1/2 -- 🤖 migrating sa yaml

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/resources/serviceaccount-31012024.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/resources/serviceaccount-31012024.tf
@@ -1,0 +1,15 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  serviceaccount_name = "circleci-migrated"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+


### PR DESCRIPTION
1/2

1. merge this PR in
2. copy the new token to wherever it needs to go '''cloud-platform decode-secret -s circleci-migrated-token -n hmpps-activities-management-preprod'''
3. merge in the second PR which will delete your old serviceaccount yaml files

Feel free to change the newly added serviceaccount terraform.

[Docs for migration](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/moving-service-accounts-to-terraform.html#moving-from-yaml-defined-service-accounts-to-terraform-module)