### PR TITLE
PI-1841 apply db upgrade 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/rds.tf
@@ -15,9 +15,6 @@ module "rds" {
   # db instance class
   db_instance_class = "db.t4g.small"
 
-  prepare_for_major_upgrade = true
-  allow_major_version_upgrade = true
-
   # change the postgres version as you see fit.
   db_engine_version      = "14.10"
   environment_name       = var.environment-name


### PR DESCRIPTION
Previous attempt to upgrade to postgres 16 failed because version wasn't at 14.10 beforehand, so minor update to 14.10 first to permit major upgrade to 16 afterwards