### PR TITLE
Use correct teamname ccr uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }
@@ -23,7 +23,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }
@@ -36,7 +36,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-clair-taskforce"
+      GithubTeam = "laa-claim-for-payment"
     }
   }
 }
@@ -23,7 +23,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-clair-taskforce"
+      GithubTeam = "laa-claim-for-payment"
     }
   }
 }
@@ -36,7 +36,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-clair-taskforce"
+      GithubTeam = "laa-claim-for-payment"
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }
@@ -23,7 +23,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }
@@ -36,7 +36,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }


### PR DESCRIPTION
Changed namespace to use laa-clair-taskforce instead of laa-claim-for-payment