### PR TITLE
:wrench: Increasing CPU limit and request of canary app to in live-2 to match live

### DIFF
--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/values.yaml
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-canary-app-eks/resources/values.yaml
@@ -24,8 +24,8 @@ ingress:
 
 resources:
   limits:
-    cpu: 4m
+    cpu: 100m
     memory: 32Mi
   requests:
-    cpu: 2m
+    cpu: 40m
     memory: 16Mi


### PR DESCRIPTION
CPU is around 3m all the time. And throttling when the pods gets shifted. This PR increase the requests and limits to accommodate the spikes.

This is related to this [ticketed issue](https://github.com/ministryofjustice/cloud-platform/issues/5399).