### PR TITLE
Update the team that owns Datahub

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/00-namespace.yaml
@@ -12,5 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Datahub Catalogue"
     cloud-platform.justice.gov.uk/owner: "Data Catalogue: "
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/data-catalogue"
-    cloud-platform.justice.gov.uk/team-name: "data-platform"
+    cloud-platform.justice.gov.uk/team-name: "data-catalogue"
     cloud-platform.justice.gov.uk/review-after: "2024-12-01"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/variables.tf
@@ -29,7 +29,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "data-platform"
+  default     = "data-catalogue"
 }
 
 variable "environment" {


### PR DESCRIPTION
data-platform used to contain data-catalogue + analytical platform teams, and now only contains the analytical platform team.

data-catalogue is the correct set of users who should be managing this one.