### PR TITLE
intranet-dev add CloudFront alias with acm and route53 records

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/acm.tf
@@ -1,34 +1,38 @@
-# CloudFront alias certificate.
+# An aws_acm_certificate for the CloudFront alias.
 
-# resource "aws_acm_certificate" "cloudfront_alias_cert" {
-#   domain_name       = var.cloudfront_alias
-#   validation_method = "DNS"
+resource "aws_acm_certificate" "cloudfront_alias_cert" {
+  domain_name       = var.cloudfront_alias
+  validation_method = "DNS"
 
-#   tags = {
-#     business-unit          = var.business_unit
-#     application            = var.application
-#     is-production          = var.is_production
-#     environment-name       = var.environment
-#     owner                  = var.team_name
-#     infrastructure-support = var.infrastructure_support
-#     namespace              = var.namespace
-#     team_name              = var.team_name
-#   }
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+    team_name              = var.team_name
+  }
 
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
-# CloudFront alias certificate validation.
+# aws_acm_certificate_validation for the CloudFront alias.
+# This is part of the validation workflow and not a a real-world entity in AWS.
+# The resource is used together with aws_route53_record and aws_acm_certificate
+# to request a DNS validated certificate, deploy the required validation records 
+# and wait for validation to complete.
 
-# resource "aws_acm_certificate_validation" "cloudfront_alias_cert_validation" {
-#   certificate_arn         = aws_acm_certificate.cloudfront_alias_cert.arn
-#   validation_record_fqdns = aws_route53_record.cert-validations[*].fqdn 
+resource "aws_acm_certificate_validation" "cloudfront_alias_cert_validation" {
+  certificate_arn         = aws_acm_certificate.cloudfront_alias_cert.arn
+  validation_record_fqdns = aws_route53_record.cert-validations[*].fqdn 
 
-#   timeouts {
-#     create = "10m"
-#   }
+  timeouts {
+    create = "10m"
+  }
 
-#   depends_on = [aws_route53_record.cert-validations]
-# }
+  depends_on = [aws_route53_record.cert_validations]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/acm.tf
@@ -28,7 +28,7 @@ resource "aws_acm_certificate" "cloudfront_alias_cert" {
 
 resource "aws_acm_certificate_validation" "cloudfront_alias_cert_validation" {
   certificate_arn         = aws_acm_certificate.cloudfront_alias_cert.arn
-  validation_record_fqdns = aws_route53_record.cert-validations[*].fqdn 
+  validation_record_fqdns = aws_route53_record.cert_validations[*].fqdn 
 
   timeouts {
     create = "10m"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cloudfront.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/cloudfront.tf
@@ -24,8 +24,8 @@ module "cloudfront" {
   # Configuration
   bucket_id            = module.s3_bucket.bucket_name
   bucket_domain_name   = "${module.s3_bucket.bucket_name}.s3.eu-west-2.amazonaws.com"
-  # aliases              = [var.cloudfront_alias]
-  # aliases_cert_arn     = aws_acm_certificate.cloudfront_alias_cert.arn
+  aliases              = [var.cloudfront_alias]
+  aliases_cert_arn     = aws_acm_certificate.cloudfront_alias_cert.arn
   
   # An array of public keys with comments, to be used for CloudFront. Includes an optional entry for an expiring key
   trusted_public_keys = local.expiring_trusted_key.encoded_key == null ? [local.trusted_key] : [local.trusted_key, local.expiring_trusted_key]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/route53.tf
@@ -1,0 +1,40 @@
+# Get the kubernetes secret 'route53-zone-output' from intranet-production namespace.
+# This secret contains the zone_id of the hosted zone.
+
+data "kubernetes_secret" "route53_zone_output" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = "intranet-production"
+  }
+}
+
+# Create an A record in the hosted zone for the CloudFront alias.
+# Note, the zone_id parameter is set to the zone_id from the intranet-production kubernetes secret.
+# And the alias.zone_id parameter is set to the CloudFront hosted zone id.
+
+resource "aws_route53_record" "data" {
+  zone_id = data.kubernetes_secret.route53_zone_output.data["zone_id"]
+  name    = var.cloudfront_alias
+  type    = "A"
+
+  alias {
+    evaluate_target_health = false
+    name                   = module.cloudfront.cloudfront_url
+    zone_id                = module.cloudfront.cloudfront_hosted_zone_id
+  }
+}
+
+# In acm.tf, an aws_acm_certificate resource is created for the CloudFront alias.
+# As the validation method is set to DNS, a route53 record is created here for the certificate validation.
+
+resource "aws_route53_record" "cert_validations" {
+  count           = length(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options)
+
+  zone_id         = data.kubernetes_secret.route53_zone_output.data["zone_id"]
+
+  name            = element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_name, count.index)
+  type            = element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_type, count.index)
+  records         = [element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_value, count.index)]
+  ttl             = 60
+  allow_overwrite = true
+}


### PR DESCRIPTION
To merge **after** Cloud Platform NS are added to DNS for `intranet.justice.gov.uk`. 