### PR TITLE
Fix: rds version mismatch in hmpps-book-secure-move-api-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -105,7 +105,7 @@ module "rds-read-replica" {
   skip_final_snapshot        = "true"
   db_backup_retention_period = 0
 
-  db_engine_version = "16.2"
+  db_engine_version = "16.3"
   rds_family        = "postgres16"
 
   providers = {


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.3 to 16.2
 ```

