### PR TITLE
PIC-4271 Update pingdom healthkick url in court-probation-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/pingdom.tf
@@ -20,12 +20,12 @@ resource "pingdom_check" "prepare-a-case-production-check" {
 resource "pingdom_check" "crime-portal-gateway-check" {
   type                     = "http"
   name                     = var.application
-  host                     = var.crime-portal-mirror-gateway-domain
+  host                     = "health-kick.prison.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
-  url                      = "/health"
+  url                      = "/https/${var.crime-portal-mirror-gateway-domain}"
   encryption               = true
   port                     = 443
   tags                     = "hmpps, probation-in-court, crime-portal-gateway, cloudplatform-managed"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/pingdom.tf
@@ -4,12 +4,12 @@ provider "pingdom" {
 resource "pingdom_check" "prepare-a-case-production-check" {
   type                     = "http"
   name                     = var.application
-  host                     = var.prepare-case-domain
+  host                     = "health-kick.prison.service.justice.gov.uk"
   resolution               = 1
   notifywhenbackup         = true
   sendnotificationwhendown = 6
   notifyagainevery         = 0
-  url                      = "/health"
+  url                      = "/https/${var.prepare-case-domain}"
   encryption               = true
   port                     = 443
   tags                     = "hmpps, prepare-a-case, cloudplatform-managed"


### PR DESCRIPTION
This uses the [health-kick repo](https://github.com/ministryofjustice/health-kick) to proxy any /health checks by pingdom to our internal services.