### PR TITLE
Correct Template Naming and Removed Skip File

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-certificate-form/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-certificate-form/resources/variables.tf
@@ -6,7 +6,7 @@ variable "vpc_name" {
 variable "github_repository_name" {
   description = "The name of the GitHub repository"
   type        = string
-  default     = "opertions-engineering-flask-template"
+  default     = "operations-engineering-flask-template"
 }
 
 variable "kubernetes_cluster" {


### PR DESCRIPTION
Missing 'a' from autogenerated Terraform template name.