### PR TITLE
Bump defaultRequest of platform pods

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/02-limitrange.yaml
@@ -12,6 +12,6 @@ spec:
       cpu: 250m
       memory: 800Mi
     defaultRequest:
-      cpu: 10m
-      memory: 128Mi
+      cpu: 50m
+      memory: 256Mi
     type: Container


### PR DESCRIPTION
We have a platform namespace that consists of a large number of small pods that support data being input to the forms deployed to the public on formbuilder.

We have recently been seeing more restarts on these pods, as we reserve a small number of pods and allow a generous 'burst' threshold, but each pod is small and I believe larger requests are when we see the pod restarts. 

As this limit range applies to all pods in the namespace, I'd like to have them reserve slightly more and burst less, in the hopes of seeing fewer pod restarts and refused connections.

This PR is on our prod sandbox namespace to start, so we can monitor the increased reserve and if it has any effect on pod restarts there, before rolling out to the prod live environment.