### PR TITLE
Setting up new RDS service for our new Postgres database (PREPROD)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/rds_postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/rds_postgres.tf
@@ -1,0 +1,132 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.2"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = false
+  db_max_allocated_storage     = "500"
+
+  # PostgresSQL specifics
+  db_engine                = "postgres"
+  db_engine_version        = "15"
+  rds_family               = "postgres15"
+  db_instance_class        = "db.t4g.micro"
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  providers = {
+    aws = aws.london_without_default_tags
+  }
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+}
+
+module "read_replica" {
+  # default off
+  count  = 0
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.2"
+
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  # If any other inputs of the RDS is passed in the source db which are different from defaults,
+  # add them to the replica
+
+
+  # It is mandatory to set the below values to create read replica instance
+
+  # Set the database_name of the source db
+  db_name = module.rds.database_name
+
+  # Set the db_identifier of the source db
+  replicate_source_db = module.rds.db_identifier
+
+  # Set to true. No backups or snapshots are created for read replica
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = aws.london
+  }
+
+  # If db_parameter is specified in source rds instance, use the same values.
+  # If not specified you dont need to add any. It will use the default values.
+
+  # db_parameter = [
+  #   {
+  #     name         = "rds.force_ssl"
+  #     value        = "0"
+  #     apply_method = "immediate"
+  #   }
+  # ]
+}
+
+resource "kubernetes_secret" "read_replica" {
+  # default off
+  count = 0
+
+  metadata {
+    name      = "rds-postgresql-read-replica-output"
+    namespace = var.namespace
+  }
+
+  # The database_username, database_password, database_name values are same as the source RDS instance.
+  # Uncomment if count > 0
+
+  /*
+  data = {
+    rds_instance_endpoint = module.read_replica.rds_instance_endpoint
+    rds_instance_address  = module.read_replica.rds_instance_address
+  }
+  */
+}
+
+# Configmap to store non-sensitive data related to the RDS instance
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}


### PR DESCRIPTION
We are currently in the process of creating a Postgres Database to temporarily store hmpps-related events. Once a table is initialised within Postgres, it will be used by both the event notifier and the event handler.