### PR TITLE
Court Probation PreProd: Add wproofreader to TLS certificate list

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/07-certificate.yaml
@@ -13,4 +13,5 @@ spec:
     - court-list-splitter-preprod.hmpps.service.justice.gov.uk
     - court-hearing-event-receiver-preprod.hmpps.service.justice.gov.uk
     - pre-sentence-service-preprod.hmpps.service.justice.gov.uk
+    - pre-sentence-service-wproofreader-preprod.hmpps.service.justice.gov.uk
     - court-case-test-app-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Add wproofreader to TLS certificate list for PreProd

This means it can use https, a secure form of data transfer.