### PR TITLE
Fix: rds version mismatch in family-mediators-api-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
@@ -18,7 +18,7 @@ module "rds-instance" {
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000"
   db_engine                = "postgres"
-  db_engine_version        = "16.3"
+  db_engine_version        = "16.4"
   rds_family               = "postgres16"
   prepare_for_major_upgrade = false
 


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.4 to 16.3
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-b