### PR TITLE
chore: Update tf DB engine version to match console version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds-instance" {
 
   # Database configuration
   db_engine                = "oracle-se2"
-  db_engine_version        = "19.0.0.0.ru-2023-07.rur-2023-07.r1"
+  db_engine_version        = "19.0.0.0.ru-2024-01.rur-2024-01.r1"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.medium"
   db_allocated_storage     = "300"


### PR DESCRIPTION
minior version was upgraded in maintenance window. update the terraform file to match the databse version in the aws console

![image](https://github.com/user-attachments/assets/434365d4-eca7-4f1c-a011-e0c43cec1b68)

![image](https://github.com/user-attachments/assets/ab036995-ada5-4e6b-98cf-278c57992b7e)
