### PR TITLE
CJS-54 MSSQL RDS read-only replica created

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/irsa.tf
@@ -9,9 +9,10 @@ module "irsa" {
   namespace            = var.namespace # this is also used as a tag
 
   role_policy_arns = {
-    unprocessed_sqs = module.unprocessed_documents_and_events_sqs.irsa_policy_arn
-    process_sqs     = module.process_sqs.irsa_policy_arn
-    rds_mssql       = module.rds_mssql.irsa_policy_arn
+    unprocessed_sqs   = module.unprocessed_documents_and_events_sqs.irsa_policy_arn
+    process_sqs       = module.process_sqs.irsa_policy_arn
+    rds_mssql         = module.rds_mssql.irsa_policy_arn
+    rds_mssql_replica = module.rds_mssql_read_replica.irsa_policy_arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/rds-mssql.tf
@@ -20,8 +20,8 @@ module "rds_mssql" {
 
   # SQL Server specifics
   db_engine            = "sqlserver-ex"
-  db_engine_version    = "15.00.4236.7.v1"
-  rds_family           = "sqlserver-ex-15.0"
+  db_engine_version    = "16.00.4095.4.v1"
+  rds_family           = "sqlserver-ex-16.0"
   db_instance_class    = "db.t3.small"
   db_allocated_storage = 32 # minimum of 20GiB for SQL Server
 
@@ -52,9 +52,62 @@ resource "kubernetes_secret" "rds_mssql" {
   }
 
   data = {
-    rds_instance_endpoint = module.rds_mssql.rds_instance_endpoint
     database_username     = module.rds_mssql.database_username
     database_password     = module.rds_mssql.database_password
+  }
+}
+
+resource "kubernetes_config_map" "rds_mssql" {
+  metadata {
+    name      = "rds-mssql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds_mssql.rds_instance_endpoint
     rds_instance_address  = module.rds_mssql.rds_instance_address
+  }
+}
+
+module "rds_mssql_read_replica" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.2"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # Set the db_identifier of the source db
+  replicate_source_db = module.rds_mssql.db_identifier
+
+  # Set to true. No backups or snapshots are created for read replica
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+resource "kubernetes_config_map" "rds_mssql_read_replica" {
+  metadata {
+    name      = "rds-mssql-read-replica-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds_mssql_read_replica.rds_instance_endpoint
+    rds_instance_address  = module.rds_mssql_read_replica.rds_instance_address
   }
 }


### PR DESCRIPTION
- Create read-only replica
- Upgrade the database to SQL server 2022 from SQL server 2019
- Add config maps for both primary and read-only replicas for instance endpoints and addresses
- Add secret for username and password