### PR TITLE
Fix: rds version mismatch in aaf-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/aaf-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/aaf-dev/resources/rds-postgresql.tf
@@ -20,7 +20,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.0"
+  db_engine_version = "16.1"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
 


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.1 to 16.0
 ```

