### PR TITLE
Minor tweaks to CCLF dev RDS config

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/rds.tf
@@ -10,8 +10,7 @@ module "rds-instance-migrated" {
   team_name              = var.team_name
   business_unit          = var.business_unit
 
-  enable_rds_auto_start_stop = true
-
+  enable_rds_auto_start_stop = false
 
   # Database configuration
   db_engine                = "oracle-se2"
@@ -23,13 +22,13 @@ module "rds-instance-migrated" {
   db_name                  = "CCLF"
   license_model            = "license-included"
   db_iops                  = 0
-  character_set_name       = "WE8MSWIN1252" # problem  
+  character_set_name       = "WE8MSWIN1252"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
 
   # enable performance insights
-  performance_insights_enabled = true
+  performance_insights_enabled = false
 
   snapshot_identifier = "arn:aws:rds:eu-west-2:754256621582:snapshot:cclf-dev-cp-migration-23092024-manual-copy"
 


### PR DESCRIPTION
* Disables enable_rds_auto_start_stop as this interferes with the running of the application
* Disables performance_insights_enabled as we do not currently need this and we can save money by disabling it
* Removes an outdated comment