### PR TITLE
chore: bump rds to 14.11 to match live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/variables.tf
@@ -30,10 +30,10 @@ variable "repo_name" {
   default = "c100-application"
 }
 
-# Database 
+# Database
 
 variable "db_engine_version" {
-  default = "14.7"
+  default = "14.11"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
Bumps RDS version from 14.7 to 14.11 to match automatic upgrade via AWS.

Pipeline should show no terraform changes as this change is already live.