### PR TITLE
court-case-service-prod: Add service pod 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/service-pod.tf
@@ -1,0 +1,7 @@
+
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.0.0" # use the latest release
+
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name
+}


### PR DESCRIPTION
Add service pod to PreProd in order to gain AWS CLI access to SQS queues