### PR TITLE
Update RDS IDs in CCLF UAT Prometheus rules

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/05-prometheus.yaml
@@ -10,84 +10,84 @@ spec:
   - name: database-rules
     rules:
     - alert: CCLF-RDS-High-CPU
-      expr: aws_rds_cpuutilization_average{dbinstance_identifier="cloud-platform-73d0dce4a90613e1"} > 75
+      expr: aws_rds_cpuutilization_average{dbinstance_identifier="cloud-platform-a6e1cf58f91e81c0"} > 75
       for: 1m
       labels:
         severity: laa-crown-court-litigator-fees-uat
       annotations:
         message: CCLF UAT RDS CPU usage is over 75%
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/LOHP/pages/4891410498/Monitoring+and+Alerting"
-        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-73d0dce4a90613e1;is-cluster=false;tab=monitoring"
+        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-a6e1cf58f91e81c0;is-cluster=false;tab=monitoring"
 
     - alert: CCLF-RDS-Low-Storage
-      expr: aws_rds_free_storage_space_average{dbinstance_identifier="cloud-platform-73d0dce4a90613e1"} < 1024*1024*1024
+      expr: aws_rds_free_storage_space_average{dbinstance_identifier="cloud-platform-a6e1cf58f91e81c0"} < 1024*1024*1024
       for: 1m
       labels:
         severity: laa-crown-court-litigator-fees-uat
       annotations:
         message: CCLF UAT RDS free storage space is less than 1GB
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/LOHP/pages/4891410498/Monitoring+and+Alerting"
-        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-73d0dce4a90613e1;is-cluster=false;tab=monitoring"
+        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-a6e1cf58f91e81c0;is-cluster=false;tab=monitoring"
 
     - alert: CCLF-RDS-High-Read-Latency
-      expr: aws_rds_read_latency_average{dbinstance_identifier="cloud-platform-73d0dce4a90613e1"} > 0.5
+      expr: aws_rds_read_latency_average{dbinstance_identifier="cloud-platform-a6e1cf58f91e81c0"} > 0.5
       for: 1m
       labels:
         severity: laa-crown-court-litigator-fees-uat
       annotations:
         message: CCLF UAT RDS read latency is over 0.5 seconds
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/LOHP/pages/4891410498/Monitoring+and+Alerting"
-        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-73d0dce4a90613e1;is-cluster=false;tab=monitoring"
+        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-a6e1cf58f91e81c0;is-cluster=false;tab=monitoring"
 
     - alert: CCLF-RDS-High-Write-Latency
-      expr: aws_rds_write_latency_average{dbinstance_identifier="cloud-platform-73d0dce4a90613e1"} > 0.5
+      expr: aws_rds_write_latency_average{dbinstance_identifier="cloud-platform-a6e1cf58f91e81c0"} > 0.5
       for: 1m
       labels:
         severity: laa-crown-court-litigator-fees-uat
       annotations:
         message: CCLF UAT RDS write latency is over 0.5 seconds
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/LOHP/pages/4891410498/Monitoring+and+Alerting"
-        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-73d0dce4a90613e1;is-cluster=false;tab=monitoring"
+        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-a6e1cf58f91e81c0;is-cluster=false;tab=monitoring"
 
     - alert: CCLF-RDS-Low-Freeable-Memory
-      expr: aws_rds_freeable_memory_average{dbinstance_identifier="cloud-platform-73d0dce4a90613e1"} < 500*1024*1024
+      expr: aws_rds_freeable_memory_average{dbinstance_identifier="cloud-platform-a6e1cf58f91e81c0"} < 500*1024*1024
       for: 1m
       labels:
         severity: laa-crown-court-litigator-fees-uat
       annotations:
         message: CCLF UAT RDS freeable memory is less than 500MB
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/LOHP/pages/4891410498/Monitoring+and+Alerting"
-        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-73d0dce4a90613e1;is-cluster=false;tab=monitoring"
+        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-a6e1cf58f91e81c0;is-cluster=false;tab=monitoring"
 
     - alert: CCLF-RDS-High-Write-IOPS
-      expr: aws_rds_write_iops_average{dbinstance_identifier="cloud-platform-73d0dce4a90613e1"} > 300
+      expr: aws_rds_write_iops_average{dbinstance_identifier="cloud-platform-a6e1cf58f91e81c0"} > 300
       for: 1m
       labels:
         severity: laa-crown-court-litigator-fees-uat
       annotations:
         message: CCLF UAT RDS write operations are over 300 per second
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/LOHP/pages/4891410498/Monitoring+and+Alerting"
-        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-73d0dce4a90613e1;is-cluster=false;tab=monitoring"
+        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-a6e1cf58f91e81c0;is-cluster=false;tab=monitoring"
 
     - alert: CCLF-RDS-High-Read-IOPS
-      expr: aws_rds_read_iops_average{dbinstance_identifier="cloud-platform-73d0dce4a90613e1"} > 300
+      expr: aws_rds_read_iops_average{dbinstance_identifier="cloud-platform-a6e1cf58f91e81c0"} > 300
       for: 1m
       labels:
         severity: laa-crown-court-litigator-fees-uat
       annotations:
         message: CCLF UAT RDS read operations are over 300 per second
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/LOHP/pages/4891410498/Monitoring+and+Alerting"
-        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-73d0dce4a90613e1;is-cluster=false;tab=monitoring"
+        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-a6e1cf58f91e81c0;is-cluster=false;tab=monitoring"
 
     - alert: CCLF-RDS-High-Database-Connections
-      expr: aws_rds_database_connections_average{dbinstance_identifier="cloud-platform-73d0dce4a90613e1"} > 65
+      expr: aws_rds_database_connections_average{dbinstance_identifier="cloud-platform-a6e1cf58f91e81c0"} > 65
       for: 5m
       labels:
         severity: laa-crown-court-litigator-fees-uat
       annotations:
         message: CCLF UAT RDS number of database connections is over 65
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/LOHP/pages/4891410498/Monitoring+and+Alerting"
-        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-73d0dce4a90613e1;is-cluster=false;tab=monitoring"
+        dashboard_url: "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2#database:id=cloud-platform-a6e1cf58f91e81c0;is-cluster=false;tab=monitoring"
 
   - name: application-rules
     rules:


### PR DESCRIPTION
Following the migration of the database from Landing Zone, the id of the RDS instance we want to monitor has changed. This brings the alerts in line with that change.