### PR TITLE
Set Pingdom to check /ping endpoint for pq-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/pingdom.tf
@@ -8,7 +8,7 @@ resource "pingdom_check" "parliamentary-questions-production-cloud-platform-heal
   notifywhenbackup         = true
   sendnotificationwhendown = 3
   notifyagainevery         = 0
-  url                      = "/healthcheck"
+  url                      = "/ping"
   encryption               = true
   port                     = 443
   tags                     = "businessunit_central_digital,application_parliamentary_questions,component_healthcheck,isproduction_true,environment_prod,infrastructuresupport_staff_tools_and_services"


### PR DESCRIPTION
The healthcheck endpoint relies on the status of an external service (PQA API). Using /ping will just signal if the web application itself is available or not.