### PR TITLE
MAP-2068 increase memories to fix OOM error in generic-data-extractor

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 2000m
-      memory: 1024Mi
+      memory: 2048Mi
     defaultRequest:
       cpu: 10m
-      memory: 512Mi
+      memory: 1024Mi
     type: Container


### PR DESCRIPTION
The generic data extractor used by Use of Force is intermittently failing. Pod logs show an OOM error.
Increasing memory to see if this fixes issue