### PR TITLE
(Do Not Merge) Destroy preprod visit scheduler RDS and restore terraform apply pipeline

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/irsa.tf
@@ -8,7 +8,7 @@ locals {
   sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
 
   rds_policies = {
-    visit_scheduler_rds              = module.visit_scheduler_rds.irsa_policy_arn,
+    # visit_scheduler_rds              = module.visit_scheduler_rds.irsa_policy_arn,
     prison_visit_booker_registry_rds = module.prison_visit_booker_registry_rds.irsa_policy_arn
   }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -1,61 +1,6 @@
-module "visit_scheduler_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
-  vpc_name               = var.vpc_name
-  team_name              = var.team_name
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  environment_name       = var.environment
-  infrastructure_support = var.infrastructure_support
-  namespace              = var.namespace
-
-  allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade   = false
-  db_engine                   = "postgres"
-  db_engine_version           = "15.7"
-  rds_family                  = "postgres15"
-  db_instance_class           = "db.t4g.small"
-  db_max_allocated_storage    = "16300"
-  db_allocated_storage        = "16000"
-  db_iops                     = "12000"
-  db_password_rotated_date    = "2023-03-22"
-
-  providers = {
-    aws = aws.london
-  }
-}
-
-resource "kubernetes_secret" "visit_scheduler_rds" {
-  metadata {
-    name      = "visit-scheduler-rds"
-    namespace = var.namespace
-  }
-
-  data = {
-    rds_instance_endpoint = module.visit_scheduler_rds.rds_instance_endpoint
-    database_name         = module.visit_scheduler_rds.database_name
-    database_username     = module.visit_scheduler_rds.database_username
-    database_password     = module.visit_scheduler_rds.database_password
-    rds_instance_address  = module.visit_scheduler_rds.rds_instance_address
-  }
-}
-
-# This places a secret for this preprod RDS instance in the production namespace,
-# this can then be used by a kubernetes job which will refresh the preprod data.
-resource "kubernetes_secret" "visit_scheduler_rds_refresh_creds" {
-  metadata {
-    name      = "visit-scheduler-rds-output-preprod"
-    namespace = "visit-someone-in-prison-backend-svc-prod"
-  }
-
-  data = {
-    rds_instance_endpoint = module.visit_scheduler_rds.rds_instance_endpoint
-    database_name         = module.visit_scheduler_rds.database_name
-    database_username     = module.visit_scheduler_rds.database_username
-    database_password     = module.visit_scheduler_rds.database_password
-    rds_instance_address  = module.visit_scheduler_rds.rds_instance_address
-  }
-}
+# Deleted visit-scheduler-rds, secret, and db restore password
+# To be re-built and restored from pg_dump in a separate PR soon after this one
+# see https://dsdmoj.atlassian.net/wiki/spaces/PSCH/pages/5269618719/Database+downsizing
 
 module "prison_visit_booker_registry_rds" {
   source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"


### PR DESCRIPTION
Destroys the preprod scheduler DB so it can be rebuilt as an appropriately (smaller) sized db instance.

see https://dsdmoj.atlassian.net/wiki/spaces/PSCH/pages/5269618719/Database+downsizing 