### PR TITLE
CRM457-1487: Allow ingress from UAT on DEV

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/04-networkpolicy.yaml
@@ -43,6 +43,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               cloud-platform.justice.gov.uk/namespace: laa-assess-crime-forms-dev
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: laa-crime-application-store-uat
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Allow ingress from UAT (laa-crime-application-store-uat) on DEV (laa-crime-application-store-dev)

This is to allow connection of a metabase instance hosted in UAT to postgres pod databases (helm chart created) in DEV 