### PR TITLE
APG-557 Add Prometheus alert rules for preprod namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/00-namespace.yaml
@@ -13,3 +13,4 @@ metadata:
     cloud-platform.justice.gov.uk/owner: "Accredited Programmes: team.acp@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-accredited-programmes-ui,https://github.com/ministryofjustice/hmpps-accredited-programmes-api"
     cloud-platform.justice.gov.uk/team-name: "accredited-programmes-team"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "accredited-programmes-events"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/05-prometheusrules.yaml
@@ -1,0 +1,114 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: hmpps-accredited-programmes-preprod
+  labels:
+    role: alert-rules
+    namespace: hmpps-accredited-programmes-preprod
+  name: hmpps-accredited-programmes-preprod
+spec:
+
+  groups:
+  - name: hmpps-accredited-programmes-preprod
+    rules:
+    
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="hmpps-accredited-programmes-preprod"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="hmpps-accredited-programmes-preprod"} > 0) > 90
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+  
+    - alert: KubePod-NotReady
+      expr: |-
+        sum by (namespace, pod) (kube_pod_status_phase{namespace="hmpps-accredited-programmes-preprod", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} has been in a non-ready state for longer than 15 minutes
+
+    - alert: KubePod-CrashLooping
+      expr: |-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-accredited-programmes-preprod"}[10m]) * 60 * 10 > 3
+      for: 10m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message:  Namespace {{ $labels.namespace }} - Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
+
+    - alert: nginx-SlowResponses
+      expr: |-
+        avg(rate(nginx_ingress_controller_request_duration_seconds_sum{exported_namespace = "hmpps-accredited-programmes-preprod"}[5m])
+        /
+        rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = "hmpps-accredited-programmes-preprod"}[5m]) > 0) by (ingress) >2
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: ingress {{ $labels.ingress }} is serving slow responses over 2 seconds
+
+    - alert: nginx-5xx-Error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="hmpps-accredited-programmes-preprod", status=~"5.."}[5m]))*270 > 10
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: An HTTP 5xx error has occurred.
+
+    - alert: nginx-Server-Error
+      expr: sum(increase(http_server_requests_seconds_count{outcome="SERVER_ERROR", namespace="hmpps-accredited-programmes-preprod"}[10m])) > 1
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: There has been a server error response from the Application in the past 10 minutes. This may indicate a problem with the application processing requests.
+
+    - alert: CPU-high-threshold
+      expr: "(sum(rate(container_cpu_usage_seconds_total{namespace=\"hmpps-accredited-programmes-preprod\", container=\"infox-application\", image!=\"\"} [5m])) / sum(kube_pod_container_resource_limits{namespace=\"hmpps-accredited-programmes-preprod\", container=\"infox-application\", unit=\"core\"})) * 100 > 75"
+      for: 5m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod 
+      annotations:
+        message: CPU usage compared to the CPU limit on the container is more than 75% for 5m
+
+    - alert: Memory-high-threshold
+      expr: "(sum(container_memory_working_set_bytes{namespace=\"hmpps-accredited-programmes-preprod\", container=\"infox-application\", image!=\"\"}) / sum(kube_pod_container_resource_limits{namespace=\"hmpps-accredited-programmes-preprod\", container=\"infox-application\", unit=\"byte\"})) * 100 > 85"
+      for: 5m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod 
+      annotations:
+        message: Memory usage compared to the Memory limit on the container is more than 85% for 5m
+
+    - alert: RDS-CPU-exceeds-threshold
+      expr: aws_rds_cpuutilization_average{dbinstance_identifier="cloud-platform-e431ac1e7401f6e8"} > 95
+      for: 10m
+      annotations:
+        message: RDS Pre-prod database has high CPU (>95%) for more than ten minutes.
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+
+    - alert: RDS-Read-latency-high
+      expr: aws_rds_read_latency_average{dbinstance_identifier="cloud-platform-e431ac1e7401f6e8"} > 0.5
+      for: 1m
+      annotations:
+        message: RDS Pre-prod database read latency is over 0.5 seconds
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+
+    - alert: RDS-Write-latency-high
+      expr: aws_rds_write_latency_average{dbinstance_identifier="cloud-platform-e431ac1e7401f6e8"} > 0.5
+      for: 1m
+      annotations:
+        message: RDS Pre-prod database write latency is over 0.5 seconds
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+
+    - alert: RDS-Free-storage-space
+      expr: aws_rds_free_storage_space_average{dbinstance_identifier="cloud-platform-e431ac1e7401f6e8"} < 1024*1024*1024
+      for: 5m
+      annotations:
+        message: RDS Pre-prod database free storage space is less than 1GB
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod


### PR DESCRIPTION
- Introduce multiple Prometheus alerts for resource quotas, pod status, nginx performance, and RDS metrics within the hmpps-accredited-programmes-preprod namespace. 
- Add Slack alert channel metadata to the namespace definition.