### PR TITLE
chore: 🤖 bump aws provider and rds module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -42,7 +42,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
   # VPC configuration
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.67.0"
+      version = "~> 5.78.0"
     }
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
Allowing this namespaces' aws provider to bump to latest release to support GuardDuty Malware protection functionality in terraform.

Thread:
https://mojdt.slack.com/archives/C57UPMZLY/p1732635068587109

relates to https://github.com/ministryofjustice/cloud-platform/issues/6517