### PR TITLE
Bump RDS version for laa-assess-crime-forms-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-uat/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -15,6 +15,7 @@ module "rds" {
   allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "10000"
+  db_allocated_storage         = "20"
   deletion_protection          = true
   enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   db_password_rotated_date     = "07-10-2024"
@@ -42,7 +43,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
 
   vpc_name               = var.vpc_name
 


### PR DESCRIPTION
Also set the minimum storage value to prevent an error