### PR TITLE
chore: bump test rds storage for io2 storage type

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/rds.tf
@@ -11,7 +11,7 @@ module "rds" {
   db_max_allocated_storage     = "500"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
-  maintenance_window           = "Fri:17:00-Fri:17:30"
+  maintenance_window           = "Mon:11:00-Mon:11:30"
   storage_type                 = "io2"
   apply_immediately            = false
   db_iops                      = "3000"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/rds.tf
@@ -15,7 +15,7 @@ module "rds" {
   storage_type                 = "io2"
   apply_immediately            = false
   db_iops                      = "3000"
-  db_allocated_storage         = "20"
+  db_allocated_storage         = "100"
 
   # PostgreSQL specifics
   db_engine         = "postgres"


### PR DESCRIPTION
- seems minimum storage for io2 is 100 GiB for PostgreSQL
![image](https://github.com/user-attachments/assets/ecec8e97-3323-45d0-8a78-ad198da788f2)

- will delete the rds after testing