### PR TITLE
Clean up prepare_for_major_update flags

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
@@ -10,7 +10,6 @@ module "submitter-rds-instance-2" {
   infrastructure_support     = var.infrastructure_support
   team_name                  = var.team_name
   business_unit              = "Platforms"
-  prepare_for_major_upgrade  = true
   db_engine_version          = "15.5"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -10,7 +10,6 @@ module "user-datastore-rds-instance-2" {
   infrastructure_support     = var.infrastructure_support
   team_name                  = var.team_name
   business_unit              = "Platforms"
-  prepare_for_major_upgrade  = true
   db_engine_version          = "15.5"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class


### PR DESCRIPTION
These RDS instance updates are complete, no longer need this and can revert to default