### PR TITLE
Restore variable removed in last PR

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/resources/serviceaccount.tf
@@ -1,6 +1,7 @@
 module "serviceaccount" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
 
+  serviceaccount_name  = "circleci"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_rules = var.serviceaccount_rules


### PR DESCRIPTION
restore 

```
  serviceaccount_name  = "circleci"
```

as the last PR store k8 auth from working https://app.circleci.com/pipelines/github/ministryofjustice/laa-crime-application-store/338/workflows/e9ae8460-3f62-478e-a70c-d59effbb8b11/jobs/2100/steps

and this was the only significant difference that could be identified as a potential cause