### PR TITLE
Delete no longer used staging RDS secret

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
@@ -32,22 +32,6 @@ module "complexity-of-need-rds" {
   }
 }
 
-resource "kubernetes_secret" "complexity-of-need-rds" {
-  metadata {
-    name      = "hmpps-complexity-of-need-rds-instance-output"
-    namespace = "hmpps-complexity-of-need-staging"
-  }
-
-  data = {
-    rds_instance_endpoint = module.complexity-of-need-rds.rds_instance_endpoint
-    postgres_name         = module.complexity-of-need-rds.database_name
-    postgres_host         = module.complexity-of-need-rds.rds_instance_address
-    postgres_user         = module.complexity-of-need-rds.database_username
-    postgres_password     = module.complexity-of-need-rds.database_password
-    rds_instance_address  = module.complexity-of-need-rds.rds_instance_address
-  }
-}
-
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-instance-output"


### PR DESCRIPTION
We have a secret with a different name (`rds-instance-output`), so this one is no longer needed.