### PR TITLE
Fix: rds version mismatch in hmpps-complexity-of-need-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds" {
   environment_name         = var.environment
   infrastructure_support   = var.infrastructure_support
 
-  db_engine_version           = "15.6"
+  db_engine_version           = "15.7"
   rds_family                  = "postgres15"
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.7 to 15.6
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b