### PR TITLE
Add CCR production pingdom tag

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/pingdom.tf
@@ -12,7 +12,7 @@ resource "pingdom_check" "laa-crown-court-remuneration-production" {
   url                      = "/ccr/"
   encryption               = true
   port                     = 443
-  tags                     = "businessunit_${var.business_unit},application_${var.application},component_ping,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.team_name}"
+  tags                     = "businessunit_${var.business_unit},application_${var.application},component_ping,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.team_name},laa_production_environment_dashboard"
   probefilters             = "region:EU"
   integrationids           = [138616]
 }


### PR DESCRIPTION
Adds the `laa_production_environment_dashboard` tag to CCR production pingdom check to add the check to the LAA dashboard.