### PR TITLE
Fix: rds version mismatch in laa-check-client-qualifies-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-staging/resources/rds.tf
@@ -24,7 +24,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "14.10"
+  db_engine_version = "14.12"
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.small"


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 14.12 to 14.10
 ```

