### PR TITLE
adding variable driven buckets.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/irsa.tf
@@ -4,10 +4,14 @@ module "irsa" {
   eks_cluster_name = var.eks_cluster_name
 
   service_account_name = "laa-sds-serviceaccount-${var.environment}"
-  role_policy_arns = {
-    dynamodb = aws_iam_policy.auditdb_policy.arn
-    s3       = module.s3_bucket.irsa_policy_arn
-  }
+
+  role_policy_arns = merge(
+    {
+      dynamodb         = aws_iam_policy.auditdb_policy.arn,
+      s3 = module.s3_bucket.irsa_policy_arn
+    },
+    { for name, module in module.s3_buckets : name => module.irsa_policy_arn }
+  )
 
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/s3.tf
@@ -16,6 +16,20 @@ module "s3_bucket" {
   namespace              = var.namespace
 }
 
+module "s3_buckets" {
+  source   = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.2.0"
+  for_each = toset(var.bucket_names)
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+  bucket_name            = "${each.value}-${var.environment}"
+}
+
 
 resource "kubernetes_secret" "s3_bucket" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/variables.tf
@@ -140,3 +140,8 @@ variable "serviceaccount_rules" {
     }
   ]
 }
+
+variable "bucket_names" {
+  type = list(string)
+  default = ["laa-sds-internal", "laa-sds-equiniti"]
+}


### PR DESCRIPTION
If this works it will make onboarding alot erasier for new teams as they will only require a name for the bucket.  we will leave it to teams to make sure there name is unique, we cant have generated names as the name for the bucket needs to be added to a configuration mapping an application to a bucket