### PR TITLE
SAA-1628 this change removes now redundant prisoner offender events which have been replace with prisoner search events.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-activities-management.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-activities-management.tf
@@ -84,8 +84,6 @@ resource "aws_sns_topic_subscription" "activities_domain_events_subscription" {
   endpoint  = module.activities_domain_events_queue.sqs_arn
   filter_policy = jsonencode({
     eventType = [
-      "prison-offender-events.prisoner.released",
-      "prison-offender-events.prisoner.received",
       "prison-offender-events.prisoner.merged",
       "prison-offender-events.prisoner.cell.move",
       "prison-offender-events.prisoner.non-association-detail.changed",


### PR DESCRIPTION
This removes now redundant events which have been superseded by events added in the transitional PR [here](https://github.com/ministryofjustice/cloud-platform-environments/pull/22130).