### PR TITLE
intranet-dev - use associate flag to disacotiate an old trusted_public_key

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cloudfront.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cloudfront.tf
@@ -7,18 +7,19 @@ data "kubernetes_secret" "cloudfront_input_secret" {
 
 locals {
   trusted_key          = {
-    encoded_key = data.kubernetes_secret.cloudfront_input_secret.data["AWS_CLOUDFRONT_PUBLIC_KEY"]
+    encoded_key = data.kubernetes_secret.cloudfront_input_secret.data.AWS_CLOUDFRONT_PUBLIC_KEY
     comment     = ""
+    associate   = true
   }
   expiring_trusted_key = {
-    encoded_key = try(data.kubernetes_secret.cloudfront_input_secret.data["AWS_CLOUDFRONT_PUBLIC_KEY_EXPIRING"], null)
+    encoded_key = try(data.kubernetes_secret.cloudfront_input_secret.data.AWS_CLOUDFRONT_PUBLIC_KEY_EXPIRING, null)
     comment     = ""
+    associate   = true
   }
 }
 
 module "cloudfront" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-cloudfront-edits?ref=cloudfront-functions-draft"
-
 
   # Configuration
   bucket_id            = module.s3_bucket.bucket_name
@@ -27,7 +28,10 @@ module "cloudfront" {
   # aliases_cert_arn     = aws_acm_certificate.cloudfront_alias_cert.arn
   
   # An array of public keys with comments, to be used for CloudFront. Includes an optional entry for an expiring key
-  trusted_public_keys = local.expiring_trusted_key.encoded_key == null ? [local.trusted_key] : [local.trusted_key, local.expiring_trusted_key]
+  # trusted_public_keys = local.expiring_trusted_key.encoded_key == null ? [local.trusted_key] : [local.trusted_key, local.expiring_trusted_key]
+
+  # var.trusted_public_keys[0] is here so that it can be disassociated from the key group. Then deleted.
+  trusted_public_keys = [local.trusted_key, var.trusted_public_keys[0]]
 
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/variables.tf
@@ -87,3 +87,26 @@ variable "cloudfront_alias" {
   type        = string
   default     = "cdn.dev.intranet.justice.gov.uk"
 }
+
+variable "trusted_public_keys" {
+  description = "Public key pems to be used for CloudFront"
+  type = list(object({
+    encoded_key = string
+    comment     = string
+  }))
+  default     = [{ 
+    encoded_key  = <<-EOT
+    -----BEGIN PUBLIC KEY-----
+    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhmdbKSd2S+w4YWcbxUT
+    4prLNfKOhXmM2r3eIWkDP1CM1YomLbNffumjwXqvXo9SynXMdTVt6DK0yEcoeBq3
+    DADoKmBvAUjr69nMqlbLz6hfadzmGt3KD65QWn5hTPu/DcQmL0tj+XXHIv04HEoK
+    i20XhRdWh/pf1Ix1Lb8lF4AgKE9EJZX4pLpbb6IjYft9WAjDQTEfS1bkfQ1Q7Yo/
+    fPfSq+8DGF4TgSjqCEZHeEC4vWnXbBxrk8W1exipIBbtjNPYc9vdQeuRuU9QZrXz
+    QcYnJJQGcmmICthXIUn6Ekygx5OVbyU3BFcsYpLcpo/TkH4FJQtSUQTF7EqYIrOG
+    cQIDAQAB
+    -----END PUBLIC KEY-----
+    EOT
+    comment  = "Another public key"
+    associate = false
+  }]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/variables.tf
@@ -93,6 +93,7 @@ variable "trusted_public_keys" {
   type = list(object({
     encoded_key = string
     comment     = string
+    associate   = bool
   }))
   default     = [{ 
     encoded_key  = <<-EOT


### PR DESCRIPTION
```
Error: deleting CloudFront PublicKey (K3P2N9XAOU6Q1Y): PublicKeyInUse: The Cloudfront public key is currently associated with either Key Group or a field level encryption profile.
```