### PR TITLE
Update integrations/github version for HMPPS Integrations (Dev) (Attempt #2)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-dev/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = "~> 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Update the `integrations/github` version, accidentally updated the template project, which I've reverted in https://github.com/ministryofjustice/cloud-platform-environments/pull/29203