### PR TITLE
Remove old cccd-dev SQS IAM ARNs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/irsa.tf
@@ -14,10 +14,10 @@ module "irsa" {
   role_policy_arns = {
     s3              = module.cccd_s3_bucket.irsa_policy_arn
     sns_submitted   = module.cccd_claims_submitted.irsa_policy_arn
-#    sqs_ccr         = module.claims_for_ccr.irsa_policy_arn
+    sqs_ccr         = module.claims_for_ccr.irsa_policy_arn
     sqs_cclf        = module.claims_for_cclf.irsa_policy_arn
     sqs_responses   = module.responses_for_cccd.irsa_policy_arn
-#    sqs_ccr_dlq     = module.ccr_dead_letter_queue.irsa_policy_arn
+    sqs_ccr_dlq     = module.ccr_dead_letter_queue.irsa_policy_arn
     sqs_cclf_dlq    = module.cclf_dead_letter_queue.irsa_policy_arn
     sqs_respons_dlq = module.cccd_response_dead_letter_queue.irsa_policy_arn
     rds             = module.cccd_rds.irsa_policy_arn

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/messaging.tf
@@ -127,7 +127,6 @@ resource "aws_sqs_queue_policy" "claims_for_cclf_policy" {
           "Effect": "Allow",
           "Principal": {
           "AWS": [
-            "arn:aws:iam::411213865113:role/LAA-CCLF-development-AppInfrastructureT-AppEc2Role-ADMNU7CYTI7R",
             "arn:aws:iam::754256621582:role/cloud-platform-irsa-de9466b31f4c736e-live"
               ]
           },
@@ -180,33 +179,6 @@ EOF
   providers = {
     aws = aws.london
   }
-}
-
-resource "aws_sqs_queue_policy" "responses_for_cccd" {
-  queue_url = module.responses_for_cccd.sqs_id
-
-  policy = <<EOF
-  {
-    "Version": "2012-10-17",
-    "Id": "${module.responses_for_cccd.sqs_arn}/SQSDefaultPolicy",
-    "Statement":
-      [
-        {
-          "Sid": "LandingZonePolicy",
-          "Effect": "Allow",
-          "Principal": {
-          "AWS": [
-            "arn:aws:iam::411213865113:role/LAA-CCLF-development-AppInfrastructureT-AppEc2Role-ADMNU7CYTI7R"
-              ]
-          },
-          "Resource": "${module.responses_for_cccd.sqs_arn}",
-          "Action": "sqs:SendMessage"
-        }
-      ]
-  }
-
-EOF
-
 }
 
 module "ccr_dead_letter_queue" {


### PR DESCRIPTION
These relate to the LAA Landing Zone CCLF dev environment which is no longer in use, following migration of the CCLF application to Cloud Platform