### PR TITLE
chore: fix rds version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
@@ -11,7 +11,7 @@ module "submitter-rds-instance-2" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.5"
+  db_engine_version          = "15.7"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -11,7 +11,7 @@ module "user-datastore-rds-instance-2" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.5"
+  db_engine_version          = "15.7"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
   db_allocated_storage       = "100"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -11,7 +11,7 @@ module "user-datastore-rds-instance-2" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.7"
+  db_engine_version          = "15.5"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
   db_allocated_storage       = "100"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-history.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-history.tf
@@ -17,7 +17,7 @@ module "rds-history" {
 
   # change the postgres version as you see fit.
   prepare_for_major_upgrade = false
-  db_engine_version         = "15.5"
+  db_engine_version         = "15.7"
 
   environment_name          = var.environment
   infrastructure_support    = var.infrastructure_support

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
@@ -10,7 +10,7 @@ module "dps_rds" {
   application              = var.application
   is_production            = var.is_production
   namespace                = var.namespace
-  db_engine_version        = "15.5"
+  db_engine_version        = "15.7"
   db_instance_class        = "db.t4g.micro"
   db_max_allocated_storage = "500" # maximum storage for autoscaling
   environment_name         = var.environment_name


### PR DESCRIPTION
fix below error

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b/builds/3333#L66be2760:19667

```
FATA[2036] error running terraform on namespace formbuilder-platform-live-production: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-83a92686e95e340d): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 4964ad67-509d-4b9c-b000-cc9cc4d88874, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.5

  with module.submitter-rds-instance-2.aws_db_instance.rds,
  on .terraform/modules/submitter-rds-instance-2/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {


Error: updating RDS DB Instance (cloud-platform-0de5d47b58e993d4): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 25db879d-172b-4268-9e88-0ed435cc403d, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.5

  with module.user-datastore-rds-instance-2.aws_db_instance.rds,
  on .terraform/modules/user-datastore-rds-instance-2/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {

```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d/builds/3334#L66be277e:6881
```
2024/09/12 10:36:40 Running Terraform Apply for namespace: hmpps-workload-prod
FATA[1048] error running terraform on namespace hmpps-workload-prod: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-a0e237161da3b955): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: e4e7785a-2d27-45ce-bea1-39b0f83be636, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.5

  with module.rds-history.aws_db_instance.rds,
  on .terraform/modules/rds-history/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-e/builds/3338#L66be2788:12200
```
2024/09/12 10:50:31 Running Terraform Apply for namespace: manage-soc-cases-dev
FATA[1876] error running terraform on namespace manage-soc-cases-dev: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-67fca2282ccae5f3): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 60a07a61-329b-43b1-a5aa-ea7491a8188f, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.5

  with module.dps_rds.aws_db_instance.rds,
  on .terraform/modules/dps_rds/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {


```