### PR TITLE
Add test subdomains before rollout to prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/07-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/07-certificates.yaml
@@ -1,0 +1,25 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test1.magistrates.judiciary.uk
+  namespace: hale-platform-dev
+spec:
+  secretName: magistrates-test1-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - test1.magistrates.judiciary.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test1.victimscommissioner.org.uk
+  namespace: hale-platform-dev
+spec:
+  secretName: victimscommissioner-test1-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - test1.victimscommissioner.org.uk


### PR DESCRIPTION
This sets up some dummy subdomains to use for a test that will later be run on production.