### PR TITLE
CCQ Prod rollback and downgrade RDS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.1"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.1"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit


### PR DESCRIPTION
We are planning on upgrading our production RDS modules to 7.0.0 out of Cloud Platform support hours (24/07/2024 - 08:15)
In the unlikely case of a failure when upgrading we need an approved PR reverting the changes.

This PR is a revert of: https://github.com/ministryofjustice/cloud-platform-environments/pull/24610 this PR should not be required to be merged in.

It is failing a check because it does not upgrade to the latest version, but this is expected as a rollback PR.