### PR TITLE
Add slack-webhook as aws secret court-probation-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/secrets.tf
@@ -21,5 +21,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7,               # Required
       k8s_secret_name         = "liverpool-pre-pilot-users" # The name of the secret in k8s
     },
+    "probation-in-court-slack-webhook" = {
+      description             = "Contains the slack webhook url to send notifications",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "probation-in-court-slack-webhook"
+    },
   }
 }


### PR DESCRIPTION
Add slack-webhook url as an aws secret for court-probation-dev