### PR TITLE
Fix typo in secret name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-prod/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-orchestration-prod/resources/secret.tf
@@ -86,7 +86,7 @@ module "secrets_manager" {
       k8s_secret_name         = "maat-orchestration-alert-webhook-prod"
     },
     "ingress_external_allowlist_source_range" = {
-      description             = "The external IP allowlist for Orchestration Test",
+      description             = "The external IP allowlist for Orchestration Prod",
       recovery_window_in_days = 7,
       k8s_secret_name         = "ingress-external-allowlist-source-range"
     },


### PR DESCRIPTION
This PR fixes a typo in the `ingress_external_allowlist_source_range` for the `laa-maat-orchestration-prod` namespace.