### PR TITLE
Hale Platform Prod - Test Route53 file in subfolder

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-module.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-module.tf
@@ -1,0 +1,3 @@
+module "route53_module" {
+  source = "./route53/*.tf"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-module.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-module.tf
@@ -1,3 +1,3 @@
 module "route53_module" {
-  source = "./route53/*.tf"
+  source = "./route53"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
@@ -8,8 +8,13 @@ terraform {
     }
   }
 
-  content {
-      source = "./*-route53.tf"
+ # Dynamically include all Terraform files in the subfolder as sources
+  dynamic "module" {
+    for_each = fileset("./", "*.tf")
+
+    content {
+      source = "./${module.key}"
+    }
   }
  
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
@@ -7,15 +7,8 @@ terraform {
       version = "~> 4.67.0"
     }
   }
+}
 
- # Dynamically include all Terraform files in the subfolder as sources
-  dynamic "module" {
-    for_each = fileset("./", "*.tf")
-
-    content {
-      source = "./${module.key}"
-    }
-  }
- 
-
+terraform {
+  source = "./*-route53.tf"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
@@ -1,6 +1,8 @@
 terraform {
   source = "./*-route53.tf"
 
+  required_version = ">= 1.2.5"
+  
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
@@ -1,3 +1,11 @@
 terraform {
   source = "./*-route53.tf"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67.0"
+    }
+  }
+
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  source = "./*-route53.tf"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
@@ -8,6 +8,9 @@ terraform {
     }
   }
 
-  source = "./*-route53.tf"
+  content {
+      source = "./*-route53.tf"
+  }
+ 
 
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/main.tf
@@ -1,13 +1,13 @@
 terraform {
-  source = "./*-route53.tf"
-
   required_version = ">= 1.2.5"
-  
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.67.0"
     }
   }
+
+  source = "./*-route53.tf"
 
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/test-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53/test-route53.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "test_route53_txt_record" {
+  zone_id = aws_route53_zone.victimscode_route53_zone.zone_id
+  name    = "victimscode.org.uk"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["test"]
+}


### PR DESCRIPTION
We want to tidy up out resources folder as theres a growing number of route53 files.

We want to put all the route53 tf files in a subfolder. We have informed the only to do this would be to create a module.

This is a test to see if the txt record is created. 
