### PR TITLE
SAA-1629 adding missing prisoner alert domain event for the activities serivce in preprod.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-activities-management.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-activities-management.tf
@@ -91,6 +91,7 @@ resource "aws_sns_topic_subscription" "activities_domain_events_subscription" {
       "prison-offender-events.prisoner.non-association-detail.changed",
       "prison-offender-events.prisoner.activities-changed",
       "prison-offender-events.prisoner.appointments-changed",
+      "prisoner-offender-search.prisoner.alerts-updated",
       "incentives.iep-review.inserted",
       "incentives.iep-review.updated",
       "incentives.iep-review.deleted"


### PR DESCRIPTION
Adds subscription to the prisoner alerts updated domain event for the activities management service in preprod.

We already subscribe to this in dev, see PR [here](https://github.com/ministryofjustice/cloud-platform-environments/pull/21954).  We are now in the process of rolling this out to preprod and then prod.  Prod will be done as a separate PR.