### PR TITLE
Rename the mapps queue to match new consumer name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
@@ -11,10 +11,10 @@ locals {
 
   clients = ["mapps", "heartbeat", "ctrlo", "pnd", "event-service", "mryall", "moj-pes", "maspin", "kilco", "meganexus","bmadley","serco"]
   client_queues = {
-    "mapps.client.org" = module.event_mapps_queue.sqs_name
-    pnd                = module.event_pnd_queue.sqs_name
-    maspin             = module.event_pnd_queue.sqs_name # testing
-    mryall             = module.event_pnd_queue.sqs_name # testing
-    meganexus          = module.event_plp_queue.sqs_name
+    mapps     = module.event_mapps_queue.sqs_name
+    pnd       = module.event_pnd_queue.sqs_name
+    maspin    = module.event_pnd_queue.sqs_name # testing
+    mryall    = module.event_pnd_queue.sqs_name # testing
+    meganexus = module.event_plp_queue.sqs_name
   }
 }


### PR DESCRIPTION
I think the old consumer name with dots in was causing problems in our service, so I'm updating to this service name without dots.