### PR TITLE
RR-920 - Subscribe to prison-offender events in preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-education-and-work-plan-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-preprod/resources/hmpps-education-and-work-plan-api.tf
@@ -84,8 +84,8 @@ resource "aws_sns_topic_subscription" "education_and_work_plan_domain_events_sub
   endpoint  = module.education_and_work_plan_domain_events_queue.sqs_arn
   filter_policy = jsonencode({
     eventType = [
-      "ciag-induction.created",
-      "ciag-induction.updated"
+      "prison-offender-events.prisoner.released",
+      "prison-offender-events.prisoner.received"
     ]
   })
 
@@ -108,32 +108,6 @@ resource "kubernetes_secret" "education_and_work_plan_dlq" {
   metadata {
     name      = "education-and-work-plan-domain-events-sqs-dl-instance-output"
     namespace = "hmpps-education-and-work-plan-preprod"
-  }
-
-  data = {
-    sqs_queue_url  = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_id
-    sqs_queue_arn  = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_arn
-    sqs_queue_name = module.education_and_work_plan_domain_events_dead_letter_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "ciag_domain_events_queue" {
-  metadata {
-    name      = "ciag-domain-events-sqs-instance-output"
-    namespace = "hmpps-education-employment-preprod"
-  }
-
-  data = {
-    sqs_queue_url  = module.education_and_work_plan_domain_events_queue.sqs_id
-    sqs_queue_arn  = module.education_and_work_plan_domain_events_queue.sqs_arn
-    sqs_queue_name = module.education_and_work_plan_domain_events_queue.sqs_name
-  }
-}
-
-resource "kubernetes_secret" "ciag_dlq" {
-  metadata {
-    name      = "ciag-domain-events-sqs-dl-instance-output"
-    namespace = "hmpps-education-employment-preprod"
   }
 
   data = {


### PR DESCRIPTION
`hmpps-education-and-work-plan` - subscribe to `prison-offender-events.prisoner.released` and `prison-offender-events.prisoner.received` events in dev

Our queues etc were already setup and subscribing to different events (from a previous iteration of our API). The previous events are no longer sent by anything and our kotlin code does not listen to them. But we do now need to listen to `prison-offender-events.prisoner.released` and `prison-offender-events.prisoner.received` events