### PR TITLE
App store UAT: revert DB upgrade changes

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/resources/rds-postgresql.tf
@@ -11,7 +11,7 @@ module "rds" {
   vpc_name = var.vpc_name
 
   # RDS configuration
-  allow_minor_version_upgrade  = false
+  allow_minor_version_upgrade  = true
   allow_major_version_upgrade  = false
   prepare_for_major_upgrade    = false
   performance_insights_enabled = false
@@ -22,7 +22,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.1"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.small"
 
@@ -59,7 +59,7 @@ module "read_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.1"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
   db_max_allocated_storage     = "1000"


### PR DESCRIPTION
App store UAT: revert DB upgrade changes

Previous PRs to upgrade the primary and read replica databases did
not work so reverting the changes to try and start again.
