### PR TITLE
Adjust CCR UAT RDS settings

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds-instance" {
   team_name              = var.team_name
   business_unit          = var.business_unit
 
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop = false
 
   # Database configuration
   db_engine                = "oracle-se2"
@@ -32,7 +32,7 @@ module "rds-instance" {
   allow_major_version_upgrade = "false"
 
   # enable performance insights
-  performance_insights_enabled = true
+  performance_insights_enabled = false
 
   snapshot_identifier = "arn:aws:rds:eu-west-2:754256621582:snapshot:ccr-sandbox-dev-encrypted-for-cp"
 


### PR DESCRIPTION
* Disables `enable_rds_auto_start_stop` as disabling the database overnight is causing alerts and potential errors in the application when restarting. We may want to re-enable this in future but disabling for now will give us time to investigate properly.
* Disables `performance_insights_enabled` as we are not using this feature and disabling will save money.