### PR TITLE
Fix: rds version mismatch in hmpps-breach-notice-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-dev/resources/rds.tf
@@ -16,7 +16,7 @@ module "rds" {
   db_instance_class = "db.t4g.small"
 
   # change the postgres version as you see fit.
-  db_engine_version      = "16.1"
+  db_engine_version      = "16.3"
   environment_name       = var.environment_name
   infrastructure_support = var.infrastructure_support
   maintenance_window     = var.maintenance_window

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-preprod/resources/rds.tf
@@ -16,7 +16,7 @@ module "rds" {
   db_instance_class = "db.t4g.small"
 
   # change the postgres version as you see fit.
-  db_engine_version      = "16.1"
+  db_engine_version      = "16.3"
   environment_name       = var.environment_name
   infrastructure_support = var.infrastructure_support
   maintenance_window     = var.maintenance_window


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.3 to 16.1
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b