### PR TITLE
fix: Revert RDS module version for LAA namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-instance" {
-  source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.0.0"
+  source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=migration"
   vpc_name = var.vpc_name
 
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-mtn" {
-  source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.0.0"
+  source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=migration"
   vpc_name = var.vpc_name
 
   application            = var.application


### PR DESCRIPTION
These 2 namespaces are using ref=migration for their migration work and we should keep it instead of using 7.0.0.

Concourse error [here](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/5415.6#L667507c5:8004)

