### PR TITLE
Upgrade to 15.2

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/editor.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/editor.tf
@@ -11,7 +11,7 @@ module "editor-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.5"
+  db_engine_version          = "15.2"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
@@ -11,7 +11,7 @@ module "metadata-api-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.5"
+  db_engine_version          = "15.2"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
   db_allocated_storage       = "300"


### PR DESCRIPTION
This namespace failed to upgrade to 15.5 as it was on 12.14 not 12.17, according to the [upgrade paths](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion) I should be able to go to 15.2 then 15.5.

No plans to change engine type at this time as all v15 are supported