### PR TITLE
Remove cluster admin role binding from old SA

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/01-rbac.yaml
@@ -32,11 +32,6 @@ subjects:
   - kind: ServiceAccount
     name: formbuilder-editor-workers-test
     namespace: formbuilder-saas-test
-  # ...but only the dev service token cache can read the dev
-  # service tokens
-  - kind: ServiceAccount
-    name: formbuilder-service-token-cache-test-dev
-    namespace: formbuilder-platform-test-dev
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
New SA uses a module generated role binding with tighter permission scope