### PR TITLE
RR-641 - Revert changes to education-and-work-plan in domain-events-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-education-and-work-plan-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-education-and-work-plan-api.tf
@@ -1,0 +1,144 @@
+module "education_and_work_plan_domain_events_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
+
+  # Queue configuration
+  sqs_name                  = "education_and_work_plan_domain_events_queue"
+  encrypt_sqs_kms           = "true"
+  message_retention_seconds = 1209600
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.education_and_work_plan_domain_events_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+
+EOF
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the queue
+  namespace              = var.namespace
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "education_and_work_plan_domain_events_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
+
+  # Queue configuration
+  sqs_name        = "education_and_work_plan_domain_events_dl"
+  encrypt_sqs_kms = "true"
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the queue
+  namespace              = var.namespace
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_sqs_queue_policy" "education_and_work_plan_domain_events_queue_policy" {
+  queue_url = module.education_and_work_plan_domain_events_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.education_and_work_plan_domain_events_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.education_and_work_plan_domain_events_queue.sqs_arn}",
+          "Action": "SQS:SendMessage",
+          "Condition":
+                      {
+                        "ArnEquals":
+                          {
+                            "aws:SourceArn": "${module.hmpps-domain-events.topic_arn}"
+                          }
+                        }
+        }
+      ]
+  }
+
+EOF
+
+}
+
+resource "aws_sns_topic_subscription" "education_and_work_plan_domain_events_subscription" {
+  provider  = aws.london
+  topic_arn = module.hmpps-domain-events.topic_arn
+  protocol  = "sqs"
+  endpoint  = module.education_and_work_plan_domain_events_queue.sqs_arn
+  filter_policy = jsonencode({
+    eventType = [
+      "ciag-induction.created",
+      "ciag-induction.updated"
+    ]
+  })
+
+}
+
+resource "kubernetes_secret" "education_and_work_plan_domain_events_queue" {
+  metadata {
+    name      = "education-and-work-plan-domain-events-sqs-instance-output"
+    namespace = "hmpps-education-and-work-plan-dev"
+  }
+
+  data = {
+    sqs_queue_url  = module.education_and_work_plan_domain_events_queue.sqs_id
+    sqs_queue_arn  = module.education_and_work_plan_domain_events_queue.sqs_arn
+    sqs_queue_name = module.education_and_work_plan_domain_events_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "education_and_work_plan_dlq" {
+  metadata {
+    name      = "education-and-work-plan-domain-events-sqs-dl-instance-output"
+    namespace = "hmpps-education-and-work-plan-dev"
+  }
+
+  data = {
+    sqs_queue_url  = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_id
+    sqs_queue_arn  = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_arn
+    sqs_queue_name = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "ciag_domain_events_queue" {
+  metadata {
+    name      = "ciag-domain-events-sqs-instance-output"
+    namespace = "hmpps-education-employment-dev"
+  }
+
+  data = {
+    sqs_queue_url  = module.education_and_work_plan_domain_events_queue.sqs_id
+    sqs_queue_arn  = module.education_and_work_plan_domain_events_queue.sqs_arn
+    sqs_queue_name = module.education_and_work_plan_domain_events_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "ciag_dlq" {
+  metadata {
+    name      = "ciag-domain-events-sqs-dl-instance-output"
+    namespace = "hmpps-education-employment-dev"
+  }
+
+  data = {
+    sqs_queue_url  = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_id
+    sqs_queue_arn  = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_arn
+    sqs_queue_name = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/outputs-to-ssm-parameters.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/outputs-to-ssm-parameters.tf
@@ -14,6 +14,8 @@ locals {
     (module.activities_domain_events_dead_letter_queue.sqs_name)                    = module.activities_domain_events_dead_letter_queue.irsa_policy_arn,
     (module.hdc_domain_events_queue.sqs_name)                                       = module.hdc_domain_events_queue.irsa_policy_arn,
     (module.hdc_domain_events_dead_letter_queue.sqs_name)                           = module.hdc_domain_events_dead_letter_queue.irsa_policy_arn,
+    (module.education_and_work_plan_domain_events_queue.sqs_name)                   = module.education_and_work_plan_domain_events_queue.irsa_policy_arn,
+    (module.education_and_work_plan_domain_events_dead_letter_queue.sqs_name)       = module.education_and_work_plan_domain_events_dead_letter_queue.irsa_policy_arn,
     (module.keyworker_api_queue.sqs_name)                                           = module.keyworker_api_queue.irsa_policy_arn,
     (module.keyworker_api_dead_letter_queue.sqs_name)                               = module.keyworker_api_dead_letter_queue.irsa_policy_arn,
     (module.in_cell_queue.sqs_name)                                                 = module.in_cell_queue.irsa_policy_arn,

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/variables.tf
@@ -29,6 +29,7 @@ variable "additional_topic_clients" {
     "hmpps-assessments-dev",
     "hmpps-community-accommodation-dev",
     "hmpps-complexity-of-need-staging",
+    "hmpps-education-and-work-plan-dev",
     "hmpps-education-employment-dev",
     "hmpps-incentives-dev",
     "hmpps-interventions-dev",


### PR DESCRIPTION
This PR reverts [this change](https://github.com/ministryofjustice/cloud-platform-environments/pull/21064/files) I made earlier, which caused the following error:

```
FATA[0046] error running terraform on namespace hmpps-domain-events-dev: unable to apply Terraform: exit status 1

Error: deleting IAM Policy (arn:aws:iam::754256621582:policy/cloud-platform/sqs/cloud-platform-sqs-7f8e777ec329): DeleteConflict: Cannot delete a policy attached to entities.
	status code: 409, request id: 8f044e96-566e-41ae-81df-98ce18215dc1
```

I'll look into this separately, but in the meantime I'm assuming it might be best to revert that change.