### PR TITLE
BAVL-476 remove SNS subcription to domain events for legacy BVLS in preprod. Now handled by re-platformed service.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/irsa.tf
@@ -5,8 +5,6 @@ locals {
   sqs_queues = {
     "Digital-Prison-Services-preprod-whereabouts_api_queue"                  = "offender-events-preprod",
     "Digital-Prison-Services-preprod-whereabouts_api_queue_dl"               = "offender-events-preprod",
-    "Digital-Prison-Services-preprod-whereabouts_api_domain_events_queue"    = "hmpps-domain-events-preprod"
-    "Digital-Prison-Services-preprod-whereabouts_api_domain_events_queue_dl" = "hmpps-domain-events-preprod"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns : item.name => item.value }
 }


### PR DESCRIPTION
This change removes domain event subscription for legacy BVLS code in preprod.

These domain events are now handled by the live re-platformed version of the service.
