### PR TITLE
Migrate CCLF Staging database from LZ to CP

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/irsa.tf
@@ -13,8 +13,7 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     sqs_cclf_claims = aws_iam_policy.cclf_stg_policy.arn
-    rds = module.rds-instance-trial.irsa_policy_arn
-    # cclf_copy_snapshot = aws_iam_policy.cclf_copy_snapshot_policy.arn
+    rds = module.rds-instance-migrated.irsa_policy_arn
   }
 
   # Tags
@@ -59,40 +58,6 @@ resource "aws_iam_policy" "cclf_stg_policy" {
     infrastructure-support = var.infrastructure_support
   }
 }
-
-# data "aws_iam_policy_document" "cclf_copy_snapshot_policy_document" {
-#   # Provide list of permissions and target AWS account resources to allow access to
-#   statement {
-#     sid  = "CCLFPolicyCopySnapshotUAT"
-#     effect = "Allow"
-#     actions = [
-#       "rds:CopyDBSnapshot",
-#       "kms:CreateGrant",
-#       "kms:DescribeKey",
-#     ]
-#     resources = [
-#       "arn:aws:rds:eu-west-2:411213865113:snapshot:cclf-dev-for-copy-over-to-cloud-platform",
-#       "arn:aws:kms:eu-west-2:754256621582:key/92d71916-6237-4c84-ac42-6b58fe591fc0",
-#       "arn:aws:kms:eu-west-2:902837325998:key/8d0bca3a-0e0f-48a7-abee-2c0693d008b1",
-#     ]
-#   }
-
-# }
-
-# resource "aws_iam_policy" "cclf_copy_snapshot_policy" {
-#   name        = "cclf_copy_snapshot_policy"
-#   policy      = data.aws_iam_policy_document.cclf_copy_snapshot_policy_document.json
-#   description = "Policy for Cloud Platform to assume role in data platform dev account for CCLF"
-
-#   tags = {
-#     business-unit          = var.business_unit
-#     application            = var.application
-#     is-production          = var.is_production
-#     environment-name       = var.environment
-#     owner                  = var.github_owner
-#     infrastructure-support = var.infrastructure_support
-#   }
-# }
 
 module "service_pod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.0.0" # use the latest release

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/rds.tf
@@ -1,4 +1,4 @@
-module "rds-instance-trial" {
+module "rds-instance-migrated" {
   source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=migration"
   vpc_name = var.vpc_name
 
@@ -30,7 +30,7 @@ module "rds-instance-trial" {
   # enable performance insights
   performance_insights_enabled = false
 
-  snapshot_identifier = "arn:aws:rds:eu-west-2:754256621582:snapshot:cclf-uat-for-cp-trial" # update with snapshot value, once created and moved from LZ to CP
+  snapshot_identifier = "arn:aws:rds:eu-west-2:754256621582:snapshot:cclf-staging-cp-migration-snapshot-11-11-24"
 
   providers = {
     aws = aws.london
@@ -135,10 +135,10 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data = {
-    database_name     = module.rds-instance-trial.database_name
-    database_host     = module.rds-instance-trial.rds_instance_address
-    database_port     = module.rds-instance-trial.rds_instance_port
-    database_username = module.rds-instance-trial.database_username
-    database_password = module.rds-instance-trial.database_password
+    database_name     = module.rds-instance-migrated.database_name
+    database_host     = module.rds-instance-migrated.rds_instance_address
+    database_port     = module.rds-instance-migrated.rds_instance_port
+    database_username = module.rds-instance-migrated.database_username
+    database_password = module.rds-instance-migrated.database_password
   }
 }


### PR DESCRIPTION
* Updates `snapshot_identifier` in `rds.tf` to use final snapshot from the CCLF staging database
* Renames RDS module from `rds-instance-trial` to `rds-instance-migrated` to force recreation of the database, and updates references in `rds.tf` and `irsa.tf`
* deletes unneeded commented config from `irsa.tf`
