### PR TITLE
🌐 Add Observability Platform Route 53 records for User Guide and PagerDuty Status Page

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,20 +1,27 @@
 {
   "features": {
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:0": {
-      "version": "0.0.2",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:db720f840ce5015117b1b1e7649dc59b8ac6b34a8786f07ab727dd081140737f",
-      "integrity": "sha256:db720f840ce5015117b1b1e7649dc59b8ac6b34a8786f07ab727dd081140737f"
+      "version": "0.0.3",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:249e6f164df67ce38c8217c25e52d89ac1267d79536669647eed14fd2609f715",
+      "integrity": "sha256:249e6f164df67ce38c8217c25e52d89ac1267d79536669647eed14fd2609f715"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:0": {
-      "version": "0.0.3",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform@sha256:1629c0feb5f64cd27ccaca2de356c2648aabebafd89cf5b1fdb699af3c23e6b7",
-      "integrity": "sha256:1629c0feb5f64cd27ccaca2de356c2648aabebafd89cf5b1fdb699af3c23e6b7",
-      "dependsOn": ["ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:0"]
+      "version": "0.0.4",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform@sha256:e5254698b7b38234c01f4dcb3e69eef21a1d00b1148beb27e2c2e18f57588a3a",
+      "integrity": "sha256:e5254698b7b38234c01f4dcb3e69eef21a1d00b1148beb27e2c2e18f57588a3a",
+      "dependsOn": [
+        "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:0"
+      ]
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:0": {
-      "version": "0.0.3",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:7dee22517978ccf52d5c9052e8a1e160a4e12b3b3fda467b5f3308e45ea32fe9",
-      "integrity": "sha256:7dee22517978ccf52d5c9052e8a1e160a4e12b3b3fda467b5f3308e45ea32fe9"
+      "version": "0.0.4",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:8ac98932cf2832b2e451bee7afbbafcdefc1572b3baf909e8b5db8439ad81949",
+      "integrity": "sha256:8ac98932cf2832b2e451bee7afbbafcdefc1572b3baf909e8b5db8439ad81949"
+    },
+    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:0": {
+      "version": "0.0.5",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:d9915b6c4320f13835ce7fd08887421c9dde1c38a3f17acd303a22f6fdaf5f00",
+      "integrity": "sha256:d9915b6c4320f13835ce7fd08887421c9dde1c38a3f17acd303a22f6fdaf5f00"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:0": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:0": {}
+    "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:0": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:0": {},
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/observability-platform-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/observability-platform-production/resources/route53.tf
@@ -26,3 +26,51 @@ resource "aws_route53_record" "github_pages" {
   ttl     = "300"
   records = ["185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153"]
 }
+
+resource "aws_route53_record" "github_pages_user_guide" {
+  zone_id = aws_route53_zone.observability_platform_service_justice_gov_uk.zone_id
+  name    = "user-guide.observability-platform.service.justice.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["ministryofjustice.github.io"]
+}
+
+resource "aws_route53_record" "pagerduty_status_page_mail_cname" {
+  zone_id = aws_route53_zone.observability_platform_service_justice_gov_uk.zone_id
+  name    = "em3198.status.observability-platform.service.justice.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["u31181182.wl183.sendgrid.net"]
+}
+
+resource "aws_route53_record" "pagerduty_status_page_dkim1" {
+  zone_id = aws_route53_zone.observability_platform_service_justice_gov_uk.zone_id
+  name    = "pdt._domainkey.status.observability-platform.service.justice.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["pdt.domainkey.u31181182.wl183.sendgrid.net"]
+}
+
+resource "aws_route53_record" "pagerduty_status_page_dkim2" {
+  zone_id = aws_route53_zone.observability_platform_service_justice_gov_uk.zone_id
+  name    = "pdt2._domainkey.status.observability-platform.service.justice.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["pdt2.domainkey.u31181182.wl183.sendgrid.net"]
+}
+
+resource "aws_route53_record" "pagerduty_status_page_tls_certificate" {
+  zone_id = aws_route53_zone.observability_platform_service_justice_gov_uk.zone_id
+  name    = "_7b1f5f499647d5625e8166e2422c72c6.status.observability-platform.service.justice.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["_8f93439130be05bb1bb1561c7859212d.mhbtsbpdnt.acm-validations.aws"]
+}
+
+resource "aws_route53_record" "pagerduty_status_page_http_traffic" {
+  zone_id = aws_route53_zone.observability_platform_service_justice_gov_uk.zone_id
+  name    = "status.observability-platform.service.justice.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["cd-b65eda1882c1a51ed8b07272c09d3795.hosted-status.pagerduty.com"]
+}


### PR DESCRIPTION
This pull request:

- Amends the dev container definition
  - Updates `aws` to `0.0.3`
  - Updates `cloud-platform` to `0.0.4`
  - Updates `kubernetes` to `0.0.4`
  - Adds `terraform` at `0.0.5`
- Adds records for `user-guide.observability-platform.service.justice.gov.uk`
- Adds records for `status.observability-platform.service.justice.gov.uk`