### PR TITLE
Update redis auth url preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/elasticache.tf
@@ -28,6 +28,6 @@ resource "kubernetes_secret" "redis-preprod" {
   data = {
     primary_endpoint_address = module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address
     auth_token               = module.ec-cluster-offender-management-allocation-manager.auth_token
-    url                      = "rediss://dummyuser:${module.ec-cluster-offender-management-allocation-manager.auth_token}@${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}:6379"
+    url                      = "rediss://:${module.ec-cluster-offender-management-allocation-manager.auth_token}@${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}:6379"
   }
 }


### PR DESCRIPTION
Fixes deprecation warning:

```The Redis connection was configured with username "dummyuser", but the provided password was for the default user. This will start failing in redis-rb 5.0.0```