### PR TITLE
Add tagging to access aws resources for court-probation-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/main.tf
@@ -4,16 +4,37 @@ terraform {
 }
 provider "aws" {
   region = "eu-west-2"
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 # To be use in case the resources need to be created in London
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 # To be use in case the resources need to be created in Ireland
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 provider "github" {
   token = var.github_token


### PR DESCRIPTION
Enable access to aws resources for court probation DEV