### PR TITLE
Re-enable events on prod for reporting

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/hmpps-prison-visits-event.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/hmpps-prison-visits-event.tf
@@ -18,6 +18,8 @@ resource "aws_sns_topic_subscription" "hmpps_prison_visits_event_subscription" {
       "prison-offender-events.prisoner.received",
       "prison-offender-events.prisoner.restriction.changed",
       "prison-offender-events.prisoner.person-restriction.upserted",
+      "prison-offender-events.prisoner.contact-approved",
+      "prison-offender-events.prisoner.contact-unapproved",
       "prisoner-offender-search.prisoner.alerts-updated",
     ]
   })


### PR DESCRIPTION
Re-enable prison-offender-events.prisoner.contact-approved and prison-offender-events.prisoner.contact-unapproved events on prod for reporting.