### PR TITLE
BAVL-213 adding subscription to the video booking cancelled domain event for the BVLS service.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
@@ -109,6 +109,7 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
   filter_policy = jsonencode({
     eventType = [
       "book-a-video-link.video-booking.created",
+      "book-a-video-link.video-booking.cancelled",
       "book-a-video-link.appointment.created"
     ]
   })


### PR DESCRIPTION
Adding subscription to a new BLVS domain event to for the BVLS service for processing the cancellation of booking events.