### PR TITLE
add new hmppt cloud template for each CAS service for prod environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/elasticache.tf
@@ -34,5 +34,6 @@ resource "kubernetes_secret" "elasticache_redis" {
     primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
     auth_token               = module.elasticache_redis.auth_token
     member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    replication_group_id     = module.elasticache_redis.replication_group_id
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-approved-premises-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-approved-premises-api.tf
@@ -1,0 +1,16 @@
+module "hmpps_approved_premises_api" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo = "hmpps-approved-premises-api"
+  application = "hmpps-approved-premises-api"
+  github_team = "hmpps-community-accommodation"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
+  selected_branch_patterns      = ["main"] # Optional
+  protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "prod" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-approved-premises-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-approved-premises-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps_approved_premises_ui" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo = "hmpps-approved-premises-ui"
+  application = "hmpps-approved-premises-ui"
+  github_team = "hmpps-community-accommodation"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
+  selected_branch_patterns      = ["main"] # Optional
+  protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "prod" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-community-accommodation-tier-2-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-community-accommodation-tier-2-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps_community_accommodation_tier_2_ui" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo = "hmpps-community-accommodation-tier-2-ui"
+  application = "hmpps-community-accommodation-tier-2-ui"
+  github_team = "hmpps-community-accommodation"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
+  selected_branch_patterns      = ["main"] # Optional
+  protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "prod" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-temporary-accommodation-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-temporary-accommodation-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps_temporary_accommodation_ui" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo = "hmpps-temporary-accommodation-ui"
+  application = "hmpps-temporary-accommodation-ui"
+  github_team = "hmpps-community-accommodation"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
+  selected_branch_patterns      = ["main"] # Optional
+  protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "prod" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = ">= 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Following [this pr](Following this https://github.com/ministryofjustice/cloud-platform-environments/pull/29975, adding this for the test environment) adds hmpps cloud template for the prod environment