### PR TITLE
Remove redundant sqs config from test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/messaging-queues.tf
@@ -147,80 +147,6 @@ module "unlink_queue_dead_letter_queue" {
   }
 }
 
-module "laa_status_update_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
-
-  # Queue configuration
-  sqs_name                  = "laa-status-update-queue"
-  encrypt_sqs_kms           = var.encrypt_sqs_kms
-  message_retention_seconds = var.message_retention_seconds
-
-  redrive_policy = <<EOF
-  {
-    "deadLetterTargetArn": "${module.laa_status_update_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
-  }
-  EOF
-
-  # Tags
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  team_name              = var.team_name # also used for naming the queue
-  namespace              = var.namespace
-  environment_name       = var.environment_name
-  infrastructure_support = var.infrastructure_support
-
-  providers = {
-    aws = aws.london
-  }
-}
-
-resource "aws_sqs_queue_policy" "laa_status_update_queue_policy" {
-  queue_url = module.laa_status_update_queue.sqs_id
-
-  policy = <<EOF
-  {
-    "Version": "2012-10-17",
-    "Id": "${module.laa_status_update_queue.sqs_arn}/SQSDefaultPolicy",
-    "Statement":
-      [
-        {
-          "Sid": "ConsumePolicy",
-          "Effect": "Allow",
-          "Principal": {
-          "AWS": [
-            "arn:aws:iam::013163512034:role/LAA-maat-cd-api-test-ECSTaskExecutionRole-16OJF9QOHVKZ0"
-              ]
-          },
-          "Resource": "${module.laa_status_update_queue.sqs_arn}",
-          "Action": "sqs:*"
-        }
-      ]
-  }
-   EOF
-}
-
-module "laa_status_update_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
-
-  # Queue configuration
-  sqs_name        = "laa-status-update-queue-dl"
-  encrypt_sqs_kms = var.encrypt_sqs_kms
-
-  # Tags
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  team_name              = var.team_name # also used for naming the queue
-  namespace              = var.namespace
-  environment_name       = var.environment_name
-  infrastructure_support = var.infrastructure_support
-
-  providers = {
-    aws = aws.london
-  }
-}
-
 module "hearing_resulted_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
 
@@ -389,12 +315,6 @@ resource "kubernetes_secret" "create_link_queue" {
     sqs_url_d_unlink                 = module.unlink_queue_dead_letter_queue.sqs_id
     sqs_arn_d_unlink                 = module.unlink_queue_dead_letter_queue.sqs_arn
     sqs_name_d_unlink                = module.unlink_queue_dead_letter_queue.sqs_name
-    sqs_url_laa_status               = module.laa_status_update_queue.sqs_id
-    sqs_arn_laa_status               = module.laa_status_update_queue.sqs_arn
-    sqs_name_laa_status              = module.laa_status_update_queue.sqs_name
-    sqs_url_d_laa_status             = module.laa_status_update_dead_letter_queue.sqs_id
-    sqs_arn_d_laa_status             = module.laa_status_update_dead_letter_queue.sqs_arn
-    sqs_name_d_laa_status            = module.laa_status_update_dead_letter_queue.sqs_name
     sqs_url_hearing_resulted         = module.hearing_resulted_queue.sqs_id
     sqs_arn_hearing_resulted         = module.hearing_resulted_queue.sqs_arn
     sqs_name_hearing_resulted        = module.hearing_resulted_queue.sqs_name


### PR DESCRIPTION
The following is now redundant so we want to remove the config from test:
laa_status_update_queue
laa_status_update_queue_policy
laa_status_update_dead_letter_queue