### PR TITLE
Destroy redundant copy of visit booker registry preprod RDS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/irsa.tf
@@ -9,7 +9,6 @@ locals {
 
   rds_policies = {
     visit_scheduler_rds              = module.visit_scheduler_rds.irsa_policy_arn,
-    prison_visit_booker_registry_rds = module.prison_visit_booker_registry_rds.irsa_policy_arn
     prison_visit_booker_reg_rds      = module.prison_visit_booker_reg_rds.irsa_policy_arn
   }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -54,32 +54,6 @@ resource "kubernetes_secret" "visit_scheduler_rds_refresh_creds" {
   }
 }
 
-module "prison_visit_booker_registry_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
-  vpc_name               = var.vpc_name
-  team_name              = var.team_name
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  environment_name       = var.environment
-  infrastructure_support = var.infrastructure_support
-  namespace              = var.namespace
-
-  allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade   = false
-  db_engine                   = "postgres"
-  db_engine_version           = "15.7"
-  rds_family                  = "postgres15"
-  db_instance_class           = "db.t4g.small"
-  db_max_allocated_storage     = "16300"
-  db_password_rotated_date    = "2023-03-22"
-  performance_insights_enabled = true
-
-  providers = {
-    aws = aws.london
-  }
-}
-
 resource "kubernetes_secret" "prison_visit_booker_registry_rds" {
   metadata {
     name      = "prison-visit-booker-registry-rds"


### PR DESCRIPTION
...Freeing up another 16TB of storage allocation