### PR TITLE
Remove username and password variables and setting strings instead

### DIFF
--- a/namespace-resources-cli-template/resources/prototype/basic-auth.tf
+++ b/namespace-resources-cli-template/resources/prototype/basic-auth.tf
@@ -7,7 +7,7 @@ resource "kubernetes_secret" "basic_auth" {
   }
 
   data = {
-    username = var.basic-auth-username
-    password = var.basic-auth-password
+    username = "prototype"
+    password = "notarealwebsite"
   }
 }


### PR DESCRIPTION
This change relates to issue [#6769](https://github.com/ministryofjustice/cloud-platform/issues/6769)

Removing the ability to set prototype credentials and instead have them set as default values.
This change has been tested in a test namespace and using the cloud-platform cli tool to ensure it works as intended.