### PR TITLE
Restore the previous preprod DB settings so the terraform apply pipel…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -16,7 +16,7 @@ module "visit_scheduler_rds" {
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "16300"
-  db_allocated_storage        = "800"
+  db_allocated_storage        = "16000"
   db_iops                     = "12000"
   db_password_rotated_date    = "2023-03-22"
 


### PR DESCRIPTION
…ine can resume

This DB has been misconfigured with 16000GB of allocated storage. 

An attempt was made to reduce the allocated storage but this isn't possible and caused an exception on the apply pipeline, and a skip file was added. 

We are in the process of creating new instances to replace it.

In the meantime, we need to put the settings back as they were and replace the skip file so we can continue with changes to this preprod namespace in the preparations for the data migration and eventual replacement of this instance