### PR TITLE
[SI-1262] Upgrade cat tool prod cloud-platform-terraform-rds-instance to v8.0.0

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit


### PR DESCRIPTION
Following changes made during Cat Tool prod outage (SI-1254) it was flagged (https://mojdt.slack.com/archives/C04JFG3QJE6/p1728319701004019?thread_ts=1728311264.704499&cid=C04JFG3QJE6) that we could upgrade our rds instance to 7.3.0 to take advantage of faster disk resources, preprod was then automatically updated from 7.3.1 to 8.0.0 so moving prod to 8.0.0