### PR TITLE
fix: 🐛 tf error

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-staging/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-staging/resources/opensearch.tf
@@ -25,8 +25,8 @@ module "opensearch" {
 
   # Production like configuration.
   cluster_config = {
-    instance_count           = 3
-    instance_type            = "r6g.large.search" # memory optimised Graviton
+    instance_count = 3
+    instance_type  = "r6g.large.search" # memory optimised Graviton
 
     # Masters do not hold data, they perform other cluster tasks.
     dedicated_master_enabled = true
@@ -35,7 +35,7 @@ module "opensearch" {
   }
 
   advanced_options = {
-    max_clause_count = 10000
+    "indices.query.bool.max_clause_count" = "10000"
   }
 
   ebs_options = {


### PR DESCRIPTION
2024/08/07 12:04:14 Running Terraform Apply for namespace: intranet-staging

FATA[1426] error running terraform on namespace intranet-staging: unable to apply Terraform: exit status 1


Error: updating OpenSearch Domain (arn:aws:es:eu-west-xxxxxx): ValidationException: Unrecognized advanced option 'max_clause_count' passed in advancedOptions.

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d/builds/2904