### PR TITLE
Find MoJ data (dev): Update URL for pingdom checks

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/pingdom.tf
@@ -4,7 +4,7 @@ provider "pingdom" {
 resource "pingdom_check" "find-moj-data-dev" {
   type                     = "http"
   name                     = "find-moj-data - dev - cloud-platform"
-  host                     = "data-platform-find-moj-data-dev.apps.live.cloud-platform.service.justice.gov.uk"
+  host                     = "dev.find-moj-data.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6


### PR DESCRIPTION
We've just removed the ingress for the old URLs as we have a service.justice.gov.uk domain now.