### PR TITLE
Add tagging to access aws resources for court-probation-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/main.tf
@@ -5,16 +5,37 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam = "probation-in-court"
+    }
+  }
 }
 
 provider "github" {


### PR DESCRIPTION
Enable access to aws resources for court probation PREPROD
