### PR TITLE
SAA-1628 this change introduces two replacement prisoner search events for the prisoner offender events. This is a transitionary change.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-activities-management.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-activities-management.tf
@@ -92,6 +92,8 @@ resource "aws_sns_topic_subscription" "activities_domain_events_subscription" {
       "prison-offender-events.prisoner.activities-changed",
       "prison-offender-events.prisoner.appointments-changed",
       "prisoner-offender-search.prisoner.alerts-updated",
+      "prisoner-offender-search.prisoner.released",
+      "prisoner-offender-search.prisoner.received",
       "incentives.iep-review.inserted",
       "incentives.iep-review.updated",
       "incentives.iep-review.deleted"


### PR DESCRIPTION
This is a transitional PR to replace two events we currently listen to with prisoner search based events instead.

The `prisoner-offender-search.prisoner.released` in particular should be used going forwards as this does not have  induced delay of 45mins for the `prison-offender-events.prisoner.released` which has caused timing issues in production.

```
prison-offender-events.prisoner.received -> prisoner-offender-search.prisoner.received
prison-offender-events.prisoner.released -> prisoner-offender-search.prisoner.released

```
As a first pass we will keep all events so we so not miss any existing events. This may be overkill.