### PR TITLE
Upgrade platform-test-dev RDS instances

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
@@ -10,8 +10,9 @@ module "submitter-rds-instance-2" {
   infrastructure_support     = var.infrastructure_support
   team_name                  = var.team_name
   business_unit              = "Platforms"
-  db_engine_version          = "14"
-  rds_family                 = "postgres14"
+  prepare_for_major_upgrade  = true
+  db_engine_version          = "15.5"
+  rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -10,8 +10,9 @@ module "user-datastore-rds-instance-2" {
   infrastructure_support     = var.infrastructure_support
   team_name                  = var.team_name
   business_unit              = "Platforms"
-  db_engine_version          = "14"
-  rds_family                 = "postgres14"
+  prepare_for_major_upgrade  = true
+  db_engine_version          = "15.5"
+  rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 
   providers = {


### PR DESCRIPTION
Going from 14.7 to 15.5 

This should satisfy the need to upgrade to latest minor version, as well as giving us longer supported life for the version of Postgres we have.