### PR TITLE
Remove cluster admin rolebinding for service-token-cache in test-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/01-rbac.yaml
@@ -32,11 +32,6 @@ subjects:
   - kind: ServiceAccount
     name: formbuilder-editor-workers-test
     namespace: formbuilder-saas-test
-  # ...but only the dev service token cache can read the dev
-  # service tokens
-  - kind: ServiceAccount
-    name: formbuilder-service-token-cache-test-production
-    namespace: formbuilder-platform-test-production
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
This has been replaced by a module derived role binding with only necessary permission