### PR TITLE
Adding cert for use by UI and API apps

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tst-em-example-app-jkn-dev/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tst-em-example-app-jkn-dev/05-certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-electronic-monitoring-datastore-cert
+  namespace: tst-em-example-app-jkn-dev
+spec:
+  secretName: hmpps-electronic-monitoring-datastore-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - hmpps-electronic-monitoring-datastore-api-dev.hmpps.service.justice.gov.uk
+    - hmpps-electronic-monitoring-datastore-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This cert will be used by our new UI and API apps in the dev environment.

N.B.: We will be moving to a new namespace once creating these is allowed again later this week. We anticipate this configuration will be ported over at that point.