### PR TITLE
Disable CNL staging ECR deletion protection

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/ecr.tf
@@ -4,6 +4,8 @@ module "ecr-repo-complexity-of-need" {
   team_name = var.team_name
   repo_name = "hmpps-complexity-of-need"
 
+  deletion_protection = false
+
   # Tags
   business_unit          = "HMPPS"
   application            = "hmpps-complexity-of-need"


### PR DESCRIPTION
This ECR is no longer in use so we can delete it.
A separate PR will be raised to actually delete it after this flag has been applied.