### PR TITLE
DSOS-2543: update bucket permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-download-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-download-dev/resources/s3.tf
@@ -25,9 +25,10 @@ data "aws_iam_policy_document" "dso_user_s3_access_policy" {
     sid    = "AllowDsoUserToReadAndPutObjectsInS3"
     effect = "Allow"
     actions = [
-      "s3:PutObject"
+      "s3:PutObject",
+      "s3:ListBucket",
+      "kms:GenerateDataKey",
     ]
-
     resources = [
       "${module.hmpps-prisoner-download_s3_bucket.bucket_arn}/*"
     ]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-download-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-download-dev/resources/s3.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "dso_user_s3_access_policy" {
     actions = [
       "s3:PutObject",
       "s3:ListBucket",
+      "kms:Encrypt",
       "kms:GenerateDataKey",
     ]
     resources = [


### PR DESCRIPTION
The referenced bucket is setup with `cloud-platform-terraform-s3-bucket` which enforces encryption as default, so we need to add some encryption permissions to our role.

Also adding a ListBucket permission, as we are using `aws s3 cp` and we think this is required.