### PR TITLE
MAP-1257 increase memory as may prevent pod OOM error

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/02-limitrange.yaml
@@ -8,8 +8,8 @@ spec:
   limits:
     - default:
         cpu: 2000m
-        memory: 1024Mi
+        memory: 2048Mi
       defaultRequest:
-        cpu: 10m
-        memory: 512Mi
+        cpu: 100m
+        memory: 1024Mi
       type: Container


### PR DESCRIPTION
Witnessing kube pod crashes in the Change Someone's cell application due to out of memory error. 
First suspicion is insufficient memory to fetch 'un-paginated' prisoner details and their images within view-residential-location page, in which the list may be 150 or more. 
Have matched memory size to that in main DPS app. 