### PR TITLE
chore: Bump RDS storage

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prison-person-api-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prison-person-api-preprod/resources/rds-postgresql.tf
@@ -14,6 +14,7 @@ module "rds" {
   allow_minor_version_upgrade  = true
   allow_major_version_upgrade  = false
   performance_insights_enabled = false
+  db_allocated_storage         = "30"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 


### PR DESCRIPTION
Fix `Error: creating RDS DB Instance (cloud-platform-8dd69b293e33c4be): InvalidParameterCombination: The maximum allocated storage must be increased by at least 10 percent.`

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-c/builds/2586#L6675879c:24599