### PR TITLE
✨ Add `github-community-prod` Namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "github-community-prod"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "github-community"
+    cloud-platform.justice.gov.uk/application: "GitHub Community UI"
+    cloud-platform.justice.gov.uk/owner: "GitHub Community: github-community@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/github-community"
+    cloud-platform.justice.gov.uk/team-name: "github-community"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: github-community-prod-admin
+  namespace: github-community-prod
+subjects:
+  - kind: Group
+    name: "github:github-community"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: github-community-prod
+spec:
+  limits:
+    - default:
+        cpu: 1000m
+        memory: 1000Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 100Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: github-community-prod
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: github-community-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: github-community-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/ecr.tf
@@ -1,0 +1,44 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.0"
+
+  repo_name = var.namespace
+
+  # set this if you use one GitHub repository to push to multiple container repositories
+  # this ensures the variable key used in the workflow is unique
+  github_actions_prefix = "development"
+
+  # enable the oidc implementation for GitHub
+  oidc_providers = ["github"]
+
+  # specify which GitHub repository you're pushing from
+  github_repositories = ["github-community"]
+
+  lifecycle_policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire images older than 14 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 14
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/irsa.tf
@@ -1,0 +1,25 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "github-community-prod"
+  namespace            = var.namespace # this is also used as a tag
+
+  # Attach the approprate policies using a key => value map
+  # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
+  # provide an output called `irsa_policy_arn` that can be used.
+  role_policy_arns = {
+    rds = module.rds.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/rds.tf
@@ -1,0 +1,38 @@
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # Database configuration
+  db_engine                   = "postgres"
+  db_engine_version           = "17"
+  rds_family                  = "postgres17"
+  db_instance_class           = "db.t4g.micro"
+  db_max_allocated_storage    = "500"
+  allow_minor_version_upgrade = "true"
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/serviceaccount.tf
@@ -1,0 +1,15 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories                  = ["github-community"]
+  github_actions_secret_kube_namespace = "PROD_KUBE_NAMESPACE"
+  github_actions_secret_kube_cert      = "PROD_KUBE_CERT"
+  github_actions_secret_kube_token     = "PROD_KUBE_TOKEN"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/variables.tf
@@ -1,0 +1,73 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Slack to GitHub username translation"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "github-community-prod"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "GitHub Community"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "github-community@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "true"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "github-community"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.39.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
## 👀 Purpose

- To provide a namespace for github community projects to be hosted and migrated away from Operations Engineering 

## ♻️ What's changed

- Added `github-community-prod` Namespace with some required infrastructure for migrating some projects