### PR TITLE
Configure secrets for the Orchestration Service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-dev/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-dev/resources/secret.tf
@@ -80,5 +80,15 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "validation-api-oauth-client-secret"
     },
+    "ingress_internal_allowlist_source_range" = {
+      description             = "The internal IP allowlist for Orchestration Dev",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "internal-allowlist-source-range"
+    },
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for Orchestration Dev",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "sentry-dsn"
+    },
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-prod/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-prod/resources/secret.tf
@@ -85,5 +85,15 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "maat-orchestration-alert-webhook-prod"
     }
+    "ingress_internal_allowlist_source_range" = {
+      description             = "The internal IP allowlist for Orchestration Prod",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "internal-allowlist-source-range"
+    },
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for Orchestration Prod",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "sentry-dsn"
+    },
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-test/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-test/resources/secret.tf
@@ -80,5 +80,15 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "validation-api-oauth-client-secret"
     },
+    "ingress_internal_allowlist_source_range" = {
+      description             = "The internal IP allowlist for Orchestration Test",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "internal-allowlist-source-range"
+    },
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for Orchestration Test",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "sentry-dsn"
+    },
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-uat/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-uat/resources/secret.tf
@@ -80,5 +80,15 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "validation-api-oauth-client-secret"
     },
+    "ingress_internal_allowlist_source_range" = {
+      description             = "The internal IP allowlist for Orchestration UAT",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "internal-allowlist-source-range"
+    },
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for Orchestration UAT",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "sentry-dsn"
+    },
   }
 }


### PR DESCRIPTION
This PR configures two new secrets for the Orchestration Service to capture the Sentry DSN and internal IP address allowlist. Making these secrets available via Secrets Manager is part of refactoring to remove the use of git-crypt from the Orchestration Service.