### PR TITLE
chore: bump rds version to match that in console

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-staging/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds-instance" {
 
   # Database configuration
   db_engine                = "oracle-se2"
-  db_engine_version        = "19.0.0.0.ru-2024-01.rur-2024-01.r1"
+  db_engine_version        = "19.0.0.0.ru-2024-04.rur-2024-04.r1"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.medium"
   db_allocated_storage     = "300"


### PR DESCRIPTION
Fix below error
```
FATA[4340] error running terraform on namespace laa-crown-court-remuneration-staging: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-258fabb333470810): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: bd07c7a0-2173-4f78-a521-ccf15ab687a2, api error InvalidParameterCombination: Cannot upgrade oracle-se2 from 19.0.0.0.ru-2024-04.rur-2024-04.r1 to 19.0.0.0.ru-2024-01.rur-2024-01.r1

  with module.rds-instance.aws_db_instance.rds,
  on .terraform/modules/rds-instance/main.tf line 144, in resource "aws_db_instance" "rds":
 144: resource "aws_db_instance" "rds" {
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d/builds/2807#L66a76b4f:26904