### PR TITLE
Update github team for CCLF dev console access

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-aws-infrastructure"
+      GithubTeam = "laa-lz-cp-migration"
     }
   }
 }


### PR DESCRIPTION
The GithubTeam value in `default_tags` in `main.tf` is set to the team previously responsible for this application. This updates the value to match the team defined in `01-rbac.yaml` (`laa-lz-cp-migration`) so that all relevant developers can access the console for this application.