### PR TITLE
Re-create-service-account-in-laa-access-civil-legal-aid-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-access-civil-legal-aid-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-access-civil-legal-aid-dev/resources/serviceaccount.tf
@@ -6,4 +6,5 @@ module "serviceaccount" {
 
   # Creates Kubernetes' GitHub actions secrets in the repository
   github_repositories = ["laa-access-civil-legal-aid"]
+  github_environments = ["dev"]
 }


### PR DESCRIPTION
Re-creates the service account with a github environment argument.