### PR TITLE
fix: Uncomment entry in serviceaccount.tf

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-entra-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-entra-test/resources/serviceaccount.tf
@@ -8,5 +8,5 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  # github_repositories = ["rd-entra-test"]
+  github_repositories = ["rd-entra-test"]
 }


### PR DESCRIPTION
Commented line in serviceaccount prevented KUBE_* secrets from being created in application repo.