### PR TITLE
upgrade S3 from hashicorp/aws version 4.00 to 5.00

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tariq-test/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tariq-test/resources/s3.tf
@@ -5,7 +5,7 @@
  *
  */
 module "s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=aws-provider-bump"
 
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tariq-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tariq-test/resources/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.67.0"
+      version = "~> 5.43.0"
     }
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
Test upgrade of S3 using aws 4.00 to 5.00 using the Branch aws-provider-bump in the Repo cloud-platform-terraform-s3-bucket
