### PR TITLE
Specify rolebinding name for 2nd service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/serviceaccount-circleci.tf
@@ -8,6 +8,7 @@ module "serviceaccount_circleci" {
 
   serviceaccount_name = "circleci-migrated"
   role_name = "circleci-migrated-role"
+  rolebinding_name = "circleci-migrated-rolebinding"
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines


### PR DESCRIPTION
Following on from https://github.com/ministryofjustice/cloud-platform-environments/pull/21567