### PR TITLE
PIC-4134 court-probation-dev: Remove SNS permissions from one of the service accounts

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/irsa.tf
@@ -54,7 +54,6 @@ module "irsa" {
     { rds_ccs = module.court_case_service_rds.irsa_policy_arn },
     { rds_pss = module.pre_sentence_service_rds.irsa_policy_arn },
     { s3 = module.crime-portal-gateway-s3-bucket.irsa_policy_arn },
-    { sns_cce = module.court-case-events.irsa_policy_arn },
     { sqs_cpg = module.crime-portal-gateway-queue.irsa_policy_arn },
     { sqs_cpg_dlq = module.crime-portal-gateway-dead-letter-queue.irsa_policy_arn },
     { sqs_ccm = module.court-case-matcher-queue.irsa_policy_arn },


### PR DESCRIPTION
Remove SNS permissions from irsa service account as it is now in the `court-facing-api` service account