### PR TITLE
Remove the A and CNAME records which were pointing to the old service…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/route53.tf
@@ -22,34 +22,3 @@ resource "kubernetes_secret" "route53_justice_zone_sec" {
     zone_id = aws_route53_zone.route53_justice_zone.zone_id
   }
 }
-
-resource "aws_route53_record" "aws_route53_record_prod_1" {
-  name    = "tribunalsdecisions.service.gov.uk."
-  zone_id = aws_route53_zone.route53_justice_zone.zone_id
-  type    = "A"
-  alias {
-    zone_id                = "Z32O12XQLNTSW2"
-    name                   = "dualstack.dtsla-utiac-lb-prod-1989357889.eu-west-1.elb.amazonaws.com."
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "aws_route53_record_cname_1" {
-  name    = "_8ba7ec9e63838fe3e3d630ce965706b3.tribunalsdecisions.service.gov.uk."
-  zone_id = aws_route53_zone.route53_justice_zone.zone_id
-  type    = "CNAME"
-  ttl     = 60
-  records = [
-    "_f26e09f08db0cba807d529c8f96282ad.nxntxfsdbd.acm-validations.aws."
-  ]
-}
-
-resource "aws_route53_record" "aws_route53_record_cname_2" {
-  name    = "_bb8ace67cedf32f565d5c771b0efa0a7.tribunalsdecisions.service.gov.uk."
-  zone_id = aws_route53_zone.route53_justice_zone.zone_id
-  type    = "CNAME"
-  ttl     = 60
-  records = [
-    "_3e5b44d91cbed8fff70574fa6f2f74ae.auiqqraehs.acm-validations.aws."
-  ]
-}


### PR DESCRIPTION
… in DSD AWS

This will make the service live in Cloud Platform at tribunalsdecisions.service.gov.uk