### PR TITLE
Tag resources to enable BaSM / AWS access - UAT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/main.tf
@@ -10,6 +10,12 @@ provider "aws" {
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = "map-developers"
+    }
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
Tagging resources to enable AWS access to BaSM UAT.

As per:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html