### PR TITLE
add v16 snapshot identifier to the postgresql manifest

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql.tf
@@ -7,6 +7,12 @@
 module "rds" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
+  # add v16's snapshot identifier
+  snapshot_identifier    = "manual-pre-v17-upgrade-20250221-161407"
+  skip_final_snapshot    = true
+  deletion_protection    = false  # temporary for restoration
+
+
   # VPC configuration
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/restored-db.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/restored-db.tf
@@ -2,7 +2,6 @@ module "restored_db" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
   # Unique identifiers
-  application            = "restored-db"  # different from the original
   db_instance_name       = "restored-v16-instance"
   
   # Snapshot config
@@ -15,12 +14,28 @@ module "restored_db" {
   db_engine_version      = "16.3"
   rds_family             = "postgres16"
   db_instance_class      = "db.t4g.micro"
+
+  # Tags
+  application            = "restored-db"  # different from the original
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = true
+  db_max_allocated_storage     = "500"
+  prepare_for_major_upgrade   = false
 }
 
 # Unique secret name
-resource "kubernetes_secret" "restored_db" {
+resource "kubernetes_secret" "restored_db_secret" {
   metadata {
-    name      = "restored-db-postgresql-output"  # unique name
+    name      = "restored-db-postgresql-output"
     namespace = var.namespace
   }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/restored-db.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/restored-db.tf
@@ -1,8 +1,5 @@
 module "restored_db" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
-
-  # Unique identifiers
-  db_instance_name       = "restored-v16-instance"
   
   # Snapshot config
   snapshot_identifier    = "manual-pre-v17-upgrade-20250221-161407"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/restored-db.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/restored-db.tf
@@ -1,0 +1,33 @@
+module "restored_db" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  # Unique identifiers
+  application            = "restored-db"  # different from the original
+  db_instance_name       = "restored-v16-instance"
+  
+  # Snapshot config
+  snapshot_identifier    = "manual-pre-v17-upgrade-20250221-161407"
+  skip_final_snapshot    = true
+  deletion_protection    = false
+
+  # Reuse other config
+  vpc_name               = var.vpc_name
+  db_engine_version      = "16.3"
+  rds_family             = "postgres16"
+  db_instance_class      = "db.t4g.micro"
+}
+
+# Unique secret name
+resource "kubernetes_secret" "restored_db" {
+  metadata {
+    name      = "restored-db-postgresql-output"  # unique name
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.restored_db.rds_instance_endpoint
+    database_name         = module.restored_db.database_name
+    database_username     = module.restored_db.database_username
+    database_password     = module.restored_db.database_password
+  }
+}


### PR DESCRIPTION
## Purpose

- reference the manual snapshot that's taken  in version 16 in the postgresql manifest
- create a new database instance to restore onto