### PR TITLE
Revert rename of find-moj-data repo

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/00-namespace.yaml
@@ -11,6 +11,6 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "data-catalogue"
     cloud-platform.justice.gov.uk/application: "Find Moj Data"
     cloud-platform.justice.gov.uk/owner: "Data catalogue team: dataplatformlabs@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/data-catalogue"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/find-moj-data"
     cloud-platform.justice.gov.uk/team-name: "data-catalogue"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/ecr.tf
@@ -12,7 +12,7 @@ module "ecr" {
 
   # OpenID Connect configuration
   oidc_providers      = ["github"]
-  github_repositories = ["data-catalogue"]
+  github_repositories = ["find-moj-data"]
 
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/serviceaccount.tf
@@ -8,5 +8,5 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  github_repositories = ["data-catalogue"]
+  github_repositories = ["find-moj-data"]
 }


### PR DESCRIPTION
We have renamed this back to the original name and created a separate `data-catalogue` repo.