### PR TITLE
BAVL-41 add ability to publish to the domain events topic (primarily for migration domain events to be used by re-platformed BVLS).

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/domain-events-topic.tf
@@ -1,0 +1,14 @@
+resource "kubernetes_secret" "whereabouts_api_domain_events_topic" {
+  metadata {
+    name      = "hmpps-domain-events-topic"
+    namespace = var.namespace
+  }
+
+  data = {
+    topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
+  }
+}
+
+data "aws_ssm_parameter" "hmpps-domain-events-topic-arn" {
+  name = "/hmpps-domain-events-${var.environment}/topic-arn"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/irsa.tf
@@ -8,7 +8,14 @@ locals {
     "Digital-Prison-Services-dev-whereabouts_api_domain_events_queue"    = "hmpps-domain-events-dev"
     "Digital-Prison-Services-dev-whereabouts_api_domain_events_queue_dl" = "hmpps-domain-events-dev"
   }
+
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns : item.name => item.value }
+  sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
+
+  # The names of the SNS topics used and the namespace which created them
+  sns_topics = {
+    "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev"
+  }
 }
 
 module "irsa" {
@@ -17,7 +24,7 @@ module "irsa" {
   eks_cluster_name     = var.eks_cluster_name
   namespace            = var.namespace
   service_account_name = var.application
-  role_policy_arns     = local.sqs_policies
+  role_policy_arns     = merge(local.sqs_policies, local.sns_policies)
   # Tags
   business_unit          = var.business_unit
   application            = var.application
@@ -30,4 +37,21 @@ module "irsa" {
 data "aws_ssm_parameter" "irsa_policy_arns" {
   for_each = local.sqs_queues
   name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
+}
+
+data "aws_ssm_parameter" "irsa_policy_arns_sns" {
+  for_each = local.sns_topics
+  name     = "/${each.value}/sns/${each.key}/irsa-policy-arn"
+}
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "irsa-output"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+    rolearn        = module.irsa.role_arn
+  }
 }


### PR DESCRIPTION
Second attempt, was missing some policy off the original PR [here](https://github.com/ministryofjustice/cloud-platform-environments/pull/26161).

whereabouts-api needs to publish a new domain event for migration of data to a new service which subscribes to the event.

This change permits whereabouts to raise domain based events (in dev initially).
