### PR TITLE
DCES-243: Create mTLS related secrets for DCES-DRC integration project

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/secret.tf
@@ -20,5 +20,15 @@ module "secrets_manager" {
       recovery_window_in_days = 7
       k8s_secret_name         = "maat-api-oauth-client-secret"
     },
+    "key-store-password" = {
+      description             = "mTLS key store password for DRC Integration Dev",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "key-store-password"
+    },
+    "trust-store-password" = {
+      description             = "mTLS Trust store password for DRC Integration Dev",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "trust-store-password"
+    },
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/secret.tf
@@ -20,15 +20,5 @@ module "secrets_manager" {
       recovery_window_in_days = 7
       k8s_secret_name         = "maat-api-oauth-client-secret"
     },
-    "key-store-password" = {
-      description             = "mTLS key store password for DRC Integration Dev",
-      recovery_window_in_days = 7
-      k8s_secret_name         = "key-store-password"
-    },
-    "trust-store-password" = {
-      description             = "mTLS Trust store password for DRC Integration Dev",
-      recovery_window_in_days = 7
-      k8s_secret_name         = "trust-store-password"
-    },
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-staging/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-staging/resources/secret.tf
@@ -20,5 +20,15 @@ module "secrets_manager" {
       recovery_window_in_days = 7
       k8s_secret_name         = "maat-api-oauth-client-secret"
     },
+    "key-store-password" = {
+      description             = "mTLS key store password for DRC Integration Stg",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "key-store-password"
+    },
+    "trust-store-password" = {
+      description             = "mTLS Trust store password for DRC Integration Stg",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "trust-store-password"
+    },
   }
 }


### PR DESCRIPTION
Adding two new secrets to be used for mTLS certificates. 