### PR TITLE
Configure secrets for the Orchestration Service UAT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-uat/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-uat/resources/secret.tf
@@ -80,5 +80,20 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "validation-api-oauth-client-secret"
     },
+    "ingress_external_allowlist_source_range" = {
+      description             = "The external IP allowlist for Orchestration UAT",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "ingress-external-allowlist-source-range"
+    },
+    "ingress_internal_allowlist_source_range" = {
+      description             = "The internal IP allowlist for Orchestration UAT",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "ingress-internal-allowlist-source-range"
+    },
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for Orchestration UAT",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "sentry-dsn"
+    },
   }
 }


### PR DESCRIPTION
This PR configures three new secrets for the production Orchestration Service to capture the Sentry DSN and IP address allowlists. Making these secrets available via Secrets Manager is part of refactoring to remove the use of git-crypt from the Orchestration Service.

[Link to Story](https://dsdmoj.atlassian.net/browse/LCAM-1562)