### PR TITLE
Adjusted access control limits on FALA Staging S3 Bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/s3.tf
@@ -9,6 +9,9 @@ module "s3" {
   infrastructure_support = var.email
   namespace              = var.namespace
 
+  acl                           = "public-read"
+  enable_allow_block_pub_access = false
+
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
- Added `public_read` ACL. 
- Disabled blocking public access.