### PR TITLE
Add secrets manager config for cccd-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/main.tf
@@ -5,6 +5,11 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+  default_tags {
+    tags = {
+      GithubTeam = "laa-claim-for-payment"
+    }
+  }
 }
 
 provider "aws" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-production/resources/secrets_manager.tf
@@ -1,0 +1,24 @@
+module "secrets_manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "read-replica" = {
+      description             = "This is the RDS read replica rds_instance_endpoint / rds-instance-endpoint",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "rds-instance-endpoint"
+    },
+    "cccd-env-secrets" = {
+      description              = "CCCD production environment secrets",
+      recovery_window_in_days  = 7,
+      k8s_secret_name          = "cccd-env-vars"
+    }
+  }
+}


### PR DESCRIPTION
Creates a new secret by adding `resources/secrets_manager.tf`. Also adds `default_tags` to `resources/main.tf` to enable console access for secrets.