### PR TITLE
LCAM 1114 Remove MAAT Client for Redundant CMA Integration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/.checksum
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/.checksum
@@ -1,3 +1,0 @@
-#This file is used by the auto pr github action. Please commit
-laa-crime-hardship-staging
-h1:fnQqXNUGlS3rRMAam+5+gjmn4n2yp+2TYxZI8Z//N9E=

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/.checksum
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/.checksum
@@ -1,0 +1,3 @@
+#This file is used by the auto pr github action. Please commit
+laa-crime-hardship-staging
+h1:fnQqXNUGlS3rRMAam+5+gjmn4n2yp+2TYxZI8Z//N9E=

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-auth/resources/cognito-cma-clients.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-auth/resources/cognito-cma-clients.tf
@@ -1,51 +1,3 @@
-resource "aws_cognito_user_pool_client" "maat_dev" {
-  name                                 = var.cognito_user_pool_maat_client_name_dev
-  user_pool_id                         = aws_cognito_user_pool.cma_user_pool.id
-  explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  allowed_oauth_flows                  = ["client_credentials"]
-  allowed_oauth_flows_user_pool_client = true
-  allowed_oauth_scopes                 = aws_cognito_resource_server.cma_resource_server.scope_identifiers
-  prevent_user_existence_errors        = "ENABLED"
-  supported_identity_providers         = ["COGNITO"]
-  generate_secret                      = true
-}
-
-resource "aws_cognito_user_pool_client" "maat_client_tst" {
-  name                                 = var.cognito_user_pool_maat_client_name_tst
-  user_pool_id                         = aws_cognito_user_pool.cma_user_pool.id
-  explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  allowed_oauth_flows                  = ["client_credentials"]
-  allowed_oauth_flows_user_pool_client = true
-  allowed_oauth_scopes                 = aws_cognito_resource_server.cma_resource_server.scope_identifiers
-  prevent_user_existence_errors        = "ENABLED"
-  supported_identity_providers         = ["COGNITO"]
-  generate_secret                      = true
-}
-
-resource "aws_cognito_user_pool_client" "maat_client_uat" {
-  name                                 = var.cognito_user_pool_maat_client_name_uat
-  user_pool_id                         = aws_cognito_user_pool.cma_user_pool.id
-  explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  allowed_oauth_flows                  = ["client_credentials"]
-  allowed_oauth_flows_user_pool_client = true
-  allowed_oauth_scopes                 = aws_cognito_resource_server.cma_resource_server.scope_identifiers
-  prevent_user_existence_errors        = "ENABLED"
-  supported_identity_providers         = ["COGNITO"]
-  generate_secret                      = true
-}
-
-resource "aws_cognito_user_pool_client" "maat_client_prd" {
-  name                                 = var.cognito_user_pool_maat_client_name_prd
-  user_pool_id                         = aws_cognito_user_pool.cma_user_pool.id
-  explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  allowed_oauth_flows                  = ["client_credentials"]
-  allowed_oauth_flows_user_pool_client = true
-  allowed_oauth_scopes                 = aws_cognito_resource_server.cma_resource_server.scope_identifiers
-  prevent_user_existence_errors        = "ENABLED"
-  supported_identity_providers         = ["COGNITO"]
-  generate_secret                      = true
-}
-
 # CFE Crime
 
 resource "aws_cognito_user_pool_client" "cfe_client_dev" {
@@ -218,8 +170,6 @@ resource "kubernetes_secret" "aws_cognito_user_pool_cma_dev" {
     namespace = var.namespace
   }
   data = {
-    maat_client_id     = aws_cognito_user_pool_client.maat_dev.id
-    maat_client_secret = aws_cognito_user_pool_client.maat_dev.client_secret
     cfe_client_id     = aws_cognito_user_pool_client.cfe_client_dev.id
     cfe_client_secret = aws_cognito_user_pool_client.cfe_client_dev.client_secret
     functional_tests_client_id = aws_cognito_user_pool_client.functional_tests_client.id
@@ -235,8 +185,6 @@ resource "kubernetes_secret" "aws_cognito_user_pool_cma_tst" {
     namespace = var.namespace
   }
   data = {
-    maat_client_id     = aws_cognito_user_pool_client.maat_client_tst.id
-    maat_client_secret = aws_cognito_user_pool_client.maat_client_tst.client_secret
     cfe_client_id     = aws_cognito_user_pool_client.cfe_client_tst.id
     cfe_client_secret = aws_cognito_user_pool_client.cfe_client_tst.client_secret
     functional_tests_client_id = aws_cognito_user_pool_client.functional_tests_client.id
@@ -252,8 +200,6 @@ resource "kubernetes_secret" "aws_cognito_user_pool_cma_uat" {
     namespace = var.namespace
   }
   data = {
-    maat_client_id     = aws_cognito_user_pool_client.maat_client_uat.id
-    maat_client_secret = aws_cognito_user_pool_client.maat_client_uat.client_secret
     cfe_client_id     = aws_cognito_user_pool_client.cfe_client_uat.id
     cfe_client_secret = aws_cognito_user_pool_client.cfe_client_uat.client_secret
     functional_tests_client_id = aws_cognito_user_pool_client.functional_tests_client.id
@@ -269,8 +215,6 @@ resource "kubernetes_secret" "aws_cognito_user_pool_cma_prd" {
     namespace = var.namespace
   }
   data = {
-    maat_client_id     = aws_cognito_user_pool_client.maat_client_prd.id
-    maat_client_secret = aws_cognito_user_pool_client.maat_client_prd.client_secret
     cfe_client_id     = aws_cognito_user_pool_client.cfe_client_prd.id
     cfe_client_secret = aws_cognito_user_pool_client.cfe_client_prd.client_secret
     functional_tests_client_id = aws_cognito_user_pool_client.functional_tests_client.id


### PR DESCRIPTION
The MAAT application no longer needs to call the CMA microservice to process mean assessments as this is being handled through the Orchestration microservice now. So I have removed the MAAT clients for each environment from the CMA Cognito user pool.