### PR TITLE
Fix tags in laa-crown-court-remuneration-dev/resources/pingdom.tf

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/pingdom.tf
@@ -12,7 +12,7 @@ resource "pingdom_check" "laa-crown-court-remuneration-dev" {
   url                      = "/ccr/"
   encryption               = true
   port                     = 443
-  tags                     = "businessunit_${var.business_unit},application_${var.application},component_ping,isproduction_${var.is_production},environment_$environment_${var.environment},infrastructuresupport_${var.application}"
+  tags                     = "businessunit_${var.business_unit},application_${var.application},component_ping,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.infrastructure_support}"
   probefilters             = "region:EU"
   integrationids           = [135401]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/variables.tf
@@ -11,7 +11,7 @@ variable "kubernetes_cluster" {
 variable "application" {
   description = "Name of the application you are deploying"
   type        = string
-  default     = "Crown Court Remuneration"
+  default     = "crown-court-remuneration"
 }
 
 variable "namespace" {


### PR DESCRIPTION
Concourse is [failing](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/4432) with the error

```
Error: 400 Bad Request: Invalid parameter tags value application_Crown Court Remuneration,businessunit_LAA,component_ping,environment_$environment_development,infrastructuresupport_Crown Court Remuneration,isproduction_false

  with pingdom_check.laa-crown-court-remuneration-dev,
  on pingdom.tf line 4, in resource "pingdom_check" "laa-crown-court-remuneration-dev"
```

I believe this is being caused by an incorrect tags in `laa-crown-court-remuneration-dev/resources/pingdom.tf`. This corrects the `environment`, `application` and `infrastructure_support` tags.