### PR TITLE
SLM-338 - update prepare_for_major_upgrade to false after updating DB version to 14.10

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
@@ -10,7 +10,7 @@ module "slmtp_api_rds" {
   infrastructure_support = var.infrastructure_support
 
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade   = true
+  prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "14.10"
   rds_family                  = "postgres14"


### PR DESCRIPTION
SLM-338 - update prepare_for_major_upgrade to false after updating SLM DB version to 14.10 for send-legal-mail-to-prisons-prod namespace.