### PR TITLE
increase rds db size to enable performance testsing in staging env

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/rds.tf
@@ -8,7 +8,7 @@ module "dps_rds" {
   namespace                 = var.namespace
   environment_name          = var.environment-name
   infrastructure_support    = var.infrastructure_support
-  db_instance_class         = "db.t4g.micro"
+  db_instance_class         = "db.t4g.small"
   db_max_allocated_storage  = "500"
   deletion_protection       = true
   prepare_for_major_upgrade = false


### PR DESCRIPTION
Temp change  to scale up the `hmpps-auth-stage` rds instance.

We're performance testing a new component and need to scale up the stage DB instance. We will revert the change once our testing is complete.