### PR TITLE
MTP-1980: Reset `prepare_for_major_upgrade` flag before upgrading PostgreSQL to 16.1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -23,7 +23,7 @@ module "rds" {
   db_allocated_storage = "5"
   db_name              = "mtp_api"
 
-  prepare_for_major_upgrade   = true
+  prepare_for_major_upgrade   = false
   allow_major_version_upgrade = false
   allow_minor_version_upgrade = false
   deletion_protection         = true

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -16,9 +16,9 @@ module "rds" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 
-  rds_family           = "postgres16"
+  rds_family           = "postgres15"
   db_engine            = "postgres"
-  db_engine_version    = "16.1"
+  db_engine_version    = "15.5"
   db_instance_class    = "db.t4g.small"
   db_allocated_storage = "5"
   db_name              = "mtp_api"


### PR DESCRIPTION
Previous attempt failed because `prepare_for_major_upgrade` was still true and terraform couldn't successfully apply the changes because of the existence of the parameter group from the PostgreSQL upgrade from `14.x` to `15.x`.