### PR TITLE
🔧 Fix Failing Deployment by Making Team Name Lowercase

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/variables.tf
@@ -29,7 +29,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "GitHub Community"
+  default     = "github-community"
 }
 
 variable "environment" {


### PR DESCRIPTION
## 👀 Purpose

- Fixes https://github.com/ministryofjustice/cloud-platform-environments/pull/29956
- Receives the following error due to the team name being uppercase, and the regex requires all lower case. The team name is being used in the ECR creation:
```
Error: creating ECR Repository (GitHub Community/github-community-prod): 
operation error ECR: CreateRepository, https response error StatusCode: 400, RequestID: 
d6e53279-2078-41eb-8515-d4d86a3c813d, InvalidParameterException: 
Invalid parameter at 'repositoryName' failed to satisfy constraint: 
'must satisfy regular expression '(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*''
```

## ♻️ What's changed

- Converted team name to lowercase