### PR TITLE
Hmpps templates - fix service account double rolebinding

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf
@@ -67,11 +67,6 @@ locals {
     },
   ]
 }
-variable "gihub_rolebinding_name" {
-  description = "Kubernetes to GitHub actions rolebinding name"
-  default     = "service-account-github-actions"
-  type        = string
-}
 
 # Service account used by github actions
 module "service_account" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf
@@ -69,7 +69,7 @@ locals {
 }
 variable "gihub_rolebinding_name" {
   description = "Kubernetes to GitHub actions rolebinding name"
-  default     = "serviceaccount-rolebinding"
+  default     = "service-account-github-actions"
   type        = string
 }
 
@@ -87,6 +87,8 @@ module "service_account" {
   github_actions_secret_kube_namespace = "KUBE_NAMESPACE"
   serviceaccount_rules                 = local.github-actions-sa_rules
   serviceaccount_token_rotated_date    = time_rotating.weekly.unix
+  role_name                            = "serviceaccount-github"
+  rolebinding_name                     = "serviceaccount-github-rolebinding"
   depends_on                           = [github_repository_environment.env]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf
@@ -67,7 +67,11 @@ locals {
     },
   ]
 }
-
+variable "gihub_rolebinding_name" {
+  description = "Kubernetes to GitHub actions rolebinding name"
+  default     = "serviceaccount-rolebinding"
+  type        = string
+}
 
 # Service account used by github actions
 module "service_account" {


### PR DESCRIPTION
This splits out the role/rolebinding for the second service account, which was breaking the deployments.