### PR TITLE
CRIMAPP-1523 Config AWS Secrets Manager on crime datastore staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/secret.tf
@@ -1,4 +1,3 @@
-
 module "secrets_manager" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/secret.tf
@@ -1,0 +1,20 @@
+
+module "secrets_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "laa-criminal-applications-datastore-secrets" = {
+      description             = "laa-criminal-applications-datastore-staging secrets",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-criminal-applications-datastore-secrets"
+    }
+  }
+}


### PR DESCRIPTION
Added the `secrets_manager` module to `laa-criminal-applications-datastore-staging` for the purpose of migrating from git-crypt to AWS Secrets Manager.