### PR TITLE
BAVL-235 listen for prison release events in BVLS so can alter video bookings accordingly.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
@@ -111,7 +111,8 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
       "book-a-video-link.video-booking.created",
       "book-a-video-link.video-booking.amended",
       "book-a-video-link.video-booking.cancelled",
-      "book-a-video-link.appointment.created"
+      "book-a-video-link.appointment.created",
+      "prisoner-offender-search.prisoner.released"
     ]
   })
 }


### PR DESCRIPTION
Listen for the prisoner released event in the Book a Video Link Service so we can alter bookings for the released offender should there be any matches.