### PR TITLE
:sparkles: Add custom domain name for prod change-dns

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-dns-form-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-dns-form-prod/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: change-dns-dev-ssl-certificate
+  namespace: operations-engineering-dns-form-prod
+spec:
+  secretName: ssl-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - change-dns.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-dns-form-prod/resources/r53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-dns-form-prod/resources/r53.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_zone" "change_dns_route53_zone" {
+  name = var.domain
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+resource "kubernetes_secret" "change_dns_route53_zone_sec" {
+  metadata {
+    name      = "change-dns-route53-zone-output"
+    namespace = var.namespace
+  }
+  data = {
+    zone_id     = aws_route53_zone.change_dns_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.change_dns_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-dns-form-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-dns-form-prod/resources/variables.tf
@@ -72,3 +72,8 @@ variable "eks_cluster_name" {
   description = "Name of the EKS cluster"
   type        = string
 }
+
+variable "domain" {
+  default = "change-dns.service.justice.gov.uk"
+  type    = string
+}


### PR DESCRIPTION
This pull request includes changes to the Terraform configuration for the DNS management in the `operations-engineering-dns-form-prod` namespace. The most important changes involve adding new resources and variables to manage Route 53 zones and secrets.

### Resource Additions:

* [`namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-dns-form-prod/resources/r53.tf`](diffhunk://#diff-2f93ac43cf77353e9bc2ceca71dad31498a1e6fd877b5974a3fc7030c855652fR1-R23): Added a new `aws_route53_zone` resource to manage DNS zones and a `kubernetes_secret` resource to store the Route 53 zone output.

### Variable Additions:

* [`namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-dns-form-prod/resources/variables.tf`](diffhunk://#diff-70b6d2ab51277028dafd494eeab9f47c4074ca49bd8c3cadd13580ac6db10c69R75-R79): Added a new variable `domain` with a default value to specify the domain for the Route 53 zone.