### PR TITLE
Create event service truststore secrets sys int api

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
@@ -96,7 +96,7 @@ resource "kubernetes_secret" "certificate_backup_secret" {
    data = {
     bucket_name =  module.certificate_backup.bucket_name
     # Secrets require mannual setup after event service certficate uploaded:
-    # event_service_certificate_path
+    event_service_certificate_path = "event-service/client.p12"
     # event_service_certificate_password
 
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
@@ -97,7 +97,7 @@ resource "kubernetes_secret" "certificate_backup_secret" {
     bucket_name =  module.certificate_backup.bucket_name
     # Secrets require mannual setup after event service certficate uploaded:
     event_service_certificate_path = "event-service/client.p12"
-    # event_service_certificate_password
+    event_service_certificate_password = "DUMMY_TEST_FOR_DEBUGGING"
 
   }
 }


### PR DESCRIPTION
Our events service is failing its initial deployment to dev I believe to Env variables not being set. I have set some dummy values in an effort to see if we can move onto a new error message.