### PR TITLE
Rename modules in hmpps-ems-cemo-ui-dev.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/serviceaccount-circleci.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/serviceaccount-circleci.tf
@@ -62,7 +62,7 @@ locals {
   ]
 }
 
-module "serviceaccount_circleci" {
+module "serviceaccount" {
   source               = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
   namespace            = var.namespace
   kubernetes_cluster   = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/serviceaccount.tf
@@ -1,4 +1,4 @@
-module "serviceaccount" {
+module "serviceaccount_github" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
 
   namespace = var.namespace


### PR DESCRIPTION
We previously renamed a terraform module to resolve a name conflict.

However, renaming the module generated an error in circleci ([link](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-electronic-monitoring-create-an-order/87/workflows/be1370c2-22ff-4431-9322-562a69e728ee/jobs/373)).

This commit:
- reverts that rename, to fix the above error
- renames another module, so that the names are not in conflict.