### PR TITLE
Exclude infinities from latency alert expression

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/05-prometheusrule.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/05-prometheusrule.yaml
@@ -80,9 +80,11 @@ spec:
             message: The average latency for view '{{ $labels.method }}' method '{{ $labels.view }}' has been above 3 seconds for a 5 minute period."
             runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
           expr: >-
-            rate(django_http_requests_latency_seconds_by_view_method_sum{namespace='data-platform-find-moj-data-prod',method='GET'}[1m])/
+            (rate(django_http_requests_latency_seconds_by_view_method_sum{namespace='data-platform-find-moj-data-prod',method='GET'}[1m])/
             rate(django_http_requests_latency_seconds_by_view_method_count{namespace='data-platform-find-moj-data-prod',method='GET'}[1m])
-            > 3
+            > 3) and (rate(django_http_requests_latency_seconds_by_view_method_sum{namespace='data-platform-find-moj-data-prod',method='GET'}[1m])/
+            rate(django_http_requests_latency_seconds_by_view_method_count{namespace='data-platform-find-moj-data-prod',method='GET'}[1m])
+            < +Inf)
           for: 5m
           labels:
             severity: find-moj-data-prod


### PR DESCRIPTION
We were computing an average by dividing the sum by the count. The count can be zero.

If the sum is 0, the expression returns NaN, and the comparison returns false.

But if the sum is non-zero, it gives +Inf, and we get an alert.

I'm not sure why we would have data points with 0 for the count, and non-zero for the sum, but we are definitely getting +Inf values and unwanted alerts, so I'm explicitly filtering out +Inf (if anyone knows a better way of fixing this, please let me know!)