### PR TITLE
Send Non-associations' `prod` alerts to our dev channel

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/00-namespace.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/slack-channel: "non-associations-dev"
-    cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "non-associations-dev"
     cloud-platform.justice.gov.uk/application: "HMPPS Non-associations Apps"
     cloud-platform.justice.gov.uk/owner: "HMPPS Non-Associations: non-associations-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-non-associations.git"


### PR DESCRIPTION
We're in the process of sending all alerts to our dev channel (`#non-associations-dev`) instead of sending everything to `#dps_alerts`.