### PR TITLE
CFE Civil PROD update pingdom url

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/pingdom.tf
@@ -4,7 +4,7 @@ provider "pingdom" {
 resource "pingdom_check" "cfe-civil-production" {
   type                     = "http"
   name                     = "Eligibility Platform - CFE Civil PRODUCTION - ping"
-  host                     = "cfe-civil.cloud-platform.service.justice.gov.uk"
+  host                     = "cfe-civil.cloud-platform.service.justice.gov.uk/status"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6


### PR DESCRIPTION
updating the URL pingdom uses to check the service is up.

the new status endpoint has a DB check

QUESTION:
We have the APPLY_SKIP_PIPELINE file on the namespace for a DB upgrade. Will that affect this PR ie. will it prevent this change from occurring until after that skip file is removed?
