### PR TITLE
Add RDS policies to service client in Visits Dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
@@ -7,6 +7,11 @@ locals {
   }
   sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
 
+  rds_policies = {
+    visit_scheduler_rds              = module.visit_scheduler_rds.irsa_policy_arn,
+    prison_visit_booker_registry_rds = module.prison_visit_booker_registry_rds.irsa_policy_arn
+  }
+  
   all_policies = merge(
     {
       hmpps_prison_visits_event_index_queue                           = module.hmpps_prison_visits_event_queue.irsa_policy_arn,
@@ -14,7 +19,9 @@ locals {
       hmpps_prison_visits_notification_alerts_index_queue             = module.hmpps_prison_visits_notification_alerts_queue.irsa_policy_arn,
       hmpps_prison_visits_notification_alerts_index_dead_letter_queue = module.hmpps_prison_visits_notification_alerts_dead_letter_queue.irsa_policy_arn,
     },
-  local.sns_policies)
+    local.sns_policies,
+    local.rds_policies
+  )
 }
 
 data "aws_ssm_parameter" "irsa_policy_arns_sns" {


### PR DESCRIPTION
Should allow the service account to be able to execute against the RDS instances, useful when using the service pod with the service client to run commands such as describe-db-instances, describe-db-snapshots.

This is dev only, but if successful will roll out to pre and prod also.