### PR TITLE
[HMRC Interface Production] Rotate CircleCI service account secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/serviceaccount.tf
@@ -4,7 +4,8 @@ module "serviceaccount" {
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
 
-  serviceaccount_name = "circleci"
+  serviceaccount_name = "circleci-migrated"
+  serviceaccount_token_rotated_date = "27-09-2024"
 
   serviceaccount_rules = [
     {


### PR DESCRIPTION
Rotate CircleCI service account secrets

This does not seem to have been migrated back in february
and the dd_mm_yyyy secret created 427+ days ago is not being used.

Current CI is using the oldest service account and getting the
```
Use tokens from the TokenRequest API or manually created secret-based tokens instead of auto-generated secret-based tokens.
```