### PR TITLE
Add info mtls certs back to infox

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/secrets.tf
@@ -15,6 +15,11 @@ module "secrets_manager" {
       recovery_window_in_days = 7,                                   # Required - number of days that AWS Secrets Manager waits before it can delete the secret
       k8s_secret_name         = "laa-infox-db-password-test"         # The name of the secret in k8s
     },
+    "laa-infox-mtls-certs" = {
+      description             = "InfoX MTLS Certificates (base64-encoded). These certificates are used to secure the Libra endpoint.", # Required
+      recovery_window_in_days = 7,                                                                                                     # Required - number of days that AWS Secrets Manager waits before it can delete the secret
+      k8s_secret_name         = "app-libra-mtls-certs"                                                                                 # The name of the secret in k8s
+    },
     "laa-infox-keystore-password" = {
       description             = "InfoX Keystore password [test].",   # Required
       recovery_window_in_days = 7,                            # Required - number of days that AWS Secrets Manager waits before it can delete the secret


### PR DESCRIPTION
This secret was removed and is required by infox, adding it back in. 