### PR TITLE
feat(workflow): change token used to use concourse-bot user to approve skip-file

### DIFF
--- a/.github/workflows/skip-file-auto-approval.yaml
+++ b/.github/workflows/skip-file-auto-approval.yaml
@@ -32,7 +32,7 @@ jobs:
       if: ${{ steps.commit-check.outputs.approval == 'approval_needed' }}
       uses: actions/github-script@v7
       with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        github-token: "${{ secrets.HAMMER_BOT_TOKEN }}"
         script: |
           github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
pull request require a member of the webops team to approve github-action-bot isnt able to approve on behalf of the webops team
