### PR TITLE
court-probation-preprod: Update slack alert channel

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/00-namespace.yaml
@@ -12,4 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Prepare a Case for Sentence"
     cloud-platform.justice.gov.uk/owner: "Prepare a Case for Sentence: prepareacaseforsentence@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/prepare-a-case"
-    cloud-platform.justice.gov.uk/slack-channel: "probation_in_court_alerts"
+    cloud-platform.justice.gov.uk/slack-channel: "probation_in_court_alerts_preprod"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "probation_in_court_alerts_preprod"


### PR DESCRIPTION
Update the slack alert channel to `probation_in_court_alerts_preprod`
