### PR TITLE
RR-637 - Reset dev RDS flags and remove skip namespace file

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/rds-postgresql.tf
@@ -17,8 +17,8 @@ module "hmpps_education_work_plan_rds" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = true
-  prepare_for_major_upgrade = true
+  allow_major_version_upgrade  = false
+  prepare_for_major_upgrade = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   enable_rds_auto_start_stop   = true # Dev database is stopped overnight between 10PM and 6AM UTC / 11PM and 7AM BST.


### PR DESCRIPTION
Now that the RDS instance has been upgraded to 15.5, we need to reset a couple of flags and remove the skip namespace file.