### PR TITLE
Court Probation Prod: Add wproofreader to TLS certificate list

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/07-certificate.yaml
@@ -12,4 +12,5 @@ spec:
     - prepare-case-probation.service.justice.gov.uk
     - court-list-splitter.hmpps.service.justice.gov.uk
     - pre-sentence-service.hmpps.service.justice.gov.uk
+    - pre-sentence-service-wproofreader.hmpps.service.justice.gov.uk
     - court-hearing-event-receiver.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Add wproofreader to TLS certificate list for Prod

This means it can use https, a secure form of data transfer.