### PR TITLE
SAA-2186 Downsize activities dev rds and add a read replica for DPR

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/irsa.tf
@@ -24,7 +24,17 @@ module "irsa" {
   eks_cluster_name     = var.eks_cluster_name
   namespace            = var.namespace
   service_account_name = "hmpps-activities-management-api"
-  role_policy_arns     = merge(local.sqs_policies, local.sns_policies, {rds_policy = module.activities_api_rds.irsa_policy_arn}, {analytical-platform = aws_iam_policy.analytical-platform.arn})
+  role_policy_arns = merge(
+    local.sqs_policies,
+    local.sns_policies,
+    {
+      rds_policy            = module.activities_api_rds.irsa_policy_arn,
+      activities_rds_policy = module.activities_rds.irsa_policy_arn
+    },
+    {
+      analytical-platform   = aws_iam_policy.analytical-platform.arn
+    }
+  )
 
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/rds.tf
@@ -66,3 +66,121 @@ resource "kubernetes_secret" "activities_api_rds" {
     rds_instance_address  = module.activities_api_rds.rds_instance_address
   }
 }
+
+
+module "activities_rds" {
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  vpc_name                    = var.vpc_name
+  team_name                   = var.team_name
+  business_unit               = var.business_unit
+  application                 = var.application
+  is_production               = var.is_production
+  namespace                   = var.namespace
+  environment_name            = var.environment
+  infrastructure_support      = var.infrastructure_support
+  rds_family                  = var.rds_family
+  allow_major_version_upgrade = "false"
+  allow_minor_version_upgrade = "true"
+  db_instance_class           = "db.t4g.small"
+  db_engine_version           = "14"
+  storage_type                = "gp3"
+  db_max_allocated_storage    = "50"
+
+  # Add parameters required for the read-replica to work
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+     {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    }
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "activities_rds" {
+  metadata {
+    name      = "activities_rds"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.activities_rds.rds_instance_endpoint
+    database_name         = module.activities_rds.database_name
+    database_username     = module.activities_rds.database_username
+    database_password     = module.activities_rds.database_password
+    rds_instance_address  = module.activities_rds.rds_instance_address
+  }
+}
+
+
+module "activities_rds_read_replica" {
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  vpc_name                    = var.vpc_name
+  team_name                   = var.team_name
+  business_unit               = var.business_unit
+  application                 = var.application
+  is_production               = var.is_production
+  namespace                   = var.namespace
+  environment_name            = var.environment
+  infrastructure_support      = var.infrastructure_support
+  rds_family                  = var.rds_family
+  allow_major_version_upgrade = "false"
+  allow_minor_version_upgrade = "true"
+  db_instance_class           = "db.t4g.small"
+  db_engine_version           = "14"
+  storage_type                = "gp3"
+  db_max_allocated_storage    = "50"
+
+  replicate_source_db         = module.activities_rds.db_identifier
+  skip_final_snapshot         = "true"
+  db_backup_retention_period  = 0
+  
+  # Add security groups for DPR
+  vpc_security_group_ids      = [data.aws_security_group.mp_dps_sg.id]
+
+  # Add parameters to enable DPR team to configure replication
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+     {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    }
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+}


### PR DESCRIPTION
This change creates two new RDS instances for the Activities and Appointments service.

The first exists to replace the current RDS instance which has been overallocated storage to near 10TB, whereas about 1GB is all that is actually needed.

The second RDS instance provides a read replica for the new RDS instance. DPR will replicate from this read replica into the DPR Datamart (data lake)

Once done, this pattern will be repeated for PreProd. Prod will also then get a read replica, but doesn't need downsizing.
