### PR TITLE
lpf-572: increase memory for pay for legal aid uat pod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-get-payments-finance-data-uat/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-get-payments-finance-data-uat/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 1000Mi
+      cpu: 4
+      memory: 16Gi
     defaultRequest:
-      cpu: 10m
-      memory: 100Mi
+      cpu: 2
+      memory: 8Gi
     type: Container


### PR DESCRIPTION
Currently memory size is too small for larger reports