### PR TITLE
intranet-production Upgrade increase RDS instance class

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds" {
   db_engine                   = "mariadb"
   db_engine_version           = "10.11.9"
   rds_family                  = "mariadb10.11"
-  db_instance_class           = "db.t4g.xlarge"
+  db_instance_class           = "db.t4g.2xlarge"
   environment_name            = var.environment
   infrastructure_support      = var.infrastructure_support
   db_allocated_storage        = "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
@@ -14,10 +14,11 @@ module "rds" {
   db_engine                   = "mariadb"
   db_engine_version           = "10.11.9"
   rds_family                  = "mariadb10.11"
-  db_instance_class           = "db.t4g.2xlarge"
+  db_instance_class           = "db.t4g.xlarge"
   environment_name            = var.environment
   infrastructure_support      = var.infrastructure_support
-  db_allocated_storage        = "50"
+  db_allocated_storage        = "400"
+  db_iops                     = "12000"
   allow_major_version_upgrade = "false"
 
   # overwrite db_parameters


### PR DESCRIPTION
Having monitored [database metrics](https://grafana.live.cloud-platform.service.justice.gov.uk/d/VR46pmwWk/aws-rds?orgId=1&var-datasource=P896B4444D3F0DAB8&var-region=default&var-dbinstanceidentifier=cloud-platform-283c8dc3f78ede0f&from=now-12h&to=now) this increase in ~~instance size~~ storage is a reaction to high DiskQueueDepth.

@wilson1000 