### PR TITLE
Use correct teamname for CCR dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }
@@ -23,7 +23,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }
@@ -36,7 +36,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-claim-for-payment"
+      GithubTeam = "laa-clair-taskforce"
     }
   }
 }


### PR DESCRIPTION
Changed namespace to use laa-clair-taskforce instead of laa-claim-for-payment