### PR TITLE
chore: 🤖 bump malformed-yaml action to latest

### DIFF
--- a/.github/workflows/malformed-yaml.yml
+++ b/.github/workflows/malformed-yaml.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ministryofjustice/github-actions/malformed-yaml@v18.1.0
+      - uses: ministryofjustice/github-actions/malformed-yaml@v18.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
resolves multi-doc parse and deleted yaml failing: https://github.com/ministryofjustice/github-actions/releases/tag/v18.1.1