### PR TITLE
chore: 🤖 deny monitoring ns access label for user ns

### DIFF
--- a/policy/namespace.rego
+++ b/policy/namespace.rego
@@ -82,3 +82,9 @@ deny[msg] {
   not input.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
   msg := "Namespace must have label 'pod-security.kubernetes.io/enforce: restricted'"
 }
+
+deny[msg] {
+  input.kind == "Namespace"
+  input.metadata.labels["component"] == "cloud-platform-monitoring-alerts"
+  msg := "Namespace must not have label 'component: cloud-platform-monitoring-alerts'"
+}


### PR DESCRIPTION
The monitoring-alerts service exclusively requires this label, CP environments must use the [correct label](https://github.com/ministryofjustice/cloud-platform-monitoring-alerts?tab=readme-ov-file#how-to-access)

relates to ministryofjustice/cloud-platform#5207