### PR TITLE
Set backup window time

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
@@ -20,6 +20,7 @@ module "track_a_query_rds" {
   db_name                    = "track_a_query_qa"
   environment_name           = var.environment
   infrastructure_support     = var.infrastructure_support
+  backup_window              = "02:00-04:00"
   enable_rds_auto_start_stop = true
   prepare_for_major_upgrade  = false
 


### PR DESCRIPTION
The automated database backups were thought to run every day, however it seems they are every 2 days. Cloud platform have suggested setting a backup window to see whether this resolves the issue. 