### PR TITLE
Adds IAM policy for SQS for dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/irsa.tf
@@ -1,0 +1,68 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "ccr-dev-service"
+  namespace            = var.namespace # this is also used as a tag
+
+  # Attach the approprate policies using a key => value map
+  # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
+  # provide an output called `irsa_policy_arn` that can be used.
+  role_policy_arns = {
+    sqs_ccr_claims         = "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-cccd-claims-for-ccr"
+    sqs_ccr_claims_dlq     = "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-cccd-claims-submitted-ccr-dlq"
+    sqs_cccd_responses     = "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-responses-for-cccd"
+    sqs_cccd_responses_dlq = "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-reponses-for-cccd-dlq"
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  infrastructure_support = var.infrastructure_support
+}
+
+data "aws_iam_policy_document" "ccr_claims_policy" {
+  # Provide list of permissions and target AWS account resources to allow access to
+  statement {
+    actions = [
+      "sqs:*",
+    ]
+    resources = [
+      "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-cccd-claims-for-ccr",
+      "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-cccd-claims-submitted-ccr-dlq",
+      "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-responses-for-cccd",
+      "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-reponses-for-cccd-dlq",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ccr_policy" {
+  name   = "ccr_policy"
+  policy = data.aws_iam_policy_document.ccr_claims_policy.json
+  description = "Policy for Cloud Platform to assume role in data platform dev account for CCR"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.github_owner
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "ccr-claims-policy"
+    namespace = var.namespace
+  }
+  data = {
+    role = module.irsa.aws_iam_role_name
+    serviceaccount = module.irsa.service_account_name.name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/variables.tf
@@ -68,6 +68,10 @@ variable "github_token" {
   default     = ""
 }
 
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster"
+}
+
 variable "serviceaccount_rules" {
   description = "The capabilities of this serviceaccount"
 


### PR DESCRIPTION
Add access policies to allow the CloudPlatform hosted CCR application to send and receive messages.
There are 4 SQS queues that CCR uses to send and receive messages to and from CCCD following a Publish/Subscribe model. Access policies on the SQS queues allows CCR to do this. 