### PR TITLE
Preparing ECR for namespace per user guidance

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/bold-lrs-microservice-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/bold-lrs-microservice-dev/resources/ecr.tf
@@ -14,6 +14,8 @@ module "ecr" {
   oidc_providers      = ["github"]
   github_repositories = ["bold-lrs-microservice"]
 
+  deletion_protection = false
+
   # Tags
   business_unit          = var.business_unit
   application            = var.application


### PR DESCRIPTION
Added `  deletion_protection = false` to ecr module to prepare to delete the bold-lrs-microservice-dev namespace.