### PR TITLE
Remove enable_rds_auto_start_stop from visit-booker-registry preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -75,7 +75,6 @@ module "prison_visit_booker_registry_rds" {
   db_max_allocated_storage    = "10000"
   db_password_rotated_date    = "2023-03-22"
 
-  enable_rds_auto_start_stop   = true
   performance_insights_enabled = true
 
   providers = {


### PR DESCRIPTION
Remove enable_rds_auto_start_stop from preprod too similar to PR raised for Prod - https://github.com/ministryofjustice/cloud-platform-environments/pull/24672