### PR TITLE
Revert "Update `integrations/github` version"

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 6.5.0"
+      version = "~> 5.39.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This reverts commit 3919424bd4db99a819658d1e89f242e2c82e5925.

Apologies, accidentally committed this to the template namespace rather than the intended namespace