### PR TITLE
Add test subdomains and tls cert mapping manifest

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/certificates.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/certificates.tf
@@ -1,0 +1,28 @@
+variable "domains" {
+  type = map(string)
+  default = {
+    "test1.magistrates.judiciary.uk"   = "magistrates-test1"
+    "test1.victimscommissioner.org.uk" = "victimscommissioner-test1"
+  }
+}
+
+resource "kubernetes_manifest" "certificate" {
+  for_each = var.domains
+
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "Certificate"
+    metadata = {
+      name      = each.key
+      namespace = "hale-platform-dev"
+    }
+    spec = {
+      dnsNames = [each.key]
+      issuerRef = {
+        kind = "ClusterIssuer"
+        name = "letsencrypt-production"
+      }
+      secretName = "${each.value}-cert"
+    }
+  }
+}


### PR DESCRIPTION
I've set up two test domains in our dev environment

- https://test1.magistrates.judiciary.uk/
- https://test1.victimscommissioner.org.uk

They both are working and have their TLS certs added the normal default CP way. This tests rolling out existing certs in this looping approach. 