### PR TITLE
Add additional LAA LZ IP range to CCLF UAT RDS Security Group

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/resources/rds.tf
@@ -65,8 +65,8 @@ resource "aws_security_group" "rds" {
   }
 }
 
-resource "aws_security_group_rule" "rule" {
-  cidr_blocks       = ["10.202.0.0/20"]
+resource "aws_security_group_rule" "rule1" {
+  cidr_blocks       = ["10.206.0.0/20"]
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 1521
@@ -74,8 +74,8 @@ resource "aws_security_group_rule" "rule" {
   security_group_id = aws_security_group.rds.id
 }
 
-resource "aws_security_group_rule" "ruleb" {
-  cidr_blocks       = ["10.202.0.0/20"]
+resource "aws_security_group_rule" "rule2" {
+  cidr_blocks       = ["10.206.0.0/20"]
   type              = "egress"
   protocol          = "tcp"
   from_port         = 1521
@@ -84,7 +84,7 @@ resource "aws_security_group_rule" "ruleb" {
 }
 
 resource "aws_security_group_rule" "rule3" {
-  cidr_blocks       = ["10.200.0.0/20"]
+  cidr_blocks       = ["10.200.16.0/20"]
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 1521
@@ -93,15 +93,13 @@ resource "aws_security_group_rule" "rule3" {
 }
 
 resource "aws_security_group_rule" "rule4" {
-  cidr_blocks       = ["10.200.0.0/20"]
+  cidr_blocks       = ["10.200.16.0/20"]
   type              = "egress"
   protocol          = "tcp"
   from_port         = 1521
   to_port           = 1521
   security_group_id = aws_security_group.rds.id
 }
-
-
 
 resource "kubernetes_secret" "rds-instance" {
   metadata {


### PR DESCRIPTION
* Fixes incorrect CIDR range for UAT HUB: `10.202.0.0/20` -> `10.206.0.0/20`
* Adds additional CIDR range for production workspace: `10.200.16.0/20`