### PR TITLE
chore: Update tf rds version to match console version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
 
   # general options
   db_engine              = "mariadb"
-  db_engine_version      = "10.11.6"
+  db_engine_version      = "10.11.8"
   rds_family             = "mariadb10.11"
   db_instance_class      = "db.t4g.xlarge"
   environment_name       = var.environment


### PR DESCRIPTION
fix below error
```
FATA[1508] error running terraform on namespace intranet-production: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-283c8dc3f78ede0f): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 6389af51-cf85-4c97-a908-2e7b60ea7ca3, api error InvalidParameterCombination: Cannot upgrade mariadb from 10.11.8 to 10.11.6

  with module.rds.aws_db_instance.rds,
  on .terraform/modules/rds/main.tf line 144, in resource "aws_db_instance" "rds":
 144: resource "aws_db_instance" "rds" {
```
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d/builds/3049#L66bcda55:7066