### PR TITLE
Add CMA config for prod Evidence Service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-prod/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-prod/resources/secret.tf
@@ -10,6 +10,16 @@ module "secrets_manager" {
   eks_cluster_name       = var.eks_cluster_name
 
   secrets = {
+    "cma_api_oauth_client_id" = {
+      description             = "CMA API oauth client ID for Evidence Prod",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "cma-api-oauth-client-id"
+    },
+    "cma_api_oauth_client_secret" = {
+      description             = "CMA API oauth client secret for Evidence Prod",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "cma-api-oauth-client-secret"
+    },
     "maat_api_oauth_client_id" = {
       description             = "MAAT API oauth client ID for Evidence Prod",
       recovery_window_in_days = 7


### PR DESCRIPTION
This PR adds secrets for OAuth credentials for the Crime Means Assessment service to the prod Evidence Service to allow it to find and update income evidence.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1404)