### PR TITLE
formbuilder-saas-test -- 🤖 migrating sa yaml formbuilder-av-test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/formbuilder-av-service-account.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/formbuilder-av-service-account.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: formbuilder-av-test
-  namespace: formbuilder-saas-test

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/serviceaccount-formbuilder-av-test.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/serviceaccount-formbuilder-av-test.tf
@@ -1,0 +1,15 @@
+module "serviceaccount_formbuilder-av-test" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  serviceaccount_name = "formbuilder-av-test-migrated"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+


### PR DESCRIPTION


1. merge this PR in
2. copy the new token to wherever it needs to go '''cloud-platform decode-secret -s formbuilder-av-test-migrated-token -n formbuilder-saas-test'''

Feel free to change and amend the newly added serviceaccount terraform in the PR.

[Docs for migration](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/moving-service-accounts-to-terraform.html#moving-from-yaml-defined-service-accounts-to-terraform-module)