### PR TITLE
Add CAS2 Bail to CAS env

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/00-namespace.yaml
@@ -13,5 +13,5 @@ metadata:
     cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
     cloud-platform.justice.gov.uk/application: "Community Accommodation"
     cloud-platform.justice.gov.uk/owner: "Community Accommodation: casdev@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git,https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-approved-premises-ui.git,https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,https://github.com/ministryofjustice/hmpps-approved-premises-api.git,https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui,https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui"
     cloud-platform.justice.gov.uk/team-name: "hmpps-community-accommodation"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/06-certificates.yaml
@@ -51,3 +51,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-community-accommodation-tier-2-dev-bail-cert
+  namespace: hmpps-community-accommodation-dev
+spec:
+  secretName: hmpps-community-accommodation-tier-2-bail-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - community-accommodation-tier-2-bail-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
We would like a dev environment for CAS2 Bail, under the existing CAS namespace because we will be calling the shared API in the future.