### PR TITLE
chore: Bump the rds version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds-instance" {
 
   # Database configuration
   db_engine                = "oracle-se2"
-  db_engine_version        = "19.0.0.0.ru-2023-07.rur-2023-07.r1"
+  db_engine_version        = "19.0.0.0.ru-2024-01.rur-2024-01.r1"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.medium"
   db_allocated_storage     = "300"


### PR DESCRIPTION
Fix `Error: updating RDS DB Instance (cloud-platform-d076dc502dcc456c): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 41a39ae1-8cb6-43f2-a791-db2a09ea0415, api error InvalidParameterCombination: Cannot upgrade oracle-se2 from 19.0.0.0.ru-2024-01.rur-2024-01.r1 to 19.0.0.0.ru-2023-07.rur-2023-07.r1`


https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d/builds/2624#L6675acf6:26280

RDS minor version was upgrade by AWS in maintenance window.
![image](https://github.com/user-attachments/assets/731695c0-1361-4cf7-8759-03cace143b7b)
