### PR TITLE
IR-283: Update RDS terraform module for `hmpps-incident-reporting-dev`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.1"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit


### PR DESCRIPTION
Depends on [hmpps-incident-reporting-api#127](https://github.com/ministryofjustice/hmpps-incident-reporting-api/pull/127)