### PR TITLE
Create secret for opensearch webhook secret

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/resources/secret.tf
@@ -1,0 +1,20 @@
+module "secrets_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "opensearch-low-priority-webhook" = {
+      description             = "Webhook for opensearch to send notifications into low-priority-alerts",   # Required
+      recovery_window_in_days = 7,               # Required
+      k8s_secret_name         = "opensearch-low-priority-webhook" # The name of the secret in k8s
+    },
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/resources/variables.tf
@@ -53,3 +53,6 @@ variable "github_token" {
   default     = ""
 }
 
+variable "eks_cluster_name" {
+  default = "live"
+}


### PR DESCRIPTION
Create a secret to store webhook for opensearch alerts to send to low priority alerts.
This relates to the issue [#6311](https://github.com/ministryofjustice/cloud-platform/issues/6311)