### PR TITLE
Fix: rds version mismatch in send-legal-mail-to-prisons-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
@@ -12,7 +12,7 @@ module "slmtp_api_rds" {
   allow_major_version_upgrade = "false"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "15.7"
+  db_engine_version           = "15.8"
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "10000"


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-e