### PR TITLE
doc: comment to keep hmpps-sre

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/01-rbac.yaml
@@ -6,14 +6,17 @@ metadata:
   namespace: hmpps-templates-dev
 subjects:
   - kind: Group
-    name: "github:hmpps-sre"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
     name: "github:hmpps-kotlin"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-typescript"
     apiGroup: rbac.authorization.k8s.io
+############## COPY - DO NOT REPLACE ##############
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+# hmpps-sre group is required for support functions
+###################################################
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
Since the hmpps-templates-dev namespace forms the basis of the namespaces for DPS apps, the support team (hmpps-sre) needs to be kept in the rbac file. This comment will (hopefully) make sure it is retained.