### PR TITLE
Lower case CCR dev business_unit

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/variables.tf
@@ -23,7 +23,7 @@ variable "namespace" {
 variable "business_unit" {
   description = "Area of the MOJ responsible for this service"
   type        = string
-  default     = "LAA"
+  default     = "legal-aid-agency"
 }
 
 variable "team_name" {


### PR DESCRIPTION
An attempt to fix failing build https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/4433:

```
Error: 400 Bad Request: Invalid parameter tags value application_crown-court-remuneration,businessunit_LAA,component_ping,environment_development,infrastructuresupport_laaclairtaskforce@digital.justice.gov.uk,isproduction_false
```

which might be being caused by the uppercase `businessunit`.