### PR TITLE
[CRM457-1792] swap s3 bucket name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/shared-s3-secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/shared-s3-secret.tf
@@ -13,7 +13,7 @@ resource "kubernetes_secret" "crime-forms-s3-secret" {
 
 resource "kubernetes_secret" "crime-forms-s3-secret-for-app-store" {
   metadata {
-    name      = "s3-policy-arns"
+    name      = "s3-bucket-output"
     namespace = "laa-crime-application-store-dev"
   }
 


### PR DESCRIPTION
refs https://github.com/ministryofjustice/cloud-platform-environments/pull/29135
changing shared secret name - using the wrong bucket name/wrong policy for requirements