### PR TITLE
CRM457-1334: Add missing namespace label

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-dev/00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "development"
+    cloud-platform.justice.gov.uk/namespace: "laa-assess-crime-forms-dev"
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"


### PR DESCRIPTION
Add missing  namespace label to namespace config

This missing label relied on by network policy in app-store-dev

This will allow connection to a postgres pod in app store dev
via internal service name from a metabase app instance 
hosted in this namespace, laa-assess-crime-forms-dev.
