### PR TITLE
SI-658-update-pathfinder-team-name-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/00-namespace.yaml
@@ -13,5 +13,5 @@ metadata:
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/pathfinder.git"
     cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
     cloud-platform.justice.gov.uk/slack-channel: "pathfinder_comms"
-    cloud-platform.justice.gov.uk/team-name: "pathfinder"
+    cloud-platform.justice.gov.uk/team-name: "DPS Pathfinder Production Releases"
     iam.amazonaws.com/permitted: "pathfinder-preprod-ap"


### PR DESCRIPTION
Update the team name for the pathfinder pre-prod namespace to the "DPS Pathfinder Production Releases" team