### PR TITLE
Fix: Update LFA Circle CI service-account role* names

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/serviceaccount-circleci.tf
@@ -4,6 +4,9 @@ module "serviceaccount_circleci" {
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
 
+  role_name = "circleci-legal-framework-uat-sa-migrated"
+  rolebinding_name = "circleci-legal-framework-uat-sa-migrated"
+
   serviceaccount_token_rotated_date = "01-01-2000"
 
   serviceaccount_name = "circleci-migrated"


### PR DESCRIPTION
The auto generated PR #20273 failed on merge due to a name clash

This adds specific role_name and rolebinding_name values