### PR TITLE
SAA-1628 this change removes now redundant prisoner offender events which have been replaced with prisoner search events.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-activities-management.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-activities-management.tf
@@ -84,8 +84,6 @@ resource "aws_sns_topic_subscription" "activities_domain_events_subscription" {
   endpoint  = module.activities_domain_events_queue.sqs_arn
   filter_policy = jsonencode({
     eventType = [
-      "prison-offender-events.prisoner.released",
-      "prison-offender-events.prisoner.received",
       "prison-offender-events.prisoner.merged",
       "prison-offender-events.prisoner.cell.move",
       "prison-offender-events.prisoner.non-association-detail.changed",


### PR DESCRIPTION
These two events are now redundant.

They have been superseded in previous PR [here](https://github.com/ministryofjustice/cloud-platform-environments/pull/22157).