### PR TITLE
Create hosted zone for find-moj-data dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "find_moj_dev_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "find_moj_dev_route53_zone_sec" {
+  metadata {
+    name      = "find-moj-data-dev-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.find_moj_dev_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.find_moj_dev_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/variables.tf
@@ -70,3 +70,8 @@ variable "github_token" {
 
 variable "eks_cluster_name" {
 }
+
+variable "domain" {
+  default = "dev.find-moj-data.service.justice.gov.uk"
+  type    = string
+}


### PR DESCRIPTION
This will be used to delegate dev.find-moj-data.justice.service.gov.uk to cloud platform.