### PR TITLE
CRIMAPP-1404 Update RDS to 8.0.0 on crime datastore staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name


### PR DESCRIPTION
Updated RDS to 8.0.0 on `laa-criminal-applications-datastore-staging`.