### PR TITLE
HEAT-213

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/rds.tf
@@ -58,7 +58,7 @@ locals {
   ])
 
   database_details = {
-    for m in local.database_list : "${m.identifier}" => m
+    for m in local.database_list : (m.identifier) => m
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/rds.tf
@@ -19,6 +19,7 @@ module "hmpps_service_catalogue" {
   }
 }
 
+
 resource "kubernetes_secret" "hmpps_service_catalogue" {
   metadata {
     name      = "rds-instance-output"
@@ -33,3 +34,64 @@ resource "kubernetes_secret" "hmpps_service_catalogue" {
     rds_instance_address  = module.hmpps_service_catalogue.rds_instance_address
   }
 }
+
+########################################################################################################
+#if there are multiple databases provisioned, then those names should be added in local variable as well. Like
+#rds_databases = {
+# "rdsAlertsDatabases.${module.hmpps_service_catalogue1.db_identifier1}" = "hmpps-service-catalogue-db1"
+# "rdsAlertsDatabases.${module.hmpps_service_catalogue2.db_identifier2}" = "hmpps-service-catalogue-db2"
+#}
+########################################################################################################## 
+
+locals {
+
+  rds_databases = {
+    "rdsAlertsDatabases.${module.hmpps_service_catalogue.db_identifier}" = "hmpps-service-catalogue-db"
+
+  }
+
+  database_list = flatten([
+    for identifier, desc in local.rds_databases : {
+      identifier = identifier
+      desc       = desc
+    }
+  ])
+
+  database_details = {
+    for m in local.database_list : "${m.identifier}" => m
+  }
+}
+
+resource "helm_release" "generic-aws-prometheus-alerts" {
+  name       = "generic-aws-prometheus-alerts"
+  repository = "https://ministryofjustice.github.io/hmpps-helm-charts"
+  chart      = "generic-aws-prometheus-alerts"
+  version    = "1.0.0"
+  namespace  = var.namespace
+
+  set {
+    name  = "targetApplication"
+    value = "hmpps-service-catalogue"
+  }
+
+  set {
+    name  = "alertSeverity"
+    value = "digital-prison-service-dev"
+  }
+
+  dynamic "set" {
+    for_each = local.database_details
+    content {
+      name  = set.value["identifier"]
+      value = set.value["desc"]
+    }
+  }
+}
+
+
+
+
+
+
+
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/versions.tf
@@ -21,5 +21,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5.1"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.11.0"
+    }
   }
 }


### PR DESCRIPTION
This change is to use separate aws rds prometheus alerts from the generic prometheus helm chart and utilizing a new chart for AWS RDS only. At the same time, this change aims to provide values required by charts at the time of terraform code application.