### PR TITLE
[SI-1255] Upgrade cat tool pp cloud-platform-terraform-rds-instance to v7.3.1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.3.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.3.1"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.3.0"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit


### PR DESCRIPTION
Following changes made during Cat Tool prod outage (SI-1254) it was flagged (https://mojdt.slack.com/archives/C04JFG3QJE6/p1728319701004019?thread_ts=1728311264.704499&cid=C04JFG3QJE6) that we could upgrade our rds instance to 7.3.0 to take advantage of faster disk resources.