### PR TITLE
CRIMAPP-1523 Config AWS Secrets Manager on crime apply production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/main.tf
@@ -5,16 +5,34 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "github" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/secret.tf
@@ -1,0 +1,19 @@
+module "secrets_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "laa-apply-for-criminal-legal-aid-secrets" = {
+      description             = "laa-apply-for-criminal-legal-aid-production secrets",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-apply-for-criminal-legal-aid-secrets"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/variables.tf
@@ -72,3 +72,7 @@ variable "github_actions_secret_kube_cluster" {
   description = "The name of the github actions secret containing the serviceaccount cluster"
   default     = "KUBE_PRODUCTION_CLUSTER"
 }
+
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster"
+}


### PR DESCRIPTION
Added the `secrets_manager` module to `laa-apply-for-criminal-legal-aid-production` for the purpose of migrating from git-crypt to AWS Secrets Manager.

Added the GithubTeam default tag to resources on `laa-apply-for-criminal-legal-aid-production`.
