### PR TITLE
MTP-1980: Set `prepare_for_major_upgrade` to `true`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
@@ -23,7 +23,7 @@ module "rds" {
   db_allocated_storage = "175"
   db_name              = "mtp_api"
 
-  prepare_for_major_upgrade    = false
+  prepare_for_major_upgrade    = true
   allow_major_version_upgrade  = false
   allow_minor_version_upgrade  = false
   deletion_protection          = true


### PR DESCRIPTION
At the moment RDS instance is still at `v15.5` because the previous pipeline apply failed for some reason: https://github.com/ministryofjustice/cloud-platform-environments/pull/20828 