### PR TITLE
formbuilder-platform-live-production -- 🤖 migrating sa yaml formbuilder-submitter-workers-live-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/serviceaccount-formbuilder-submitter-workers-live-production.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/serviceaccount-formbuilder-submitter-workers-live-production.tf
@@ -1,0 +1,15 @@
+module "serviceaccount_formbuilder-submitter-workers-live-production" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  serviceaccount_name = "formbuilder-submitter-workers-live-production-migrated"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/submitter-workers-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/submitter-workers-service-account.yaml
@@ -1,8 +1,0 @@
----
-# Source: formbuilder-platform/templates/submitter-workers-service-account.yaml
-# auto-generated from fb-cloud-platforms-environments
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: formbuilder-submitter-workers-live-production
-  namespace: formbuilder-platform-live-production


### PR DESCRIPTION


1. merge this PR in
2. copy the new token to wherever it needs to go '''cloud-platform decode-secret -s formbuilder-submitter-workers-live-production-migrated-token -n formbuilder-platform-live-production'''

Feel free to change and amend the newly added serviceaccount terraform in the PR.

[Docs for migration](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/moving-service-accounts-to-terraform.html#moving-from-yaml-defined-service-accounts-to-terraform-module)