### PR TITLE
LAWS-3733: removed snapshot identifier from RDS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/rds.tf
@@ -31,7 +31,7 @@ module "rds-instance" {
   # enable performance insights
   performance_insights_enabled = true
 
-  snapshot_identifier = "************" # update with snapshot value, once created and moved from LZ to CP
+  # snapshot_identifier = "************" # update with snapshot value, once created and moved from LZ to CP
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
LAWS-3733: removed snapshot identifier from RDS