### PR TITLE
Update name of service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/fb-av-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/fb-av-service-account.tf
@@ -1,5 +1,5 @@
 locals {
-  fb_av_service_account_name = "formbuilder-av-terraform-saas-test"
+  fb_av_service_account_name = "formbuilder-av-test"
 }
 
 resource "kubernetes_service_account" "formbuilder_av_saas_test_service_account" {


### PR DESCRIPTION
We've now had old service accounts removed, we will rotate back to this service name to avoid updating downstream references