### PR TITLE
Disable ECR deletion protection for gha-runner-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-gha-runner-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-gha-runner-dev/resources/ecr.tf
@@ -22,4 +22,5 @@ module "ecr" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
This PR disables ECR deletion protection in advance of namespace removal