### PR TITLE
remove underscores from secret names

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/secret.tf
@@ -28,12 +28,12 @@ module "secrets_manager" {
     "catalogue_token" = {
       description             = "Catalogue token for Datahub API Access",
       recovery_window_in_days = 7,
-      k8s_secret_name         = "catalogue_token"
+      k8s_secret_name         = "catalogue-token"
     },
     "secret_key" = {
       description             = "Django secret key",
       recovery_window_in_days = 7,
-      k8s_secret_name         = "secret_key"
+      k8s_secret_name         = "secret-key"
     },
   }
 }


### PR DESCRIPTION
underscores in secret names were causing the terraform apply to fail. This corrects that