### PR TITLE
LAALAA STG reduce DB allocated storage

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/rds.tf
@@ -12,7 +12,7 @@ module "laa_laa_rds_postgres_14" {
   db_engine              = "postgres"
   db_engine_version      = "14"
   db_instance_class      = "db.t4g.micro"
-  db_allocated_storage   = "50"
+  db_allocated_storage   = "20"
   db_name                = "laalaa"
   db_parameter           = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
   rds_family             = "postgres14"


### PR DESCRIPTION
as suggested here: https://mojdt.slack.com/archives/C57UPMZLY/p1731581806150019?thread_ts=1731579913.865319&cid=C57UPMZLY

reducing to 15 failed with an error saying it had to be minimum of 20.
https://concourse.cloud-platform.service.justice.gov.uk/builds/22700703
So reverted it to 20