### PR TITLE
Upgrade RDS Maria DB to latest version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-dev/resources/rds.tf
@@ -11,18 +11,19 @@ module "rds" {
   performance_insights_enabled = false
 
   # general options
-  db_instance_class           = "db.t4g.small"
-  environment_name            = var.environment
-  infrastructure_support      = var.infrastructure_support
-  allow_major_version_upgrade = "false"
+  db_instance_class      = "db.t4g.small"
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
 
   # turn off database outside of work hours - turns off at 10PM and restart it at 6AM UTC (11PM and 7AM BST).
   enable_rds_auto_start_stop = true
 
   # using mysql
   db_engine         = "mariadb"
-  db_engine_version = "10.4"
-  rds_family        = "mariadb10.4"
+  db_engine_version = "10.11"
+  rds_family        = "mariadb10.11"
+
+  prepare_for_major_upgrade = true
 
   # overwrite db_parameters
   db_parameter = [


### PR DESCRIPTION
Even though this is upgrading from 10.4 -> 10.11 apparently it qualifies as a major update. Following this teams lead https://github.com/ministryofjustice/cloud-platform-environments/pull/26924