### PR TITLE
Adds sre team to dev rbac config (1/5)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/01-rbac.yaml
@@ -11,6 +11,9 @@ subjects:
   - kind: Group
     name: "github:hmpps-community-accommodation"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
This is 1 of 5 PRs which adds the SRE team into the Community Accommodation Services (CAS) environments