### PR TITLE
Fix: rds version mismatch in hmpps-candidate-matching-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/rds.tf
@@ -13,7 +13,7 @@ module "candidate_matching_rds" {
   prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.micro"
   db_max_allocated_storage    = "500"
-  db_engine_version           = "16.2"
+  db_engine_version           = "16.3"
   enable_rds_auto_start_stop  = true
 
   providers = {


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.3 to 16.2
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b