### PR TITLE
CRM457-1468: Try adding a metric configuration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/s3.tf
@@ -180,6 +180,11 @@ EOF
   }
 }
 
+resource "aws_s3_bucket_metric" "entire-bucket-metric" {
+  bucket = module.s3_bucket.id
+  name   = "laa-submit-crime-forms-uploads"
+}
+
 
 resource "kubernetes_secret" "s3_bucket" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/s3.tf
@@ -181,7 +181,7 @@ EOF
 }
 
 resource "aws_s3_bucket_metric" "entire-bucket-metric" {
-  bucket = module.s3_bucket.id
+  bucket = module.s3_bucket.bucket_name
   name   = "laa-submit-crime-forms-uploads"
 }
 


### PR DESCRIPTION
Hoping to define a metrics filter that filters _all_ objects in the bucket, so that in [Grafana](https://grafana.live.cloud-platform.service.justice.gov.uk/d/AWSS31iWk/aws-s3?orgId=1&var-datasource=P896B4444D3F0DAB8&var-region=default&var-bucket=cloud-platform-5964914c521cc2f2700c40908cdf2e30&var-filterid=) the 'Filtered Requests' graph gets populated.

I know that I haven't included a `filter` block, but the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_metric) states that that block requires me to give criteria to filter by, and I don't want to actually filter anything out. 

Also the docs suggest I should give the bucket `id` in this block, but that attribute doesn't exist so I'm trying `bucket_name` instead.