### PR TITLE
CDPT-1819: Peoplefinder DB Update from postgres 12 to 16

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/APPLY_PIPELINE_SKIP_THIS_NAMESPACE
@@ -1,0 +1,1 @@
+Apply pipeline skip this namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
@@ -16,8 +16,8 @@ module "peoplefinder_rds" {
   db_instance_class          = "db.t4g.micro"
   db_max_allocated_storage   = "500"
   db_engine                  = "postgres"
-  db_engine_version          = "16.2"
-  rds_family                 = "postgres16"
+  db_engine_version          = "12.18"
+  rds_family                 = "postgres12"
   db_backup_retention_period = "7"
   db_name                    = "peoplefinder_development"
   enable_rds_auto_start_stop = true

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
@@ -16,8 +16,8 @@ module "peoplefinder_rds" {
   db_instance_class          = "db.t4g.micro"
   db_max_allocated_storage   = "500"
   db_engine                  = "postgres"
-  db_engine_version          = "12.18"
-  rds_family                 = "postgres12"
+  db_engine_version          = "16.2"
+  rds_family                 = "postgres16"
   db_backup_retention_period = "7"
   db_name                    = "peoplefinder_development"
   enable_rds_auto_start_stop = true


### PR DESCRIPTION
Following https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-to-a-new-major-database-version