### PR TITLE
CRM457-1699: Ignore 5xx errors on metabase ingress appstore UAT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/05-prometheus-custom-rules.yaml
@@ -37,17 +37,17 @@ spec:
         # 
         # Finally, for the purposes of this alert, we filter out any values of our resulting dictionary that are not positive.
             sum by (ingress) (
-              nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-uat",status=~"500|502|503|504"}
+              nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-uat",status=~"500|502|503|504",ingress!~".+metabase"}
             )
           -
             (
                 sum by (ingress) (
-                  nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-uat",status=~"500|502|503|504"} offset 2m
+                  nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-uat",status=~"500|502|503|504",ingress!~".+metabase"} offset 2m
                 )
               or
                 (
                     sum by (ingress) (
-                      nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-uat",status=~"500|502|503|504"}
+                      nginx_ingress_controller_requests{exported_namespace="laa-crime-application-store-uat",status=~"500|502|503|504",ingress!~".+metabase"}
                     )
                   -
                     1

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/05-prometheus-custom-rules.yaml
@@ -63,7 +63,7 @@ spec:
         dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/laa-crime-store-grafana-golden/laa-non-standard-crime-claims-golden-signals?orgId=1&refresh=5m&var-datasource=prometheus&var-namespace=laa-crime-application-store-uat
 
     - alert: KubeLowPodCount
-      expr: sum (kube_pod_status_phase{namespace="laa-crime-application-store-uat", phase="Running"}) < 1
+      expr: sum (kube_pod_status_phase{namespace="laa-crime-application-store-uat", phase="Running"}) < 3
       labels:
         severity: laa-crime-forms-team-pre-prod
       annotations:


### PR DESCRIPTION
Ignore 5xx errors on metabase ingress

Because they are noisy and unimportant as far as we understand
