### PR TITLE
fix: update rds version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-test/resources/editor.tf
@@ -11,7 +11,7 @@ module "editor-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = false
-  db_engine_version          = "15.5"
+  db_engine_version          = "15.7"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 


### PR DESCRIPTION
fix below error

```
2024/09/12 15:15:46 Running Terraform Apply for namespace: formbuilder-saas-test
FATA[2387] error running terraform on namespace formbuilder-saas-test: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-39a50b9fc8f3c40b): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 153feb49-ee66-4e01-b3fc-2d461eadd12b, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.5

  with module.editor-rds-instance.aws_db_instance.rds,
  on .terraform/modules/editor-rds-instance/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {

```
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b/builds/3337#L66be2dbb:20208