### PR TITLE
Civil Apply Production: Add github tags to AWS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/main.tf
@@ -5,19 +5,38 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = "laa-apply-for-legal-aid"
+    }
+  }
 }
 
 # To be use in case the resources need to be created in London
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = "laa-apply-for-legal-aid"
+    }
+  }
 }
 
 # To be use in case the resources need to be created in Ireland
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      GithubTeam = "laa-apply-for-legal-aid"
+    }
+  }
 }
+
 provider "github" {
   token = var.github_token
   owner = var.github_owner


### PR DESCRIPTION
This is to enable AWS secret management