### PR TITLE
court-case-service-prod : Add AWS secret key to contain app insights connection string

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/secrets-manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/secrets-manager.tf
@@ -15,5 +15,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "probation-in-court-slack-webhook"
     },
+    "applicationinsights-connection-string" = {
+      description             = "Contains the application insights connection string for prod",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "applicationinsights-connection-string-prod"
+    }
   }
 }


### PR DESCRIPTION
Add AWS secret key to contain app insights connection string

This will include the application insights prod connection string. This is a part of the appinsights migration to major version 3