### PR TITLE
Addressed CI errors

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -94,10 +94,16 @@ resource "aws_api_gateway_resource" "proxy" {
   path_part   = "{proxy+}"
 }
 
-resource "aws_api_gateway_resource" "sqs_resource" {
+resource "aws_api_gateway_resource" "sqs_parent_resource" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway.id
   parent_id   = aws_api_gateway_rest_api.api_gateway.root_resource_id
-  path_part   = "{receive-events}"
+  path_part   = "events"
+}
+
+resource "aws_api_gateway_resource" "sqs_resource" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway.id
+  parent_id   = aws_api_gateway_resource.sqs_parent_resource.id
+  path_part   = "{get-events}"
 }
 
 resource "aws_api_gateway_method" "proxy" {
@@ -152,11 +158,11 @@ resource "aws_api_gateway_integration" "proxy_http_proxy" {
 
 resource "aws_api_gateway_integration" "sqs_integration" {
   rest_api_id             = aws_api_gateway_rest_api.api_gateway.id
-  resource_id             = aws_api_gateway_resource.sqs_resource.id
+  resource_id             = aws_api_gateway_resource.sqs_parent_resource.id
   http_method             = aws_api_gateway_method.sqs_method.http_method
   type                    = "AWS"
   integration_http_method = "GET"
-  uri                     = "${var.cloud_platform_integration_api_url}/{receive-events}"
+  uri                     = "${var.cloud_platform_integration_api_url}/{get-events}"
 
   request_parameters = {
     "integration.request.querystring.Action" = "method.request.querystring.Action"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/iam.tf
@@ -166,15 +166,14 @@ resource "aws_iam_policy" "api_gateway_sqs_policy" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = "sqs:ReceiveMessage"
-        Resource = [
-          module.event_test_client_queue
-        ]
+        Effect   = "Allow"
+        Action   = "sqs:ReceiveMessage"
+        Resource = module.event_test_client_queue
       }
     ]
   })
 }
+
 
 resource "aws_iam_role_policy_attachment" "api_gateway_sqs_policy_attachment" {
   role       = aws_iam_role.api_gateway_sqs_role.name


### PR DESCRIPTION
[platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/4104](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/4104)

[3:36](https://mojdt.slack.com/archives/D07141MN8FJ/p1713969361675569)
2024/04/24 13:44:12 Running Terraform Apply for namespace: hmpps-integration-api-dev
FATA[0045] error running terraform on namespace hmpps-integration-api-dev: unable to apply Terraform: exit status 1
Error: creating API Gateway Resource: BadRequestException: A sibling ({proxy+}) of this resource already has a variable path part -- only one is allowed
  with aws_api_gateway_resource.sqs_resource,
  on api_gateway.tf line 97, in resource “aws_api_gateway_resource” “sqs_resource”:
  97: resource “aws_api_gateway_resource” “sqs_resource” {
Error: creating IAM Policy (hmpps-integration-api-dev-api-gateway-sqs-policy): MalformedPolicyDocument: Syntax errors in policy.
	status code: 400, request id: 0f2b0787-e881-484f-90c0-96c9cfd7ecc5
  with aws_iam_policy.api_gateway_sqs_policy,
  on iam.tf line 162, in resource “aws_iam_policy” “api_gateway_sqs_policy”:
 162: resource “aws_iam_policy” “api_gateway_sqs_policy” {
   subcommand=apply
   
   ////
   
   To address these errors I made changed the resource hierarchy in api_gateway.tf and I fixed the JSON in iam.tf