### PR TITLE
Chore/update cas dev rds

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
@@ -13,6 +13,8 @@ module "rds" {
   db_instance_class            = "db.t3.small"
   rds_family                   = "postgres14"
   allow_major_version_upgrade  = "false"
+  backup_window                = var.rds_backup_window
+  maintenance_window           = var.rds_maintenance_window
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
@@ -13,6 +13,8 @@ module "rds" {
   db_instance_class            = "db.t3.small"
   rds_family                   = "postgres14"
   allow_major_version_upgrade  = "false"
+  allow_minor_version_upgrade  = "true"
+
   backup_window                = var.rds_backup_window
   maintenance_window           = var.rds_maintenance_window
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
   db_engine_version            = "14"
   db_instance_class            = "db.t3.small"
   rds_family                   = "postgres14"
-  allow_major_version_upgrade  = "true"
+  allow_major_version_upgrade  = "false"
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/variables.tf
@@ -57,3 +57,10 @@ variable "github_token" {
 }
 
 variable "eks_cluster_name" {}
+
+variable "rds_backup_window" {
+  default = "22:00-23:59"
+}
+variable "rds_maintenance_window" {
+  default = "sun:00:00-sun:03:00"
+}


### PR DESCRIPTION
- We were asking to update the CAS postgres minor version due to it soon being deprecated.
- We found that it has already been moved from 14.7 to 14.10
- While we're here we want to make this more automated going forwards so we enable automatic minor updates. Before we do we assign an explicit maintenance window so we are clear about avoiding disruption to users
- While we're here we also make test no longer auto update major versions so it behaves like prod, providing greater environment parity
