### PR TITLE
Fix: rds version mismatch in hmpps-registers-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/rds.tf
@@ -11,7 +11,7 @@ module "prisons_rds" {
 
   db_instance_class         = "db.t4g.small"
   db_engine                 = "postgres"
-  db_engine_version         = "16.3"
+  db_engine_version         = "16.4"
   rds_family                = "postgres16"
   db_max_allocated_storage  = "10000"
     # use "allow_major_version_upgrade" when upgrading the major version of an engine


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.4 to 16.3
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-c