### PR TITLE
BAVL-476 remove SNS subcription to offender events for legacy BVLS in whereabouts. Now handled by re-platformed service.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/whereabouts-sub-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-preprod/resources/whereabouts-sub-queue.tf
@@ -105,5 +105,5 @@ resource "aws_sns_topic_subscription" "whereabouts_api_subscription" {
   topic_arn     = module.offender_events.topic_arn
   protocol      = "sqs"
   endpoint      = module.whereabouts_api_queue.sqs_arn
-  filter_policy = "{\"eventType\":[\"DATA_COMPLIANCE_DELETE-OFFENDER\", \"APPOINTMENT_CHANGED\"]}"
+  filter_policy = "{\"eventType\":[\"DATA_COMPLIANCE_DELETE-OFFENDER\"]}"
 }


### PR DESCRIPTION
This change removes offender event APPOINTMENT_CHANGED subscription for legacy BVLS code in whereabouts-api preprod.

This event is now handled by the live re-platformed version of the service.
