### PR TITLE
Added HMPPS Assess Risks and Needs Handover Service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/00-namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-handover-service-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "dev"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps-assessments-dev"
+    cloud-platform.justice.gov.uk/application: "Handover Service"
+    cloud-platform.justice.gov.uk/owner: "Assess risks and needs: assess-risks-and-needs@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-assess-risks-and-needs"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-handover-service"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/01-rbac.yaml
@@ -1,0 +1,19 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-handover-service-dev-admin
+  namespace: hmpps-handover-service-dev
+subjects:
+  - kind: Group
+    name: "github:hmpps-sentence-planning"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-assessments"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:dps-tech"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-handover-service-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 500Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-handover-service-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-handover-service-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-handover-service-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/05-certificates.yml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/05-certificates.yml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: sentence-plan
+  namespace: hmpps-handover-service-dev
+spec:
+  secretName: hmpps-handover-service-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - handover-service-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/elasticache.tf
@@ -1,0 +1,29 @@
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  node_type            = "cache.t4g.micro"
+  engine_version       = "7.0"
+  parameter_group_name = "default.redis7"
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    replication_group_id     = module.elasticache_redis.replication_group_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/serviceaccount-circleci.tf
@@ -1,0 +1,15 @@
+module "serviceaccount_circleci" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  serviceaccount_name = "circleci-migrated"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/variables.tf
@@ -1,0 +1,69 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "HMPPS Handover Service"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "hmpps-handover-service-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "hmpps-assessments"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "dev"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "assess-risks-and-needs@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "assess-risks-and-needs"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-handover-service-dev/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.39.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
- Removed `hmpps-handover-service` due to generic name
- Added `hmpps-assess-risks-and-needs-handover-service` and setup configuration again to match new project name, namespace etc.