### PR TITLE
fix: update rds version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/variables.tf
@@ -43,7 +43,7 @@ variable "db_engine" {
 }
 
 variable "db_engine_version" {
-  default = "14.11"
+  default = "14.12"
 }
 
 variable "db_instance_class" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/rds.tf
@@ -18,7 +18,7 @@ module "rds_alfresco" {
   # PostgreSQL specifics
   db_engine                 = "postgres"
   prepare_for_major_upgrade = false
-  db_engine_version         = "14.10"
+  db_engine_version         = "14.12"
   rds_family                = "postgres14"
   db_instance_class         = "db.m7g.xlarge"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds-mtn" {
 
   # Database configuration
   db_engine                = "oracle-se2"
-  db_engine_version        = "19.0.0.0.ru-2024-04.rur-2024-04.r1"
+  db_engine_version        = "19.0.0.0.ru-2024-07.rur-2024-07.r1"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.medium"
   db_allocated_storage     = "300"


### PR DESCRIPTION
fix below error
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-a/builds/3358#L66be3c51:12607
```
2024/09/13 12:57:49 Running Terraform Apply for namespace: court-probation-dev
FATA[1875] error running terraform on namespace court-probation-dev: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-aaade99b4f658d25): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 113f7549-66a0-4161-9c64-bbcd63773fa0, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.11

  with module.court_case_service_rds.aws_db_instance.rds,
  on .terraform/modules/court_case_service_rds/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b/builds/3348#L66be38b5:37160
```
2024/09/13 11:51:50 Running Terraform Apply for namespace: hmpps-delius-alfresco-preprod
FATA[5130] error running terraform on namespace hmpps-delius-alfresco-preprod: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-a066adb9989d7f7c): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 4de36554-8aa7-4c60-ba30-6b0bd957f948, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.10

  with module.rds_alfresco.aws_db_instance.rds,
  on .terraform/modules/rds_alfresco/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {
```
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d/builds/3348.1#L66be3af2:29912
```
2024/09/13 12:35:23 Running Terraform Apply for namespace: laa-crown-court-remuneration-dev
FATA[4290] error running terraform on namespace laa-crown-court-remuneration-dev: unable to apply Terraform: exit status 1

Error: updating RDS DB Instance (cloud-platform-bb83da2ed8245f4d): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: eb846fc4-a461-4498-a4d8-9106184a7f50, api error InvalidParameterCombination: Cannot upgrade oracle-se2 from 19.0.0.0.ru-2024-07.rur-2024-07.r1 to 19.0.0.0.ru-2024-04.rur-2024-04.r1

  with module.rds-mtn.aws_db_instance.rds,
  on .terraform/modules/rds-mtn/main.tf line 166, in resource "aws_db_instance" "rds":
 166: resource "aws_db_instance" "rds" {

```
