### PR TITLE
Attach new assume role policy to the irsa policy 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/irsa.tf
@@ -49,7 +49,7 @@ module "irsa" {
     s3                        = module.s3_bucket.irsa_policy_arn
     sqs_map_queue             = module.makeaplea_queue.irsa_policy_arn
     sqs_map_queue_dead_letter = module.makeaplea_dead_letter_queue.irsa_policy_arn
-    sqs_assume_role           = assume_role_policy.arn
+    sqs_assume_role           = aws_iam_policy.assume_role_policy.arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/irsa.tf
@@ -49,6 +49,7 @@ module "irsa" {
     s3                        = module.s3_bucket.irsa_policy_arn
     sqs_map_queue             = module.makeaplea_queue.irsa_policy_arn
     sqs_map_queue_dead_letter = module.makeaplea_dead_letter_queue.irsa_policy_arn
+    sqs_assume_role           = assume_role_policy.arn
   }
 
   # Tags
@@ -58,6 +59,24 @@ module "irsa" {
   team_name              = var.team_name
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+}
+
+data "aws_iam_policy_document" "document" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = [
+      "${module.makeaplea_queue.irsa_policy_arn}",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "assume_role_policy" {
+  name        = "${var.namespace}-assume-role"
+  path        = "/${var.namespace}/"
+  policy      = data.aws_iam_policy_document.document.json
+  description = "Assume role policy for makeaplea sqs queue resource"
 }
 
 resource "kubernetes_secret" "irsa" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/irsa.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "document" {
       "sts:AssumeRole"
     ]
     resources = [
-      "${module.makeaplea_queue.irsa_policy_arn}",
+      module.makeaplea_queue.irsa_policy_arn,
     ]
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/outputs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/outputs.tf
@@ -1,7 +1,9 @@
 output "irsa_policy_arn" {
   value = module.makeaplea_queue.irsa_policy_arn
+  description = "IRSA Policy arn"
 }
 
 output "sqs_id_arn" {
   value = module.makeaplea_queue.assume_role_policy.arn
+  description = "sqs assume role policy arn"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/outputs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/outputs.tf
@@ -1,0 +1,7 @@
+output "irsa_policy_arn" {
+  value = module.makeaplea_queue.irsa_policy_arn
+}
+
+output "sqs_id_arn" {
+  value = module.makeaplea_queue.assume_role_policy.arn
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/outputs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makeaplea-dev/resources/outputs.tf
@@ -1,9 +1,0 @@
-output "irsa_policy_arn" {
-  value = module.makeaplea_queue.irsa_policy_arn
-  description = "IRSA Policy arn"
-}
-
-output "sqs_id_arn" {
-  value = module.makeaplea_queue.assume_role_policy.arn
-  description = "sqs assume role policy arn"
-}


### PR DESCRIPTION
Celery tasks requires an assume role policy allow irsa role access to the specific sqs queues