### PR TITLE
Adds our legacy staging S3 resource to user-policy to allow one-way sync.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
@@ -1,0 +1,52 @@
+module "irsa" {
+  source                = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+  eks_cluster_name      = var.eks_cluster_name
+  namespace             = var.namespace
+  service_account_name  = "${var.namespace}-cross-service"
+  role_policy_arns      = { s3 = aws_iam_policy.intranet_dev_s3_staging.arn }
+}
+
+data "aws_iam_policy_document" "intranet_dev_s3_staging" {
+  # A list of permissions and target AWS account resources to allow access to
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::intranet2-staging-storage-h1d4c9820k0u"
+    ]
+  }
+  statement {
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::intranet2-staging-storage-h1d4c9820k0u/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "intranet_dev_s3_staging" {
+  name   = "intranet_dev_s3_staging"
+  policy = data.aws_iam_policy_document.intranet_dev_s3_staging.json
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "cross_irsa" {
+  metadata {
+    name      = "cross-irsa-output"
+    namespace = var.namespace
+  }
+  data = {
+    role = module.irsa.aws_iam_role_name
+    serviceaccount = module.irsa.service_account_name.name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
@@ -52,7 +52,8 @@ resource "kubernetes_secret" "cross_irsa" {
     namespace = var.namespace
   }
   data = {
-    role = module.cross_irsa.aws_iam_role_name
-    serviceaccount = module.cross_irsa.service_account_name.name
+    role           = module.cross_irsa.role_name
+    rolearn        = module.irsa_laa_test_viewer.role_arn
+    serviceaccount = module.cross_irsa.service_account.name
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
@@ -1,4 +1,4 @@
-module "irsa" {
+module "cross_irsa" {
   source                = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
   eks_cluster_name      = var.eks_cluster_name
   namespace             = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
@@ -1,8 +1,14 @@
 module "cross_irsa" {
   source                = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+  business_unit         = var.business_unit
+  application            = var.application
   eks_cluster_name      = var.eks_cluster_name
   namespace             = var.namespace
   service_account_name  = "${var.namespace}-cross-service"
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
   role_policy_arns      = { s3 = aws_iam_policy.intranet_dev_s3_staging.arn }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
@@ -52,7 +52,7 @@ resource "kubernetes_secret" "cross_irsa" {
     namespace = var.namespace
   }
   data = {
-    role = module.irsa.aws_iam_role_name
-    serviceaccount = module.irsa.service_account_name.name
+    role = module.cross_irsa.aws_iam_role_name
+    serviceaccount = module.cross_irsa.service_account_name.name
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
@@ -53,7 +53,7 @@ resource "kubernetes_secret" "cross_irsa" {
   }
   data = {
     role           = module.cross_irsa.role_name
-    rolearn        = module.irsa_laa_test_viewer.role_arn
+    rolearn        = module.cross_irsa.role_arn
     serviceaccount = module.cross_irsa.service_account.name
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cross-iam-role-sa.tf
@@ -1,15 +1,15 @@
 module "cross_irsa" {
-  source                = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
-  business_unit         = var.business_unit
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+  business_unit          = var.business_unit
   application            = var.application
-  eks_cluster_name      = var.eks_cluster_name
-  namespace             = var.namespace
-  service_account_name  = "${var.namespace}-cross-service"
+  eks_cluster_name       = var.eks_cluster_name
+  namespace              = var.namespace
+  service_account_name   = "${var.namespace}-cross-service"
   is_production          = var.is_production
   team_name              = var.team_name
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
-  role_policy_arns      = { s3 = aws_iam_policy.intranet_dev_s3_staging.arn }
+  role_policy_arns       = { s3 = aws_iam_policy.intranet_dev_s3_staging.arn }
 }
 
 data "aws_iam_policy_document" "intranet_dev_s3_staging" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/irsa.tf
@@ -5,7 +5,7 @@ module "irsa" {
   eks_cluster_name = var.eks_cluster_name
 
   # IRSA configuration
-  service_account_name = "intranet-dev-service"
+  service_account_name = "${var.namespace}-service"
   namespace            = var.namespace # this is also used as a tag
 
   role_policy_arns = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
@@ -9,10 +9,9 @@ module "s3_bucket" {
   namespace              = var.namespace
   providers = {
     aws = aws.london
-  }
-  # Adds staging S3 resources to user-policy to allow one-way sync.
-  # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
-  user_policy = <<EOF
+    # Adds staging S3 resources to user-policy to allow one-way sync.
+    # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
+    user_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -51,6 +50,7 @@ module "s3_bucket" {
   ]
 }
 EOF
+  }
 
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
@@ -8,7 +8,7 @@ module "s3_bucket" {
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
   providers = {
-    aws = aws.london
+    aws = aws.london,
     # Adds staging S3 resources to user-policy to allow one-way sync.
     # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
     user_policy = <<EOF

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
@@ -10,6 +10,48 @@ module "s3_bucket" {
   providers = {
     aws = aws.london
   }
+  # Adds staging S3 resources to user-policy to allow one-way sync.
+  # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
+  user_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "$${bucket_arn}",
+        "arn:aws:s3:::intranet2-staging-storage-h1d4c9820k0u"
+      ]
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "$${bucket_arn}/*"
+      ]
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::intranet2-staging-storage-h1d4c9820k0u/*"
+      ]
+    }
+  ]
+}
+EOF
+
 }
 
 resource "kubernetes_secret" "s3_bucket" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
@@ -10,49 +10,6 @@ module "s3_bucket" {
   providers = {
     aws = aws.london
   }
-
-  # Adds staging S3 resources to user-policy to allow one-way sync.
-  # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
-  user_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetBucketLocation",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "$${bucket_arn}",
-        "arn:aws:s3:::intranet2-staging-storage-h1d4c9820k0u"
-      ]
-    },
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": [
-        "$${bucket_arn}/*"
-      ]
-    },
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::intranet2-staging-storage-h1d4c9820k0u/*"
-      ]
-    }
-  ]
-}
-EOF
-
 }
 
 resource "kubernetes_secret" "s3_bucket" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/s3.tf
@@ -8,10 +8,12 @@ module "s3_bucket" {
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
   providers = {
-    aws = aws.london,
-    # Adds staging S3 resources to user-policy to allow one-way sync.
-    # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
-    user_policy = <<EOF
+    aws = aws.london
+  }
+
+  # Adds staging S3 resources to user-policy to allow one-way sync.
+  # https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets
+  user_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -50,7 +52,6 @@ module "s3_bucket" {
   ]
 }
 EOF
-  }
 
 }
 


### PR DESCRIPTION
We intend to sync from a source S3 bucket `intranet2-staging-storage-h1d4c9820k0u`, owned by a different AWS account.

Following the [Migrate from existing buckets guide](https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket#migrate-from-existing-buckets), I understand that the source bucket must be added to the `user_policy` here.

This PR adds the relevant change to our s3 resource definition.

cc: @EmilyHazlehurst @wilson1000 