### PR TITLE
Add 2 dummy secrets to laa-cwa-test namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/secret.tf
@@ -1,5 +1,5 @@
 module "secrets_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=version" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4" # use the latest release
   team_name              = var.team_name
   application            = var.application
   business_unit          = var.business_unit


### PR DESCRIPTION
Adding 2 dummy secrets to laa-cwa-test namespace to work through CP documentation on using secrets.