### PR TITLE
[SI-928] Update ClamAV Refresh job service account - pathfinder prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/serviceaccount-refreshclamav.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/serviceaccount-refreshclamav.tf
@@ -7,10 +7,12 @@ locals {
       ]
       resources = [
         "deployment",
+        "deployments",
       ]
       verbs = [
         "patch",
         "get",
+        "update",
       ]
     },
   ]


### PR DESCRIPTION
Follows on from: https://github.com/ministryofjustice/cloud-platform-environments/pull/22774

Applies the same fix to `pathfinder` prod