### PR TITLE
BAVL-41 subcribing to a new video link bookings migration event raised by the whereabouts-api.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
@@ -113,7 +113,8 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
       "book-a-video-link.video-booking.cancelled",
       "book-a-video-link.appointment.created",
       "prisoner-offender-search.prisoner.released",
-      "prison-offender-events.prisoner.merged"
+      "prison-offender-events.prisoner.merged",
+      "whereabouts-api.videolink.migrate"
     ]
   })
 }


### PR DESCRIPTION
This changes adds the subscription to a new domain event raised by the whereabouts-api to support the migration of video bookings from old BVLS into the new re-platformed version of BVLS.