### PR TITLE
⬆️ Bump ECR Module to 7.1.0

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-flask-template/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-flask-template/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.0"
 
   # Repository configuration
   repo_name = var.namespace


### PR DESCRIPTION
This release is currently in pre-release. It creates the registry as a secret, meaning we don't expose the account number in plain text.