### PR TITLE
change team name back

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/00-namespace.yaml
@@ -12,5 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Find Moj Data"
     cloud-platform.justice.gov.uk/owner: "Data catalogue team: dataplatformlabs@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/data-catalogue"
-    cloud-platform.justice.gov.uk/team-name: "data-catalogue"
+    cloud-platform.justice.gov.uk/team-name: "data-platform-labs"
     cloud-platform.justice.gov.uk/review-after: ""


### PR DESCRIPTION
Github team name haas not changed yet so reverting back