### PR TITLE
Increase CCR staging prometheus threshold

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-staging/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-staging/05-prometheus.yaml
@@ -80,12 +80,12 @@ spec:
         dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-8eccc874fa0f1708;is-cluster=false;tab=monitoring"
 
     - alert: CCR-RDS-High-Database-Connections
-      expr: aws_rds_database_connections_average{dbinstance_identifier="cloud-platform-8eccc874fa0f1708"} > 65
+      expr: aws_rds_database_connections_average{dbinstance_identifier="cloud-platform-8eccc874fa0f1708"} > 125
       for: 5m
       labels:
         severity: laa-crown-court-remuneration-staging
       annotations:
-        message: CCR STAGING RDS number of database connections is over 65
+        message: CCR STAGING RDS number of database connections is over 125
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/AAC/pages/3160014895/Crown+Court+Remuneration+CCR+Runbook#Monitoring-and-Alerting"
         dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-8eccc874fa0f1708;is-cluster=false;tab=monitoring"
 


### PR DESCRIPTION
The current threshold leads to noisy alerts. Increase the threshold to a more accurate value for this environment.