### PR TITLE
Civil applications datastore: Prepare for removing namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-applications-datastore-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-applications-datastore-uat/resources/ecr.tf
@@ -22,4 +22,6 @@ module "ecr" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+
+  deletion_protection = false 
 }


### PR DESCRIPTION
Add `deletion_protection = false` so files can be removed in next PR