### PR TITLE
Update CCLF to use newly migrated production database

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/irsa.tf
@@ -13,8 +13,7 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     sqs_cclf_claims = aws_iam_policy.cclf_prod_policy.arn
-    rds = module.rds-instance-trial.irsa_policy_arn
-    # cclf_copy_snapshot = aws_iam_policy.cclf_copy_snapshot_policy.arn
+    rds = module.rds-instance-migrated.irsa_policy_arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/rds.tf
@@ -1,4 +1,4 @@
-module "rds-instance-trial" {
+module "rds-instance-migrated" {
   source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=migration"
   vpc_name = var.vpc_name
 
@@ -30,7 +30,7 @@ module "rds-instance-trial" {
   # enable performance insights
   performance_insights_enabled = false
 
-  snapshot_identifier = "arn:aws:rds:eu-west-2:754256621582:snapshot:cclf-uat-for-cp-trial" # update with snapshot value, once created and moved from LZ to CP
+  snapshot_identifier = "arn:aws:rds:eu-west-2:754256621582:snapshot:cclf-prod-cutover-cp-snapshot-final-230125"
 
   providers = {
     aws = aws.london
@@ -117,10 +117,10 @@ resource "kubernetes_secret" "rds-instance" {
   }
 
   data = {
-    database_name     = module.rds-instance-trial.database_name
-    database_host     = module.rds-instance-trial.rds_instance_address
-    database_port     = module.rds-instance-trial.rds_instance_port
-    database_username = module.rds-instance-trial.database_username
-    database_password = module.rds-instance-trial.database_password
+    database_name     = module.rds-instance-migrated.database_name
+    database_host     = module.rds-instance-migrated.rds_instance_address
+    database_port     = module.rds-instance-migrated.rds_instance_port
+    database_username = module.rds-instance-migrated.database_username
+    database_password = module.rds-instance-migrated.database_password
   }
 }


### PR DESCRIPTION
* Updates `snapshot_identifier` in `rds.tf` to use the new snapshot
* Renames the RDS module to `rds-instance-migrated` to force a rebuild of the database, and updates all references to the module