### PR TITLE
Remove references to test2 namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-allocation-manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/ecr-allocation-manager.tf
@@ -4,6 +4,8 @@ module "ecr-repo-allocation-manager" {
   team_name = var.team_name
   repo_name = "offender-management-allocation-manager"
 
+  deletion_protection = false
+
   # Tags
   business_unit          = var.business_unit
   application            = var.application
@@ -14,50 +16,6 @@ module "ecr-repo-allocation-manager" {
 
   providers = {
     aws = aws.london
-  }
-}
-
-resource "kubernetes_secret" "ecr-repo-allocation-manager" {
-  metadata {
-    name      = "ecr-repo-allocation-manager"
-    namespace = "offender-management-staging"
-  }
-
-  data = {
-    repo_url = module.ecr-repo-allocation-manager.repo_url
-  }
-}
-
-resource "kubernetes_secret" "ecr-repo-allocation-manager-test" {
-  metadata {
-    name      = "ecr-repo-allocation-manager"
-    namespace = "offender-management-test"
-  }
-
-  data = {
-    repo_url = module.ecr-repo-allocation-manager.repo_url
-  }
-}
-
-resource "kubernetes_secret" "ecr-repo-allocation-manager-test2" {
-  metadata {
-    name      = "ecr-repo-allocation-manager"
-    namespace = "offender-management-test2"
-  }
-
-  data = {
-    repo_url = module.ecr-repo-allocation-manager.repo_url
-  }
-}
-
-resource "kubernetes_secret" "ecr-repo-allocation-manager-preprod" {
-  metadata {
-    name      = "ecr-repo-allocation-manager"
-    namespace = "offender-management-preprod"
-  }
-
-  data = {
-    repo_url = module.ecr-repo-allocation-manager.repo_url
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
@@ -19,49 +19,6 @@ module "ec-cluster-offender-management-allocation-manager" {
   }
 }
 
-resource "kubernetes_secret" "ec-cluster-offender-management-allocation-manager-staging" {
-  metadata {
-    name      = "elasticache-offender-management-allocation-manager-token-cache-${var.environment_name}"
-    namespace = var.namespace
-  }
-
-  data = {
-    primary_endpoint_address = module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address
-    auth_token               = module.ec-cluster-offender-management-allocation-manager.auth_token
-    url                      = "rediss://dummyuser:${module.ec-cluster-offender-management-allocation-manager.auth_token}@${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}:6379"
-  }
-}
-
-resource "kubernetes_secret" "ec-cluster-offender-management-allocation-manager-test" {
-  metadata {
-    name      = "elasticache-offender-management-allocation-manager-token-cache-test"
-    namespace = "offender-management-test"
-  }
-
-  data = {
-    primary_endpoint_address = module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address
-    auth_token               = module.ec-cluster-offender-management-allocation-manager.auth_token
-    url                      = "rediss://dummyuser:${module.ec-cluster-offender-management-allocation-manager.auth_token}@${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}:6379"
-  }
-}
-
-resource "kubernetes_secret" "ec-cluster-offender-management-allocation-manager-test2" {
-  metadata {
-    name      = "elasticache-offender-management-allocation-manager-token-cache-test2"
-    namespace = "offender-management-test2"
-  }
-
-  data = {
-    primary_endpoint_address = module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address
-    auth_token               = module.ec-cluster-offender-management-allocation-manager.auth_token
-    url                      = "rediss://dummyuser:${module.ec-cluster-offender-management-allocation-manager.auth_token}@${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}:6379"
-  }
-}
-
-###
-### New secrets below. Above secrets to be removed once no longer in use
-###
-
 resource "kubernetes_secret" "redis-staging" {
   metadata {
     name      = "allocation-elasticache-redis"
@@ -79,19 +36,6 @@ resource "kubernetes_secret" "redis-test" {
   metadata {
     name      = "allocation-elasticache-redis"
     namespace = "offender-management-test"
-  }
-
-  data = {
-    primary_endpoint_address = module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address
-    auth_token               = module.ec-cluster-offender-management-allocation-manager.auth_token
-    url                      = "rediss://dummyuser:${module.ec-cluster-offender-management-allocation-manager.auth_token}@${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}:6379"
-  }
-}
-
-resource "kubernetes_secret" "redis-test2" {
-  metadata {
-    name      = "allocation-elasticache-redis"
-    namespace = "offender-management-test2"
   }
 
   data = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/main.tf
@@ -32,9 +32,6 @@ provider "aws" {
   }
 }
 
-locals {
-  dev_namespaces = toset([var.namespace, "offender-management-test", "offender-management-test2"])
-}
 provider "github" {
   token = var.github_token
   owner = var.github_owner

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds.tf
@@ -69,22 +69,3 @@ resource "kubernetes_secret" "allocation-rds-test" {
     postgres_password     = module.allocation-rds.database_password
   }
 }
-
-resource "kubernetes_secret" "allocation-rds-test2" {
-  metadata {
-    name      = "allocation-rds-instance-output"
-    namespace = "offender-management-test2"
-  }
-
-  data = {
-    rds_instance_endpoint = module.allocation-rds.rds_instance_endpoint
-    rds_instance_address  = module.allocation-rds.rds_instance_address
-    database_name         = module.allocation-rds.database_name
-    database_username     = module.allocation-rds.database_username
-    database_password     = module.allocation-rds.database_password
-    postgres_name         = module.allocation-rds.database_name
-    postgres_host         = module.allocation-rds.rds_instance_address
-    postgres_user         = module.allocation-rds.database_username
-    postgres_password     = module.allocation-rds.database_password
-  }
-}


### PR DESCRIPTION
The `offender-management-test2` namespace is about to be deleted as no longer used.

Also prepare to remove ECR repo (`deletion_protection = false`) as it is not used.