### PR TITLE
PI-2751 Move DLQ notification schedule back 30 minutes

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration/07-dlq-notify.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration/07-dlq-notify.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: dlq-notify
 spec:
-  schedule: 30 7 * * 1-5
+  schedule: 0 8 * * 1-5
   concurrencyPolicy: Replace
   jobTemplate:
     spec:


### PR DESCRIPTION
Integration services are scheduled to start up at 6:30, but occasionally take longer than 30 minutes as the Delius database is still warming up.

See also https://github.com/ministryofjustice/hmpps-probation-integration-services/pull/4617