### PR TITLE
Adjust CCR dev RDS settings

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds-mtn" {
   team_name              = var.team_name
   business_unit          = var.business_unit
 
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop = false
 
   # Database configuration
   db_engine                = "oracle-se2"
@@ -32,7 +32,7 @@ module "rds-mtn" {
   allow_major_version_upgrade = "false"
 
   # enable performance insights
-  performance_insights_enabled = true
+  performance_insights_enabled = false
 
   snapshot_identifier = "arn:aws:rds:eu-west-2:754256621582:snapshot:ccr-dev-cp-migration-21062024-manual-copy"
 


### PR DESCRIPTION
* Disables `enable_rds_auto_start_stop` as stopping the database overnight is causing alerts and potential errors in the application when restarting. We may want to re-enable this in future but disabling for now will give us time to investigate properly.
* Disables `performance_insights_enabled` as we are not using this feature and disabling will save money.