### PR TITLE
FALA STG service account permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/serviceaccount.tf
@@ -19,6 +19,7 @@ module "serviceaccount" {
         "services",
         "pods",
         "configmaps",
+        "persistentvolumeclaims",
       ]
       verbs = [
         "patch",


### PR DESCRIPTION
FALA STG service account is responsible for deleting deployments and needs permission to delete the associated PVC thids PR adds that permission