### PR TITLE
Ignore garbage latency metric values in Find MoJ data test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/05-prometheusrule.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-test/05-prometheusrule.yaml
@@ -84,7 +84,7 @@ spec:
           expr: >-
             rate(django_http_requests_latency_seconds_by_view_method_sum{namespace='data-platform-find-moj-data-test',method='GET'}[1m])/
             rate(django_http_requests_latency_seconds_by_view_method_count{namespace='data-platform-find-moj-data-test',method='GET'}[1m])
-            > 2
+            > 2 < +Inf
           for: 2m
           labels:
             severity: find-moj-data-test


### PR DESCRIPTION
Previously: https://github.com/ministryofjustice/cloud-platform-environments/pull/26417