### PR TITLE
Align pre-prod with prod db

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -15,7 +15,9 @@ module "visit_scheduler_rds" {
   db_engine_version           = "15.7"
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
-  db_max_allocated_storage    = "10000"
+  db_max_allocated_storage    = "16300"
+  db_allocated_storage        = "16000"
+  db_iops                     = "12000"
   db_password_rotated_date    = "2023-03-22"
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -74,7 +74,9 @@ module "prison_visit_booker_registry_rds" {
   db_engine_version           = "15.7"
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
-  db_max_allocated_storage    = "10000"
+  db_max_allocated_storage     = "16300"
+  db_allocated_storage         = "16000"
+  db_iops                     = "12000"
   db_password_rotated_date    = "2023-03-22"
 
   performance_insights_enabled = true


### PR DESCRIPTION
We replicate prod data into pre-prod and having them as different sizes could result in errors in the future. Aligning them as they are technically the same