### PR TITLE
Add certificate for find-moj-data service domain

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/06-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: find-moj-data-cert
+  namespace: data-platform-find-moj-data-prod
+spec:
+  secretName: find-moj-data-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - find-moj-data.service.justice.gov.uk


### PR DESCRIPTION
We also need certificates covering the dev. test. preprod. subdomains, but I'll set them up in their own namespaces.