### PR TITLE
Subscribe to the event - prison-offender-events.prisoner.booking.moved - Preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/domain-events-queue-adjustments-prisoner.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/domain-events-queue-adjustments-prisoner.tf
@@ -110,7 +110,8 @@ resource "aws_sns_topic_subscription" "hmpps_adjustments_prisoner_subscription" 
     eventType = [
       "prisoner-offender-search.prisoner.released",
       "prisoner-offender-search.prisoner.received",
-      "prison-offender-events.prisoner.merged"
+      "prison-offender-events.prisoner.merged",
+      "prison-offender-events.prisoner.booking.moved"
     ]
   })
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/domain-events-queue-adjustments-prisoner.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/domain-events-queue-adjustments-prisoner.tf
@@ -110,8 +110,7 @@ resource "aws_sns_topic_subscription" "hmpps_adjustments_prisoner_subscription" 
     eventType = [
       "prisoner-offender-search.prisoner.released",
       "prisoner-offender-search.prisoner.received",
-      "prison-offender-events.prisoner.merged",
-      "prison-offender-events.prisoner.booking.moved"
+      "prison-offender-events.prisoner.merged"
     ]
   })
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-preprod/resources/domain-events-queue-adjustments-prisoner.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-preprod/resources/domain-events-queue-adjustments-prisoner.tf
@@ -110,7 +110,8 @@ resource "aws_sns_topic_subscription" "hmpps_adjustments_prisoner_subscription" 
     eventType = [
       "prisoner-offender-search.prisoner.released",
       "prisoner-offender-search.prisoner.received",
-      "prison-offender-events.prisoner.merged"
+      "prison-offender-events.prisoner.merged",
+      "prison-offender-events.prisoner.booking.moved"
     ]
   })
 }


### PR DESCRIPTION
This enables Adjustment-API to listen to the event and keep in the sync the moving of adjustments in a booking from one prisoner to another.

https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/ministryofjustice/prison-offender-events/main/async-api.yml&readOnly.

This is a backward compatible change.
https://github.com/ministryofjustice/hmpps-adjustments-api/pull/232