### PR TITLE
BAVL-439 remove the migration event from the new BVLS service now it is live and all data from the old service has been migrated.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
@@ -115,7 +115,6 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
       "prisoner-offender-search.prisoner.released",
       "prison-offender-events.prisoner.merged",
       "prison-offender-events.prisoner.video-appointment.cancelled",
-      "whereabouts-api.videolink.migrate"
     ]
   })
 }


### PR DESCRIPTION
Now that the new BVLS service is live and all data from the old service is migrated, we no longer need to subscribe to the migrate data event.