### PR TITLE
Bump serviceaccount module to 1.1.0

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/aaf-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/aaf-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/accessibility-book-club/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/accessibility-book-club/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/accredited-programmes-community-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/accredited-programmes-community-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/accredited-programmes-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/accredited-programmes-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ap-app-poc-bde/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ap-app-poc-bde/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ap-firebreak-superset/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ap-firebreak-superset/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/artefact-library/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/artefact-library/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/bh-app-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/bh-app-dev/resources/serviceaccount-circleci.tf
@@ -1,6 +1,6 @@
 # Service account for circleci
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci-migrated"
   role_name           = "circleci"
   rolebinding_name    = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/bh-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/bh-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/bold-rr-ops-pilot-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/bold-rr-ops-pilot-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/categorisation-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/categorisation-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cdpt-redirect-service-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cdpt-redirect-service-dev/resources/serviceaccount.tf
@@ -1,6 +1,6 @@
 
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging-mtr/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging-mtr/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-crime-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-crime-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-apply-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-apply-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-copilot-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-copilot-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-development/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cla-reform-design/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cla-reform-design/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-non-standard-magistrate-fee-high-fidelity/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-non-standard-magistrate-fee-high-fidelity/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-example-application/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-example-application/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-hammer-bot/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-hammer-bot/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-label-pods/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-label-pods/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-metrics/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-metrics/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-monitoring-alerts-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-monitoring-alerts-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-prototype-demo/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-prototype-demo/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-reports-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   github_repositories = ["cloud-platform-how-out-of-date-are-we"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-service-pod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-service-pod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/service-account-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/service-account-github.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/serviceaccount.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/serviceaccount.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/serviceaccount.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courts-local-scorecard-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courts-local-scorecard-dev/resources/serviceaccount.tf
@@ -1,6 +1,6 @@
 
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courts-local-scorecard-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courts-local-scorecard-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test1/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test1/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test2/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test2/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/crmfour-proto/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/crmfour-proto/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ct-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ct-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ct-tact-list-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ct-tact-list-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/danglen-testing-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/danglen-testing-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-eng-uploader-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ap-rshiny-notesbook-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ap-rshiny-notesbook-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-aqa-website-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bentham-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bentham-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bentham-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bentham-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bold-case-info-dashboard-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bold-case-info-dashboard-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bold-case-info-dashboard-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-bold-case-info-dashboard-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccma-gold-scorecards-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccma-gold-scorecards-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccma-gold-scorecards-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccma-gold-scorecards-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccmbpt-analytics-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccmbpt-analytics-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccmbpt-analytics-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccmbpt-analytics-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccmbpt-guidance-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccmbpt-guidance-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccpt-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccpt-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccpt-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ccpt-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-email-traffic-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-email-traffic-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-email-traffic-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-email-traffic-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-monitoring-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-monitoring-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-monitoring-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-monitoring-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-networkanalysis-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-networkanalysis-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-networkanalysis-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cjsm-networkanalysis-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-contracts-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-contracts-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-contracts-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-contracts-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-familyman-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-familyman-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-xhibit-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-xhibit-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-xhibit-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-xhibit-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-coroner-stat-tool-ext-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-coroner-stat-tool-ext-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-coroner-stat-tool-ext-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-coroner-stat-tool-ext-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cost-to-serve-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cost-to-serve-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cost-to-serve-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-cost-to-serve-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-criminal-scenario-tool-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-criminal-scenario-tool-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-criminal-scenario-tool-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-criminal-scenario-tool-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-crown-flow-explorer-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-crown-flow-explorer-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-crown-flow-explorer-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-crown-flow-explorer-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-crown-sitting-days-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-crown-sitting-days-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-crown-sitting-days-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-crown-sitting-days-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-data-discovery-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-data-discovery-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-data-platform-new-app-runthrough-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-data-platform-new-app-runthrough-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-defcalc-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-defcalc-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-defcalc-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-defcalc-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-acc-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-acc-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-acc-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-acc-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-pwb-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-pwb-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-pwb-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-pwb-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-ws-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-ws-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-ws-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-ws-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-drug-conveyancing-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-drug-conveyancing-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-drug-conveyancing-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-drug-conveyancing-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-exit-survey-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-exit-survey-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-exit-survey-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-exit-survey-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-auth-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-auth-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-auth-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-auth-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-reporting-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-reporting-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-reporting-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gifts-reporting-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gold-scorecard-form-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gold-scorecard-form-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gold-scorecard-form-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gold-scorecard-form-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gpc-anomalies-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gpc-anomalies-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gpc-anomalies-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-gpc-anomalies-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hlt-portal-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hlt-portal-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hlt-portal-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hlt-portal-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmcts-ccpt-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmcts-ccpt-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmcts-ccpt-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmcts-ccpt-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmpps-hr-dashboard-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmpps-hr-dashboard-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmpps-hr-dashboard-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hmpps-hr-dashboard-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-document-manager-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-document-manager-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-document-manager-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-document-manager-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-search-tool-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-search-tool-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-search-tool-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-hr-policy-search-tool-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-imb-fees-consultation-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-imb-fees-consultation-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-imb-fees-consultation-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-imb-fees-consultation-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-intel-app-homepage-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-intel-app-homepage-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-intel-app-homepage-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-intel-app-homepage-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-invoice-nlp-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-invoice-nlp-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-invoice-nlp-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-invoice-nlp-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-jdl-visulizer-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-jdl-visulizer-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-jdl-visulizer-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-jdl-visulizer-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-reviews-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-reviews-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-reviews-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-reviews-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-wm2-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-wm2-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-wm2-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-judicial-wm2-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ltc-capabilites-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ltc-capabilites-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ltc-capabilites-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-ltc-capabilites-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-matrix-booking-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-matrix-booking-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-matrix-booking-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-matrix-booking-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mlp-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mlp-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mlp-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mlp-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mmp-web-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mmp-web-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mmp-web-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-mmp-web-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-model-redevelopment-website-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-model-redevelopment-website-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-model-redevelopment-website-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-model-redevelopment-website-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-moj-officehub-locator-webapp-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-moj-officehub-locator-webapp-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-moj-officehub-locator-webapp-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-moj-officehub-locator-webapp-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-occupeye-shiny-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-occupeye-shiny-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-occupeye-shiny-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-occupeye-shiny-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-officehub-cms-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-officehub-cms-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-officehub-cms-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-officehub-cms-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-lpa-dashboard-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-lpa-dashboard-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-lpa-dashboard-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-lpa-dashboard-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-mi-dashdemo-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-mi-dashdemo-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-mi-dashdemo-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-opg-mi-dashdemo-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pay-gap-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pay-gap-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pay-gap-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pay-gap-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-data-self-serve-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-data-self-serve-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-data-self-serve-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-data-self-serve-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-dashboard-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-dashboard-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-dashboard-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-dashboard-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-engagement-prediction-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-engagement-prediction-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-engagement-prediction-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-engagement-prediction-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-prediction-tool-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-prediction-tool-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-prediction-tool-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-people-survey-prediction-tool-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pfg-dash-moj-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pfg-dash-moj-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pfg-dash-moj-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pfg-dash-moj-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pi-form-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pi-form-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pi-form-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-pi-form-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-estate-digital-map-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-estate-digital-map-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-estate-digital-map-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-estate-digital-map-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-network-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-network-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-network-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-network-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-visitor-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-visitor-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-visitor-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prison-visitor-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prisons-ready-reckoner-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prisons-ready-reckoner-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prisons-ready-reckoner-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-prisons-ready-reckoner-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-mi-dashboard-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-mi-dashboard-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-mi-dashboard-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-mi-dashboard-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-recruitment-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-recruitment-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-recruitment-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-recruitment-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-shiny-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-shiny-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-shiny-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-shiny-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-staffing-model-dash-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-staffing-model-dash-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-staffing-model-dash-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-probation-staffing-model-dash-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-regime-dashboard-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-regime-dashboard-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-regime-dashboard-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-regime-dashboard-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-remuneration-tool-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-remuneration-tool-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-remuneration-tool-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-remuneration-tool-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-safety-diagnostic-tool-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-safety-diagnostic-tool-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-safety-diagnostic-tool-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-safety-diagnostic-tool-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-sat-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-sat-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-sat-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-sat-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-draft-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-draft-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-draft-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-draft-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-segmentation-tool-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-statistics-explorer-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-statistics-explorer-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-statistics-explorer-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-statistics-explorer-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-stats-web-analytics-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-stats-web-analytics-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-stats-web-analytics-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-stats-web-analytics-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-strategic-estates-tool-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-strategic-estates-tool-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-strategic-estates-tool-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-strategic-estates-tool-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-tax-compliance-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-tax-compliance-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-tax-compliance-app-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-tax-compliance-app-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-temperature-check-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-temperature-check-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-temperature-check-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-temperature-check-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-development/resources/github-actions-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-development/resources/github-actions-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "github_actions_serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   kubernetes_cluster  = var.kubernetes_cluster
   namespace           = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-aws-microservice-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-aws-microservice-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-daap-api/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-daap-api/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-hello-world-mat-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-hello-world-mat-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/github-actions-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-production/resources/github-actions-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "github_actions_serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   kubernetes_cluster  = var.kubernetes_cluster
   namespace           = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-transfer-api-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-transfer-api-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dex-mi-production/resources/serviceaccount-tiller.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dex-mi-production/resources/serviceaccount-tiller.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_tiller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-reporting-mi-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-reporting-mi-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dpr-nomis-port-forwarder/resources/serviceaccount-nomis-port-forwarder.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dpr-nomis-port-forwarder/resources/serviceaccount-nomis-port-forwarder.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_nomis-port-forwarder" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dpr-nomis-port-forwarder/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dpr-nomis-port-forwarder/resources/serviceaccount.tf
@@ -4,7 +4,7 @@
  *
 */
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = "dpr-nomis-port-forwarder"
   github_repositories = ["dpr-nomis-port-forwarder"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "26-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dv-cloudplatform-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dv-cloudplatform-dev/resources/serviceaccount-circleci.tf
@@ -1,6 +1,6 @@
 # Service account for circleci
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci-migrated"
   role_name           = "circleci"
   rolebinding_name    = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dv-cloudplatform-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dv-cloudplatform-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dwf-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dwf-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/eligibility-estimate/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/eligibility-estimate/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-base-adapter-test/resources/circleci-service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/circleci-service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_accounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_accounts.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 module "serviceaccount_formbuilder-av-live-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -94,7 +94,7 @@ module "serviceaccount_formbuilder-av-live-dev" {
 }
 
 module "serviceaccount_formbuilder-pdf-generator-live-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -109,7 +109,7 @@ module "serviceaccount_formbuilder-pdf-generator-live-dev" {
 }
 
 module "serviceaccount_formbuilder-submitter-workers-live-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -124,7 +124,7 @@ module "serviceaccount_formbuilder-submitter-workers-live-dev" {
 }
 
 module "serviceaccount_formbuilder-user-datastore-live-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -139,7 +139,7 @@ module "serviceaccount_formbuilder-user-datastore-live-dev" {
 }
 
 module "serviceaccount_formbuilder-user-filestore-live-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/circleci-service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/service_accounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/service_accounts.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 module "serviceaccount_formbuilder-av-live-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -94,7 +94,7 @@ module "serviceaccount_formbuilder-av-live-production" {
 }
 
 module "serviceaccount_formbuilder-pdf-generator-live-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -109,7 +109,7 @@ module "serviceaccount_formbuilder-pdf-generator-live-production" {
 }
 
 module "serviceaccount_formbuilder-submitter-workers-live-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -124,7 +124,7 @@ module "serviceaccount_formbuilder-submitter-workers-live-production" {
 }
 
 module "serviceaccount_formbuilder-user-datastore-live-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -139,7 +139,7 @@ module "serviceaccount_formbuilder-user-datastore-live-production" {
 }
 
 module "serviceaccount_formbuilder-user-filestore-live-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/circleci-service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_accounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_accounts.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 module "serviceaccount_formbuilder-av-test-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -94,7 +94,7 @@ module "serviceaccount_formbuilder-av-test-dev" {
 }
 
 module "serviceaccount_formbuilder-pdf-generator-test-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -109,7 +109,7 @@ module "serviceaccount_formbuilder-pdf-generator-test-dev" {
 }
 
 module "serviceaccount_formbuilder-submitter-workers-test-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -124,7 +124,7 @@ module "serviceaccount_formbuilder-submitter-workers-test-dev" {
 }
 
 module "serviceaccount_formbuilder-user-datastore-test-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -139,7 +139,7 @@ module "serviceaccount_formbuilder-user-datastore-test-dev" {
 }
 
 module "serviceaccount_formbuilder-user-filestore-test-dev" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/circleci-service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_accounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_accounts.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 module "serviceaccount_formbuilder-av-test-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -94,7 +94,7 @@ module "serviceaccount_formbuilder-av-test-production" {
 }
 
 module "serviceaccount_formbuilder-pdf-generator-test-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -109,7 +109,7 @@ module "serviceaccount_formbuilder-pdf-generator-test-production" {
 }
 
 module "serviceaccount_formbuilder-submitter-workers-test-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -124,7 +124,7 @@ module "serviceaccount_formbuilder-submitter-workers-test-production" {
 }
 
 module "serviceaccount_formbuilder-user-datastore-test-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -139,7 +139,7 @@ module "serviceaccount_formbuilder-user-datastore-test-production" {
 }
 
 module "serviceaccount_formbuilder-user-filestore-test-production" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-product-page-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-product-page-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/circleci-service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/circleci-service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-live-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-live-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-services-test-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/haar-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/haar-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-demo/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-demo/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activity-management-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activity-management-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-afer-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-afer-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-dev/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-preprod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-prod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prototypes/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prototypes/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-api-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-ui-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-ui-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-ui-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-ui-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-ui-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-ui-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-authorization-server-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-authorization-server-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-bvl-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-bvl-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ciag-induction-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ciag-induction-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-design/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-design/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-preprod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-prod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-custody-manager-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-custody-manager-dev/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cvl-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cvl-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-shared/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-shared/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfrsco-poc/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfrsco-poc/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-dev/resources/serviceaccount.tf
@@ -80,7 +80,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-preprod/resources/serviceaccount.tf
@@ -80,7 +80,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-prod/resources/serviceaccount.tf
@@ -80,7 +80,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-preprod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-preprod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-preprod/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-prod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-prod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-prod/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/serviceaccount-scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/serviceaccount-scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/serviceaccount-scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/serviceaccount-scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/serviceaccount-scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/resources/serviceaccount-scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/resources/serviceaccount-scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-platform-api-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-platform-api-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-documentation-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-documentation-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "moj-cloud-platform-github-actions-serviceaccount"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "22-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "22-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-users-api-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "22-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-hdc-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-hdc-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-hpa-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-hpa-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-tool/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-tool/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-preprod/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-preprod/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/service_account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/service_account.tf
@@ -1,5 +1,5 @@
 module "service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/service_account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/service_account.tf
@@ -1,5 +1,5 @@
 module "service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/service_account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/service_account.tf
@@ -1,5 +1,5 @@
 module "service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-vision/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-vision/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-auth-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-auth-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "19-03-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "15-03-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "15-03-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "15-03-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "15-03-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-licenses-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-licenses-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"
@@ -76,7 +76,7 @@ module "circleci-sa" {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "manage-intelligence-ga"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"
@@ -76,7 +76,7 @@ module "circleci-sa" {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "manage-intelligence-ga"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "manage-intelligence-ga"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-recalls-prototype-history/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-recalls-prototype-history/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-recalls-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-recalls-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-behaviour-prototyping/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-behaviour-prototyping/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-matching-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-matching-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-dev/resources/serviceaccount.tf
@@ -80,7 +80,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-preprod/resources/serviceaccount.tf
@@ -64,7 +64,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-prod/resources/serviceaccount.tf
@@ -80,7 +80,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-moic-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-moic-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "08-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "08-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "08-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-user-roles-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-user-roles-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-user-roles-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-user-roles-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/serviceaccounts.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-dev/resources/serviceaccount-circleti.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-dev/resources/serviceaccount-circleti.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-preprod/resources/serviceaccount-circleti.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-preprod/resources/serviceaccount-circleti.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-prod/resources/serviceaccount-circleti.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-prod/resources/serviceaccount-circleti.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-dev/resources/serviceaccount-circleci.tf
@@ -1,6 +1,6 @@
 # Service account for circleci
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci"
   role_name           = "circleci"
   rolebinding_name    = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-dev/resources/serviceaccount-scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-dev/resources/serviceaccount-scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-preprod/resources/serviceaccount-circleci.tf
@@ -1,6 +1,6 @@
 # Service account for circleci
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci"
   role_name           = "circleci"
   rolebinding_name    = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-preprod/resources/serviceaccount-scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-preprod/resources/serviceaccount-scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/serviceaccount-circleci.tf
@@ -1,6 +1,6 @@
 # Service account for circleci
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci"
   role_name           = "circleci"
   rolebinding_name    = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/serviceaccount-scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/serviceaccount-scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/serviceaccount-scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/serviceaccount-scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"
@@ -76,7 +76,7 @@ module "circleci-sa" {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "hmpps-portfolio-management"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"
@@ -76,7 +76,7 @@ module "circleci-sa" {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "hmpps-portfolio-management"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-dev/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-preprod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-prod/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prepare-a-case-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prepare-a-case-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-education/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-education/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-casenotes-search-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-casenotes-search-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-dev/resources/serviceaccount.tf
@@ -80,7 +80,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-preprod/resources/serviceaccount.tf
@@ -80,7 +80,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-prod/resources/serviceaccount.tf
@@ -80,7 +80,7 @@ locals {
 
 # Service account for circleci
 module "circleci-sa" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name  = "circleci"
   role_name            = "circleci"
   rolebinding_name     = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "08-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-absence-management-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-absence-management-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-dev/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-dev/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-preprod/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-preprod/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/github-actions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/github-actions.tf
@@ -1,5 +1,5 @@
 module "github_actions_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/github-actions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/github-actions.tf
@@ -1,5 +1,5 @@
 module "github_actions_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/github-actions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/github-actions.tf
@@ -1,5 +1,5 @@
 module "github_actions_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-design-history/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-design-history/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-reference-data-prod/resources/serviceaccount-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-reference-data-prod/resources/serviceaccount-github.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   github_repositories = ["hmpps-reference-data"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-review-send-recall-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-review-send-recall-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-dev/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-dev/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-preprod/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-preprod/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-test/resources/serviceaccount-circleci.tf
@@ -1,6 +1,6 @@
 # Service account for circleci
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci"
   role_name           = "circleci"
   rolebinding_name    = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-kotlin/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-kotlin/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-typescript/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-typescript/resources/serviceaccount-circleci.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-services-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-services-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-uof-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-uof-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-visit-someone-in-prison-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-visit-someone-in-prison-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-wmt-workload-poc-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-wmt-workload-poc-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/interventions-design-history/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/interventions-design-history/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-archive-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-archive-dev/resources/serviceaccount.tf
@@ -1,6 +1,6 @@
 
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-demo/resources/service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-demo/resources/service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-staging/resources/service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-staging/resources/service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/jacksapp-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/jacksapp-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-archiver-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-archiver-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-demo/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-demo/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/kristian-helloworld/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/kristian-helloworld/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/kv-app-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/kv-app-dev/resources/serviceaccount-circleci.tf
@@ -1,6 +1,6 @@
 # Service account for circleci
 module "circleci-sa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   serviceaccount_name = "circleci-migrated"
   role_name           = "circleci"
   rolebinding_name    = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/kv-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/kv-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ky-first-cp-app-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ky-first-cp-app-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-architect-info/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-architect-info/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-dev/resources/circleci-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-dev/resources/circleci-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-dev/resources/github-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-dev/resources/github-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/resources/circleci-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/resources/circleci-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-uat/resources/circleci-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-uat/resources/circleci-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-dev-crm4/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-dev-crm4/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-non-standard-magistrate-fee-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-billing-alpha-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-billing-alpha-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-civil/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-civil/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-ebs-azure-ad-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-ebs-azure-ad-dev/resources/serviceaccount.tf
@@ -1,6 +1,6 @@
 module "serviceaccount" {
 
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-training/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev-crm4/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev-crm4/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-api-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev-crm4/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev-crm4/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-applications-adaptor-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-applications-adaptor-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-applications-adaptor-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-applications-adaptor-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-applications-adaptor-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-applications-adaptor-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-applications-adaptor-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-applications-adaptor-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-mock-api-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-mock-api-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-mock-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-mock-api-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-uat/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-uat/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-uat/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-uat/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-test/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-test/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-uat/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-uat/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-review-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-review-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-uat/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-uat/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-report-service-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-get-payments-finance-data-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-get-payments-finance-data-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-govuk-notify-orchestrator-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   serviceaccount_name = "circleci"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/serviceaccount-github-actions.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_github_actions" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-development/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-development/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-preproduction/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-preproduction/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-means-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-means-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount-github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-prd/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-prd/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount-github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount-github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-tst/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-not-on-libra-auto-search-application-tst/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount-github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-pay-for-la-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-pay-for-la-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/circleci-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/circleci-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/github-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/github-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-prod/resources/circleci-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-prod/resources/circleci-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-uat/resources/circleci-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-uat/resources/circleci-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-test-viewer/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-test-viewer/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-view-court-data-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-view-court-data-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-zap-dast/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-zap-dast/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/launchpad-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/launchpad-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legacy-systems-x-product-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legacy-systems-x-product-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/maintenance-pages/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makerecall-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makerecall-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makerecalldecisions-design-history/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makerecalldecisions-design-history/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-a-workforce/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-a-workforce/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/serviceaccount.tf
@@ -65,7 +65,7 @@ locals {
 
 # Service account used by github actions
 module "service_account" {
-  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
   serviceaccount_name                  = "manage-intelligence-ga"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-pom-cases-design-history/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-pom-cases-design-history/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-supervisions-design-history/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-supervisions-design-history/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/moj-frontend/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/moj-frontend/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/serviceaccounts.tf
@@ -376,7 +376,7 @@ resource "kubernetes_role_binding" "emails" {
 }
 
 module "service-account-circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
@@ -412,7 +412,7 @@ module "service-account-circleci" {
 }
 
 module "service-account-github-actions" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mpc-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mpc-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mrd-proto/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mrd-proto/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/nettest/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/nettest/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-case-notes-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-case-notes-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-case-notes-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "08-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/scheduled-downtime.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/scheduled-downtime.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "08-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "08-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test2/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-test2/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-auth0-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-auth0-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-example-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-example-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-example-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-example-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-join-github-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-join-github-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-join-github-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-join-github-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-metadata-poc/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-metadata-poc/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering/resources/operations-engineering-reports-prod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering/resources/operations-engineering-reports-prod.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/opg-lpa-fd-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/opg-lpa-fd-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/opg-sirius-prototypes/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/opg-sirius-prototypes/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/serviceaccount-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/serviceaccount-github.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
   github_repositories = ["hmpps-pact-broker"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/service-account-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/service-account-github.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/serviceaccount-refreshclamav.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "refresh_clamav_serviceaccount" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "refreshclamav"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/service-account-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/service-account-github.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.eks_cluster_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/poornima-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/poornima-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pre-sentence-service-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pre-sentence-service-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-services-feedback-and-support-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-to-probation-update-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-to-probation-update-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-to-probation-update-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-to-probation-update-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-to-probation-update-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-to-probation-update-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-exercise/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-exercise/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-sighting/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-sighting/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/refer-python-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/refer-python-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/request-info-from-moj/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/request-info-from-moj/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/resettlement-passport-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/resettlement-passport-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rob-sandbox/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rob-sandbox/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rp-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rp-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sdejong-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sdejong-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sentence-and-offence-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sentence-and-offence-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sm-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sm-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/soc-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/soc-production/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/soc-reporting-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/soc-reporting-dev/resources/serviceaccount.tf
@@ -1,6 +1,6 @@
 # to create github actions/service account for soc reporting and entry
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/soc-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/soc-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sqstesting-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sqstesting-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tariq-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tariq-test/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source                            = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace                         = var.namespace
   kubernetes_cluster                = var.kubernetes_cluster
   serviceaccount_token_rotated_date = "29-02-2024"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/serviceaccount-tiller.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/serviceaccount-tiller.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_tiller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/service-account-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/service-account-github.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.eks_cluster_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/serviceaccount-tiller.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/serviceaccount-tiller.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_tiller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/serviceaccount-tiller.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/serviceaccount-tiller.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_tiller" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/verification-report-pilot/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/verification-report-pilot/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/victim-witness-info-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/victim-witness-info-prototype/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/serviceaccount-circleci.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_circleci" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-preprod/resources/scheduled-downtime-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-preprod/resources/scheduled-downtime-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "scheduled_downtime_service_account" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-preprod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-serviceaccount/releases/tag/1.1.0
- Bump serviceaccount module from 1.0.1 to 1.1.0
- Bump serviceaccount module from 1.0.0 to 1.1.0

Related to: https://github.com/ministryofjustice/cloud-platform/issues/5418