### PR TITLE
CFE Civil PROD update pingdom url correctly

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/pingdom.tf
@@ -4,12 +4,12 @@ provider "pingdom" {
 resource "pingdom_check" "cfe-civil-production" {
   type                     = "http"
   name                     = "Eligibility Platform - CFE Civil PRODUCTION - ping"
-  host                     = "cfe-civil.cloud-platform.service.justice.gov.uk/status"
+  host                     = "cfe-civil.cloud-platform.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
-  url                      = "/"
+  url                      = "/status"
   encryption               = true
   port                     = 443
   tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_production,infrastructuresupport_platforms"


### PR DESCRIPTION
original PR failed on the apply concourse https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/3147

I had incorrectly change the host and not the url
this PR reverts to the correct host and points to the new url