### PR TITLE
Tag resources to enable BaSM / AWS access - Staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/main.tf
@@ -10,6 +10,12 @@ provider "aws" {
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = "map-developers"
+    }
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
Tagging resources to enable AWS access to BaSM Staging.

As per:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html