### PR TITLE
remove service account name from github action runner to try to fix actions issue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-dev/08-github-actions-runner.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-dev/08-github-actions-runner.yaml
@@ -13,7 +13,6 @@ spec:
       labels:
         app: github-actions-runner
     spec:
-      serviceAccountName: cd-serviceaccount
       containers:
         - name: runner
           image: quay.io/hmpps/browser-testing-github-actions-runner:latest # Built from https://github.com/ministryofjustice/browser-testing-github-actions-runner


### PR DESCRIPTION
Removed the service account name from hmpps-find-and-refer-an-intervention-dev namespace github actions runner in order to try and fix our non-running github actions e2e tests.