### PR TITLE
🍱 Bump Dev Container features

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -20,7 +20,7 @@ or
 
 ### GitHub Codespaces
 
-Launch from GitHub
+1. Launch from GitHub
 
 ### Locally
 

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,27 +1,27 @@
 {
   "features": {
-    "ghcr.io/ministryofjustice/devcontainer-feature/aws:0": {
-      "version": "0.0.3",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:249e6f164df67ce38c8217c25e52d89ac1267d79536669647eed14fd2609f715",
-      "integrity": "sha256:249e6f164df67ce38c8217c25e52d89ac1267d79536669647eed14fd2609f715"
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:bb07a76c8e7a6b630a2056ce959addddee436e3f9936c69b9163eff54f58dbd5",
+      "integrity": "sha256:bb07a76c8e7a6b630a2056ce959addddee436e3f9936c69b9163eff54f58dbd5"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:0": {
-      "version": "0.0.4",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform@sha256:e5254698b7b38234c01f4dcb3e69eef21a1d00b1148beb27e2c2e18f57588a3a",
-      "integrity": "sha256:e5254698b7b38234c01f4dcb3e69eef21a1d00b1148beb27e2c2e18f57588a3a",
+      "version": "0.0.5",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform@sha256:4ae4c572ff604ac6cf6ac1bb42c8131350d40619b0ef2a7d90566559d98910fc",
+      "integrity": "sha256:4ae4c572ff604ac6cf6ac1bb42c8131350d40619b0ef2a7d90566559d98910fc",
       "dependsOn": [
-        "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:0"
+        "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1"
       ]
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:0": {
-      "version": "0.0.4",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:8ac98932cf2832b2e451bee7afbbafcdefc1572b3baf909e8b5db8439ad81949",
-      "integrity": "sha256:8ac98932cf2832b2e451bee7afbbafcdefc1572b3baf909e8b5db8439ad81949"
+    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:0ec758e44468ba2a8b70b87613762ab04e50f7bb5eac8f2aea592cff213dbde5",
+      "integrity": "sha256:0ec758e44468ba2a8b70b87613762ab04e50f7bb5eac8f2aea592cff213dbde5"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:af3b3891cf31ff373df29998c690257d6f21f2ee4536bc4d692856408ef0c83a",
-      "integrity": "sha256:af3b3891cf31ff373df29998c690257d6f21f2ee4536bc4d692856408ef0c83a"
+      "version": "1.1.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:34eb8c510a11fc44abb8173519215fcb6b82715b94e647c69089ee23773c6dc8",
+      "integrity": "sha256:34eb8c510a11fc44abb8173519215fcb6b82715b94e647c69089ee23773c6dc8"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "cloud-platform-environments",
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
-    "ghcr.io/ministryofjustice/devcontainer-feature/aws:0": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:0": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {}
   }

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Install devcontainers/cli
         id: install_devcontainer_cli


### PR DESCRIPTION
This pull request:

- Updates `ghcr.io/ministryofjustice/devcontainer-feature/aws` to `1.0.0`
- Updates `ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform` to `0.0.5`
- Updates `ghcr.io/ministryofjustice/devcontainer-feature/kubernetes` to `1.0.1`
- Updates `ghcr.io/ministryofjustice/devcontainer-feature/terraform` to `1.1.0`
- Updates `actions/checkout` to `v4.1.2`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 