### PR TITLE
Remove CCR landing zone SQS access policies

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/irsa.tf
@@ -14,10 +14,10 @@ module "irsa" {
   role_policy_arns = {
     s3              = module.cccd_s3_bucket.irsa_policy_arn
     sns_submitted   = module.cccd_claims_submitted.irsa_policy_arn
-    sqs_ccr         = module.claims_for_ccr.irsa_policy_arn
+#    sqs_ccr         = module.claims_for_ccr.irsa_policy_arn
     sqs_cclf        = module.claims_for_cclf.irsa_policy_arn
     sqs_responses   = module.responses_for_cccd.irsa_policy_arn
-    sqs_ccr_dlq     = module.ccr_dead_letter_queue.irsa_policy_arn
+#    sqs_ccr_dlq     = module.ccr_dead_letter_queue.irsa_policy_arn
     sqs_cclf_dlq    = module.cclf_dead_letter_queue.irsa_policy_arn
     sqs_respons_dlq = module.cccd_response_dead_letter_queue.irsa_policy_arn
     rds             = module.cccd_rds.irsa_policy_arn


### PR DESCRIPTION
disable CCR policies for landing zone until migrated sqs policies have been fully tested and migrated