### PR TITLE
Remove service account from laa-access-civil-legal-aid-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-access-civil-legal-aid-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-access-civil-legal-aid-uat/resources/serviceaccount.tf
@@ -1,9 +1,0 @@
-module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
-
-  namespace = var.namespace
-  kubernetes_cluster = var.kubernetes_cluster
-
-  # Creates Kubernetes' GitHub actions secrets in the repository
-  github_repositories = ["laa-access-civil-legal-aid"]
-}


### PR DESCRIPTION
Removes the service account from laa-access-civil-legal-aid so it can be re-created in a subsequent PR.