### PR TITLE
Don't switch db off overnight

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-dev/resources/rds-postgresql.tf
@@ -8,7 +8,7 @@ module "rds" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
 
   # turn off the db overnight (between 22:00 and 06:00)
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop = false
 
   # VPC configuration
   vpc_name = var.vpc_name


### PR DESCRIPTION
As we are now using this for demos to potential users, we have discovered that there appears to be a warm up period for the db when accessed from the service for the first time.

To prevent db connection errors on the first few db requests each day, keep the database on permanently.