### PR TITLE
court-probation-prod: Update severity label to alertmanager routing

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/08-prometheus-sqs.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/08-prometheus-sqs.yaml
@@ -18,7 +18,7 @@ spec:
         sum(aws_sqs_approximate_age_of_oldest_message_maximum{queue_name="probation-in-court-prod-crime-portal-gateway-queue"} offset 5m) by (queue_name) > 15 * 60
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: SQS-number-of-messages-crime-portal-gateway
       annotations:
         message: SQS - {{ $labels.queue_name }} - number of messages={{ $value }} (exceeds 20), check consumers are healthy.  https://grafana.live-1.cloud-platform.service.justice.gov.uk/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $labels.queue_name }}&from=now-6h&to=now
@@ -27,7 +27,7 @@ spec:
         sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="probation-in-court-prod-crime-portal-gateway-queue"} offset 5m) by (queue_name) > 20
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: SQS-events-dlq-not-empty-crime-portal-gateway
       annotations:
         message: SQS Deadletter queue - {{ $labels.queue_name }} has {{ $value }} messages
@@ -36,7 +36,7 @@ spec:
         sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="probation-in-court-prod-crime-portal-gateway-dead-letter-queue"} offset 5m) by (queue_name) > 0
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: SQS-oldest-message-court-case-matcher
       annotations:
         message: SQS - {{ $labels.queue_name }} has message older than 15mins, check consumers are healthy.  https://grafana.live-1.cloud-platform.service.justice.gov.uk/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $labels.queue_name }}&from=now-6h&to=now
@@ -45,7 +45,7 @@ spec:
         sum(aws_sqs_approximate_age_of_oldest_message_maximum{queue_name="probation-in-court-prod-court-case-matcher-queue"} offset 5m) by (queue_name) > 15 * 60
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: SQS-number-of-messages-court-case-matcher
       annotations:
         message: SQS - {{ $labels.queue_name }} - number of messages={{ $value }} (exceeds 1000), check consumers are healthy.  https://grafana.live-1.cloud-platform.service.justice.gov.uk/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $labels.queue_name }}&from=now-6h&to=now
@@ -54,7 +54,7 @@ spec:
         sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="probation-in-court-prod-court-case-matcher-queue"} offset 5m) by (queue_name) > 1000
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: SQS-events-dlq-not-empty-court-case-matcher
       annotations:
         message: SQS Deadletter queue - {{ $labels.queue_name }} has {{ $value }} messages
@@ -63,7 +63,7 @@ spec:
         sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="probation-in-court-prod-court-case-matcher-dead-letter-queue"} offset 5m) by (queue_name) > 0
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: SQS-oldest-message-court-case-service
       annotations:
         message: SQS - {{ $labels.queue_name }} has message older than 15mins, check consumers are healthy.  https://grafana.live-1.cloud-platform.service.justice.gov.uk/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $labels.queue_name }}&from=now-6h&to=now
@@ -72,7 +72,7 @@ spec:
         sum(aws_sqs_approximate_age_of_oldest_message_maximum{queue_name="Digital-Prison-Services-prod-pic_probation_offender_events_queue"} offset 5m) by (queue_name) > 15 * 60
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: SQS-number-of-messages-court-case-service
       annotations:
         message: SQS - {{ $labels.queue_name }} - number of messages={{ $value }} (exceeds 1000), check consumers are healthy.  https://grafana.live-1.cloud-platform.service.justice.gov.uk/d/AWSSQS000/aws-sqs?orgId=1&var-datasource=Cloudwatch&var-region=default&var-queue={{ $labels.queue_name }}&from=now-6h&to=now
@@ -81,7 +81,7 @@ spec:
         sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="Digital-Prison-Services-prod-pic_probation_offender_events_queue"} offset 5m) by (queue_name) > 1000
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: SQS-events-dlq-not-empty-court-case-service
       annotations:
         message: SQS Deadletter queue - {{ $labels.queue_name }} has {{ $value }} messages
@@ -90,4 +90,4 @@ spec:
         sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="Digital-Prison-Services-prod-pic_probation_offender_events_queue_dl"} offset 5m) by (queue_name) > 0
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/09-prometheus-k8s.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/09-prometheus-k8s.yaml
@@ -24,14 +24,13 @@ spec:
         message: ingress {{ $labels.ingress }} is serving 5XX responses
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
       expr: |-
-        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="court-probation-prod", status=~"5.*", ingress="court-case-service"}[1m]) * 60 > 4)
+        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="court-probation-prod", status=~"5.*", ingress="court-case-service"}[1m]) * 60 > 4) by (ingress)
       for: 1m
       labels:
         severity: probation_in_court_alerts_prod
     - alert: KubeQuotaExceeded
       annotations:
-        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
-          }}% of its {{ $labels.resource }} quota.
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
       expr: |-
         100 * kube_resourcequota{namespace="court-probation-prod", job="kube-state-metrics", type="used"}
@@ -43,8 +42,7 @@ spec:
         severity: probation_in_court_alerts_prod
     - alert: KubePodCrashLooping
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
-          }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
       expr: rate(kube_pod_container_status_restarts_total{namespace="court-probation-prod", job="kube-state-metrics"}[15m])
         * 60 * 5 > 0
@@ -63,8 +61,7 @@ spec:
         severity: probation_in_court_alerts_prod
     - alert: KubeDeploymentGenerationMismatch
       annotations:
-        message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
-          }} does not match, this indicates that the Deployment has failed but has
+        message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has
           not been rolled back.
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
       expr: |-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/09-prometheus-k8s.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/09-prometheus-k8s.yaml
@@ -44,8 +44,7 @@ spec:
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
-      expr: rate(kube_pod_container_status_restarts_total{namespace="court-probation-prod", job="kube-state-metrics"}[15m])
-        * 60 * 5 > 0
+      expr: rate(kube_pod_container_status_restarts_total{namespace="court-probation-prod", job="kube-state-metrics"}[15m]) * 60 * 5 > 0
       for: 1h
       labels:
         severity: probation_in_court_alerts_prod
@@ -106,7 +105,7 @@ spec:
         message: Pre Sentence Service wproofreader is returning 5xx responses
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2680750089/Monitoring+and+Alerting
       expr: |-
-        sum(rate(nginx_ingress_controller_requests{ingress=~"pre-sentence-service-wproofreader-v1-2", exported_namespace="laa-apply-for-legalaid-production", status=~"5.."}[5m]))*270 > 0
+        sum(rate(nginx_ingress_controller_requests{ingress="pre-sentence-service-wproofreader-v1-2", exported_namespace="court-probation-prod", status=~"5.."}[5m]))*270 > 0
       for: 10m
       labels:
         severity: probation_in_court_alerts_prod  

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/09-prometheus-k8s.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/09-prometheus-k8s.yaml
@@ -18,7 +18,7 @@ spec:
         avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="court-probation-prod", status=~"5.*", ingress!="court-case-service"}[1m]) * 60 > 0) by (ingress)
       for: 1m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: ErrorResponsesCCS
       annotations:
         message: ingress {{ $labels.ingress }} is serving 5XX responses
@@ -27,7 +27,7 @@ spec:
         avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="court-probation-prod", status=~"5.*", ingress="court-case-service"}[1m]) * 60 > 4)
       for: 1m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: KubeQuotaExceeded
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
@@ -40,7 +40,7 @@ spec:
           > 90
       for: 15m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
@@ -50,7 +50,7 @@ spec:
         * 60 * 5 > 0
       for: 1h
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: KubePodNotReady
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
@@ -60,7 +60,7 @@ spec:
         phase=~"Pending|Unknown"}) > 0
       for: 1h
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -73,7 +73,7 @@ spec:
         kube_deployment_metadata_generation{namespace="court-probation-prod", job="kube-state-metrics"}
       for: 15m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: KubeDeploymentReplicasMismatch
       annotations:
         message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
@@ -85,7 +85,7 @@ spec:
         kube_deployment_status_replicas_available{namespace="court-probation-prod", job="kube-state-metrics"}
       for: 1h
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: RDSHighCpuCourtCaseService
       annotations:
         message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has high CPU (>95%) for more than ten minutes.
@@ -94,7 +94,7 @@ spec:
         aws_rds_cpuutilization_average{dbinstance_identifier="cloud-platform-37a1ac1b9a12702e"} > 95
       for: 10m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: RDSHighCpuPreSentenceService
       annotations:
         message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has high CPU (>95%) for more than five minutes.
@@ -103,7 +103,7 @@ spec:
         aws_rds_cpuutilization_average{dbinstance_identifier="cloud-platform-e98703fc54157c2d"} > 95
       for: 5m
       labels:
-        severity: prepare-a-case
+        severity: probation_in_court_alerts_prod
     - alert: pre-sentence-service-wproofreader-serving-5xx
       annotations:
         message: Pre Sentence Service wproofreader is returning 5xx responses
@@ -112,4 +112,4 @@ spec:
         sum(rate(nginx_ingress_controller_requests{ingress=~"pre-sentence-service-wproofreader-v1-2", exported_namespace="laa-apply-for-legalaid-production", status=~"5.."}[5m]))*270 > 0
       for: 10m
       labels:
-        severity: prepare-a-case  
+        severity: probation_in_court_alerts_prod  


### PR DESCRIPTION
Update the severity label to `probation_in_court_alerts_prod` to link to a new Alertmanager routing.

This is part of a wider feature to split out our alert notifications based off of the environment - sending alerts based off that too.