### PR TITLE
fix replica upgrade

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -23,7 +23,7 @@ module "rds-instance" {
   db_engine_version    = "15.2"
   rds_family           = "postgres15"
 
-  prepare_for_major_upgrade = true
+  prepare_for_major_upgrade = false
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_minor_version_upgrade = "false"
   allow_major_version_upgrade = "false"
@@ -89,6 +89,7 @@ module "rds-read-replica" {
 
   db_name             = null # "db_name": conflicts with replicate_source_db
   replicate_source_db = module.rds-instance.db_identifier
+  prepare_for_major_upgrade = true
 
   # Set to true for replica database. No backups or snapshots are created for read replica
   skip_final_snapshot        = "true"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -89,7 +89,7 @@ module "rds-read-replica" {
 
   db_name             = null # "db_name": conflicts with replicate_source_db
   replicate_source_db = module.rds-instance.db_identifier
-  prepare_for_major_upgrade = true
+  prepare_for_major_upgrade = false
 
   # Set to true for replica database. No backups or snapshots are created for read replica
   skip_final_snapshot        = "true"


### PR DESCRIPTION
This PR has 2 commits.
- First to disable the prepare_for_upgrade flag on primary rds and enable for read-replica. This is then applied manually to fix the terraform error  DBParameterGroupAlreadyExists: Parameter group cloud-platform-XXX already exists
- 2nd commit to disable the flag in read replica
