### PR TITLE
Update CAS dev support email address

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/00-namespace.yaml
@@ -12,6 +12,6 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "community-accommodation-service-tier-3-team"
     cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
     cloud-platform.justice.gov.uk/application: "Community Accommodation"
-    cloud-platform.justice.gov.uk/owner: "Community Accommodation: cas3@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "Community Accommodation: casdev@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git,https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui"
     cloud-platform.justice.gov.uk/team-name: "hmpps-community-accommodation"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/variables.tf
@@ -29,7 +29,7 @@ variable "environment" {
 
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
-  default     = "cas3@digital.justice.gov.uk"
+  default     = "casdev@digital.justice.gov.uk"
 }
 
 variable "is_production" {


### PR DESCRIPTION
We now have a shared inbox rather than the original CAS3 only email that we had at the time of setting up our environments. This should ensure no requests are lost.