### PR TITLE
MTP-1980: Revert `prepare_for_major_upgrade` before upgrade to `16.1`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
@@ -23,7 +23,7 @@ module "rds" {
   db_allocated_storage = "175"
   db_name              = "mtp_api"
 
-  prepare_for_major_upgrade    = true
+  prepare_for_major_upgrade    = false
   allow_major_version_upgrade  = false
   allow_minor_version_upgrade  = false
   deletion_protection          = true


### PR DESCRIPTION
This needs to go back to false before the jump from PostgreSQL `15.5` to `16.1`.