### PR TITLE
intranet-dev: Add a base domain dev.intranet.justice.gov.uk 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/06-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: intranet-dev-cert
+  namespace: intranet-dev
+spec:
+  secretName: intranet-dev-cert-secret
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - dev.intranet.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cloudfront.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cloudfront.tf
@@ -25,8 +25,8 @@ resource "kubernetes_secret" "cloudfront_url" {
   }
 
   data = {
-    cloudfront_alias          = var.cloudfront_alias
-    cloudfront_url            = module.cloudfront.cloudfront_url
-    cloudfront_public_key_ids = module.cloudfront.cloudfront_public_key_ids
+    cloudfront_alias       = var.cloudfront_alias
+    cloudfront_url         = module.cloudfront.cloudfront_url
+    cloudfront_public_keys = module.cloudfront.cloudfront_public_keys
   }
 } 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "intranet_route53_zone" {
+  name = var.base_domain
+
+  tags = {
+    business_unit          = var.business_unit
+    application            = var.application
+    is_production          = var.is_production
+    team_name              = var.team_name
+    namespace              = var.namespace
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id      = aws_route53_zone.intranet_route53_zone.zone_id
+    name_servers = join("\n", aws_route53_zone.intranet_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/variables.tf
@@ -76,10 +76,16 @@ variable "github_actions_secret_kube_token" {
   default     = "KUBE_TOKEN"
 }
 
-variable "cloudfront_alias" {
-  description = "Aliases for the CloudFront distribution"
+variable "base_domain" {
+  description = "The base domain used for creating the Route53 zone. The website will be available here."
   type        = string
-  default     = "cdn.dev-intranet.apps.live.cloud-platform.service.justice.gov.uk"
+  default     = "dev.intranet.justice.gov.uk"
+}
+
+variable "cloudfront_alias" {
+  description = "Aliases for the CloudFront distribution. Should be a subdomain of the base domain."
+  type        = string
+  default     = "cdn.dev.intranet.justice.gov.uk"
 }
 
 variable "trusted_public_keys" {


### PR DESCRIPTION
Created route53 & cert definitions.

This is a step towards having a subdomain for CloudFront CDN. 

We'll pass the name_servers output to operations-engineering.

CC @wilson1000 