### PR TITLE
PI-2447 Set API Gateway pass-through behaviour to WHEN_NO_TEMPLATES

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway-assume-role-endpoint.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway-assume-role-endpoint.tf
@@ -28,6 +28,7 @@ resource "aws_api_gateway_integration" "sts_integration" {
     "integration.request.querystring.Tags.member.1.Value" = "context.identity.clientCert.subjectDN"
     "integration.request.querystring.Version"             = "'2011-06-15'"
   }
+  passthrough_behavior = "WHEN_NO_TEMPLATES"
 }
 
 resource "aws_iam_role" "sts_integration" {


### PR DESCRIPTION
Possible provider bug - setting passthrough_behavior then removing it does not update AWS.