### PR TITLE
SAA-1629 correcting the prisoner alert event type for activities management, it was incorrect.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-activities-management.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-activities-management.tf
@@ -91,7 +91,7 @@ resource "aws_sns_topic_subscription" "activities_domain_events_subscription" {
       "prison-offender-events.prisoner.non-association-detail.changed",
       "prison-offender-events.prisoner.activities-changed",
       "prison-offender-events.prisoner.appointments-changed",
-      "prison-offender-search.prisoner.alerts-updated",
+      "prisoner-offender-search.prisoner.alerts-updated",
       "incentives.iep-review.inserted",
       "incentives.iep-review.updated",
       "incentives.iep-review.deleted"


### PR DESCRIPTION
The subscription to the Domain event 'alerts updated' in activities management was not quite right.

This PR corrects that mistake.