### PR TITLE
CCLF update development rds high database connection threshold

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/05-prometheus.yaml
@@ -80,12 +80,12 @@ spec:
         dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-bb83da2ed8245f4d;is-cluster=false;tab=monitoring"
 
     - alert: CCR-RDS-High-Database-Connections
-      expr: aws_rds_database_connections_average{dbinstance_identifier="cloud-platform-bb83da2ed8245f4d"} > 50
+      expr: aws_rds_database_connections_average{dbinstance_identifier="cloud-platform-bb83da2ed8245f4d"} > 65
       for: 5m
       labels:
         severity: laa_crown_court_renumeration_alerts_dev
       annotations:
-        message: CCR DEV RDS number of database connections is over 50
+        message: CCR DEV RDS number of database connections is over 65
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/AAC/pages/3160014895/Crown+Court+Remuneration+CCR+Runbook#Monitoring-and-Alerting"
         dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-bb83da2ed8245f4d;is-cluster=false;tab=monitoring"
 


### PR DESCRIPTION
We want to alert when the expected number of connections is exceeded, and therefore the alert threshold needs to be increased to take into account the size of the connection pool.