### PR TITLE
increase db instance for Community Accommodation Services databases

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds" {
   namespace                    = var.namespace
   performance_insights_enabled = true
   db_engine_version            = "14"
-  db_instance_class            = "db.t3.small"
+  db_instance_class            = "db.t3.xlarge"
   rds_family                   = "postgres14"
   allow_major_version_upgrade  = "false"
 


### PR DESCRIPTION
We have had several incidents wherein we have maxed out our database CPU usage, which has then lead to maxing out our connections. This has lead to service incidents in two occasions, which affects the three different services that our API serves.

We believe the root of this cause is some particularly gnarly queries that are eagerly loading in more data than they need. Whilst we are tackling these queries, we would like to increase the instance of our DB considerably whilst we refactor them.

We will look to reduce the size of the instance once this has been done.