### PR TITLE
AP-5606: Reduce noise from not founds [Civil Apply UAT]

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-uat/05-prometheus.yaml
@@ -24,7 +24,7 @@ spec:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
     - alert: NotFound-Threshold-Reached
-      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-apply-for-legalaid-uat"}[86400s])) * 86400 > 100
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-apply-for-legalaid-uat"}[300s])) * 300 > 20
       for: 1m
       labels:
         severity: apply-for-legal-aid-uat


### PR DESCRIPTION
Reduce alert noisiness.

Currently this is a noisy alert because once you get
a significant number of 404s from a scripted probe then
we keep including them in the total for 24 hours. So subsequent
"genuine" 404s are more likely to trip the alert for the next
24 hours, resulting in unimportant alert noise in the slack channel.

This is trying to only alert if 20+ 404s or more are seen in the last 5 minutes
for 1 minute.


