### PR TITLE
Addressing errors in CI

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -103,7 +103,7 @@ resource "aws_api_gateway_resource" "sqs_parent_resource" {
 resource "aws_api_gateway_resource" "sqs_resource" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway.id
   parent_id   = aws_api_gateway_resource.sqs_parent_resource.id
-  path_part   = "{get-events}"
+  path_part   = "get-events"
 }
 
 resource "aws_api_gateway_method" "proxy" {
@@ -162,7 +162,7 @@ resource "aws_api_gateway_integration" "sqs_integration" {
   http_method             = aws_api_gateway_method.sqs_method.http_method
   type                    = "AWS"
   integration_http_method = "GET"
-  uri                     = "${var.cloud_platform_integration_api_url}/{get-events}"
+  uri                     = "arn:aws:apigateway:${var.region}:sqs:path/${module.event_test_client_queue.sqs_arn}"
 
   request_parameters = {
     "integration.request.querystring.Action" = "method.request.querystring.Action"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/iam.tf
@@ -168,7 +168,7 @@ resource "aws_iam_policy" "api_gateway_sqs_policy" {
       {
         Effect   = "Allow"
         Action   = "sqs:ReceiveMessage"
-        Resource = module.event_test_client_queue
+        Resource = module.event_test_client_queue.sqs_arn
       }
     ]
   })


### PR DESCRIPTION
Addressing these errors:
Error: creating API Gateway Integration: NotFoundException: Invalid Method identifier specified

  with aws_api_gateway_integration.sqs_integration,
  on api_gateway.tf line 159, in resource "aws_api_gateway_integration" "sqs_integration":
 159: resource "aws_api_gateway_integration" "sqs_integration" {


Error: putting API Gateway Integration Response: NotFoundException: Invalid Method identifier specified

  with aws_api_gateway_integration_response.sqs_integration_response,
  on api_gateway.tf line 174, in resource "aws_api_gateway_integration_response" "sqs_integration_response":
 174: resource "aws_api_gateway_integration_response" "sqs_integration_response" {


Error: creating IAM Policy (hmpps-integration-api-dev-api-gateway-sqs-policy): MalformedPolicyDocument: Syntax errors in policy.
	status code: 400, request id: 96cd516a-c4e5-465d-9d72-dc907cc6dccc

  with aws_iam_policy.api_gateway_sqs_policy,
  on iam.tf line 162, in resource "aws_iam_policy" "api_gateway_sqs_policy":
 162: resource "aws_iam_policy" "api_gateway_sqs_policy" {



//// Changes made: ///
- the resource is targeting the sqs via ARN in iam.tf
- the integration now uses the ARN in the URI and not the URL
 
 