### PR TITLE
BaSM Pre-prod add security group for DPR

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/rds.tf
@@ -36,6 +36,9 @@ module "rds-instance" {
     aws = aws.london
   }
 
+  # Add security groups for DPR
+  vpc_security_group_ids     = [data.aws_security_group.mp_dps_sg.id]
+
   db_parameter = [
     {
       name         = "rds.force_ssl"


### PR DESCRIPTION
Add the security group so that the DPR team can ingest Pre-prod data