### PR TITLE
pre-sentence-service-prod: Upgrade RDS minor version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds-pre-sentence-service.tf
@@ -10,7 +10,7 @@ module "pre_sentence_service_rds" {
   is_production                = var.is_production
   rds_family                   = "postgres14"
   db_instance_class            = "db.t4g.small"
-  db_engine_version            = "14.10"
+  db_engine_version            = "14.11"
   allow_major_version_upgrade  = false
   prepare_for_major_upgrade    = false
   performance_insights_enabled = true


### PR DESCRIPTION
Upgrade `pre-sentence-service` RDS minor version to 14.11 to match non-prod instance for database dev/prod parity

for **Prod**