### PR TITLE
Remove ECR deletion protection for ct-prototype

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ct-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ct-prototype/resources/ecr.tf
@@ -14,4 +14,5 @@ module "ecr-repo" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
Doing this in preparation for deleting the whole namespace.