### PR TITLE
Add cas2v2 dev cloud template

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/hmpps-community-accommodation-tier-2-bail-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/hmpps-community-accommodation-tier-2-bail-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-community-accommodation-tier-2-bail-ui" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo = "hmpps-community-accommodation-tier-2-bail-ui"
+  application = "hmpps-community-accommodation-tier-2-bail-ui"
+  github_team = "hmpps-community-accommodation"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation", "hmpps-community-accommodation-tier-2"] # Optional team that should review deployments to this environment.
+  selected_branch_patterns      = ["main", "feature-dev/*"] # Optional
+  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}


### PR DESCRIPTION
Following the likes of [this pr](https://github.com/ministryofjustice/cloud-platform-environments/pull/29989) I added CAS2v2 (or CAS2 Bail UI) cloud template, as I didn't realise that not doing that would remove all their secrets