### PR TITLE
CRIMAPP-1523 Config AWS Secrets Manager on crime metabase

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/main.tf
@@ -5,19 +5,37 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
+
 provider "github" {
   token = var.github_token
   owner = var.github_owner
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/secret.tf
@@ -1,0 +1,19 @@
+module "secrets_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "laa-criminal-applications-metabase-secrets" = {
+      description             = "laa-criminal-applications-metabase secrets",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-criminal-applications-metabase-secrets"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/variables.tf
@@ -53,3 +53,6 @@ variable "github_token" {
   default     = ""
 }
 
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster"
+}


### PR DESCRIPTION
Added the `secrets_manager` module to `laa-criminal-applications-metabase` for the purpose of migrating from git-crypt to AWS Secrets Manager.

Added the GithubTeam default tag to resources on `laa-criminal-applications-metabase`.