### PR TITLE
court-case-service-dev: Add service pod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/service-pod.tf
@@ -1,0 +1,6 @@
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.0.0"
+
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name
+}


### PR DESCRIPTION
Add service pod to DEV in order to gain AWS CLI access to SQS queues.