### PR TITLE
PIC-4134 Rename irsa modules in PreProd

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/irsa.tf
@@ -10,7 +10,7 @@ locals {
   sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
 }
 
-module "irsa" {
+module "court-facing-api-irsa" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
 
   # EKS configuration
@@ -39,7 +39,7 @@ module "irsa" {
   infrastructure_support = var.infrastructure_support
 }
 
-module "court-case-service-irsa" {
+module "irsa" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
 
   # EKS configuration

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/service-pod.tf
@@ -2,12 +2,12 @@ module "court-case-service_pod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.0.1"
 
   namespace            = var.namespace
-  service_account_name = module.court-case-service-irsa.service_account.name
+  service_account_name = module.irsa.service_account.name
 }
 
 module "court-facing-api-service_pod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.0.1"
 
   namespace            = var.namespace
-  service_account_name = module.irsa.service_account.name
+  service_account_name = module.court-facing-api-irsa.service_account.name
 }


### PR DESCRIPTION
Rename the irsa modules in **PreProd**. This keeps the irsa module unchanged with a new custom irsa module created.