### PR TITLE
Fix: rds version mismatch in laa-court-data-adaptor-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds-instance.tf
@@ -10,7 +10,7 @@ module "court_data_adaptor_rds" {
   environment_name       = "prod"
   infrastructure_support = var.infrastructure_support
   rds_family             = "postgres14"
-  db_engine_version      = "14.10"
+  db_engine_version      = "14.12"
 
   allow_major_version_upgrade = "true"
   db_instance_class           = "db.t4g.small"


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 14.12 to 14.10
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d