### PR TITLE
✨ Add `operations-engineering-kpi-dashboard-poc` namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "operations-engineering-kpi-dashboard-poc"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "operations-engineering"
+    cloud-platform.justice.gov.uk/application: "KPI Metrics Monitoring Proof of Concept"
+    cloud-platform.justice.gov.uk/owner: "Operations Engineering: operations-engineering@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/operations-engineering"
+    cloud-platform.justice.gov.uk/team-name: "operations-engineering"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: operations-engineering-kpi-dashboard-poc-admin
+  namespace: operations-engineering-kpi-dashboard-poc
+subjects:
+  - kind: Group
+    name: "github:operations-engineering"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: operations-engineering-kpi-dashboard-poc
+spec:
+  limits:
+    - default:
+        cpu: 1000m
+        memory: 1000Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 100Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: operations-engineering-kpi-dashboard-poc
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: operations-engineering-kpi-dashboard-poc
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: operations-engineering-kpi-dashboard-poc
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/irsa.tf
@@ -1,0 +1,25 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "operations-engineering-kpi-dashboard-poc"
+  namespace            = var.namespace # this is also used as a tag
+
+  # Attach the approprate policies using a key => value map
+  # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
+  # provide an output called `irsa_policy_arn` that can be used.
+  role_policy_arns = {
+    rds = module.rds.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/rds.tf
@@ -1,0 +1,38 @@
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.2"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # Database configuration
+  db_engine                   = "postgres"
+  db_engine_version           = "15"
+  rds_family                  = "postgres15"
+  db_instance_class           = "db.t4g.micro"
+  db_max_allocated_storage    = "500"
+  allow_minor_version_upgrade = "true"
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/serviceaccount.tf
@@ -1,0 +1,15 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories                  = ["operations-engineering-kpi-dashboard-poc"]
+  github_actions_secret_kube_namespace = "POC_KUBE_NAMESPACE"
+  github_actions_secret_kube_cert      = "POC_KUBE_CERT"
+  github_actions_secret_kube_token     = "POC_KUBE_TOKEN"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/variables.tf
@@ -1,0 +1,73 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Slack to GitHub username translation"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "operations-engineering-kpi-dashboard-poc"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "operations-engineering"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "operations-engineering@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "operations-engineering"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.39.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4420
- To start storing live KPI data 

## ♻️ What's changed

- Added `operations-engineering-kpi-dashboard-poc` namespace
- Added PostgresDB to store KPI Data

## 📝 Notes

- This namespace is mainly to extend the PoC to prove the capture of live data instead of using locally stubbed data