### PR TITLE
add the snapshot identifier to the rds-msql module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
@@ -25,6 +25,8 @@ module "rds_mysql" {
   db_instance_class = "db.t4g.micro"
   db_parameter      = []
 
+  snapshot_identifier = "rds:cloud-platform-b3b919c90c5897c4-2025-02-17-14-18"
+
   # Tags
   application            = var.application
   business_unit          = var.business_unit


### PR DESCRIPTION
relates to https://github.com/ministryofjustice/cloud-platform/issues/5401

## Purpose

- adds the **snapshot_identifier**'s value to the rds-mysql manifest
- references step [3](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rds-snapshots.html#3-update-your-current-rds-manifest-file-usually-called-rds-tf-in-the-cloud-platform-environments-repo-to-include-snapshot-identifier-and-raise-the-pr)