### PR TITLE
add comment to hmpps-template-typescript

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-typescript/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-template-typescript/01-rbac.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hmpps-template-typescript-admin
   namespace: hmpps-template-typescript
 subjects:
+# Please keep hmpps-sre and hmpps-typescript groups
+# in this section to help with support
   - kind: Group
     name: "github:hmpps-sre"
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Minor change to request that when the hmpps-template-typescript namespace entry is used as a template, not to remove the two groups that are in the rbac file.