### PR TITLE
VB-4893, update PVB DEV, route53 url

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "route53_zone" {
-  name = "prisonvisits-dev.service.gov.uk"
+  name = "dev.prisonvisits.service.justice.gov.uk"
 
   tags = {
     business-unit          = var.business_unit
@@ -20,31 +20,6 @@ resource "kubernetes_secret" "route53_zone_sec" {
 
   data = {
     zone_id = aws_route53_zone.route53_zone.zone_id
-  }
-}
-
-resource "aws_route53_zone" "route53_justice_zone" {
-  name = "prisonvisits-dev.service.justice.gov.uk"
-
-  tags = {
-    business-unit          = "HMPPS"
-    application            = "PVB"
-    is-production          = var.is_production
-    environment-name       = var.environment_name
-    owner                  = var.team_name
-    infrastructure-support = var.infrastructure_support
-    namespace              = var.namespace
-  }
-}
-
-resource "kubernetes_secret" "route53_justice_zone_sec" {
-  metadata {
-    name      = "route53-justice-zone-output"
-    namespace = var.namespace
-  }
-
-  data = {
-    zone_id = aws_route53_zone.route53_justice_zone.zone_id
   }
 }
 


### PR DESCRIPTION
Update PVB Dev route53 rule, both services can use the domain `dev.prisonvisits.service.justice.gov.uk`  (as both should be internal, not publicly accessible) 

Staff will use subdomain 'staff.----'