### PR TITLE
Extend S3 file retention to 30 days

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-filestore.tf
@@ -23,15 +23,15 @@ module "user-filestore-s3-bucket" {
       enabled                                = true
       id                                     = "expire-28d"
       prefix                                 = "28d/"
-      abort_incomplete_multipart_upload_days = 28
+      abort_incomplete_multipart_upload_days = 30
       expiration = [
         {
-          days = 28
+          days = 30
         },
       ]
       noncurrent_version_expiration = [
         {
-          days = 28
+          days = 30
         },
       ]
     },
@@ -69,13 +69,4 @@ resource "kubernetes_secret" "user-filestore-s3-bucket" {
     bucket_arn  = module.user-filestore-s3-bucket.bucket_arn
     bucket_name = module.user-filestore-s3-bucket.bucket_name
   }
-}
-
-# set up the service pod
-module "service_pod" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.0.0" # use the latest release
-
-  # Configuration
-  namespace            = var.namespace
-  service_account_name = module.user-filestore-irsa.service_account.name # this uses the service account name from the irsa module
 }


### PR DESCRIPTION
No changing the prefix/folder name as we have downstream code that expects it.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html#lifecycle-expire-minimum-storage

based on this, I think there is no cost difference to hold for 30 days over 28 but could prevent an issue we are seeing where files are deleted at 00:00 on retention expiry but records that reference the files are deleted 28 days after creation. This will ensure files are always available and records that reference them will be deleted first.