### PR TITLE
Change label on env vars secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/secrets_manager.tf
@@ -10,7 +10,7 @@ module "secrets_manager" {
   eks_cluster_name       = var.eks_cluster_name
 
   secrets = {
-    "read-replica" = {
+    "cccd_env_vars" = {
       description             = "CCCD environment variables",
       recovery_window_in_days = 7
       k8s_secret_name         = "cccd-env-vars"


### PR DESCRIPTION
When I created this secret in AWS Secrets Manager I copied the template from another environment without fully understanding all the details. I now realise that the label I gave it is not helpful. I presume that just changing the key will not trigger any changes. Can you please confirm? Thanks.