### PR TITLE
Enabling ECR deletion for Electronic monitoring datastore temp namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tst-em-example-app-jkn-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tst-em-example-app-jkn-dev/resources/ecr.tf
@@ -14,6 +14,8 @@ module "ecr" {
   oidc_providers      = ["github"]
   github_repositories = ["tst-em-example-app-jkn"]
 
+  deletion_protection = false
+
   # Tags
   business_unit          = var.business_unit
   application            = var.application


### PR DESCRIPTION
This is part of a migration:
1. [Add a preprod environment ](https://github.com/ministryofjustice/cloud-platform-environments/pull/26750)(previous PR)
2. Prepare existing dev namespace ECR for deletion (**this** PR)
3. [Remove existing dev environment which is in an incorrect namespace](https://github.com/ministryofjustice/cloud-platform-environments/pull/26753) (next PR)
4. [Add a dev environment](https://github.com/ministryofjustice/cloud-platform-environments/pull/26754) (fourth PR)
