### PR TITLE
Add serviceaccount get permissions for cd sa (prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-prod/resources/variables.tf
@@ -106,6 +106,7 @@ variable "serviceaccount_rules" {
         "deployment",
         "secrets",
         "services",
+        "serviceaccounts",
         "configmaps",
         "pods",
         "replicationcontrollers",


### PR DESCRIPTION
Give permissions for the cd-serviceaccount to get service accounts in the hmpps-delis-alfresco-prod namespace. This is to fix the deployment pipeline.