### PR TITLE
Enabled public read on laa-fala-production S3 bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/s3.tf
@@ -9,6 +9,9 @@ module "s3" {
   infrastructure_support = var.email
   namespace              = var.namespace
 
+  acl                           = "public-read"
+  enable_allow_block_pub_access = false
+
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
Sets ACL on FALA S3 Bucket to `public-read`.
Disables `enable_allow_block_pub_access`.