### PR TITLE
Make a plea dev: rename iam policy to fix concourse error

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/api-gateway-iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/api-gateway-iam.tf
@@ -105,7 +105,7 @@ resource "kubernetes_secret" "iac_fees_apigw_iam" {
 
 resource "aws_iam_policy" "api_gw_cloudwatch_logs_policy" {
   provider = aws.ireland
-  name        = "api_gw_cloudwatch_logs_policy"
+  name        = "api_cloudwatch_logs_policy"
   path        = "/"
   description = "API Gateway permissions to write logs to CloudWatch"
 


### PR DESCRIPTION
The prevoius PR failed due to duplicate IAM policy name: https://github.com/ministryofjustice/cloud-platform-environments/pull/21388