### PR TITLE
restore to a state before data was seeded

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
@@ -25,7 +25,7 @@ module "rds_mysql" {
   db_instance_class = "db.t4g.micro"
   db_parameter      = []
 
-  snapshot_identifier = "rds:cloud-platform-b3b919c90c5897c4-2025-02-17-14-18"
+  snapshot_identifier = "rds:cloud-platform-b3b919c90c5897c4-finalsnapshot"
 
   # Tags
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
@@ -25,7 +25,7 @@ module "rds_mysql" {
   db_instance_class = "db.t4g.micro"
   db_parameter      = []
 
-  snapshot_identifier = "rds:cloud-platform-b3b919c90c5897c4-finalsnapshot"
+  snapshot_identifier = "cloud-platform-b3b919c90c5897c4-finalsnapshot"
 
   # Tags
   application            = var.application


### PR DESCRIPTION
## Purpose

- restores the database using an older **snapshot identifier** to restore the RDS database to a state before data was seeded to it
- the restoration comes after data was seeded to the database and a manual snapshot had been taken
- a manual snapshot wasn't taken [here](https://github.com/ministryofjustice/cloud-platform-environments/pull/29768) before the restore attempt, so the data was lost after the database was recreated.

relates to https://github.com/ministryofjustice/cloud-platform/issues/5401