### PR TITLE
Update Common-Platform-and-delius-queue filter policy prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/common-platform-and-delius-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/common-platform-and-delius-queue.tf
@@ -2,6 +2,11 @@ resource "aws_sns_topic_subscription" "common-platform-and-delius-queue-subscrip
   topic_arn = data.aws_ssm_parameter.court-topic.value
   protocol  = "sqs"
   endpoint  = module.common-platform-and-delius-queue.sqs_arn
+  filter_policy = jsonencode({
+    messageType = [
+      "COMMON_PLATFORM_HEARING"
+    ]
+  })
 }
 
 module "common-platform-and-delius-queue" {


### PR DESCRIPTION
- Update the sqs queue filter policy to receive common-platform hearing messages and not libra messages in prod