### PR TITLE
[LASB-3628] Add secret to laa-crown-court-contribution environments

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-dev/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-dev/resources/secret.tf
@@ -29,6 +29,11 @@ module "secrets_manager" {
       description             = "Hardship API oauth client secret for CCC Dev",
       recovery_window_in_days = 7
       k8s_secret_name         = "hardship-api-oauth-client-secret"
+    },
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for CCC Dev",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "sentry-dsn"
     }
   }
 }


### PR DESCRIPTION
Add secret for Sentry DSN to laa-crown-court-contribution dev, test, uat and prod environments.