### PR TITLE
Remove enable_rds_auto_start_stop flag from production db

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
@@ -59,8 +59,6 @@ module "prison_visit_booker_registry_rds" {
   db_instance_class           = "db.t4g.micro"
   db_max_allocated_storage    = "500"
   db_password_rotated_date    = "2023-03-22"
-
-  enable_rds_auto_start_stop   = true
   performance_insights_enabled = true
 
   providers = {


### PR DESCRIPTION
## What is the aim of this PR?
We want to keep our booker-api database available 24hrs in production environment.