### PR TITLE
Fix snapshotid conflict

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
@@ -25,7 +25,7 @@ module "rds_mysql" {
   db_instance_class = "db.t4g.micro"
   db_parameter      = []
 
-  snapshot_identifier = "rds:cloud-platform-b3b919c90c5897c4-2025-02-19-14-58"
+  snapshot_identifier = "folarin-test-manual-snapshot-2025-02-19"
 
   # Tags
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-mysql.tf
@@ -25,7 +25,7 @@ module "rds_mysql" {
   db_instance_class = "db.t4g.micro"
   db_parameter      = []
 
-  snapshot_identifier = "cloud-platform-b3b919c90c5897c4-finalsnapshot"
+  snapshot_identifier = "rds:cloud-platform-b3b919c90c5897c4-2025-02-19-14-58"
 
   # Tags
   application            = var.application


### PR DESCRIPTION
## Fix

- use the manually-taken snapshot to recreate the database
- attempting to restore by using the final snapshot of the deleted DB will fail because Terraform will (by default) attempt 
   to create a final snapshot with the same name for the database that's to be deleted/recreated, hence the conflict.

relates to https://github.com/ministryofjustice/cloud-platform/issues/5401