### PR TITLE
Disable start stop - track-a-query-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
@@ -20,7 +20,7 @@ module "track_a_query_rds" {
   db_name                    = "track_a_query_staging"
   environment_name           = var.environment
   infrastructure_support     = var.infrastructure_support
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop = false
   prepare_for_major_upgrade  = false
 
   providers = {


### PR DESCRIPTION
Part of the investigation to resolve the database backup retention issue - https://github.com/ministryofjustice/cloud-platform/issues/6684