### PR TITLE
BaSM API Preprod: Move DPR groups to rds-instance

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -42,9 +42,32 @@ module "rds-instance" {
     aws = aws.london
   }
 
+  # Add security groups for DPR
+  vpc_security_group_ids      = [data.aws_security_group.mp_dps_sg.id]
+
   db_parameter = [
     {
       name         = "rds.force_ssl"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+     {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
       value        = "0"
       apply_method = "immediate"
     }
@@ -119,32 +142,9 @@ module "rds-read-replica" {
     aws = aws.london
   }
 
-  # Add security groups for DPR
-  vpc_security_group_ids      = [data.aws_security_group.mp_dps_sg.id]
-
   db_parameter = [
     {
       name         = "rds.force_ssl"
-      value        = "0"
-      apply_method = "immediate"
-    },
-    {
-      name         = "rds.logical_replication"
-      value        = "1"
-      apply_method = "pending-reboot"
-    },
-     {
-      name         = "shared_preload_libraries"
-      value        = "pglogical"
-      apply_method = "pending-reboot"
-    },
-    {
-      name         = "max_wal_size"
-      value        = "1024"
-      apply_method = "immediate"
-    },
-    {
-      name         = "wal_sender_timeout"
       value        = "0"
       apply_method = "immediate"
     }


### PR DESCRIPTION
Previously, I [added the DPR Security groups](https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352/Configure+DPS+RDS+Service+for+DPR+Ingestion#Setup-Connectivity) to `rds-read-replica` database.


However, the rds-read-replica database is read-only.
When I attempt to add the Postgres User for DPR:

```
CREATE ROLE digital_prison_reporting ...
ERROR:  cannot execute CREATE ROLE in a read-only transaction
```

Here, we add the DPR Security groups to the `rds-instance` 