### PR TITLE
CJS-102/CJS-244 Add git repo to namespace and service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/00-namespace.yaml
@@ -17,6 +17,7 @@ metadata:
                                                 https://github.com/ministryofjustice/moj-cjse-xhibit-ingestion-api,
                                                 https://github.com/ministryofjustice/moj-cjse-xhibit-subscription-api,
                                                 https://github.com/ministryofjustice/moj-cjse-xhibit-notification-api,
-                                                https://github.com/ministryofjustice/moj-cjse-xhibit-ingestion-processor"
+                                                https://github.com/ministryofjustice/moj-cjse-xhibit-ingestion-processor,
+                                                https://github.com/ministryofjustice/moj-cjse-xhibit-webportal-prototype"
     cloud-platform.justice.gov.uk/team-name: "moj-cjse"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/serviceaccount.tf
@@ -10,7 +10,8 @@ module "serviceaccount" {
                             "moj-cjse-xhibit-ingestion-api",
                             "moj-cjse-xhibit-subscription-api",
                             "moj-cjse-xhibit-notification-api",
-                            "moj-cjse-xhibit-ingestion-processor"
+                            "moj-cjse-xhibit-ingestion-processor",
+                            "moj-cjse-xhibit-webportal-prototype"
                          ]
   serviceaccount_rules = var.serviceaccount_rules
   # This GitHub environmet will need to be created manually first


### PR DESCRIPTION
The following repo is added to the service account and namespace: [moj-cjse-xhibit-webportal-prototype](https://github.com/ministryofjustice/moj-cjse-xhibit-webportal-prototype)