### PR TITLE
CRIMAPP-1523 Config AWS Secrets Manager on crime review staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/secret.tf
@@ -1,0 +1,20 @@
+
+module "secrets_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "laa-review-criminal-legal-aid-secrets" = {
+      description             = "laa-review-criminal-legal-aid-staging secrets",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-review-criminal-legal-aid-secrets"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/variables.tf
@@ -75,3 +75,7 @@ variable "github_actions_secret_kube_cluster" {
   description = "The name of the github actions secret containing the serviceaccount cluster"
   default     = "KUBE_STAGING_CLUSTER"
 }
+
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster"
+}


### PR DESCRIPTION
Added the `secrets_manager` module to `laa-review-criminal-legal-aid-staging` for the purpose of migrating from git-crypt to AWS Secrets Manager.