### PR TITLE
Create Route53 hosted zones in find-moj-data namezones

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "find_moj_dev_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "find_moj_dev_route53_zone_sec" {
+  metadata {
+    name      = "find-moj-data-dev-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.find_moj_dev_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.find_moj_dev_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/variables.tf
@@ -70,3 +70,8 @@ variable "github_token" {
 
 variable "eks_cluster_name" {
 }
+
+variable "domain" {
+  default = "dev.find-moj-data.service.justice.gov.uk"
+  type    = string
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "find_moj_preprod_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "find_moj_preprod_route53_zone_sec" {
+  metadata {
+    name      = "find-moj-data-preprod-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.find_moj_preprod_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.find_moj_preprod_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/versions.tf
@@ -19,3 +19,8 @@ terraform {
     }
   }
 }
+
+variable "domain" {
+  default = "preprod.find-moj-data.service.justice.gov.uk"
+  type    = string
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "find_moj_data_prod_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "find_moj_data_prod_route53_zone_sec" {
+  metadata {
+    name      = "find-moj-data-prod-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.find_moj_data_prod_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.find_moj_data_prod_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/variables.tf
@@ -70,3 +70,8 @@ variable "github_token" {
 
 variable "eks_cluster_name" {
 }
+
+variable "domain" {
+  default = "find-moj-data.service.justice.gov.uk"
+  type    = string
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "find_moj_data_test_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "find_moj_data_test_route53_zone_sec" {
+  metadata {
+    name      = "find-moj-data-test-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.find_moj_data_test_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.find_moj_data_test_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/resources/variables.tf
@@ -70,3 +70,8 @@ variable "github_token" {
 
 variable "eks_cluster_name" {
 }
+
+variable "domain" {
+  default = "test.find-moj-data.service.justice.gov.uk"
+  type    = string
+}


### PR DESCRIPTION
I'm following the instructions https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/route53-zone.html#creating-a-route-53-hosted-zone so that we can delegate the following domains to cloud platform:

- find-moj-data.service.justice.gov.uk
- dev.find-moj-data.service.justice.gov.uk
- test.find-moj-data.service.justice.gov.uk
- pre-prod.find-moj-data.service.justice.gov.uk
