### PR TITLE
CRM457-1907: Remove DB engine version minor component Assess PROD 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/resources/rds-postgresql.tf
@@ -60,7 +60,7 @@ module "read_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.1"
+  db_engine_version = "16"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
   # It is mandatory to set the below values to create read replica instance


### PR DESCRIPTION
cloud platform guide says it should not have this version
component.
