### PR TITLE
Make a plea dev: add iam role for listing queues

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/irsa.tf
@@ -15,22 +15,22 @@
 #   policy      = data.aws_iam_policy_document.s3_policy_doc.json
 # }
 
-# data "aws_iam_policy_document" "sqs_policy_doc" {
-#   statement {
-#     actions = [
-#       "sqs:*",
-#     ]
-#     resources = [
-#       "*",
-#     ]
-#   }
-# }
+data "aws_iam_policy_document" "sqs_policy_doc" {
+  statement {
+    actions = [
+      "sqs:listqueues",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
 
-# resource "aws_iam_policy" "sqs_policy" {
-#   name        = "irsa-access-to-sqs"
-#   path        = "/cloud-platform/"
-#   policy      = data.aws_iam_policy_document.sqs_policy_doc.json
-# }
+resource "aws_iam_policy" "sqs_policy" {
+  name        = "irsa-access-to-sqs"
+  path        = "/cloud-platform/"
+  policy      = data.aws_iam_policy_document.sqs_policy_doc.json
+}
 
 module "irsa" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
@@ -47,7 +47,7 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     s3                        = module.s3_bucket.irsa_policy_arn
-    sqs_map_queue             = module.makeaplea_queue.irsa_policy_arn
+    sqs_map_queue             = aws_iam_policy.sqs_policy.arn
     sqs_map_queue_dead_letter = module.makeaplea_dead_letter_queue.irsa_policy_arn
   }
 


### PR DESCRIPTION
The celery worker in the make a plea app is complaining that it is not authorized to perform: sqs:listqueues.