### PR TITLE
RR-638 - Upgrade RDS to postgres 15.5 - pre-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/rds-postgresql.tf
@@ -12,7 +12,8 @@ module "hmpps_education_work_plan_rds" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = false
+  allow_major_version_upgrade  = true
+  prepare_for_major_upgrade = true
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   enable_rds_auto_start_stop   = true # Pre-prod database is stopped overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
@@ -20,8 +21,8 @@ module "hmpps_education_work_plan_rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.7"
-  rds_family        = "postgres14"
+  db_engine_version = "15.5"
+  rds_family        = "postgres15"
   db_instance_class = "db.t4g.micro"
 
   # Tags


### PR DESCRIPTION
Upgrade pre-prod RDS instance to 15.5, according to [this guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-to-a-new-major-database-version).