### PR TITLE
Ensure token names match

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
@@ -50,7 +50,7 @@ resource "kubernetes_service_account" "service_token_cache_service_account" {
 
 resource "kubernetes_secret_v1" "service_token_cache_token" {
   metadata {
-    name      = "formbuilder-service-token-cache-test-production-token"
+    name      = "${local.sa_name}-token"
     namespace = var.namespace
     annotations = {
       "kubernetes.io/service-account.name" = local.sa_name


### PR DESCRIPTION
Concourse failed as the token name was wrong, using the local variable as a way to ensure this reference is always correct