### PR TITLE
CRM457-1289: Production caseworker network policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/00-namespace.yaml
@@ -6,7 +6,8 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
     pod-security.kubernetes.io/enforce: restricted
-        cloud-platform.justice.gov.uk/namespace: "laa-assess-crime-forms-prod"
+    cloud-platform.justice.gov.uk/namespace: "laa-assess-crime-forms-prod"
+    component: allow-laa-crime-application-store-api-production
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "laa-non-standard-crime-claims"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/00-namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
     pod-security.kubernetes.io/enforce: restricted
+        cloud-platform.justice.gov.uk/namespace: "laa-assess-crime-forms-prod"
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
     cloud-platform.justice.gov.uk/slack-channel: "laa-non-standard-crime-claims"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-laa-crime-application-store-api-production
+  namespace: laa-assess-crime-forms-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: laa-crime-application-store-production


### PR DESCRIPTION
[Update network policies so that Caseworker application talks to datastore via Cloud Platform rather than via an external url](https://dsdmoj.atlassian.net/browse/CRM457-1289)

Add namespace label and network policy