### PR TITLE
Remove old cccd-production SQS IAM ARNs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/messaging.tf
@@ -59,7 +59,6 @@ resource "aws_sqs_queue_policy" "claims_for_ccr_policy" {
           "Effect": "Allow",
           "Principal": {
           "AWS": [
-            "arn:aws:iam::842522700642:role/LAA-CCR-production-AppInfrastructureTem-AppEc2Role-UJMXOZWB9CDD",
             "arn:aws:iam::754256621582:role/cloud-platform-irsa-f825723bcfd1125d-live"
               ]
           },
@@ -197,8 +196,7 @@ resource "aws_sqs_queue_policy" "responses_for_cccd" {
           "Effect": "Allow",
           "Principal": {
           "AWS": [
-            "arn:aws:iam::842522700642:role/LAA-CCLF-production-AppInfrastructureTe-AppEc2Role-6CJZ29BBMKIT",
-            "arn:aws:iam::842522700642:role/LAA-CCR-production-AppInfrastructureTem-AppEc2Role-UJMXOZWB9CDD"
+            "arn:aws:iam::842522700642:role/LAA-CCLF-production-AppInfrastructureTe-AppEc2Role-6CJZ29BBMKIT"
               ]
           },
           "Resource": "${module.responses_for_cccd.sqs_arn}",


### PR DESCRIPTION
These relate to the CCR Landing Zone environment which no longer exists.