### PR TITLE
Authorise the probation-in-court GitHub team to preprod resources

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/main.tf
@@ -5,16 +5,37 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+    default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+    default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 
 provider "github" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/variables.tf
@@ -62,3 +62,9 @@ variable "eks_cluster_name" {
 
 variable "kubernetes_cluster" {
 }
+
+variable "slack_channel" {
+    type        = string
+    description = "Cloud Platform will contact our team via this slack channel"
+    default     = "pic-mafia"
+}


### PR DESCRIPTION
### Authorise the probation-in-court GitHub team to preprod resources

- Allow the probation-in-court github team to access preprod aws resources via the aws console