### PR TITLE
CRIMAPP-1509 Update RDS to 8.0.1 on crime datastore production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
   application            = var.application
   business_unit          = var.business_unit


### PR DESCRIPTION
Updated RDS to 8.0.1 on `laa-criminal-applications-datastore-production`.