### PR TITLE
Revert CAS RDS instance size on test env (as load testing complete)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds" {
   namespace                    = var.namespace
   performance_insights_enabled = true
   db_engine_version            = "14"
-  db_instance_class            = "db.t3.xlarge"
+  db_instance_class            = "db.t3.small"
   rds_family                   = "postgres14"
   allow_major_version_upgrade  = "true"
 


### PR DESCRIPTION
**Background**
* We temporarily scaled up our test db for load testing
* Load testing is now complete

**PR changes** 
* Scale the DB back down (revert previous scale up)