### PR TITLE
Create 06-github-actions-runner.yaml

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/06-github-actions-runner.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/06-github-actions-runner.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-actions-runner
+  namespace: hmpps-sentence-plan-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: github-actions-runner
+  template:
+    metadata:
+      labels:
+        app: github-actions-runner
+    spec:
+      serviceAccountName: cd-serviceaccount
+      containers:
+        - name: runner
+          image: quay.io/hmpps/browser-testing-github-actions-runner:latest # Built from https://github.com/ministryofjustice/browser-testing-github-actions-runner
+          resources:
+            limits:
+              memory: 8000Mi
+              cpu: 2000m
+          securityContext:
+            runAsUser: 1001 # 'runner' user
+          env:
+            - name: RUNNER_NAME # Switch this to "RUNNER_NAME_PREFIX" if we start using multiple instances
+              value: hmpps-arns-integrations-test-runner
+            - name: RUNNER_WORKDIR
+              value: '/_work'
+            - name: LABELS
+              value: moj-cloud-platform
+            - name: REPO_URL
+              value: https://github.com/ministryofjustice/hmpps-arns-integrations-test-playwright-poc
+            - name: RUN_AS_ROOT
+              value: 'false'
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-actions-runner-token
+                  key: ACCESS_TOKEN
+            - name: ImageOS # Required for Ruby: https://github.com/ruby/setup-ruby#using-self-hosted-runners
+              value: ubuntu20


### PR DESCRIPTION
Adding this yaml to enable runs of e2e test via Github actions.