### PR TITLE
Upgrade from 12.14 to 15.2

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
@@ -10,8 +10,9 @@ module "editor-rds-instance" {
   infrastructure_support     = var.infrastructure_support
   team_name                  = var.team_name
   business_unit              = "Platforms"
-  db_engine_version          = "12"
-  rds_family                 = "postgres12"
+  prepare_for_major_upgrade  = true
+  db_engine_version          = "15.2"
+  rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
@@ -10,8 +10,9 @@ module "metadata-api-rds-instance" {
   infrastructure_support     = var.infrastructure_support
   team_name                  = var.team_name
   business_unit              = "Platforms"
-  db_engine_version          = "12"
-  rds_family                 = "postgres12"
+  prepare_for_major_upgrade  = true
+  db_engine_version          = "15.2"
+  rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 
   providers = {


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion According to this, we can major upgrade from 12.14 to 15.2 then on to 16+

This PR applies the prepare for major upgrade flag and upgrades to 15.2