### PR TITLE
:recycle: Change repository name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-poc/resources/ecr.tf
@@ -11,7 +11,7 @@ module "ecr-repo" {
   oidc_providers = ["github"]
 
   # specify which GitHub repository you're pushing from
-  github_repositories = ["operations-engineering-kpi-dashboard-poc"]
+  github_repositories = ["operations-engineering-kpi-dashboard"]
 
   lifecycle_policy = <<EOF
 {


### PR DESCRIPTION
The operations-engineering-kpi-dashboard-poc GitHub repository has had a name change and the OIDC has stopped working. This change corrects this error.