### PR TITLE
Renamed dev cert secret to align with ingress

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/06-certificate.yaml
@@ -5,7 +5,7 @@ metadata:
   name: find-moj-data-dev-cert
   namespace: data-platform-find-moj-data-dev
 spec:
-  secretName: find-moj-data-dev-cert
+  secretName: find-moj-data-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer


### PR DESCRIPTION
- The secret needs to align with the app's ingress file according to [guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/custom-domain-cert.html#certificate-character-limit)