### PR TITLE
Add yaml metadata check action 

### DIFF
--- a/.github/workflows/yaml-metadata-change-check.yaml
+++ b/.github/workflows/yaml-metadata-change-check.yaml
@@ -1,0 +1,49 @@
+name: Check YAML metadata for changes to name or namespace
+
+on:
+  pull_request:
+    paths:
+      - namespaces/live.cloud-platform.service.justice.gov.uk/*/*.yaml
+      - namespaces/live.cloud-platform.service.justice.gov.uk/*/*.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  yaml-metadata-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - id: yaml-metadata-check
+        name: Check Yaml Metadata for changes 
+        uses: ministryofjustice/cloud-platform-environments/cmd/yaml-metadata-change-check@yaml-metadata-change-check
+        env:
+          GET_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Comment Yaml Metadata change   
+        uses: actions/github-script@v7
+        if: steps.yaml-metadata-check.outputs.changes == 'true'
+        env:
+          RESULT: "${{ steps.yaml-metadata-check.outputs.result }}"
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+                const output = `#### YAML changes to metadata name or namespace detected:
+                <details><summary>Show</summary>
+                <code>${process.env.RESULT}</code>
+                </details>`;
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: output
+                })
+                
+      - name: Set to fail if changes detected 
+        if: steps.yaml-metadata-check.outputs.changes == 'true'
+        run: exit 1

--- a/cmd/yaml-metadata-change-check/Dockerfile
+++ b/cmd/yaml-metadata-change-check/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.23-alpine
+
+ENV \
+    CGO_ENABLED=0 \
+    GOOS=linux
+
+WORKDIR /go/bin
+
+COPY go.mod /go/bin
+COPY go.sum /go/bin
+RUN go mod download
+COPY . /go/bin
+
+RUN go build -ldflags "-s -w" .
+
+CMD ["yaml-metadata-change-check"]

--- a/cmd/yaml-metadata-change-check/go.mod
+++ b/cmd/yaml-metadata-change-check/go.mod
@@ -1,0 +1,11 @@
+module github.com/ministryofjustice/cloud-platform-environments/cmd/yaml-metadata-change-check
+
+go 1.23.2
+
+require (
+	github.com/google/go-github/v64 v64.0.0
+	github.com/sethvargo/go-githubactions v1.3.0
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require github.com/google/go-querystring v1.1.0 // indirect

--- a/cmd/yaml-metadata-change-check/go.sum
+++ b/cmd/yaml-metadata-change-check/go.sum
@@ -1,0 +1,14 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v64 v64.0.0 h1:4G61sozmY3eiPAjjoOHponXDBONm+utovTKbyUb2Qdg=
+github.com/google/go-github/v64 v64.0.0/go.mod h1:xB3vqMQNdHzilXBiO2I+M7iEFtHf+DP/omBOv6tQzVo=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/sethvargo/go-githubactions v1.3.0 h1:Kg633LIUV2IrJsqy2MfveiED/Ouo+H2P0itWS0eLh8A=
+github.com/sethvargo/go-githubactions v1.3.0/go.mod h1:7/4WeHgYfSz9U5vwuToCK9KPnELVHAhGtRwLREOQV80=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/cmd/yaml-metadata-change-check/main.go
+++ b/cmd/yaml-metadata-change-check/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+
+	"flag"
+	"log"
+	"os"
+
+	githubaction "github.com/sethvargo/go-githubactions"
+
+	utils "github.com/ministryofjustice/cloud-platform-environments/cmd/yaml-metadata-change-check/utils"
+)
+
+var (
+	token    = flag.String("token", os.Getenv("GET_TOKEN"), "GitHub Personal Access Token")
+	ref      = flag.String("ref", os.Getenv("GITHUB_REF"), "Branch Name")
+	repo     = flag.String("repo", os.Getenv("GITHUB_REPOSITORY"), "Repository Name")
+	owner    string
+	repoName string
+	pull     int
+)
+
+func main() {
+	owner, repoName, pull = utils.GetOwnerRepoPull(*ref, *repo)
+
+	flag.Parse()
+	client := utils.GitHubClient(*token)
+
+	files, _, err := utils.GetPullRequestFiles(client, owner, repoName, pull)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, file := range files {
+		// get pull request file
+		if utils.SelectFile(file) != nil {
+			//Get Branch content
+			ref, err := utils.GetPullRequestBranch(client, owner, repoName, pull)
+			if err != nil {
+				log.Fatalf("Error fetching pull request branch: %v\n", err)
+			}
+
+			content, err := utils.GetFileContent(client, file, owner, repoName, ref)
+			if err != nil {
+				fmt.Printf("Policy file has been deleted, skipping")
+				break
+			}
+
+			branchFile, err := utils.DecodeContent(content)
+			if err != nil {
+				log.Fatalf("Error decoding file content: %v\n", err)
+			}
+
+			//Get main content
+			mainContent, err := utils.GetFileContent(client, file, owner, repoName, "main")
+			if err != nil {
+				fmt.Printf("New policy file created, skipping")
+				break
+			}
+
+			mainFile, err := utils.DecodeContent(mainContent)
+			if err != nil {
+				log.Fatalf("Error decoding file content: %v\n", err)
+			}
+
+			splitMainDoc := utils.SplitYAMLDocuments([]byte(mainFile))
+			splitBranchDoc := utils.SplitYAMLDocuments([]byte(branchFile))
+
+			fmt.Printf("Number of documents in file %s: %d\n", *file.Filename, len(splitMainDoc))
+			fmt.Printf("Number of documents in file %s: %d\n", *file.Filename, len(splitBranchDoc))
+
+			mainPolicies := utils.ParseYAMLDocuments(splitMainDoc)
+			branchPolicies := utils.ParseYAMLDocuments(splitBranchDoc)
+
+			var expectedPolicyCountDiff int
+			actualPolicyCountDiff := 0
+
+			if (len(splitMainDoc) - len(branchPolicies)) < 0 {
+				expectedPolicyCountDiff = len(branchPolicies) - len(splitMainDoc)
+			} else {
+				expectedPolicyCountDiff = len(splitMainDoc) - len(branchPolicies)
+			}
+
+			// Compare policies from the first file against the second file
+			for _, mainPolicy := range mainPolicies {
+				found := false
+				for _, branchPolicy := range branchPolicies {
+					if mainPolicy.Metadata.Name == branchPolicy.Metadata.Name && mainPolicy.Metadata.Namespace == branchPolicy.Metadata.Namespace {
+						utils.CompareYAML(mainPolicy, branchPolicy)
+						found = true
+						break
+					}
+				}
+				if !found {
+					fmt.Printf("Kind %v policy, %v, in namespace %v from main %s not found in branch %s\n", mainPolicy.Kind, mainPolicy.Metadata.Name, mainPolicy.Metadata.Namespace, *file.Filename, ref)
+					actualPolicyCountDiff += 1
+				}
+			}
+
+			// Check for policies in the second file that are not in the first file
+			for _, branchPolicy := range branchPolicies {
+				found := false
+				for _, mainPolicy := range mainPolicies {
+					if branchPolicy.Metadata.Name == mainPolicy.Metadata.Name && branchPolicy.Metadata.Namespace == mainPolicy.Metadata.Namespace {
+						found = true
+						break
+					}
+				}
+				if !found {
+					fmt.Printf("Kind %v policy, %v, in namespace %v from branch %s not found in main version %s\n", branchPolicy.Kind, branchPolicy.Metadata.Name, branchPolicy.Metadata.Namespace, ref, *file.Filename)
+					actualPolicyCountDiff += 1
+				}
+			}
+			fmt.Printf("\n%d actual difference in policies in %s\n%d expected difference in %s\n", actualPolicyCountDiff, *file.Filename, expectedPolicyCountDiff, *file.Filename)
+
+			if expectedPolicyCountDiff != actualPolicyCountDiff {
+				policy_difference := actualPolicyCountDiff - expectedPolicyCountDiff
+				result_comment := fmt.Sprintf("Changes to YAML .metadata.name or .metadata.namespace detected. You cannot change these fields in a single PR, please raise separate PRs to first delete the YAML policy, and then a new PR to create it with the new values.\nDetected %d policies that did not match in PR, check logs for more details.", policy_difference)
+				fmt.Printf("\nFAIL - %s", result_comment)
+				githubaction.SetOutput("changes", "true")
+				githubaction.SetOutput("result", result_comment)
+			} else {
+				fmt.Printf("\nPASS")
+				githubaction.SetOutput("changes", "false")
+			}
+		}
+	}
+}

--- a/cmd/yaml-metadata-change-check/utils/github.go
+++ b/cmd/yaml-metadata-change-check/utils/github.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v64/github"
+)
+
+var (
+	ctx = context.Background()
+)
+
+func GitHubClient(token string) *github.Client {
+	client := github.NewClient(nil).WithAuthToken(token)
+	return client
+}
+
+func GetPullRequestBranch(client *github.Client, o, r string, n int) (string, error) {
+	pull, _, err := client.PullRequests.Get(ctx, o, r, n)
+	if err != nil {
+		return "", fmt.Errorf("error fetching pull request: %w", err)
+	}
+	return *pull.Head.Ref, nil
+}
+
+// ListFiles retrieves a list of commit files for each pull request in a GitHub repository.
+// It takes a GitHub client and a context as input parameters.
+// It returns a slice of commit files, and an error if any.
+func GetPullRequestFiles(client *github.Client, o, r string, n int) ([]*github.CommitFile, *github.Response, error) {
+	files, resp, err := client.PullRequests.ListFiles(ctx, o, r, n, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error fetching files: %w", err)
+	}
+
+	return files, resp, err
+}
+
+func SelectFile(file *github.CommitFile) *github.CommitFile {
+	// file filename contains dashboard in the name return file
+	if strings.Contains(*file.Filename, "namespaces/live") && strings.Contains(*file.Filename, ".yaml") {
+		return file
+	} else {
+		return nil
+	}
+}
+
+func GetFileContent(client *github.Client, file *github.CommitFile, owner, repo, ref string) (*github.RepositoryContent, error) {
+	opts := &github.RepositoryContentGetOptions{
+		Ref: ref,
+	}
+
+	content, _, _, err := client.Repositories.GetContents(ctx, owner, repo, *file.Filename, opts)
+	if err != nil {
+		fmt.Printf("Error fetching file content: %v\n", err)
+		return nil, err
+	}
+
+	return content, nil
+}
+
+func DecodeContent(content *github.RepositoryContent) (string, error) {
+	decodeContent, err := content.GetContent()
+	if err != nil {
+		fmt.Printf("Error decoding file content: %v\n", err)
+		return "", err
+	}
+
+	return decodeContent, nil
+}

--- a/cmd/yaml-metadata-change-check/utils/struct.go
+++ b/cmd/yaml-metadata-change-check/utils/struct.go
@@ -1,0 +1,9 @@
+package utils
+
+type YAML struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name      string `yaml:"name"`
+		Namespace string `yaml:"namespace"`
+	} `yaml:"metadata"`
+}

--- a/cmd/yaml-metadata-change-check/utils/utils.go
+++ b/cmd/yaml-metadata-change-check/utils/utils.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+func GetOwnerRepoPull(ref, repo string) (string, string, int) {
+	// get pull request files
+	githubrefS := strings.Split(ref, "/")
+	prnum := githubrefS[2]
+	pull, _ := strconv.Atoi(prnum)
+
+	repoS := strings.Split(repo, "/")
+	owner := repoS[0]
+	repoName := repoS[1]
+
+	return owner, repoName, pull
+}
+
+func SplitYAMLDocuments(data []byte) [][]byte {
+	var docs [][]byte
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var doc interface{}
+		err := decoder.Decode(&doc)
+		if err != nil {
+			break
+		}
+		docBytes, _ := yaml.Marshal(doc)
+		docs = append(docs, docBytes)
+	}
+	return docs
+}
+
+func ParseYAMLDocuments(documents [][]byte) []YAML {
+	var policies []YAML
+	for _, doc := range documents {
+		var policy YAML
+		err := yaml.Unmarshal(doc, &policy)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		policies = append(policies, policy)
+	}
+	return policies
+}
+
+func CompareYAML(yaml1, yaml2 YAML) {
+	fmt.Println("Start comparing YAML polciy")
+	if yaml1.Kind != yaml2.Kind {
+		fmt.Printf("Kind = MISMATCH: %v != %v\n", yaml1.Kind, yaml2.Kind)
+
+	} else {
+		fmt.Printf("Kind = MATCH: %v\n", yaml1.Kind)
+	}
+
+	if yaml1.Metadata.Name != yaml2.Metadata.Name {
+		fmt.Printf("Metadata.Name = MISMATCH: %v != %v\n", yaml1.Metadata.Name, yaml2.Metadata.Name)
+	} else {
+		fmt.Printf("Metadata.Name = MATCH: %v\n", yaml1.Metadata.Name)
+	}
+
+	if yaml1.Metadata.Namespace != yaml2.Metadata.Namespace {
+		fmt.Printf("Metadata.Namespace = MISMATCH: %v != %v\n", yaml1.Metadata.Namespace, yaml2.Metadata.Namespace)
+	} else {
+		fmt.Printf("Metadata.Namespace = MATCH: %v\n", yaml1.Metadata.Namespace)
+	}
+	fmt.Printf("Finished comparing polciy\n\n")
+}


### PR DESCRIPTION
This GitHub action will check that `.metadata.name` and `.metadata.namespace` are not changed in a single PR.
We want users to delete the resource first in a PR and then create a second PR that will make the new resource instead. 
Related issue: [#5568](https://github.com/ministryofjustice/cloud-platform/issues/5568)

This has been tested on a fork of `cloud-platform-environments` and has also been tested on this branch.
The test will only trigger on yaml changes in namespaces, and will only fail when it detects a change to either of the metadata fields `name` or `namespace`