### PR TITLE
Remove some resource alerts from datahub dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/05-prometheusrule.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/05-prometheusrule.yaml
@@ -253,30 +253,6 @@ spec:
 
     - name: resource-alert
       rules:
-        - alert: GMSCpuUsageHigh
-          annotations:
-            message: :warning:Service '{{ $labels.container }}' cpu usage above threshold of 90%.
-            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
-            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
-          expr: >-
-            (sum(rate(container_cpu_usage_seconds_total{namespace="data-platform-datahub-catalogue-dev", container=~".+gms"}[5m])) by (container) 
-            / sum(kube_pod_container_resource_limits{namespace="data-platform-datahub-catalogue-dev", container=~".+gms", unit="core"}) by (container)) * 100
-            > 90
-          for: 5m
-          labels:
-            severity: datahub_dev
-        - alert: GMSMemUsageHigh
-          annotations:
-            message: :warning:Service {{ $labels.container }} memory usage above 80%.
-            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
-            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
-          expr: >-
-            ((( sum(container_memory_working_set_bytes{container=~".+gms.+", namespace="data-platform-datahub-catalogue-dev"}) by (container,pod)  
-            / sum(kube_pod_container_resource_limits{container=~".+gms.+",namespace="data-platform-datahub-catalogue-dev",unit="byte"}) by (container,pod) ) * 100 ) < +Inf )
-             > 80
-          for: 5m
-          labels:
-            severity: datahub_dev
         - alert: HighPersistantVolumeUsage
           annotations:
             message: :warning:Service {{ $labels.persistentvolumeclaim }} Persistent volume is using more than 90%


### PR DESCRIPTION
These are not useful to us right now.

Previously: https://github.com/ministryofjustice/cloud-platform-environments/pull/26657