### PR TITLE
Add Role for Circle CI pipeline to access S3 bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
@@ -2,18 +2,6 @@ data "aws_eks_cluster" "eks_cluster" {
   name = var.eks_cluster_name
 }
 
-data "aws_secretsmanager_secret" "circleci" {
-  name = "cloud-platform-circleci"
-}
-
-data "aws_secretsmanager_secret_version" "circleci" {
-  secret_id = data.aws_secretsmanager_secret.circleci.id
-}
-
-data "aws_eks_cluster" "eks_cluster" {
-  name = var.eks_cluster_name
-}
-
 module "bankwizard_bucket_assumable_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version = "5.13.0"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
@@ -20,7 +20,7 @@ module "bankwizard_bucket_assumable_role" {
   create_role = true
   role_name = "bankwizard-bucket-assumable-role"
   provider_url = "https://oidc.circleci.com/org/${local.circleci_organisation_id}"
-  role_policy_arns = module.bankwizard_artifact_bucket.irsa_policy_arn
+  role_policy_arns = [module.bankwizard_artifact_bucket.irsa_policy_arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:${var.service_account_name}"]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
@@ -10,8 +10,8 @@ data "aws_secretsmanager_secret_version" "circleci" {
   secret_id = data.aws_secretsmanager_secret.circleci.id
 }
 
-locals {
-  circleci_organisation_id = jsondecode(data.aws_secretsmanager_secret_version.circleci.secret_string)["organisation_id"]
+data "aws_eks_cluster" "eks_cluster" {
+  name = var.eks_cluster_name
 }
 
 module "bankwizard_bucket_assumable_role" {
@@ -19,7 +19,7 @@ module "bankwizard_bucket_assumable_role" {
   version = "5.13.0"
   create_role = true
   role_name = "bankwizard-bucket-assumable-role"
-  provider_url = "https://oidc.circleci.com/org/${local.circleci_organisation_id}"
+  provider_url = data.aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
   role_policy_arns = [module.bankwizard_artifact_bucket.irsa_policy_arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:${var.service_account_name}"]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
@@ -1,0 +1,36 @@
+data "aws_eks_cluster" "eks_cluster" {
+  name = var.eks_cluster_name
+}
+
+data "aws_secretsmanager_secret" "circleci" {
+  name = "cloud-platform-circleci"
+}
+
+data "aws_secretsmanager_secret_version" "circleci" {
+  secret_id = data.aws_secretsmanager_secret.circleci.id
+}
+
+locals {
+  circleci_organisation_id = jsondecode(data.aws_secretsmanager_secret_version.circleci.secret_string)["organisation_id"]
+}
+
+module "bankwizard_bucket_assumable_role" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "5.13.0"
+  create_role = true
+  role_name = "bankwizard-bucket-assumable-role"
+  provider_url = "https://oidc.circleci.com/org/${local.circleci_organisation_id}"
+  role_policy_arns = module.bankwizard_artifact_bucket.irsa_policy_arn
+  oidc_subjects_with_wildcards = ["org/${local.circleci_organisation_id}/*"]
+}
+
+resource "kubernetes_secret" "bankwizard_artifact_bucket_role" {
+  metadata {
+    name      = "bankwizard-artifact-bucket-role-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_role_arn = module.bankwizard_bucket_assumable_role.iam_role_arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
@@ -21,7 +21,7 @@ module "bankwizard_bucket_assumable_role" {
   role_name = "bankwizard-bucket-assumable-role"
   provider_url = "https://oidc.circleci.com/org/${local.circleci_organisation_id}"
   role_policy_arns = module.bankwizard_artifact_bucket.irsa_policy_arn
-  oidc_subjects_with_wildcards = ["org/${local.circleci_organisation_id}/*"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:${module.serviceaccount.serviceaccount_name}"]
 }
 
 resource "kubernetes_secret" "bankwizard_artifact_bucket_role" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/s3-oidc-role.tf
@@ -21,7 +21,7 @@ module "bankwizard_bucket_assumable_role" {
   role_name = "bankwizard-bucket-assumable-role"
   provider_url = "https://oidc.circleci.com/org/${local.circleci_organisation_id}"
   role_policy_arns = module.bankwizard_artifact_bucket.irsa_policy_arn
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:${module.serviceaccount.serviceaccount_name}"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:${var.service_account_name}"]
 }
 
 resource "kubernetes_secret" "bankwizard_artifact_bucket_role" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/serviceaccount.tf
@@ -6,7 +6,7 @@ module "serviceaccount" {
 
   serviceaccount_token_rotated_date = "01-01-2000"
 
-  serviceaccount_name = "circleci-experian-dev"
+  serviceaccount_name = var.service_account_name
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-dev/resources/variables.tf
@@ -71,3 +71,9 @@ variable "github_token" {
 variable "eks_cluster_name" {
   description = "The name of the eks cluster to retrieve the OIDC information"
 }
+
+variable "service_account_name" {
+  type        = string
+  description = "The name of the service account"
+  default     = "circleci-experian-dev"
+}


### PR DESCRIPTION
This PR is to create a role that the Circle CI pipeline for https://github.com/ministryofjustice/cica-experian-bank-wizard/ can assume to download from the S3 bucket during build using OIDC.