### PR TITLE
RR-639 - Upgrade RDS to postgres 15.5 - prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prod/resources/rds-postgresql.tf
@@ -12,15 +12,16 @@ module "hmpps_education_work_plan_rds" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = false
+  allow_major_version_upgrade  = true
+  prepare_for_major_upgrade    = true
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.10"
-  rds_family        = "postgres14"
+  db_engine_version = "15.5"
+  rds_family        = "postgres15"
   db_instance_class = "db.t4g.micro"
 
   # Tags


### PR DESCRIPTION
Upgrade production RDS instance to v15.5, as explained in [this guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-to-a-new-major-database-version).

Once approved, I'll merge this out of hours.