### PR TITLE
fix: update rds version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/editor.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/editor.tf
@@ -11,7 +11,7 @@ module "editor-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = false
-  db_engine_version          = "15.5"
+  db_engine_version          = "15.7"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 


### PR DESCRIPTION
fix below error

```
2024/09/12 14:35:13 Running Terraform Apply for namespace: formbuilder-saas-live
FATA[2340] error running terraform on namespace formbuilder-saas-live: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-82ad2a679533ec45): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 403460df-abc9-4698-8e8a-a306f27c2837, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.5

  with module.editor-rds-instance.aws_db_instance.rds,
  on .terraform/modules/editor-rds-instance/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {

```
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b/builds/3336#L66be2c84:20239