### PR TITLE
Add rules to role to allow access to configmaps

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/resources/serviceaccount.tf
@@ -92,13 +92,9 @@ resource "kubernetes_role" "get_configmaps_role" {
     name      = "formbuilder-services-test-dev-get-configmaps-role"
     namespace = var.namespace
   }
-
-  dynamic "rule" {
-    for_each = var.serviceaccount_get_configmap_rules
-    content {
-      api_groups = rule.value.api_groups
-      resources  = rule.value.resources
-      verbs      = rule.value.verbs
-    }
+  rule {
+    api_groups = [""]
+    resources  = ["configmaps"]
+    verbs      = ["get", "list", "watch"]
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/resources/variables.tf
@@ -41,28 +41,3 @@ variable "github_token" {
   description = "Required by the GitHub Terraform provider"
   default     = ""
 }
-
-variable "serviceaccount_get_configmap_rules" {
-  description = "Used to allow other namespaces to get configmaps"
-
-  type = list(object({
-    api_groups = list(string),
-    resources  = list(string),
-    verbs      = list(string)
-  }))
-
-  # Only allow viewing configmaps
-  default = [
-    {
-      api_groups = [""]
-      resources = [
-        "configmaps"
-      ]
-      verbs = [
-        "get",
-        "list",
-        "watch"
-      ]
-    }
-  ]
-}


### PR DESCRIPTION
This rule appears not to have the permissions listed in the variable default, so try adding them directly

I can see when running get configmaps using the token from the service account this role is bound to that if I target the wrong namespace it says 'role not found' but if I target the correct namespace it says 'permission denied', so I guess the rules weren't applied, hopefully this does work :smile: 