### PR TITLE
DPR2-179 upgrade postgres version for dpr-fake-dps-service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -25,8 +25,8 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine              = "postgres"
-  db_engine_version      = "14.11"
-  rds_family             = "postgres14"
+  db_engine_version      = "16"
+  rds_family             = "postgres16"
   db_instance_class      = "db.t4g.micro"
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
   db_parameter = [

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -18,6 +18,7 @@ module "rds" {
   # RDS configuration
   allow_minor_version_upgrade  = true
   allow_major_version_upgrade  = true
+  prepare_for_major_upgrade    = true
   performance_insights_enabled = false
   db_allocated_storage         = "600"
   db_max_allocated_storage     = "700"
@@ -25,7 +26,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine              = "postgres"
-  db_engine_version      = "16"
+  db_engine_version      = "16.2"
   rds_family             = "postgres16"
   db_instance_class      = "db.t4g.micro"
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]


### PR DESCRIPTION
- Upgrades major version of the dpr-fake-dps-service RDS Postgres so we can do some testing with an appropriate Postgres version
- Have already added the skip apply file in a previous PR https://github.com/ministryofjustice/cloud-platform-environments/pull/28383
- This is a testing and dev database
- `aws rds describe-db-engine-versions --engine postgres --engine-version 14.11` reports that 16.2 is a valid upgrade target:
```
               {
                    "Engine": "postgres",
                    "EngineVersion": "16.2",
                    "Description": "PostgreSQL 16.2-R3",
                    "AutoUpgrade": false,
                    "IsMajorVersionUpgrade": true
                }
```