### PR TITLE
Change message retention config for visits events dlq

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-event.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-event.tf
@@ -91,6 +91,8 @@ module "hmpps_prison_visits_event_dead_letter_queue" {
   # Queue configuration
   sqs_name        = "hmpps_prison_visits_event_dlq"
   encrypt_sqs_kms = "true"
+  message_retention_seconds  = 43200 # 12 hours
+  visibility_timeout_seconds = 120 # 2 minutes
 
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-event.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-event.tf
@@ -91,7 +91,7 @@ module "hmpps_prison_visits_event_dead_letter_queue" {
   # Queue configuration
   sqs_name        = "hmpps_prison_visits_event_dlq"
   encrypt_sqs_kms = "true"
-  message_retention_seconds  = 36000 # 10 hours
+  message_retention_seconds  = 21600 # 6 hours
   visibility_timeout_seconds = 120 # 2 minutes
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-event.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-event.tf
@@ -34,7 +34,7 @@ module "hmpps_prison_visits_event_queue" {
   # Queue configuration
   sqs_name                   = "hmpps_prison_visits_event_queue"
   encrypt_sqs_kms            = "true"
-  message_retention_seconds  = 21600 # 6 hours
+  message_retention_seconds  = 43200 # 12 hours
   visibility_timeout_seconds = 120 # 2 minutes
 
   redrive_policy = jsonencode({
@@ -91,7 +91,7 @@ module "hmpps_prison_visits_event_dead_letter_queue" {
   # Queue configuration
   sqs_name        = "hmpps_prison_visits_event_dlq"
   encrypt_sqs_kms = "true"
-  message_retention_seconds  = 43200 # 12 hours
+  message_retention_seconds  = 36000 # 10 hours
   visibility_timeout_seconds = 120 # 2 minutes
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-notification-alerts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-notification-alerts.tf
@@ -79,7 +79,7 @@ module "hmpps_prison_visits_notification_alerts_dead_letter_queue" {
   # Queue configuration
   sqs_name        = "hmpps_prison_visits_notification_alerts_dlq"
   encrypt_sqs_kms = "true"
-  message_retention_seconds  = 36000 # 10 hours
+  message_retention_seconds  = 21600 # 6 hours
   visibility_timeout_seconds = 120 # 2 minutes
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-notification-alerts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-notification-alerts.tf
@@ -22,7 +22,7 @@ module "hmpps_prison_visits_notification_alerts_queue" {
   # Queue configuration
   sqs_name                   = "hmpps_prison_visits_notification_alerts_queue"
   encrypt_sqs_kms            = "true"
-  message_retention_seconds  = 21600 # 6 hours
+  message_retention_seconds  = 43200 # 12 hours
   visibility_timeout_seconds = 120 # 2 minutes
 
   redrive_policy = jsonencode({
@@ -79,6 +79,8 @@ module "hmpps_prison_visits_notification_alerts_dead_letter_queue" {
   # Queue configuration
   sqs_name        = "hmpps_prison_visits_notification_alerts_dlq"
   encrypt_sqs_kms = "true"
+  message_retention_seconds  = 36000 # 10 hours
+  visibility_timeout_seconds = 120 # 2 minutes
 
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
reduce from default. We don't need the message to exist longer than 1 business day.