### PR TITLE
Add CCLF production pingdom tag

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/pingdom.tf
@@ -12,7 +12,7 @@ resource "pingdom_check" "laa-crown-court-litigator-fees-production" {
   url                      = "/cclf/"
   encryption               = true
   port                     = 443
-  tags                     = "businessunit_${var.business_unit},application_${var.application},component_ping,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.team_name}"
+  tags                     = "businessunit_${var.business_unit},application_${var.application},component_ping,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.team_name},laa_production_environment_dashboard"
   probefilters             = "region:EU"
   integrationids           = [140132]
 }


### PR DESCRIPTION
Adds the `laa_production_environment_dashboard` tag to CCLF production to add the pingdom check to the LAA dashboard