### PR TITLE
Destroy the old oversized Visits RDS instance in PROD

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/irsa.tf
@@ -8,7 +8,6 @@ locals {
   sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
 
   rds_policies = {
-    visit_scheduler_rds              = module.visit_scheduler_rds.irsa_policy_arn,
     visit_scheduler_pg_rds           = module.visit_scheduler_pg_rds.irsa_policy_arn,
     prison_visit_booker_reg_rds      = module.prison_visit_booker_reg_rds.irsa_policy_arn
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
@@ -1,30 +1,3 @@
-module "visit_scheduler_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name               = var.vpc_name
-  team_name              = var.team_name
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  environment_name       = var.environment
-  infrastructure_support = var.infrastructure_support
-  namespace              = var.namespace
-
-  allow_major_version_upgrade  = "false"
-  prepare_for_major_upgrade    = false
-  db_engine                    = "postgres"
-  db_engine_version            = "15.7"
-  rds_family                   = "postgres15"
-  db_instance_class            = "db.t4g.small"
-  db_max_allocated_storage     = "16300"
-  db_allocated_storage         = "16000"
-  db_password_rotated_date     = "2023-05-11"
-  performance_insights_enabled = true
-
-  providers = {
-    aws = aws.london
-  }
-}
-
 resource "kubernetes_secret" "visit_scheduler_rds" {
   metadata {
     name      = "visit-scheduler-rds"
@@ -65,21 +38,6 @@ module "visit_scheduler_pg_rds" {
 
   providers = {
     aws = aws.london
-  }
-}
-
-resource "kubernetes_secret" "visit_scheduler_pg_rds" {
-  metadata {
-    name      = "visit-scheduler-pg-rds"
-    namespace = var.namespace
-  }
-
-  data = {
-    rds_instance_endpoint = module.visit_scheduler_pg_rds.rds_instance_endpoint
-    database_name         = module.visit_scheduler_pg_rds.database_name
-    database_username     = module.visit_scheduler_pg_rds.database_username
-    database_password     = module.visit_scheduler_pg_rds.database_password
-    rds_instance_address  = module.visit_scheduler_pg_rds.rds_instance_address
   }
 }
 


### PR DESCRIPTION
Destroys the old Visits scheduler RDS instance cloud-platform-c6e5432ed45afd19 which has been in a shutdown state since 5th December 19:00 

![image](https://github.com/user-attachments/assets/649e5deb-be8a-44b2-a00d-cf93418db4c5)

This has been replaced by cloud-platform-cab7a88fc55abc11  
![image](https://github.com/user-attachments/assets/43f3f1d8-65ce-47aa-8bae-597696150ceb)

