### PR TITLE
Bump rds version for sjpr-prod to 8.0.35 to match currently live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/rds-mysql.tf
@@ -24,7 +24,7 @@ module "rds_mysql" {
 
   # using mysql
   db_engine         = "mysql"
-  db_engine_version = "8.0.33"
+  db_engine_version = "8.0.35"
   rds_family        = "mysql8.0"
   db_instance_class = "db.t4g.small"
 


### PR DESCRIPTION
```Error: updating RDS DB Instance (cloud-platform-47b4127d252f498e): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: c2a93fa0-8702-4a84-9c73-e26e96927151, api error InvalidParameterCombination: Cannot upgrade mysql from 8.0.35 to 8.0.33```

Bumping version in terraform to match live state.