### PR TITLE
CRM457-1699: Ignore 5xx errors on metabase ingress appstore DEV

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-dev/05-prometheus-custom-rules.yaml
@@ -37,17 +37,17 @@ spec:
         # 
         # Finally, for the purposes of this alert, we filter out any values of our resulting dictionary that are not positive.
             sum by (ingress) (
-              nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-dev",status=~"500|502|503|504"}
+              nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-dev",status=~"500|502|503|504",ingress!~".+metabase"}
             )
           -
             (
                 sum by (ingress) (
-                  nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-dev",status=~"500|502|503|504"} offset 2m
+                  nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-dev",status=~"500|502|503|504",ingress!~".+metabase"} offset 2m
                 )
               or
                 (
                     sum by (ingress) (
-                      nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-dev",status=~"500|502|503|504"}
+                      nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-dev",status=~"500|502|503|504",ingress!~".+metabase"}
                     )
                   -
                     1


### PR DESCRIPTION
CRM457-1699: Ignore 5xx errors on metabase ingress

Because  they are noisy and unimportant as far as we understand

Note that DEV does not have a metabase instance in any event but this has been added for consistency with UAT and PROD that do.