### PR TITLE
Story: [CCLS 2191] Add Auth Secrets for LAA CCMS CAAB Apps

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-civil/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-civil/resources/secret.tf
@@ -11,14 +11,39 @@ module "secrets_manager" {
 
   secrets = {
     "saml-metadata-uri" = {
-      description             = "The URI for the SAML authentication", # Required
-      recovery_window_in_days = 7,                                     # Required
-      k8s_secret_name         = "saml-metadata-uri"                    # The name of the secret in k8s
+      description             = "The URI for the SAML authentication",              # Required
+      recovery_window_in_days = 7,                                                  # Required
+      k8s_secret_name         = "saml-metadata-uri"                                 # The name of the secret in k8s
     },
     "caab-secrets" = {
-      description             = "SOA urls and database credentials for CAAB", # Required
-      recovery_window_in_days = 7,                                            # Required
-      k8s_secret_name         = "caab-secrets"                                # The name of the secret in k8s
+      description             = "SOA urls and database credentials for CAAB",       # Required
+      recovery_window_in_days = 7,                                                  # Required
+      k8s_secret_name         = "caab-secrets"                                      # The name of the secret in k8s
+    },
+    "caab-api-auth-secrets" = {
+      description             = "Authentication secrets for CAAB API",              # Required
+      recovery_window_in_days = 7,                                                  # Required
+      k8s_secret_name         = "caab-api-auth-secrets"                             # The name of the secret in k8s
+    },
+    "caab-assessment-api-auth-secrets" = {
+      description             = "Authentication secrets for CAAB Assessment API",   # Required
+      recovery_window_in_days = 7,                                                  # Required
+      k8s_secret_name         = "caab-assessment-api-auth-secrets"                  # The name of the secret in k8s
+    },
+    "caab-ebs-api-auth-secrets" = {
+      description             = "Authentication secrets for CAAB EBS API",          # Required
+      recovery_window_in_days = 7,                                                  # Required
+      k8s_secret_name         = "caab-ebs-api-auth-secrets"                         # The name of the secret in k8s
+    },
+    "caab-soa-api-auth-secrets" = {
+      description             = "Authentication secrets for CAAB SOA API",          # Required
+      recovery_window_in_days = 7,                                                  # Required
+      k8s_secret_name         = "caab-soa-api-auth-secrets"                         # The name of the secret in k8s
+    },
+    "caab-ui-secrets" = {
+      description             = "Secrets for CAAB UI",                              # Required
+      recovery_window_in_days = 7,                                                  # Required
+      k8s_secret_name         = "caab-ui-secrets"                                   # The name of the secret in k8s
     },
   }
 }


### PR DESCRIPTION
* Added `caab-api-auth-secrets`
* Added `caab-assessment-api-auth-secrets`
* Added `caab-soa-api-auth-secrets`
* Added `caab-ebs-api-auth-secrets`
* Added `caab-ui-secrets`

This is to support app to app authentication between LAA CCMS CAAB services. Related helm chart changes: https://github.com/ministryofjustice/laa-ccms-caab-helm-charts/pull/9