### PR TITLE
formbuilder-platform-test-production -- 🤖 migrating sa yaml formbuilder-submitter-workers-test-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/serviceaccount-formbuilder-submitter-workers-test-production.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/serviceaccount-formbuilder-submitter-workers-test-production.tf
@@ -1,0 +1,15 @@
+module "serviceaccount_formbuilder-submitter-workers-test-production" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  serviceaccount_name = "formbuilder-submitter-workers-test-production-migrated"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/submitter-workers-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/submitter-workers-service-account.yaml
@@ -1,8 +1,0 @@
----
-# Source: formbuilder-platform/templates/submitter-workers-service-account.yaml
-# auto-generated from fb-cloud-platforms-environments
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: formbuilder-submitter-workers-test-production
-  namespace: formbuilder-platform-test-production


### PR DESCRIPTION


1. merge this PR in
2. copy the new token to wherever it needs to go '''cloud-platform decode-secret -s formbuilder-submitter-workers-test-production-migrated-token -n formbuilder-platform-test-production'''

Feel free to change and amend the newly added serviceaccount terraform in the PR.

[Docs for migration](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/moving-service-accounts-to-terraform.html#moving-from-yaml-defined-service-accounts-to-terraform-module)