### PR TITLE
Remove repeated service account name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/elliotsmith-rnd-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/elliotsmith-rnd-dev/resources/serviceaccount.tf
@@ -4,8 +4,6 @@ module "serviceaccount" {
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
 
-  serviceaccount_name = "serviceaccount-${var.namespace}"
-
   serviceaccount_token_rotated_date = "01-01-2000"
 
   # Uncomment and provide repository names to create github actions secrets


### PR DESCRIPTION
Remove manually-named service account and use the default name. This service account is used by github, so we don't need to pay any attention to it.

Keep the custom name in irsa.tf only, as this is the service account we'll use to talk to AWS from the application running in the Kubernetes namespace.