### PR TITLE
Change group `farsight-devs` to `hmpps-farsight-reduce-re-offend` for the Education & Work Plan `dev` namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-education-and-work-plan-dev
 subjects:
   - kind: Group
-    name: "github:farsight-devs"
+    name: "github:hmpps-farsight-reduce-re-offend"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"


### PR DESCRIPTION
Change the group name from `farsight-devs` to `hmpps-farsight-reduce-re-offend` for the Education & Work Plan `dev` namespace (because that is the GH group that maintains the associated projects)