### PR TITLE
TM-517, adding LAA production VPC CIDR to CCR Staging and UAT RDS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/resources/rds.tf
@@ -113,6 +113,24 @@ resource "aws_security_group_rule" "rule4" {
   security_group_id = aws_security_group.rds.id
 }
 
+resource "aws_security_group_rule" "rule5" {
+  cidr_blocks       = ["10.205.0.0/20"]
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 1521
+  to_port           = 1521
+  security_group_id = aws_security_group.rds.id
+}
+
+resource "aws_security_group_rule" "rule6" {
+  cidr_blocks       = ["10.205.0.0/20"]
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 1521
+  to_port           = 1521
+  security_group_id = aws_security_group.rds.id
+}
+
 resource "kubernetes_secret" "rds-instance" {
   metadata {
     name      = "rds-ccr-${var.environment}"


### PR DESCRIPTION
Adding LAA Production VPC CIDR to CCR Staging and UAT RDS so that the windows EC2 instance I created in LAA Production can be used to access the DBs in CP. https://dsdmoj.atlassian.net/browse/TM-517 