### PR TITLE
chore: Bump RDS max allocated storage

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prison-person-api-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prison-person-api-preprod/resources/rds-postgresql.tf
@@ -15,6 +15,7 @@ module "rds" {
   allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_allocated_storage         = "30"
+  db_max_allocated_storage     = "11000"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 


### PR DESCRIPTION
Fix `Error: creating RDS DB Instance (cloud-platform-8dd69b293e33c4be): InvalidParameterCombination: The maximum allocated storage must be increased by at least 10 percent.
	status code: 400, request id: 0981f485-c3d1-4f1c-809f-791b89edb893`

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/5740#L6675b81f:24