### PR TITLE
BAVL-390 listen for the domain event video appointment cancelled in the prod BVLS service so the appropriate action can be taken.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-prod/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-prod/resources/domain-events-queue-bvls.tf
@@ -114,6 +114,7 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
       "book-a-video-link.appointment.created",
       "prisoner-offender-search.prisoner.released",
       "prison-offender-events.prisoner.merged",
+      "prison-offender-events.prisoner.video-appointment.cancelled",
       "whereabouts-api.videolink.migrate"
     ]
   })


### PR DESCRIPTION
Adds listening for a new event to the prod BVLS service so the appropriate action can be taken if/when the event occurs.

This change has already been applied to our dev and preprod environments.