### PR TITLE
CRM457-1287 update service account release versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/circleci-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/circleci-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   serviceaccount_name  = "circleci"
   namespace = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/github-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/github-serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount_github" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster


### PR DESCRIPTION
Update service account release versions to latest to remove warnings that slow down or time out helm deployments