### PR TITLE
feat: 🎸 turn on label pods webhook

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-label-pods/06-mutating-webhook.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-label-pods/06-mutating-webhook.yaml
@@ -1,30 +1,30 @@
-# apiVersion: admissionregistration.k8s.io/v1
-# kind: MutatingWebhookConfiguration
-# metadata:
-#   name: label-pods-with-github-team
-#   labels:
-#     name: api
-#   annotations:
-#     cert-manager.io/inject-ca-from: cloud-platform-label-pods/serving-cert
-# webhooks:
-#   - name: api.cloud-platform-label-pods.svc.cluster.local
-#     namespaceSelector:
-#       matchExpressions:
-#         - key: kubernetes.io/metadata.name
-#           operator: NotIn
-#           values: ["cloud-platform-label-pods"]
-#     failurePolicy: Ignore
-#     sideEffects: None
-#     admissionReviewVersions: ["v1", "v1beta1"]
-#     clientConfig:
-#       caBundle: Cg==
-#       service:
-#         name: api
-#         namespace: cloud-platform-label-pods
-#         path: "/mutate/pod"
-#     rules:
-#       - operations: ["CREATE"]
-#         apiGroups: [""]
-#         apiVersions: ["v1"]
-#         resources: ["pods"]
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: label-pods-with-github-team
+  labels:
+    name: api
+  annotations:
+    cert-manager.io/inject-ca-from: cloud-platform-label-pods/serving-cert
+webhooks:
+  - name: api.cloud-platform-label-pods.svc.cluster.local
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: ["cloud-platform-label-pods"]
+    failurePolicy: Ignore
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
+    clientConfig:
+      caBundle: Cg==
+      service:
+        name: api
+        namespace: cloud-platform-label-pods
+        path: "/mutate/pod"
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
 


### PR DESCRIPTION
this will label pods all newly created pods with their github teams (pulled from rbac rolebinding) with the following format `<team-a>_<team-b>`