### PR TITLE
Add new Route53 zone - justiceinspectorates.gov.uk

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/justiceinspectorates.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/justiceinspectorates.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "justiceinspectorates_route53_zone" {
+  name = "justiceinspectorates.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "justiceinspectorates_route53_zone" {
+  metadata {
+    name      = "justiceinspectorates-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.justiceinspectorates_route53_zone.zone_id
+  }
+}


### PR DESCRIPTION
Add a new Route53 zone for a new domain coming onto the platform.