### PR TITLE
Change team to team responsible for CCLF staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-crown-court-litigator-fees-staging
 subjects:
   - kind: Group
-    name: "github:laa-lz-cp-migration"
+    name: "github:laa-clair-taskforce"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-lz-cp-migration"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }


### PR DESCRIPTION
    Migration of CCLF is complete. laa-clair-taskforce is responsible now.

    JIRA ticket - https://dsdmoj.atlassian.net/browse/CTSKF-922