### PR TITLE
court-case-service-dev Update rds terraform module version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds-pre-sentence-service.tf
@@ -1,5 +1,5 @@
 module "pre_sentence_service_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.1"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.0.0"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "court_case_service_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.1"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.0.0"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit


### PR DESCRIPTION
Update the RDS terraform module version for `court-case-service-dev`

This includes an update to our ca-cert-identifier to `rds-ca-rsa2048-g1` as the previous is soon about to reach EOL.

