### PR TITLE
removed serviceAccountName: cd-serviceaccount to try to fix Github ac…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/06-github-actions-runner.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/06-github-actions-runner.yaml
@@ -13,7 +13,6 @@ spec:
       labels:
         app: github-actions-runner
     spec:
-      serviceAccountName: cd-serviceaccount
       containers:
         - name: runner
           image: quay.io/hmpps/browser-testing-github-actions-runner:latest # Built from https://github.com/ministryofjustice/browser-testing-github-actions-runner


### PR DESCRIPTION
Trying to remove serviceAccountName: cd-serviceaccount to hopefully fix the Github actions run. 
Job is firing but this error was found on the runner logs:

8m24s (x20 over 46m)  Warning  FailedCreate    ReplicaSet/github-actions-runner-86b5d68b64  Error creating: pods "github-actions-runner-86b5d68b64-" is forbidden: error looking up service account hmpps-sentence-plan-test/cd-serviceaccount: serviceaccount "cd-serviceaccount" not found