### PR TITLE
fix: update rds version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
@@ -11,7 +11,7 @@ module "rds" {
   infrastructure_support = var.email
 
   db_engine                    = "postgres"
-  db_engine_version            = "14.10"
+  db_engine_version            = "14.12"
   db_instance_class            = "db.t3.small"
   db_allocated_storage         = "5"
   db_name                      = "datacaptureservice"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -11,7 +11,7 @@ module "hmcts-complaints-adapter-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
 
-  db_engine_version        = "14.10"
+  db_engine_version        = "14.12"
   rds_family               = "postgres14"
   db_instance_class        = "db.t4g.micro"
   db_max_allocated_storage = "500" # maximum storage for autoscaling

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-prod/resources/rds.tf
@@ -28,7 +28,7 @@ module "rds" {
   db_engine = "postgres"
 
   # change the postgres version as you see fit.
-  db_engine_version = "14.10"
+  db_engine_version = "14.12"
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.small"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -69,7 +69,7 @@ module "prison_visit_booker_registry_rds" {
   allow_major_version_upgrade = "false"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "15.5"
+  db_engine_version           = "15.7"
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "10000"


### PR DESCRIPTION
fix below error
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-a/builds/3356#L66be367f:8869

```
2024/09/13 08:47:05 Running Terraform Apply for namespace: claim-criminal-injuries-compensation-dev
FATA[1345] error running terraform on namespace claim-criminal-injuries-compensation-dev: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-ed3ba666ad23a2d9): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: e3c17579-e551-4d91-a142-a61b872a6f56, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.10

  with module.rds.aws_db_instance.rds,
  on .terraform/modules/rds/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b/builds/3347#L66be3693:24284
```
2024/09/13 09:08:58 Running Terraform Apply for namespace: hmcts-complaints-formbuilder-adapter-staging
FATA[2643] error running terraform on namespace hmcts-complaints-formbuilder-adapter-staging: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-0e706258a5046b1b): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 806dc2b3-dd6a-4625-af64-dcddc70150e4, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.10

  with module.hmcts-complaints-adapter-rds-instance.aws_db_instance.rds,
  on .terraform/modules/hmcts-complaints-adapter-rds-instance/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d/builds/3347#L66be3689:25368
```
2024/09/13 09:23:32 Running Terraform Apply for namespace: laa-crime-means-assessment-prod
FATA[3522] error running terraform on namespace laa-crime-means-assessment-prod: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-a3e934020e9774ed): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: a0aaa1ad-b638-4b4b-b910-dfffa81688fc, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.10

  with module.rds.aws_db_instance.rds,
  on .terraform/modules/rds/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-e/builds/3353#L66be3675:30560
```
2024/09/13 09:40:45 Running Terraform Apply for namespace: visit-someone-in-prison-backend-svc-preprod
FATA[4551] error running terraform on namespace visit-someone-in-prison-backend-svc-preprod: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-dda6d077d1df7076): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 320db500-9ed2-4633-97ba-d6fb303c73d2, api error InvalidParameterCombination: Cannot upgrade postgres from 15.7 to 15.5

  with module.prison_visit_booker_registry_rds.aws_db_instance.rds,
  on .terraform/modules/prison_visit_booker_registry_rds/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {
```