### PR TITLE
Add cross-iam role for AP S3 bucket access

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-hr-smart-knowledge-management-dev/resources/cross-iam-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-hr-smart-knowledge-management-dev/resources/cross-iam-role.tf
@@ -1,0 +1,33 @@
+data "aws_iam_policy_document" "mojap-rd_access_policy_doc" {
+  # Provide list of permissions and target AWS account resources to allow access to
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-rd",
+    ]
+  }
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-rd/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "mojap-rd_access_policy" {
+  name   = "rd-hr-smart-knowledge-management-dev_rd_access_policy"
+  policy = data.aws_iam_policy_document.mojap-rd_access_policy_doc.json
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-hr-smart-knowledge-management-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-hr-smart-knowledge-management-dev/resources/irsa.tf
@@ -12,7 +12,8 @@ module "irsa" {
   # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
-    s3  = module.s3_bucket.irsa_policy_arn
+    s3_local = module.s3_bucket.irsa_policy_arn
+    s3 = aws_iam_policy.mojap-rd_access_policy.arn
   }
 
   # Tags


### PR DESCRIPTION
Note that the irsa config was already in place, so this just extends it to provide access to the Analytical Platform bucket.