### PR TITLE
intranet-dev - Remove aliases and certs etc. To validate the PEM/restrictions on CloudFront worked.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/acm.tf
@@ -1,71 +1,71 @@
-resource "aws_route53_zone" "cloudfront_route53_zone" {
-  name = var.cloudfront_alias
+# resource "aws_route53_zone" "cloudfront_route53_zone" {
+#   name = var.cloudfront_alias
 
-  tags = {
-    business_unit          = var.business_unit
-    application            = var.application
-    is_production          = var.is_production
-    team_name              = var.team_name
-    namespace              = var.namespace
-    environment_name       = var.environment
-    infrastructure_support = var.infrastructure_support
-  }
-}
+#   tags = {
+#     business_unit          = var.business_unit
+#     application            = var.application
+#     is_production          = var.is_production
+#     team_name              = var.team_name
+#     namespace              = var.namespace
+#     environment_name       = var.environment
+#     infrastructure_support = var.infrastructure_support
+#   }
+# }
 
-resource "aws_acm_certificate" "cloudfront_alias_cert" {
-  domain_name       = var.cloudfront_alias
-  validation_method = "DNS"
+# resource "aws_acm_certificate" "cloudfront_alias_cert" {
+#   domain_name       = var.cloudfront_alias
+#   validation_method = "DNS"
 
-  tags = {
-    business-unit          = var.business_unit
-    application            = var.application
-    is-production          = var.is_production
-    environment-name       = var.environment
-    owner                  = var.team_name
-    infrastructure-support = var.infrastructure_support
-    namespace              = var.namespace
-    team_name              = var.team_name
-  }
+#   tags = {
+#     business-unit          = var.business_unit
+#     application            = var.application
+#     is-production          = var.is_production
+#     environment-name       = var.environment
+#     owner                  = var.team_name
+#     infrastructure-support = var.infrastructure_support
+#     namespace              = var.namespace
+#     team_name              = var.team_name
+#   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
 
-resource "aws_route53_record" "cert-validations" {
-  count           = length(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options)
+# resource "aws_route53_record" "cert-validations" {
+#   count           = length(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options)
 
-  zone_id         = aws_route53_zone.cloudfront_route53_zone.zone_id
+#   zone_id         = aws_route53_zone.cloudfront_route53_zone.zone_id
 
-  name            = element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_name, count.index)
-  type            = element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_type, count.index)
-  records         = [element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_value, count.index)]
-  ttl             = 60
-  allow_overwrite = true
+#   name            = element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_name, count.index)
+#   type            = element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_type, count.index)
+#   records         = [element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_value, count.index)]
+#   ttl             = 60
+#   allow_overwrite = true
 
-  depends_on      = [aws_acm_certificate.cloudfront_alias_cert]
-}
+#   depends_on      = [aws_acm_certificate.cloudfront_alias_cert]
+# }
 
-resource "aws_acm_certificate_validation" "cloudfront_alias_cert_validation" {
-  certificate_arn         = aws_acm_certificate.cloudfront_alias_cert.arn
-  validation_record_fqdns = aws_route53_record.cert-validations[*].fqdn 
+# resource "aws_acm_certificate_validation" "cloudfront_alias_cert_validation" {
+#   certificate_arn         = aws_acm_certificate.cloudfront_alias_cert.arn
+#   validation_record_fqdns = aws_route53_record.cert-validations[*].fqdn 
 
-  timeouts {
-    create = "10m"
-  }
+#   timeouts {
+#     create = "10m"
+#   }
 
-  depends_on = [aws_route53_record.cert-validations]
-}
+#   depends_on = [aws_route53_record.cert-validations]
+# }
 
-resource "aws_route53_record" "cloudfront_aws_route53_record" {
-  name    = var.cloudfront_alias
-  zone_id = aws_route53_zone.cloudfront_route53_zone.zone_id
-  type    = "A"
+# resource "aws_route53_record" "cloudfront_aws_route53_record" {
+#   name    = var.cloudfront_alias
+#   zone_id = aws_route53_zone.cloudfront_route53_zone.zone_id
+#   type    = "A"
 
-  alias {
-    name                   = module.cloudfront.cloudfront_url
-    zone_id                = module.cloudfront.cloudfront_hosted_zone_id
-    evaluate_target_health = false
-  }
-}
+#   alias {
+#     name                   = module.cloudfront.cloudfront_url
+#     zone_id                = module.cloudfront.cloudfront_hosted_zone_id
+#     evaluate_target_health = false
+#   }
+# }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cloudfront.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cloudfront.tf
@@ -4,8 +4,8 @@ module "cloudfront" {
   # Configuration
   bucket_id            = module.s3_bucket.bucket_name
   bucket_domain_name   = "${module.s3_bucket.bucket_name}.s3.eu-west-2.amazonaws.com"
-  aliases              = [var.cloudfront_alias]
-  aliases_cert_arn     = aws_acm_certificate.cloudfront_alias_cert.arn
+  # aliases              = [var.cloudfront_alias]
+  # aliases_cert_arn     = aws_acm_certificate.cloudfront_alias_cert.arn
   trusted_public_keys  = var.trusted_public_keys
 
   # Tags


### PR DESCRIPTION
This PR removes:

- CloudFront aliases.
- Route53 records
- acm certificates.

This is an aim to at least prove that the PEM and access restriction that I added to the CloudFront module is working as intended.