### PR TITLE
Disable ECR deletion protection for flask-template

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-flask-template/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-flask-template/resources/ecr.tf
@@ -23,4 +23,5 @@ module "ecr" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
This PR disables ECR deletion protection in advance of namespace removal