### PR TITLE
justice-gov-uk-production Temp. add a database to restore a snapshot, then export as .sql

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/irsa.tf
@@ -11,6 +11,9 @@ module "irsa" {
   role_policy_arns = {
     s3  = module.s3_bucket.irsa_policy_arn,
     ecr = module.ecr_credentials.irsa_policy_arn
+
+    rds     = module.rds.irsa_policy_arn
+    rds_tmp = module.rds_tmp.irsa_policy_arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds-tmp.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds-tmp.tf
@@ -1,0 +1,68 @@
+module "rds_tmp" {
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.0.0"
+  vpc_name      = var.vpc_name
+  team_name     = var.team_name
+  business_unit = var.business_unit
+  application   = var.application
+  namespace     = var.namespace
+  is_production = var.is_production
+
+  # turn off performance insights
+  performance_insights_enabled = false
+
+  # general options
+  db_engine                   = "mariadb"
+  db_engine_version           = "10.11.6"
+  rds_family                  = "mariadb10.11"
+  db_instance_class           = "db.t4g.medium"
+  db_allocated_storage        = "5"
+  environment_name            = var.environment
+  infrastructure_support      = var.infrastructure_support
+  allow_major_version_upgrade = "false"
+  deletion_protection = true
+
+  # overwrite db_parameters
+  db_parameter = [
+    {
+      name         = "character_set_client"
+      value        = "utf8mb4"
+      apply_method = "immediate"
+    },
+    {
+      name         = "character_set_server"
+      value        = "utf8mb4"
+      apply_method = "immediate"
+    }
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "rds_tmp" {
+  metadata {
+    name      = "rds-tmp-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds_tmp.rds_instance_endpoint
+    database_name         = module.rds_tmp.database_name
+    database_username     = module.rds_tmp.database_username
+    database_password     = module.rds_tmp.database_password
+    rds_instance_address  = module.rds_tmp.rds_instance_address
+  }
+}
+
+resource "kubernetes_config_map" "rds_tmp" {
+  metadata {
+    name      = "rds-tmp-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds_tmp.database_name
+    db_identifier = module.rds_tmp.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds-tmp.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds-tmp.tf
@@ -19,7 +19,6 @@ module "rds_tmp" {
   environment_name            = var.environment
   infrastructure_support      = var.infrastructure_support
   allow_major_version_upgrade = "false"
-  deletion_protection = true
 
   # overwrite db_parameters
   db_parameter = [


### PR DESCRIPTION
`rds-tmp.tf` is a copy of `rds.tf` except for naming and db_instance_class.

The intention is to use the service pod to restore a snapshot to rds_tmp, then connect to the db to export the database in .sql format.

cc @wilson1000 - I went against using the snapshot property as that required manual intervention from the Cloud Platform team - and this was looks like not too much additional work.