### PR TITLE
Update 04-networkpolicy.yaml - Cymulate IP Range for Pen Testing

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/04-networkpolicy.yaml
@@ -3,6 +3,8 @@ kind: NetworkPolicy
 metadata:
   name: default
   namespace: hmpps-accredited-programmes-dev
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: 54.217.50.18/32,52.208.202.111/32,52.49.144.209/32,51.155.102.238/32
 spec:
   podSelector: {}
   policyTypes:


### PR DESCRIPTION
**What this change is:**

We have added the [Cymulate](https://cymulate.com/) egress IP range supplied by MoJ internal pen-testers to the inbound whitelist.

We have also added the IP of one of our dev laptops so we can verify the change prior to pen-testing.

**Why this change is required**

The MoJ internal pen-test uses a cloud-based tool, Cymulate, and this needs to access our build in Dev to run the tests.

**NOTE**

This is temporary and will be removed following the pen-test.