### PR TITLE
update memory for deployment test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-dev/08-github-actions-runner.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-dev/08-github-actions-runner.yaml
@@ -18,7 +18,7 @@ spec:
           image: quay.io/hmpps/browser-testing-github-actions-runner:latest # Built from https://github.com/ministryofjustice/browser-testing-github-actions-runner
           resources:
             limits:
-              memory: 4000Mi
+              memory: 5000Mi
               cpu: 1000m
           securityContext:
             runAsUser: 1001 # 'runner' user


### PR DESCRIPTION
Update to the memory amount to test a redeployment of the github-actions-runner.