### PR TITLE
fix: update rds version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
@@ -10,7 +10,7 @@ module "submitter-rds-instance-2" {
   infrastructure_support     = var.infrastructure_support
   team_name                  = var.team_name
   business_unit              = "Platforms"
-  db_engine_version          = "15.5"
+  db_engine_version          = "15.7"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
@@ -17,7 +17,7 @@ module "allocation-rds" {
   environment_name            = "production"
   infrastructure_support      = "manage-pom-cases@digital.justice.gov.uk"
   db_engine                   = "postgres"
-  db_engine_version           = "15.6"
+  db_engine_version           = "15.7"
   rds_family                  = "postgres15"
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false


### PR DESCRIPTION
fix below error

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b/builds/3335#L66be2b55:18392

```
FATA[1878] error running terraform on namespace formbuilder-platform-test-dev: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-49237c541a078a82): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 5f7c1bd4-73bb-44c2-9c6a-eb462f73b866, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.5

  with module.submitter-rds-instance-2.aws_db_instance.rds,
  on .terraform/modules/submitter-rds-instance-2/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {

```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-e/builds/3340#L66be2b69:17068
```
FATA[2518] error running terraform on namespace offender-management-production: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-0fe5d72ea3e106e5): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: f08fa376-98a4-4d4f-b890-2d99be6e491f, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.6

  with module.allocation-rds.aws_db_instance.rds,
  on .terraform/modules/allocation-rds/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {

```