### PR TITLE
CRM457-1061: Update serviceaccount permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev/resources/serviceaccount.tf
@@ -32,13 +32,17 @@ variable "serviceaccount_rules" {
         "deployment",
         "secrets",
         "services",
-        "configmaps",
+        "serviceaccounts",
         "pods",
+        "pods/exec",
+        "configmaps",
+        "persistentvolumeclaims",
       ]
       verbs = [
         "patch",
         "get",
         "create",
+        "update",
         "delete",
         "list",
         "watch",
@@ -50,11 +54,15 @@ variable "serviceaccount_rules" {
         "extensions",
         "apps",
         "networking.k8s.io",
+        "batch",
       ]
       resources = [
         "deployments",
         "ingresses",
-        "replicasets"
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "statefulsets",
       ]
       verbs = [
         "get",


### PR DESCRIPTION
Repeating for `laa-claim-non-standard-magistrate-fee-dev` what we did recently for `laa-claim-non-standard-magistrate-fee-dev` to aid dynamic per-branch releases