### PR TITLE
Fix: rds version mismatch in hmpps-launchpad-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/rds-launchpad-auth-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/rds-launchpad-auth-postgresql.tf
@@ -20,7 +20,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.2"
+  db_engine_version = "16.3"
   rds_family        = "postgres16"
   backup_window     = "02:00-04:00"
   db_instance_class = "db.t4g.large"


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.3 to 16.2
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-c