### PR TITLE
formbuilder-platform-test-dev -- 🤖 migrating sa yaml formbuilder-submitter-workers-test-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/serviceaccount-formbuilder-submitter-workers-test-dev.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/serviceaccount-formbuilder-submitter-workers-test-dev.tf
@@ -1,0 +1,15 @@
+module "serviceaccount_formbuilder-submitter-workers-test-dev" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  serviceaccount_name = "formbuilder-submitter-workers-test-dev-migrated"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/submitter-workers-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/submitter-workers-service-account.yaml
@@ -1,8 +1,0 @@
----
-# Source: formbuilder-platform/templates/submitter-workers-service-account.yaml
-# auto-generated from fb-cloud-platforms-environments
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: formbuilder-submitter-workers-test-dev
-  namespace: formbuilder-platform-test-dev


### PR DESCRIPTION


1. merge this PR in
2. copy the new token to wherever it needs to go '''cloud-platform decode-secret -s formbuilder-submitter-workers-test-dev-migrated-token -n formbuilder-platform-test-dev'''

Feel free to change and amend the newly added serviceaccount terraform in the PR.

[Docs for migration](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/moving-service-accounts-to-terraform.html#moving-from-yaml-defined-service-accounts-to-terraform-module)