### PR TITLE
Adds SRE team to CAS prod rbac config (5/5)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/01-rbac.yaml
@@ -11,6 +11,9 @@ subjects:
   - kind: Group
     name: "github:hmpps-community-accommodation"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
This is 5 of 5 PRs which adds the SRE team into the Community Accommodation Services (CAS) environments