### PR TITLE
LAA CLA Backend Production - Downgrade RDS module back to 6.0.1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -9,7 +9,7 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds_postgres_14" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.1"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.1"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit


### PR DESCRIPTION
# What is this purpose of this PR?
We are planning on upgrading our production RDS modules to 7.0.0 out of Cloud Platform support hours (24/07/2024 - 08:15)
In the unlikely case of a failure when upgrading we need an approved PR reverting the changes.

This PR is a revert of: [https://github.com/ministryofjustice/cloud-platform-environments/pull/24516/files](https://github.com/ministryofjustice/cloud-platform-environments/pull/24516/files), this PR should not be required to be merged in.