### PR TITLE
chore: refining RDS variables - DataHub prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/rds-postgresql.tf
@@ -6,8 +6,9 @@ module "rds" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = true
-  prepare_for_major_upgrade    = true
+  allow_major_version_upgrade  = false
+  prepare_for_major_upgrade    = false
+  deletion_protection          = true
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   enable_rds_auto_start_stop   = false # turn off database overnight 22:00-06:00 UTC.


### PR DESCRIPTION
adding deletion protection for prod instance, and turning off major upgrade prep vars
