### PR TITLE
formbuilder-saas-live -- 🤖 migrating sa yaml formbuilder-av-live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/formbuilder-av-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/formbuilder-av-service-account.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: formbuilder-av-live
-  namespace: formbuilder-saas-live

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/serviceaccount-formbuilder-av-live.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/serviceaccount-formbuilder-av-live.tf
@@ -1,0 +1,15 @@
+module "serviceaccount_formbuilder-av-live" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  serviceaccount_name = "formbuilder-av-live-migrated"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+


### PR DESCRIPTION


1. merge this PR in
2. copy the new token to wherever it needs to go '''cloud-platform decode-secret -s formbuilder-av-live-migrated-token -n formbuilder-saas-live'''

Feel free to change and amend the newly added serviceaccount terraform in the PR.

[Docs for migration](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/moving-service-accounts-to-terraform.html#moving-from-yaml-defined-service-accounts-to-terraform-module)