### PR TITLE
Add new repo to work through deploying an app on CP example

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/ecr.tf
@@ -16,7 +16,7 @@ module "ecr" {
   oidc_providers = ["github", "circleci"]
 
   # REQUIRED: GitHub repositories that push to this container repository
-  github_repositories = ["laa-cwa-feature-tests", "laa-cwa"]
+  github_repositories = ["laa-cwa-feature-tests", "laa-cwa", "turbo-memory"]
 
   # OPTIONAL: GitHub environments, to create variables as actions variables in your environments
   # github_environments = ["production"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/serviceaccount.tf
@@ -8,7 +8,7 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  github_repositories = ["laa-cwa-feature-tests", "laa-cwa"]
+  github_repositories = ["laa-cwa-feature-tests", "laa-cwa", "turbo-memory"]
 
   serviceaccount_rules = [
     {


### PR DESCRIPTION
Add new repo to out existing namespace laa-cwa-test to work through the deploying an application to CP example doc.
