### PR TITLE
Adding alternate role name to avoid duplicating the default

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/resources/serviceaccount.tf
@@ -3,6 +3,7 @@ module "serviceaccount" {
 
   namespace                            = var.namespace
   kubernetes_cluster                   = var.kubernetes_cluster
+  role_name                            = var.serviceaccount_role_name
   serviceaccount_rules                 = var.serviceaccount_rules
   github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
   github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/resources/variables.tf
@@ -88,6 +88,12 @@ variable "github_actions_secret_kube_token" {
   default     = "KUBE_TOKEN"
 }
 
+variable "serviceaccount_role_name" {
+  type        = string
+  description = "Role name for the service account for the github actions runner"
+  default     = "-github-actions-serviceaccount-role"
+}
+
 variable "serviceaccount_rules" {
   description = "The capabilities of this service account"
 


### PR DESCRIPTION
When applying an earlier PR, it failed due to:
```shell
Error: roles.rbac.authorization.k8s.io "serviceaccount-role" already exists

  with module.serviceaccount.kubernetes_role.github_actions_role,
  on .terraform/modules/serviceaccount/main.tf line 47, in resource "kubernetes_role" "github_actions_role":
  47: resource "kubernetes_role" "github_actions_role" {
```

Adding a role_name to avoid this.