### PR TITLE
Updated team name to laa-clair-taskforce in all CCLF environments

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-crown-court-litigator-fees-dev
 subjects:
   - kind: Group
-    name: "github:laa-lz-cp-migration"
+    name: "github:laa-clair-taskforce"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-lz-cp-migration"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/00-namespace.yaml
@@ -12,5 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Crown Court Litigator Fees"
     cloud-platform.justice.gov.uk/owner: "Crime Higher Billing: laaclairtaskforce@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-crown-court-litigator-fees"
-    cloud-platform.justice.gov.uk/team-name: "laa-lz-cp-migration"
+    cloud-platform.justice.gov.uk/team-name: "laa-clair-taskforce"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-crown-court-litigator-fees-production
 subjects:
   - kind: Group
-    name: "github:laa-lz-cp-migration"
+    name: "github:laa-clair-taskforce"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-lz-cp-migration"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-crown-court-litigator-fees-staging
 subjects:
   - kind: Group
-    name: "github:laa-lz-cp-migration"
+    name: "github:laa-clair-taskforce"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-lz-cp-migration"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-crown-court-litigator-fees-uat
 subjects:
   - kind: Group
-    name: "github:laa-lz-cp-migration"
+    name: "github:laa-clair-taskforce"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-uat/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-lz-cp-migration"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }


### PR DESCRIPTION
JIRA link - https://dsdmoj.atlassian.net/browse/CTSKF-922

As we (LAA Crime Higher Billing) have migrated the CCLF application to run on Cloud-Platform, we want to replace Ops' github team with our own to grant us access.

