### PR TITLE
Ctskf 756 ccr setup site pingdom health stats

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/pingdom.tf
@@ -1,0 +1,17 @@
+provider "pingdom" {
+}
+
+resource "pingdom_check" "laa-crown-court-remuneration-dev" {
+  type                     = "http"
+  name                     = "cica - dev - cloud-platform - claim"
+  host                     = "dev.laa-crown-court-remuneration-dev.service.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/"
+  encryption               = true
+  port                     = 443
+  tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_uat,infrastructuresupport_platforms"
+  probefilters             = "region:EU"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/pingdom.tf
@@ -3,16 +3,16 @@ provider "pingdom" {
 
 resource "pingdom_check" "laa-crown-court-remuneration-dev" {
   type                     = "http"
-  name                     = "cica - dev - cloud-platform - claim"
-  host                     = "dev.laa-crown-court-remuneration-dev.service.justice.gov.uk"
+  name                     = "Crown court remuneration dev"
+  host                     = "ccr-dev.apps.live.cloud-platform.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
-  url                      = "/"
+  url                      = "/ccr/"
   encryption               = true
   port                     = 443
-  tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_uat,infrastructuresupport_platforms"
+  tags                     = "businessunit_${var.business_unit},application_${var.application},component_ping,isproduction_${var.is_production},environment_$environment_${var.environment},infrastructuresupport_${var.application}"
   probefilters             = "region:EU"
   integrationids           = [135401]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/pingdom.tf
@@ -14,4 +14,5 @@ resource "pingdom_check" "laa-crown-court-remuneration-dev" {
   port                     = 443
   tags                     = "businessunit_platforms,application_prometheus,component_healthcheck,isproduction_true,environment_uat,infrastructuresupport_platforms"
   probefilters             = "region:EU"
+  integrationids           = [135401]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23.0"
     }
+    pingdom = {
+      source  = "DrFaust92/pingdom"
+      version = "~> 1.3.1"
+    }
   }
 }


### PR DESCRIPTION
This follows the [How to create pingdom checks](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-pingdom-checks.html#creating-pingdom-checks)

It adds 2 files in the resources directory of laa-crown-court-remuneration-dev to `versions.tf` and creates a `pingdom.tf` file.

It also adds an integrationids to the pingdom.tf. 

### Link to ticket
[CCR setup site Pingdom health stats](https://dsdmoj.atlassian.net/browse/CTSKF-756l)