### PR TITLE
Electronic monitoring dev resource

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/emds-s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/emds-s3.tf
@@ -1,0 +1,35 @@
+module "emds_s3" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.1.0"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+}
+
+
+resource "aws_s3_bucket_notification" "emds_s3_notification" {
+  bucket = module.emds_s3.bucket_name
+
+  queue {
+    id        = "emds-s3-upload-event"
+    queue_arn = module.emds_submit_queue.sqs_arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+}
+
+
+resource "kubernetes_secret" "emds_s3" {
+  metadata {
+    name      = "emds-s3"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.emds_s3.bucket_arn
+    bucket_name = module.emds_s3.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/emds-s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/emds-s3.tf
@@ -11,17 +11,6 @@ module "emds_s3" {
 }
 
 
-resource "aws_s3_bucket_notification" "emds_s3_notification" {
-  bucket = module.emds_s3.bucket_name
-
-  queue {
-    id        = "emds-s3-upload-event"
-    queue_arn = module.emds_submit_queue.sqs_arn
-    events    = ["s3:ObjectCreated:*"]
-  }
-}
-
-
 resource "kubernetes_secret" "emds_s3" {
   metadata {
     name      = "emds-s3"


### PR DESCRIPTION
Creating a bucket under the hmpps-em dev namespace for the purpose of ingesting unstructured data via the electronic monitoring landing zone. The existing resource is associated with CEMO, a parallel but separate project, and so separating resources is preferable.