### PR TITLE
[SI-928] Update ClamAV Refresh job service account - manage-soc-cases/dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/serviceaccount-refreshclamav.tf
@@ -6,9 +6,11 @@ locals {
         "extensions",
       ]
       resources = [
+        "deployment",
         "deployments",
       ]
       verbs = [
+        "patch",
         "get",
         "update",
       ]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/serviceaccount-refreshclamav.tf
@@ -6,11 +6,11 @@ locals {
         "extensions",
       ]
       resources = [
-        "deployment",
+        "deployments",
       ]
       verbs = [
-        "patch",
         "get",
+        "update",
       ]
     },
   ]


### PR DESCRIPTION
Updates the refreshclamav service account config for manage-soc-cases/dev only. 

If successful in resolving the issue, will apply to pre-prod, prod, and pathfinder dev / pre-prod / prod. 