### PR TITLE
RND-202 Scope rd-ai-nexus-dev service account to development environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-dev/resources/serviceaccount.tf
@@ -9,4 +9,5 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["rd-ai-nexus"]
+  github_environments = [var.environment]
 }


### PR DESCRIPTION
This sets the environment as "development" for this namespace so that we can segregate deployments in future.