### PR TITLE
Court Probation Prod: Include pre-sentence-service in certificates

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/07-certificate.yaml
@@ -11,4 +11,5 @@ spec:
   dnsNames:
     - prepare-case-probation.service.justice.gov.uk
     - court-list-splitter.hmpps.service.justice.gov.uk
+    - pre-sentence-service.hmpps.service.justice.gov.uk
     - court-hearing-event-receiver.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Include pre-sentence-service in certificates so that it can use TLS e.g. https