### PR TITLE
[SI-1253] Setup SQS queue for offender release events for cat api

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_categorisation-sub-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_categorisation-sub-queue.tf
@@ -326,7 +326,7 @@ resource "aws_sqs_queue_policy" "offender_categorisation_api_events_queue_policy
 }
 
 
-resource "aws_sns_topic_subscription" "prisoner_search_event_queue_subscription" {
+resource "aws_sns_topic_subscription" "offender_categorisation_api_prisoner_search_event_queue_subscription" {
   topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
   protocol  = "sqs"
   endpoint  = module.offender_categorisation_api_events_queue.sqs_arn

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_categorisation-sub-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/offender_categorisation-sub-queue.tf
@@ -220,3 +220,121 @@ resource "aws_sns_topic_subscription" "offender_categorisation_ui_subscription" 
   endpoint      = module.offender_categorisation_ui_events_queue.sqs_arn
   filter_policy = "{\"eventType\":[\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"BOOKING_NUMBER-CHANGED\",\"prisoner-offender-search.prisoner.released\"]}"
 }
+
+############################################################################################
+
+module "offender_categorisation_api_events_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
+
+  # Queue configuration
+  sqs_name                  = "offender_categorisation_api_events_queue"
+  encrypt_sqs_kms           = "true"
+  message_retention_seconds = 1209600
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.offender_categorisation_events_dead_letter_queue.sqs_arn}","maxReceiveCount": 3
+  }
+  EOF
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the queue
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "offender_categorisation_api_events_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
+
+  # Queue configuration
+  sqs_name        = "offender_categorisation_api_events_queue_dl"
+  encrypt_sqs_kms = "true"
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the queue
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "offender_categorisation_api_events_queue" {
+  metadata {
+    name      = "offender-categorisation-api-offender-events-sqs-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    url  = module.offender_categorisation_api_events_queue.sqs_id
+    arn  = module.offender_categorisation_api_events_queue.sqs_arn
+    name = module.offender_categorisation_api_events_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "offender_categorisation_api_events_dead_letter_queue" {
+  metadata {
+    name      = "offender-categorisation-api-offender-events-sqs-dl-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    url  = module.offender_categorisation_api_events_dead_letter_queue.sqs_id
+    arn  = module.offender_categorisation_api_events_dead_letter_queue.sqs_arn
+    name = module.offender_categorisation_api_events_dead_letter_queue.sqs_name
+  }
+}
+
+resource "aws_sqs_queue_policy" "offender_categorisation_api_events_queue_policy" {
+  queue_url = module.offender_categorisation_api_events_queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.offender_categorisation_api_events_queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Effect": "Allow",
+          "Principal": {"AWS": "*"},
+          "Resource": "${module.offender_categorisation_api_events_queue.sqs_arn}",
+          "Action": "SQS:SendMessage",
+          "Condition":
+                      {
+                        "ForAnyValue:ArnEquals":
+                          {
+                            "aws:SourceArn": ["${module.offender_events.topic_arn}", "${data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value}"]
+                          }
+                        }
+        }
+      ]
+  }
+  EOF
+}
+
+
+resource "aws_sns_topic_subscription" "prisoner_search_event_queue_subscription" {
+  topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
+  protocol  = "sqs"
+  endpoint  = module.offender_categorisation_api_events_queue.sqs_arn
+  filter_policy = jsonencode({
+    eventType = [
+      "prisoner-offender-search.prisoner.updated",
+      "prisoner-offender-search.prisoner.received",
+      "prisoner-offender-search.prisoner.released",
+    ]
+  })
+}


### PR DESCRIPTION
I need to listen for Offender Released events. I have specified more than this currently, to ensure I see _some_ events (ones I assume are more frequently sent) before narrowing this down.

My aim is to provide the minimal configuration to enable this functionality.