### PR TITLE
NON-318: Send `preprod` alerts to dev Slack channel

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/00-namespace.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/slack-channel: "non-associations-dev"
-    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "non-associations-dev"
     cloud-platform.justice.gov.uk/application: "HMPPS Non-associations Apps"
     cloud-platform.justice.gov.uk/owner: "HMPPS Non-Associations: non-associations-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-non-associations.git"


### PR DESCRIPTION
Send non-associations' `preprod` alerts to our dev Slack channel.