### PR TITLE
BaSM - Add API endpoint to SSL Certificate / dnsNames

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/certificate.yaml
@@ -10,3 +10,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
   - api.bookasecuremove.service.justice.gov.uk
+  - hmpps-book-secure-move-api-production.apps.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
The certificate is currently valid for: `api.bookasecuremove.service.justice.gov.uk`

But the web frontend uses `hmpps-book-secure-move-api-production.apps.cloud-platform.service.justice.gov.uk`

So we are adding: `hmpps-book-secure-move-api-production.apps.cloud-platform.service.justice.gov.uk` to the list of dnsNames for the SSL certificate

https://dsdmoj.atlassian.net/browse/MAP-1976