### PR TITLE
Upgrade from 12.17 to 15.5

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
@@ -11,8 +11,8 @@ module "editor-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "16.1"
-  rds_family                 = "postgres16"
+  db_engine_version          = "15.5"
+  rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
@@ -11,8 +11,8 @@ module "editor-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.2"
-  rds_family                 = "postgres15"
+  db_engine_version          = "16.1"
+  rds_family                 = "postgres16"
   db_instance_class          = var.db_instance_class
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
@@ -11,8 +11,8 @@ module "metadata-api-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "16.1"
-  rds_family                 = "postgres16"
+  db_engine_version          = "15.5"
+  rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/metadata_api.tf
@@ -11,8 +11,8 @@ module "metadata-api-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.2"
-  rds_family                 = "postgres15"
+  db_engine_version          = "16.1"
+  rds_family                 = "postgres16"
   db_instance_class          = var.db_instance_class
 
   providers = {


### PR DESCRIPTION
Going by the email comms regarding upgrading, we were expecting to go from 12.14 to 15.2

<img width="573" alt="image" src="https://github.com/ministryofjustice/cloud-platform-environments/assets/7647632/7a2f43e8-cf46-4c1c-88d5-977c7566414b">

When applying the upgrade to 15, we get this failure
<img width="1870" alt="image" src="https://github.com/ministryofjustice/cloud-platform-environments/assets/7647632/7785a5e1-7411-4b91-becf-24e02ee8377e">


According to https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion 12.17 can target 16.1, but we will need to go to 15.5 and then upgrade the engine from t4g to support 16+