### PR TITLE
APG 361 - Add RDS credentials secret for pre-prod refresh on production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/rds-postgresql.tf
@@ -62,3 +62,20 @@ resource "kubernetes_config_map" "rds" {
     db_identifier = module.rds.db_identifier
   }
 }
+
+# Inject pre-prod DB credentials for refresh job running on production
+resource "kubernetes_secret" "rds_prod_refresh_job_secret" {
+  metadata {
+    name      = "rds-postgresql-instance-output-preprod"
+    namespace = replace(var.namespace, "preprod", "prod")
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+    url                   = "jdbc:postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+  }
+}


### PR DESCRIPTION
This change introduces a Kubernetes secret to inject pre-prod RDS database credentials into the production namespace. This is needed to enable a refresh job to run on production using pre-prod database credentials.