### PR TITLE
chore: 🤖 no-ops: bump elasticache module for eks subnet sgs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/bh-app-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/bh-app-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/redis.tf
@@ -3,7 +3,7 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/redis.tf
@@ -3,7 +3,7 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-api-sandbox/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/elasticache.tf
@@ -6,7 +6,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-staging/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "check_my_diary_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "check_my_diary_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chux-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chux-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact_moj_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact_moj_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact_moj_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pac_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pac_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pac_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test1/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test1/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test2/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test2/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/elasticcache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/elasticcache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/elasticcache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/resources/elasticcache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-daap-api/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-daap-api/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/service_token_cache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/service_token_cache.tf
@@ -4,7 +4,7 @@ locals {
 
 
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/service_token_cache.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-preprod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hwpv_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hwpv_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hwpv_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-for-early-release-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-for-early-release-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-handover-service-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-handover-service-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assess_risks_and_needs_handover_service_dev_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-handover-service-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-handover-service-test/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assess_risks_and_needs_handover_service_test_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assessments_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   team_name               = var.team_name
   namespace               = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assessments_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   team_name               = var.team_name
   namespace               = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assessments_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   team_name               = var.team_name
   namespace               = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-authorization-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-authorization-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_book_video_link_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_book_video_link_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-video-link-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_book_video_link_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "candidate_matching_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "candidate_matching_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "candidate_matching_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-contacts-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-contacts-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-custody-manager-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-custody-manager-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_digital_prison_reporting_mi_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_digital_prison_reporting_mi_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_digital_prison_reporting_mi_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-test/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_digital_prison_reporting_mi_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_dpr_fake_dps_service_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_dpr_dpr_tools_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-test/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_dpr_dpr_tools_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "education_work_plan_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "education_work_plan_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prod/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prod/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "education_work_plan_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_ems_cemo_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_ems_cemo_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_ems_cemo_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-hpa-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-hpa-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_interventions_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_interventions_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_interventions_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-it-incident-hub-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-staging/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-a-supervision-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_manage_adjudications" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_manage_adjudications" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_manage_adjudications" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_intelligence_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_intelligence_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-stage/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-stage/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_intelligence_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-test/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_intelligence_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "mercury_submit_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "mercury_submit_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "mercury_submit_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-test/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "mercury_submit_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pecs-profile-ui-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pecs-profile-ui-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pecs-profile-ui-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pecs-profile-ui-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pecs-profile-ui-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pecs-profile-ui-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "pcms_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "pcms_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-qa/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "pcms_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "csc_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "csc_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "csc_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application_sync_dashboard
   environment_name        = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application_sync_dashboard
   environment_name        = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application_sync_dashboard
   environment_name        = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-casenotes-search-prototype/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-casenotes-search-prototype/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-record-a-recall-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-record-a-recall-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-record-a-recall-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-record-a-recall-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_registers_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.hmpps-registers-application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_registers_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.hmpps-registers-application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_registers_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.hmpps-registers-application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/elasticache-backend.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/elasticache-backend.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "backend_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/elasticache-backend.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/elasticache-backend.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "backend_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/elasticache-backend.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/elasticache-backend.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "backend_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_restricted_patients" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_restricted_patients" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_restricted_patients" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_strengths_based_needs_assessments_dev_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   namespace              = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_strengths_based_needs_assessments_preprod_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   namespace              = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_strengths_based_needs_assessments_prod_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   namespace              = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-test/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_strengths_based_needs_assessments_test_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   namespace              = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/elasticache.tf
@@ -1,6 +1,6 @@
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-preprod/resources/elasticache.tf
@@ -1,6 +1,6 @@
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/james-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/james-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   team_name              = "apply-for-legal-aid"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   team_name              = "apply-for-legal-aid"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "crm_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-uat/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "crm_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.application
   namespace              = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.application
   namespace              = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.application
   namespace              = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa-check-client-qualifies-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-staging/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa-check-client-qualifies-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-uat/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa-check-client-qualifies-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "lcdui_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "lcdui_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "lcdui_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-uat/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "lcdui_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-production/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "crm_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-uat/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "crm_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-archive/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-archive/resources/elasticcache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-dev/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-dev/resources/elasticcache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-prod/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-prod/resources/elasticcache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-staging/resources/eleasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-staging/resources/eleasticcache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-uat/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-uat/resources/elasticcache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-staging/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-uat/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "crm_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-uat/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "crm_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "licences_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "licences_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "licences_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_intelligence_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_soc_cases_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_soc_cases_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_soc_cases_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "oc_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "oc_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "oc_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "offender_events_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-offender-management-allocation-manager" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   application            = "offender-management-allocation-manager"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-offender-management-allocation-manager" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   application            = "offender-management-allocation-manager"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-offender-management-allocation-manager" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   node_type              = "cache.t4g.small"
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "parliamentary_questions_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "parliamentary_questions_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "parliamentary_questions_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pathfinder_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pathfinder_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pathfinder_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-prison-visits-booking-staff" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   team_name               = var.team_name
   application             = "prison-visits-booking-staff"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec-cluster-prison-visits-booking-staff" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "drupal_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -37,7 +37,7 @@ resource "kubernetes_secret" "drupal_redis" {
 }
 
 module "frontend_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "drupal_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -37,7 +37,7 @@ resource "kubernetes_secret" "drupal_redis" {
 }
 
 module "frontend_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "drupal_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -37,7 +37,7 @@ resource "kubernetes_secret" "drupal_redis" {
 }
 
 module "frontend_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/san-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/san-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-api.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_api_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-staff-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-staff-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_staff_ui_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/elasticache-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/elasticache-api.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_api_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/elasticache-staff-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/elasticache-staff-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_staff_ui_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/elasticache-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/elasticache-api.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_api_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/elasticache-staff-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/elasticache-staff-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_staff_ui_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "tva_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "tva_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "tva_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "uof_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "uof_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "uof_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-admin.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-admin.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_admin" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-public.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-public.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_public" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-staff.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-staff.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_staff" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/resources/elasticache-admin.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/resources/elasticache-admin.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_admin" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/resources/elasticache-public.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/resources/elasticache-public.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_public" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/resources/elasticache-staff.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-preprod/resources/elasticache-staff.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_staff" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/resources/elasticache-admin.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/resources/elasticache-admin.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_admin" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/resources/elasticache-public.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/resources/elasticache-public.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_public" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/resources/elasticache-staff.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-prod/resources/elasticache-staff.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_staff" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/resources/elasticache-admin.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/resources/elasticache-admin.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_admin" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/resources/elasticache-public.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/resources/elasticache-public.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_public" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/resources/elasticache-staff.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-staging/resources/elasticache-staff.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_staff" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.1.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment


### PR DESCRIPTION
relates to ministryofjustice/cloud-platform#6030

[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/releases/tag/7.1.0)