### PR TITLE
🎡 Bump Dev Container features

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,25 +1,27 @@
 {
   "features": {
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:bb07a76c8e7a6b630a2056ce959addddee436e3f9936c69b9163eff54f58dbd5",
-      "integrity": "sha256:bb07a76c8e7a6b630a2056ce959addddee436e3f9936c69b9163eff54f58dbd5"
+      "version": "1.0.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40",
+      "integrity": "sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40"
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:0": {
-      "version": "0.0.5",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform@sha256:4ae4c572ff604ac6cf6ac1bb42c8131350d40619b0ef2a7d90566559d98910fc",
-      "integrity": "sha256:4ae4c572ff604ac6cf6ac1bb42c8131350d40619b0ef2a7d90566559d98910fc",
-      "dependsOn": ["ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1"]
+    "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform@sha256:54154460f9e154ab60c85d32ee9bd1bc1b25d86f506039fa352797e60eda01cf",
+      "integrity": "sha256:54154460f9e154ab60c85d32ee9bd1bc1b25d86f506039fa352797e60eda01cf",
+      "dependsOn": [
+        "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1"
+      ]
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
-      "version": "1.0.1",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:0ec758e44468ba2a8b70b87613762ab04e50f7bb5eac8f2aea592cff213dbde5",
-      "integrity": "sha256:0ec758e44468ba2a8b70b87613762ab04e50f7bb5eac8f2aea592cff213dbde5"
+      "version": "1.0.2",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:d24f235b7578a71a60fce981d250fa300e9f353911561648c31a7022fd8ded6a",
+      "integrity": "sha256:d24f235b7578a71a60fce981d250fa300e9f353911561648c31a7022fd8ded6a"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:34eb8c510a11fc44abb8173519215fcb6b82715b94e647c69089ee23773c6dc8",
-      "integrity": "sha256:34eb8c510a11fc44abb8173519215fcb6b82715b94e647c69089ee23773c6dc8"
+      "version": "1.2.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:6343878231decb72427ea2d59d98d0c4bb6f15931d86800330f7c84df8320f6c",
+      "integrity": "sha256:6343878231decb72427ea2d59d98d0c4bb6f15931d86800330f7c84df8320f6c"
     }
   }
 }

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -9,9 +9,7 @@
       "version": "1.0.1",
       "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform@sha256:54154460f9e154ab60c85d32ee9bd1bc1b25d86f506039fa352797e60eda01cf",
       "integrity": "sha256:54154460f9e154ab60c85d32ee9bd1bc1b25d86f506039fa352797e60eda01cf",
-      "dependsOn": [
-        "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1"
-      ]
+      "dependsOn": ["ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1"]
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
       "version": "1.0.2",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:0": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform:1": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {}
   }
 }


### PR DESCRIPTION
This pull request:

> [!NOTE]
> Code formatting makes changes to `.devcontainer/devcontainer-lock.json` but this file is automatically generated

- Bumps `ghcr.io/ministryofjustice/devcontainer-feature/aws` to `1.0.1`
- Bumps `ghcr.io/ministryofjustice/devcontainer-feature/cloud-platform` to `1.0.1`
- Bumps `ghcr.io/ministryofjustice/devcontainer-feature/terraform` to `1.2.0`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 