### PR TITLE
chore: update rds version to match console

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/rds.tf
@@ -15,7 +15,7 @@ module "rds-instance" {
 
   # Database configuration
   db_engine                = "oracle-se2" # or oracle-ee
-  db_engine_version        = "19.0.0.0.ru-2024-01.rur-2024-01.r1"
+  db_engine_version        = "19.0.0.0.ru-2024-07.rur-2024-07.r1"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.medium"
   db_allocated_storage     = "300"


### PR DESCRIPTION
fix below error in apply pipeline
```
FATA[4172] error running terraform on namespace laa-crown-court-litigator-fees-staging: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-8d4efaf415be74fc): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: b815a3fd-3d8a-4dd2-a75f-b76134e5dee9, api error InvalidParameterCombination: Cannot upgrade oracle-se2 from 19.0.0.0.ru-2024-07.rur-2024-07.r1 to 19.0.0.0.ru-2024-01.rur-2024-01.r1

  with module.rds-instance.aws_db_instance.rds,
  on .terraform/modules/rds-instance/main.tf line 144, in resource "aws_db_instance" "rds":
 144: resource "aws_db_instance" "rds" {

 
   subcommand=apply
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d/builds/3298#L66bdf8d9:27360