### PR TITLE
chore: bump RDS Aurora module to 4.0.0 in nonprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/rds-aurora.tf
@@ -1,5 +1,5 @@
 module "rds_aurora" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=3.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=4.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name


### PR DESCRIPTION
Relates to ministryofjustice/cloud-platform#5893