### PR TITLE
LEP-508 Fix expiration of production image

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/ecr.tf
@@ -93,8 +93,7 @@ module "ecr_credentials" {
             "action": {
                 "type": "expire"
             }
-        },
-
+        }
     ]
 }
 EOF

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/ecr.tf
@@ -31,12 +31,12 @@ module "ecr_credentials" {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "Expire untagged images older than 14 days",
+            "description": "Keep newest 50 uat images",
             "selection": {
-                "tagStatus": "untagged",
-                "countType": "sinceImagePushed",
-                "countUnit": "days",
-                "countNumber": 14
+                "tagStatus": "tagged",
+                "tagPrefixList": ["uat"],
+                "countType": "imageCountMoreThan",
+                "countNumber": 50
             },
             "action": {
                 "type": "expire"
@@ -44,12 +44,12 @@ module "ecr_credentials" {
         },
         {
             "rulePriority": 2,
-            "description": "Keep last 30 dev and staging images",
+            "description": "Keep newest 5 staging images",
             "selection": {
                 "tagStatus": "tagged",
-                "tagPrefixList": ["dev", "staging"],
+                "tagPrefixList": ["uat"],
                 "countType": "imageCountMoreThan",
-                "countNumber": 30
+                "countNumber": 5
             },
             "action": {
                 "type": "expire"
@@ -57,16 +57,44 @@ module "ecr_credentials" {
         },
         {
             "rulePriority": 3,
-            "description": "Keep the newest 100 images and mark the rest for expiration",
+            "description": "Keep newest 5 staging_mtr images",
             "selection": {
-                "tagStatus": "any",
+                "tagStatus": "tagged",
+                "tagPrefixList": ["staging_mtr"],
                 "countType": "imageCountMoreThan",
-                "countNumber": 100
+                "countNumber": 5
             },
             "action": {
                 "type": "expire"
             }
-        }
+        },
+        {
+            "rulePriority": 4,
+            "description": "Keep the newest 10 production images and mark the rest for expiration",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["production"],
+                "countType": "imageCountMoreThan",
+                "countNumber": 10
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 4,
+            "description": "Deprecated tags - keep 5 newest",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["dev", "latest"],
+                "countType": "imageCountMoreThan",
+                "countNumber": 5
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+
     ]
 }
 EOF


### PR DESCRIPTION
Images are [now tagged by environment](https://github.com/ministryofjustice/cfe-civil/pull/558), and this change changes the lifecycle to reflect that. The idea that lots of builds of one environment does not cause the cleanup of images in use by another environment.