### PR TITLE
IR-421: Send Incident Reporting `prod` alerts to our dev channel

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/00-namespace.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/slack-channel: "incident-reporting-service-dev"
-    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "incident-reporting-service-dev"
     cloud-platform.justice.gov.uk/application: "HMPPS Incident Reporting Service"
     cloud-platform.justice.gov.uk/owner: "HMPPS Incident Reporting Service: incident-reporting-service@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-incident-reporting-api.git,https://github.com/ministryofjustice/hmpps-incident-reporting.git"


### PR DESCRIPTION
Send them to `#incident-reporting-service-dev` Instead of sending everything to `#dps_alerts`