### PR TITLE
BAVL-250 listen for prisoner merge events in BVLS so can alter video bookings accordingly

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
@@ -112,7 +112,8 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
       "book-a-video-link.video-booking.amended",
       "book-a-video-link.video-booking.cancelled",
       "book-a-video-link.appointment.created",
-      "prisoner-offender-search.prisoner.released"
+      "prisoner-offender-search.prisoner.released",
+      "prison-offender-events.prisoner.merged"
     ]
   })
 }


### PR DESCRIPTION
When a prisoner merge event occurs we need to know if this impacts any bookings in the 'book a video link service' and act accordingly.