### PR TITLE
CPR-495 Create Standard SQS queue for CPR events

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/cpr-court-cases-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/cpr-court-cases-queue.tf
@@ -1,0 +1,106 @@
+resource "aws_sns_topic_subscription" "cpr_court_cases_subscription" {
+  provider  = aws.london
+  topic_arn = data.aws_ssm_parameter.cpr_court_topic_sns_arn
+  protocol  = "sqs"
+  endpoint  = module.cpr-court-cases-queue.sqs_arn
+}
+
+module "cpr-court-cases-queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.0"
+
+  # Queue configuration
+  sqs_name                    = "cpr-court-cases"
+  encrypt_sqs_kms             = "true"
+  message_retention_seconds   = 1209600
+  visibility_timeout_seconds  = 120
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.cpr-court-cases-dlq.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = "court-case-matcher"
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+data "aws_iam_policy_document" "cpr_court_cases_sqs_queue_policy_document" {
+  statement {
+    sid     = "CprCourtEventsToQueue"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      variable = "aws:SourceArn"
+      test     = "ArnEquals"
+      values   = [data.aws_ssm_parameter.cpr_court_topic_sns_arn]
+    }
+    resources = ["*"]
+  }
+}
+
+resource "aws_sqs_queue_policy" "cpr_court_cases_queue_policy" {
+  queue_url = module.cpr-court-cases-queue.sqs_id
+  policy = data.aws_iam_policy_document.cpr_court_cases_sqs_queue_policy_document.json
+}
+
+module "cpr-court-cases-dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.0"
+
+  # Queue configuration
+  sqs_name                    = "cpr-court-cases-dlq"
+  encrypt_sqs_kms             = "true"
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = "court-case-matcher"
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+########  Secrets
+
+resource "kubernetes_secret" "cpr-court-cases-queue-secret" {
+  metadata {
+    name      = "cpr-court-cases-queue-credentials"
+    namespace = var.namespace
+  }
+
+  data = {
+    sqs_id   = module.cpr-court-cases-queue.sqs_id
+    sqs_arn  = module.cpr-court-cases-queue.sqs_arn
+    sqs_name = module.cpr-court-cases-queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "cpr-court-cases-dlq-secret" {
+  metadata {
+    name      = "cpr-court-cases-dlq-credentials"
+    namespace = var.namespace
+  }
+
+  data = {
+    sqs_id   = module.cpr-court-cases-dlq.sqs_id
+    sqs_arn  = module.cpr-court-cases-dlq.sqs_arn
+    sqs_name = module.cpr-court-cases-dlq.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/cpr-court-cases-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/cpr-court-cases-queue.tf
@@ -1,6 +1,6 @@
 resource "aws_sns_topic_subscription" "cpr_court_cases_subscription" {
   provider  = aws.london
-  topic_arn = data.aws_ssm_parameter.cpr_court_topic_sns_arn
+  topic_arn = data.aws_ssm_parameter.cpr_court_topic_sns_arn.value
   protocol  = "sqs"
   endpoint  = module.cpr-court-cases-queue.sqs_arn
 }
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "cpr_court_cases_sqs_queue_policy_document" {
     condition {
       variable = "aws:SourceArn"
       test     = "ArnEquals"
-      values   = [data.aws_ssm_parameter.cpr_court_topic_sns_arn]
+      values   = [data.aws_ssm_parameter.cpr_court_topic_sns_arn.value]
     }
     resources = ["*"]
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/data.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/data.tf
@@ -1,3 +1,7 @@
 data "aws_ssm_parameter" "hmpps-domain-events-topic-arn" {
   name = "/hmpps-domain-events-dev/topic-arn"
 }
+
+data "aws_ssm_parameter" "cpr_court_topic_sns_arn" {
+  name = "/hmpps-person-record-dev/cpr-court-topic-sns-arn"
+}


### PR DESCRIPTION
Create a **standard** SQS queue and subscribe it to the CPR SNS topic in **court-probation-dev**

Get CPRs SNS topic arn from `aws_ssm_parameter` resource in order to get the SQS queue to subscribe to it.