### PR TITLE
court-probation-prod : Update pingdom endpoint

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/pingdom.tf
@@ -25,7 +25,7 @@ resource "pingdom_check" "crime-portal-gateway-check" {
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
-  url                      = "/"
+  url                      = "/health"
   encryption               = true
   port                     = 443
   tags                     = "hmpps, probation-in-court, crime-portal-gateway, cloudplatform-managed"


### PR DESCRIPTION
Update court-probation-prod crime-portal-gateway pingdom endpoint to "/health"

This is because the "/" endpoint returns 403 http errors in production