### PR TITLE
Bump cla-backend staging replica RDS to 7.1.0

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
@@ -8,7 +8,7 @@
 # IMP NOTE: Updating to module version 5.3, existing database password will be rotated.
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 module "cla_backend_rds_postgres_14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -18,8 +18,6 @@ module "cla_backend_rds_postgres_14_replica" {
   environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 
-  # It is mandatory to set the below values to create read replica instance
-  db_name = null # "db_name": conflicts with replicate_source_db
 
   # Set the db_identifier of the source db
   replicate_source_db = module.cla_backend_rds_postgres_14.db_identifier


### PR DESCRIPTION
Bumps `cla-backend-staging` RDS Replica to RDS v.7.1.0.