### PR TITLE
SAA-2354: revert the changes to upgrade prod database to version 16.3

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/rds.tf
@@ -13,12 +13,12 @@ module "activities_api_rds" {
   namespace                   = var.namespace
   environment_name            = var.environment
   infrastructure_support      = var.infrastructure_support
-  prepare_for_major_upgrade   = true
-  rds_family                  = "postgres16"
+  prepare_for_major_upgrade   = false
+  rds_family                  = "postgres14"
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"
   db_instance_class           = "db.t4g.medium"
-  db_engine_version           = "16.3"
+  db_engine_version           = "14.12"
   performance_insights_enabled = true
 
   # Add security groups for DPR

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/rds.tf
@@ -18,7 +18,7 @@ module "activities_api_rds" {
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"
   db_instance_class           = "db.t4g.medium"
-  db_engine_version           = "14"
+  db_engine_version           = "14.12"
   performance_insights_enabled = true
 
   # Add security groups for DPR

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/rds.tf
@@ -18,7 +18,7 @@ module "activities_api_rds" {
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"
   db_instance_class           = "db.t4g.medium"
-  db_engine_version           = "14.12"
+  db_engine_version           = "14"
   performance_insights_enabled = true
 
   # Add security groups for DPR


### PR DESCRIPTION
revert the changes to upgrade prod database to version 16.3. Set the db_engine_version to 14.12 as that is what prod is at.

The prepare_for_major_upgrade was set in a prior PR to the upgrade itself and it failed to apply.