### PR TITLE
Fix CCLF UAT application name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/resources/variables.tf
@@ -11,7 +11,7 @@ variable "kubernetes_cluster" {
 variable "application" {
   description = "Name of the application you are deploying"
   type        = string
-  default     = "Crown Court Litigator Fees"
+  default     = "crown-court-litigator-fees"
 }
 
 variable "namespace" {


### PR DESCRIPTION
Fixes failing build: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/8094