### PR TITLE
Increase compute power to stop pod crash

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2000Mi
     defaultRequest:
-      cpu: 10m
-      memory: 100Mi
+      cpu: 100m
+      memory: 300Mi
     type: Container


### PR DESCRIPTION
Dev environment is always crashing as limit range was never updated as the other environments have been.