### PR TITLE
intranet-dev re-add route53 zone because deleting it was erroring

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/route53.tf
@@ -1,16 +1,16 @@
-# resource "aws_route53_zone" "intranet_route53_zone" {
-#   name = var.base_domain
+resource "aws_route53_zone" "intranet_route53_zone" {
+  name = var.base_domain
 
-#   tags = {
-#     business_unit          = var.business_unit
-#     application            = var.application
-#     is_production          = var.is_production
-#     team_name              = var.team_name
-#     namespace              = var.namespace
-#     environment_name       = var.environment
-#     infrastructure_support = var.infrastructure_support
-#   }
-# }
+  tags = {
+    business_unit          = var.business_unit
+    application            = var.application
+    is_production          = var.is_production
+    team_name              = var.team_name
+    namespace              = var.namespace
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+  }
+}
 
 # CloudFront alias certificate validations
 


### PR DESCRIPTION
Error: deleting Route53 Hosted Zone (Z10272571XL2RC8CGGC7S): HostedZoneNotEmpty: The specified hosted zone contains non-required resource record sets and so cannot be deleted.
	status code: 400, request id: a8c568fe-5df1-4417-858e-a8ed509e58b7