### PR TITLE
changed GithubTeam in default_tags

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 
   default_tags {
     tags = {
-      GithubTeam = "secure-estate-digital-team"
+      GithubTeam = var.team_name
     }
   }
 }


### PR DESCRIPTION
Updating the GithubTeam in default_tags for offender-categorisation so that we can view performance insights.