### PR TITLE
Bump pod default request

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/02-limitrange.yaml
@@ -12,6 +12,6 @@ spec:
       cpu: 250m
       memory: 300Mi
     defaultRequest:
-      cpu: 10m
-      memory: 128Mi
+      cpu: 50m
+      memory: 256Mi
     type: Container


### PR DESCRIPTION
This namespace has a number of small pods that experience a lot of horizontal scaling, and now appear to need slightly more default requested compute as they reach target utilisation and lock up/restart more regularly. 