### PR TITLE
CRM457-1360: Add networking policies permission to circle service account [DEV]

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/variables.tf
@@ -147,6 +147,7 @@ variable "serviceaccount_rules" {
         "replicasets",
         "statefulsets",
         "servicemonitors",
+        "networkpolicies",
       ]
       verbs = [
         "get",
@@ -156,22 +157,6 @@ variable "serviceaccount_rules" {
         "patch",
         "list",
         "watch",
-      ]
-    },
-    {
-      api_groups = [
-        "autoscaling"
-      ],
-      resources = [
-        "hpa",
-        "horizontalpodautoscalers"
-      ],
-      verbs = [
-        "get",
-        "update",
-        "delete",
-        "create",
-        "patch"
       ]
     }
   ]


### PR DESCRIPTION
Add networking policies permission to circle service account [DEV]

need to spin up custom networke policies labels for branch
builder.

Also removing old, no longer required hpa permissions.
