### PR TITLE
CFE Civil STG add a max allocated storage

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/rds.tf
@@ -28,6 +28,7 @@ module "rds" {
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.small"
+  db_max_allocated_storage = "500"
 
   # rds_family should be one of: postgres10, postgres11, postgres12, postgres13, postgres14
   # Pick the one that defines the postgres version the best


### PR DESCRIPTION
I want to downgrade this storage from `small` to `micro`. On all of my other PRs to do this in various STG namesapces have failed e.g
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/8758
with the same reason:
`RequestID: 287fa6e8-9521-4548-a5bb-8ee57e6d7c05, api error InvalidParameterCombination: The maximum allocated storage must be increased by at least 10 percent.`
This PR is to add a max_allocated_storage value before merging the PR to reduce the instance size and see if that works. Any suggestions you may have are welcome