### PR TITLE
BAVL-41 add ability to publish to the domain events topic in preprod (primarily for migration domain events to be used by re-platformed BVLS).

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/domain-events-topic.tf
@@ -1,0 +1,14 @@
+resource "kubernetes_secret" "whereabouts_api_domain_events_topic" {
+  metadata {
+    name      = "hmpps-domain-events-topic"
+    namespace = var.namespace
+  }
+
+  data = {
+    topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
+  }
+}
+
+data "aws_ssm_parameter" "hmpps-domain-events-topic-arn" {
+  name = "/hmpps-domain-events-${var.environment}/topic-arn"
+}


### PR DESCRIPTION
whereabouts-api needs to publish a new domain event for migration of data to a new service which subscribes to the event.

This change permits whereabouts to raise domain based events in preprod.
