### PR TITLE
Protect the Activities Dev DB instance from infinite WAL size growth

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -53,6 +53,11 @@ module "rds-instance" {
       name         = "wal_sender_timeout"
       value        = "0"
       apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "5000"
+      apply_method = "immediate"
     }
   ]
 }


### PR DESCRIPTION
This should prevent the WAL from increasing infinitely in the event of a disconnect from the DPR replicated instance