### PR TITLE
CFE MTR STG add allocated storage

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging-mtr/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging-mtr/resources/rds.tf
@@ -28,6 +28,7 @@ module "rds" {
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.micro"
+  db_max_allocated_storage = "500"
 
   # rds_family should be one of: postgres10, postgres11, postgres12, postgres13, postgres14
   # Pick the one that defines the postgres version the best


### PR DESCRIPTION
I was trying to downgrade my db instance class (from small to micro) and it failed to apply in concurse:

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/8758

I have added allocated storage to this PR, however I am not sure if I need to change the class back to `small` first, then merge this PR and the subsequently merge a PR that downgrades to `micro`.