### PR TITLE
Make custom metrics available for HPA.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/adapter-config-php-fpm.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/adapter-config-php-fpm.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adapter-config-php-fpm
+  namespace: monitoring
+data:
+  config.yaml: |
+    rules:
+    - seriesQuery: 'phpfpm_active_processes{namespace!="",pod_name!=""}'
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod_name:
+            resource: pod
+      name:
+        matches: "phpfpm_active_processes"
+        as: "phpfpm_active_processes_utilization"
+      metricsQuery: avg(phpfpm_active_processes{<<.LabelMatchers>>} / phpfpm_total_processes{<<.LabelMatchers>>}) by (<<.GroupBy>>)


### PR DESCRIPTION
## Background

Our php-fpm application does not horizontally scale well based on CPU or memory metrics.

Our pods expose custom metrics, that are more suitable for HPA, and they are ingested by prometheus.

One metric in particular `phpfpm_active_processes` looks to be a good metric for pod pressure and an indicator for HPA.

This article explains the process that I'm following

https://aspirin4k.medium.com/scaling-of-php-application-in-kubernetes-based-on-fpm-workers-utilization-15e5c7d8683a

## This PR

To scale on a custom metric, it looks like we need to add an `adapter-config`.

The added config lets us scale on `phpfpm_active_processes` by exposing the `phpfpm_active_processes_utilization` metric to use in our HPA config.