### PR TITLE
Add PPO archive site TLS cert

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/certificates.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/certificates.tf
@@ -27,6 +27,7 @@ variable "domains" {
     "www.jobs.justice.gov.uk"                        = "justicejobs-www"
     "ppo.gov.uk"                                     = "ppo"
     "www.ppo.gov.uk"                                 = "ppo-www"
+    "archive.ppo.gov.uk"                             = "ppo-archive"
     "lawcom.gov.uk"                                  = "lawcom"
     "www.lawcom.gov.uk"                              = "lawcom-www"
     "victimandwitnessinformation.org.uk"             = "victimandwitnessinformation"


### PR DESCRIPTION
Add new TLS cert to support the launch of the new PPO site, an archive site will be setup for legacy content not migrated.