### PR TITLE
Upgrade RDS TF module to v8 for NON (`preprod`)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit


### PR DESCRIPTION
This will change the storage type from `gp2` to `gp3`. The module also bumps the default storage size to 20GB (we don't specify this and it was previously default to 10GB AFAICT).