### PR TITLE
Generate event service password sys int events dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
@@ -88,6 +88,12 @@ module "certificate_backup" {
 EOF
 }
 
+resource "random_password" "event_service_certificate_password" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
 resource "kubernetes_secret" "certificate_backup_secret" {
   metadata {
     name      = "certificate-store"
@@ -95,9 +101,7 @@ resource "kubernetes_secret" "certificate_backup_secret" {
   }
    data = {
     bucket_name =  module.certificate_backup.bucket_name
-    # Secrets require mannual setup after event service certficate uploaded:
     event_service_certificate_path = "event-service/client.p12"
-    event_service_certificate_password = "DUMMY_TEST_FOR_DEBUGGING"
-
+    event_service_certificate_password = random_password.event_service_certificate_password.result
   }
 }


### PR DESCRIPTION
We'll need a password for our .p12 certificate stored in a kubernetes secret. We can have a random password created with terraform and take this password and set it as the p12 password.