### PR TITLE
BAVL-439 removing unused SQS queue domain events.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/irsa.tf
@@ -5,8 +5,6 @@ locals {
   sqs_queues = {
     "Digital-Prison-Services-prod-whereabouts_api_queue"                  = "offender-events-prod",
     "Digital-Prison-Services-prod-whereabouts_api_queue_dl"               = "offender-events-prod"
-    "Digital-Prison-Services-prod-whereabouts_api_domain_events_queue"    = "hmpps-domain-events-prod"
-    "Digital-Prison-Services-prod-whereabouts_api_domain_events_queue_dl" = "hmpps-domain-events-prod"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns : item.name => item.value }
 }


### PR DESCRIPTION
This queue is no longer used by the underlying BVLS/whereabouts-api code so can be removed.