### PR TITLE
tag all resources with team name so they are viewable in AWS Console

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/main.tf
@@ -9,6 +9,7 @@ provider "aws" {
   default_tags {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      GithubTeam    = var.team_name
       slack-channel = var.slack_channel
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   default_tags {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      GithubTeam    = var.team_name
       slack-channel = var.slack_channel
     }
   }
@@ -33,6 +35,7 @@ provider "aws" {
   default_tags {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      GithubTeam    = var.team_name
       slack-channel = var.slack_channel
     }
   }


### PR DESCRIPTION
Added 
```GithubTeam    = var.team_name```
 to main.tf file so I can view my secrets in AWS Console and resolve access issues.