### PR TITLE
Fix: rds version mismatch in hmpps-jobs-board-reporting-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-preprod/resources/rds-postgresql.tf
@@ -14,7 +14,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.2"
+  db_engine_version = "16.3"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
 


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.3 to 16.2
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-c