### PR TITLE
Override serviceaccount, role and rolebinding default values

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/serviceaccount-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/serviceaccount-github.tf
@@ -4,6 +4,10 @@ module "serviceaccount-github" {
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
 
+  serviceaccount_name = "github-serviceaccount"
+  role_name = "github-serviceaccount"
+  rolebinding_name = "github-serviceaccount"
+
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = [var.repo_name]


### PR DESCRIPTION
The serviceaccount, role and rolebinding values clashed with the default values that are being used for the circleCI module