### PR TITLE
BAVL-476 remove SNS subcription to domain events for legacy BVLS. Now handled by re-platformed service.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/irsa.tf
@@ -5,8 +5,6 @@ locals {
   sqs_queues = {
     "Digital-Prison-Services-dev-whereabouts_api_queue"                  = "offender-events-dev",
     "Digital-Prison-Services-dev-whereabouts_api_queue_dl"               = "offender-events-dev"
-    "Digital-Prison-Services-dev-whereabouts_api_domain_events_queue"    = "hmpps-domain-events-dev"
-    "Digital-Prison-Services-dev-whereabouts_api_domain_events_queue_dl" = "hmpps-domain-events-dev"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns : item.name => item.value }
 }


### PR DESCRIPTION
This change removes domain event subscription for legacy BVLS code.

These domain events are now handled by the live re-platformed version of the service.