### PR TITLE
ESWE - Candidate Matching Database - Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/rds.tf
@@ -8,11 +8,12 @@ module "candidate_matching_rds" {
   namespace                   = var.namespace
   environment_name            = var.environment
   infrastructure_support      = var.infrastructure_support
-  rds_family                  = "postgres15"
-  allow_major_version_upgrade = "false"
+  rds_family                  = "postgres16"
+  allow_major_version_upgrade = true
+  prepare_for_major_upgrade   = true
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "10000"
-  db_engine_version           = "15"
+  db_engine_version           = "16.2"
   deletion_protection         = true
 
   providers = {


### PR DESCRIPTION
Service is not currently in use so deploying to Prod is no issue.
Upgrade Postgres to 16.2