### PR TITLE
RDS-1243 - 🔐 Add preprod database secrets to production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-preprod/resources/rds-postgresql.tf
@@ -133,3 +133,19 @@ resource "kubernetes_config_map" "rds" {
     db_identifier = module.hmpps_education_work_plan_rds.db_identifier
   }
 }
+
+# This places a secret for this preprod RDS instance in the production namespace,
+# this can then be used by a kubernetes job which will refresh the preprod data.
+resource "kubernetes_secret" "rds_refresh_creds" {
+  metadata {
+    name      = "rds-postgresql-instance-output-preprod"
+    namespace = "hmpps-education-and-work-plan-prod"
+  }
+
+  data = {
+    database_name         = module.hmpps_education_work_plan_rds.database_name
+    database_username     = module.hmpps_education_work_plan_rds.database_username
+    database_password     = module.hmpps_education_work_plan_rds.database_password
+    rds_instance_address  = module.hmpps_education_work_plan_rds.rds_instance_address
+  }
+}


### PR DESCRIPTION
PR to add the preprod database secrets to the prod namespace (so that we can use the [database restore job](https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-service/README.md#prison-postgres-database-restore-cronjob) to restore the prod db to preprod)