### PR TITLE
Removed suffix from service account name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/irsa.tf
@@ -26,7 +26,7 @@ module "irsa" {
 
   eks_cluster_name     = var.eks_cluster_name
   namespace            = var.namespace
-  service_account_name = "hmpps-education-and-work-plan-api"
+  service_account_name = "hmpps-education-and-work-plan"
   role_policy_arns     = merge(local.sqs_policies, local.sns_policies, local.rds_policies)
 
   # Tags


### PR DESCRIPTION
## Overview

We want to use SQS from our UI, but the IRSA service account name is suffixed with `-api`.  Removing this so it can be used by either.