### PR TITLE
VB-5190 - Prisoner retry queue [dev]

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-allocation-prisoner-retry-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-allocation-prisoner-retry-queue.tf
@@ -1,0 +1,41 @@
+######## Prison visits allocation prisoner retry queue.
+######## This will allow the visit-allocation-api to retry and failed allocations to individual prisoners when running the prison processing job.
+######## Without it, we would need to wait until the next job to trigger (next day) or reprocess the whole prison.
+
+module "hmpps_prison_visits_allocation_prisoner_retry_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.0"
+
+  # Queue configuration
+  sqs_name                   = "hmpps_prison_visits_allocation_prisoner_retry_queue"
+  encrypt_sqs_kms            = "true"
+  message_retention_seconds  = 10800 #3 hours
+  visibility_timeout_seconds = 600 #10 mins
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the queue
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+########  Secrets
+resource "kubernetes_secret" "hmpps_prison_visits_allocation_prisoner_retry_queue" {
+  ## For metadata use - not _
+  metadata {
+    name = "sqs-prison-visits-allocation-prisoner-retry-queue-secret"
+    namespace = "visit-someone-in-prison-backend-svc-dev"
+  }
+
+  data = {
+    sqs_queue_url  = module.hmpps_prison_visits_allocation_prisoner_retry_queue.sqs_id
+    sqs_queue_arn  = module.hmpps_prison_visits_allocation_prisoner_retry_queue.sqs_arn
+    sqs_queue_name = module.hmpps_prison_visits_allocation_prisoner_retry_queue.sqs_name
+  }
+}


### PR DESCRIPTION
## What does this PR do?
Introduce a new queue for retrying prisoners on an individual basis.

## Why?
Our main batch job runs on a per-prison basis. This queue is being introduced to allow us to capture failed allocation attempts for individual prisoners, and put them onto a queue for retrying.

without this, we would need to either:
A. retry the whole prison on the main queue.
B. wait until the main batch job re-runs the following day.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5190