### PR TITLE
Temporarily increase CAS RDS instance size (on test env) for load testing

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds" {
   namespace                    = var.namespace
   performance_insights_enabled = true
   db_engine_version            = "14"
-  db_instance_class            = "db.t3.small"
+  db_instance_class            = "db.t3.xlarge"
   rds_family                   = "postgres14"
   allow_major_version_upgrade  = "true"
 


### PR DESCRIPTION
* We need out test database size to match our proeprod/prod database sizes while we run our load tests.
* This will ensure that the results of our loads tests are not skewed due to environment inconsistencies
* Once the load test run in complete we will reduce the size back down 