### PR TITLE
CPR-170 allow service account to access SNS topics

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/irsa.tf
@@ -4,7 +4,7 @@ locals {
   }
   sns_topics = {
     "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev"
-    "cloud-platform-probation-in-court-team-5b4824dca700d8b3ec75f25d24adfbb9"= "court-probation-dev"
+    "cloud-platform-probation-in-court-team-5b4824dca700d8b3ec75f25d24adfbb9" = "court-probation-dev"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
   sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
@@ -27,6 +27,8 @@ module "irsa" {
   role_policy_arns = merge(
     local.sns_policies,
     local.sqs_policies,
+    { sns_domain_events = module.cpr_delius_offender_events_queue.irsa_policy_arn },
+    { sns_court_probation = module.cpr_court_case_events_queue.irsa_policy_arn },
     { rds = module.hmpps_person_record_rds.irsa_policy_arn },
     { sqs_cpr_cce = module.cpr_court_case_events_queue.irsa_policy_arn },
     { sqs_cpr_cce_dlq = module.cpr_court_case_events_dead_letter_queue.irsa_policy_arn },

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/irsa.tf
@@ -2,8 +2,9 @@ locals {
   # *** Placeholder for incoming SQS queues ***
   sqs_queues = {
   }
-  # *** Placeholder for incoming SNS topics ***
   sns_topics = {
+    "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev"
+    "cloud-platform-probation-in-court-team-5b4824dca700d8b3ec75f25d24adfbb9"= "court-probation-dev"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
   sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }


### PR DESCRIPTION
An attempt to fix the errors shown in https://developer-portal.hmpps.service.justice.gov.uk/components/hmpps-person-record/environment/dev

> "topicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-probation-in-court-team-5b4824dca700d8b3ec75f25d24adfbb9",
>         "error": "java.util.concurrent.ExecutionException: software.amazon.awssdk.services.sns.model.AuthorizationErrorException: User: arn:aws:sts::754256621582:assumed-role/cloud-platform-irsa-3f7c5895c70903f3-live/aws-sdk-java-1708420333884 is not authorized to perform: SNS:GetTopicAttributes on resource: arn:aws:sns:eu-west-2:754256621582:cloud-platform-probation-in-court-team-5b4824dca700d8b3ec75f25d24adfbb9 because no identity-based policy allows the SNS:GetTopicAttributes action (Service: Sns, Status Code: 403, Request ID: 48f35812-f079-5095-9234-065c120a3856)"
