### PR TITLE
do not turn of prod rds overnight

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/rds-postgresql.tf
@@ -10,7 +10,7 @@ module "rds" {
   prepare_for_major_upgrade    = true
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
-  enable_rds_auto_start_stop   = true # turn off database overnight 22:00-06:00 UTC.
+  enable_rds_auto_start_stop   = false # turn off database overnight 22:00-06:00 UTC.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # PostgreSQL specifics


### PR DESCRIPTION
We don't want our prod backend to shutdown overnight as we'll be running ingestions