### PR TITLE
BAVL-13 bring cert secret names in sync with UI/API helm config/locations.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/06-certificate.yaml
@@ -5,7 +5,7 @@ metadata:
   name: book-a-video-link-dev.prison.service.justice.gov.uk
   namespace: hmpps-book-a-video-link-dev
 spec:
-  secretName: book-a-video-link-cert
+  secretName: hmpps-book-a-video-link-ui-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
@@ -19,7 +19,7 @@ metadata:
   name: book-a-video-link-api-dev.prison.service.justice.gov.uk
   namespace: hmpps-book-a-video-link-dev
 spec:
-  secretName: book-a-video-link-api-cert
+  secretName: hmpps-book-a-video-link-api-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer


### PR DESCRIPTION
Changes needed to match certs with the actual code base helm configs.

`The name of the kubernetes secret where the certificate is stored is used as a value to the helm chart - this is used to configure the ingress.`

UI [here](https://github.com/ministryofjustice/hmpps-book-a-video-link-ui/blob/main/helm_deploy/hmpps-book-a-video-link-ui/values.yaml#L18)
API [here](https://github.com/ministryofjustice/hmpps-book-a-video-link-api/blob/main/helm_deploy/hmpps-book-a-video-link-api/values.yaml#L15)