### PR TITLE
community accommodation - re-adding rds role_polciy_arn

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/irsa.tf
@@ -16,6 +16,7 @@ module "irsa" {
   service_account_name = "hmpps-community-accommodation-api-service-account"
   namespace            = var.namespace
   role_policy_arns = merge(
+    { rds = module.rds.irsa_policy_arn },
     { cas-2-sqs = module.cas-2-domain-events-listener-queue.irsa_policy_arn },
     { cas-2-sqs-dlq = module.cas-2-domain-events-listener-dlq.irsa_policy_arn },
     local.sns_policies


### PR DESCRIPTION
re-adding rds role_polciy_arn arn that was removed in 6a1e4f4c2608cc58019505eb6e885690c12206bb