### PR TITLE
Handle non-existence of ct-prototype repo

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ct-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ct-prototype/resources/ecr.tf
@@ -3,9 +3,6 @@ module "ecr-repo" {
 
   repo_name = "${var.namespace}-ecr"
 
-  oidc_providers      = ["github"]
-  github_repositories = [var.namespace]
-
   # Tags
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ct-prototype/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ct-prototype/resources/serviceaccount.tf
@@ -1,8 +1,0 @@
-module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
-
-  namespace          = var.namespace
-  kubernetes_cluster = var.kubernetes_cluster
-
-  github_repositories = [var.namespace]
-}


### PR DESCRIPTION
The repo has been deleted, so secrets can't be stored there.

NB: This is preparation for the deletion of this namespace