### PR TITLE
chore: bump 7.2.2 rds to 8.0.1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +44,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "checkmydiary_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-dev/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +44,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-preprod/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +44,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds-pre-sentence-service.tf
@@ -1,5 +1,8 @@
 module "pre_sentence_service_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "court_case_service_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test2/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test2/resources/rds.tf
@@ -1,5 +1,8 @@
 module "create_and_vary_a_licence_api_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -15,7 +18,7 @@ module "create_and_vary_a_licence_api_rds" {
   rds_family                  = "postgres15"
   prepare_for_major_upgrade   = false
   db_password_rotated_date    = "14-02-2023"
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop  = true
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
@@ -3,21 +3,24 @@
 ############################################
 
 module "rds-instance" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                   = var.vpc_name
-  team_name                  = var.team_name
-  business_unit              = var.business_unit
-  application                = var.application
-  is_production              = var.is_production
-  environment_name           = var.environment_name
-  infrastructure_support     = var.infrastructure_support
-  namespace                  = var.namespace
-  db_instance_class          = "db.t4g.micro"
-  db_max_allocated_storage   = "500"
-  rds_family                 = "postgres16"
-  db_engine                  = "postgres"
-  db_engine_version          = "16"
-  backup_window              = "06:00-08:00"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
+  vpc_name                 = var.vpc_name
+  team_name                = var.team_name
+  business_unit            = var.business_unit
+  application              = var.application
+  is_production            = var.is_production
+  environment_name         = var.environment_name
+  infrastructure_support   = var.infrastructure_support
+  namespace                = var.namespace
+  db_instance_class        = "db.t4g.micro"
+  db_max_allocated_storage = "500"
+  rds_family               = "postgres16"
+  db_engine                = "postgres"
+  db_engine_version        = "16"
+  backup_window            = "06:00-08:00"
 
   enable_rds_auto_start_stop = true
   prepare_for_major_upgrade  = false

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -1,5 +1,8 @@
 module "hmcts-complaints-adapter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_hmcts_complaints_adapter

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/rds.tf
@@ -1,6 +1,9 @@
 
 module "hmpps_assess_risks_and_needs_prod_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/rds.tf
@@ -1,5 +1,8 @@
 module "hmpps_audit_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -9,15 +12,15 @@ module "hmpps_audit_rds" {
   environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 
-  db_instance_class          = "db.t4g.micro"
-  db_max_allocated_storage   = "500"
-  rds_family                 = "postgres16"
-  db_engine_version          = "16"
-  deletion_protection        = true
-  enable_rds_auto_start_stop = true
-  prepare_for_major_upgrade  = false
-  db_engine                  = "postgres"
-  performance_insights_enabled  = true
+  db_instance_class            = "db.t4g.micro"
+  db_max_allocated_storage     = "500"
+  rds_family                   = "postgres16"
+  db_engine_version            = "16"
+  deletion_protection          = true
+  enable_rds_auto_start_stop   = true
+  prepare_for_major_upgrade    = false
+  db_engine                    = "postgres"
+  performance_insights_enabled = true
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "hmpps_audit_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -9,14 +12,14 @@ module "hmpps_audit_rds" {
   environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 
-  db_instance_class         = "db.t4g.small"
-  db_engine                 = "postgres"
-  db_engine_version         = "16"
-  rds_family                = "postgres16"
-  db_max_allocated_storage  = "10000"
-  prepare_for_major_upgrade = false
-  deletion_protection       = true
-  performance_insights_enabled  = true
+  db_instance_class            = "db.t4g.small"
+  db_engine                    = "postgres"
+  db_engine_version            = "16"
+  rds_family                   = "postgres16"
+  db_max_allocated_storage     = "10000"
+  prepare_for_major_upgrade    = false
+  deletion_protection          = true
+  performance_insights_enabled = true
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "dps_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/rds.tf
@@ -1,20 +1,23 @@
 module "dps_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                  = var.vpc_name
-  team_name                 = var.team_name
-  business_unit             = var.business_unit
-  application               = var.application
-  is_production             = var.is_production
-  namespace                 = var.namespace
-  environment_name          = var.environment-name
-  infrastructure_support    = var.infrastructure_support
-  db_instance_class         = "db.t4g.small"
-  db_max_allocated_storage  = "500"
-  deletion_protection       = true
-  prepare_for_major_upgrade = false
-  rds_family                = "postgres16"
-  db_engine                 = "postgres"
-  db_engine_version         = "16"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
+  vpc_name                     = var.vpc_name
+  team_name                    = var.team_name
+  business_unit                = var.business_unit
+  application                  = var.application
+  is_production                = var.is_production
+  namespace                    = var.namespace
+  environment_name             = var.environment-name
+  infrastructure_support       = var.infrastructure_support
+  db_instance_class            = "db.t4g.small"
+  db_max_allocated_storage     = "500"
+  deletion_protection          = true
+  prepare_for_major_upgrade    = false
+  rds_family                   = "postgres16"
+  db_engine                    = "postgres"
+  db_engine_version            = "16"
   performance_insights_enabled = true
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/rds.tf
@@ -1,5 +1,8 @@
 module "candidate_matching_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "candidate_matching_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
@@ -1,5 +1,8 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -21,7 +24,10 @@ module "rds" {
 
 module "read_replica" {
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-register-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-register-prod/resources/rds-postgresql.tf
@@ -1,6 +1,9 @@
 
 module "court-register-api-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-stage/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds_alfresco" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/rds.tf
@@ -4,7 +4,10 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "edu_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "edu_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/rds-postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/rds-postgres.tf
@@ -1,5 +1,8 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -44,7 +47,10 @@ resource "kubernetes_secret" "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -53,7 +59,7 @@ module "read_replica" {
   is_production          = var.is_production
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
-  namespace              = var.namespace  
+  namespace              = var.namespace
 
   # Set the database_name of the source db
   db_name = module.rds.database_name
@@ -64,7 +70,7 @@ module "read_replica" {
   # Set to true. No backups or snapshots are created for read replica
   skip_final_snapshot        = "true"
   db_backup_retention_period = 0
-  
+
 }
 
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "identify_remand_periods_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/rds_postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/rds_postgres.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -50,7 +53,10 @@ resource "kubernetes_secret" "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
@@ -1,5 +1,7 @@
 module "hmpps_interventions_postgres14" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -9,11 +11,11 @@ module "hmpps_interventions_postgres14" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 
-  rds_family                  = "postgres14"
-  db_engine_version           = "14.12"
-  db_instance_class           = "db.m5.large"
-  db_allocated_storage        = 20
-  allow_major_version_upgrade = "false"
+  rds_family                   = "postgres14"
+  db_engine_version            = "14.12"
+  db_instance_class            = "db.m5.large"
+  db_allocated_storage         = 20
+  allow_major_version_upgrade  = "false"
   performance_insights_enabled = true
 
   providers = {
@@ -56,7 +58,9 @@ resource "kubernetes_secret" "hmpps_interventions_refresh14_secret" {
 
 
 module "hmpps_interventions_postgres14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-dev/resources/rds-postgresql.tf
@@ -1,5 +1,8 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-preprod/resources/rds-postgresql.tf
@@ -1,5 +1,8 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/rds.tf
@@ -1,5 +1,8 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-preprod/resources/rds-postgresql.tf
@@ -1,5 +1,8 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "nomis_migration_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-preprod/resources/rds.tf
@@ -1,21 +1,24 @@
 module "hmpps_prisoner_search_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
-  vpc_name                     = var.vpc_name
-  team_name                    = var.team_name
-  business_unit                = var.business_unit
-  application                  = var.application
-  is_production                = var.is_production
-  namespace                    = var.namespace
-  environment_name             = var.environment
-  infrastructure_support       = var.infrastructure_support
-  db_instance_class            = "db.t4g.micro"
-  db_engine                    = "postgres"
-  db_engine_version            = "17"
-  rds_family                   = "postgres17"
-  deletion_protection          = true
-  prepare_for_major_upgrade    = false
-  db_max_allocated_storage     = "500"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+
+  vpc_name                  = var.vpc_name
+  team_name                 = var.team_name
+  business_unit             = var.business_unit
+  application               = var.application
+  is_production             = var.is_production
+  namespace                 = var.namespace
+  environment_name          = var.environment
+  infrastructure_support    = var.infrastructure_support
+  db_instance_class         = "db.t4g.micro"
+  db_engine                 = "postgres"
+  db_engine_version         = "17"
+  rds_family                = "postgres17"
+  deletion_protection       = true
+  prepare_for_major_upgrade = false
+  db_max_allocated_storage  = "500"
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/rds-postgresql.tf
@@ -6,7 +6,10 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -60,7 +63,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -1,6 +1,9 @@
 
 module "hmpps_strengths_based_needs_assessments_dev_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -15,7 +18,7 @@ module "hmpps_strengths_based_needs_assessments_dev_rds" {
   db_engine_version      = "16"
 
   allow_major_version_upgrade = "true"
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade   = false
 
   providers = {
     aws = aws.london

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
@@ -6,7 +6,10 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -62,7 +65,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-dev/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,9 +44,12 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
-  vpc_name               = var.vpc_name
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -9,7 +9,9 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds_postgres_14" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -17,10 +19,10 @@ module "cla_backend_rds_postgres_14" {
   is_production = var.is_production
   namespace     = var.namespace
 
-  db_name = "cla_backend"
-  db_instance_class        = "db.t4g.large"
-  db_allocated_storage     = "30"
-  db_max_allocated_storage = "1000"
+  db_name                      = "cla_backend"
+  db_instance_class            = "db.t4g.large"
+  db_allocated_storage         = "30"
+  db_max_allocated_storage     = "1000"
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
@@ -54,7 +56,9 @@ module "cla_backend_rds_postgres_14" {
 }
 
 module "cla_backend_rds_postgres_14_replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -97,7 +101,9 @@ module "cla_backend_rds_postgres_14_replica" {
 }
 
 module "cla_backend_metabase_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -105,13 +111,13 @@ module "cla_backend_metabase_rds" {
   is_production = var.is_production
   namespace     = var.namespace
 
-  db_name                  = "metabase"
-  db_engine_version        = "16"
-  db_instance_class        = "db.t4g.micro"
-  db_allocated_storage     = "5"
-  db_max_allocated_storage = "500"
-  environment_name         = var.environment-name
-  infrastructure_support   = var.infrastructure_support
+  db_name                      = "metabase"
+  db_engine_version            = "16"
+  db_instance_class            = "db.t4g.micro"
+  db_allocated_storage         = "5"
+  db_max_allocated_storage     = "500"
+  environment_name             = var.environment-name
+  infrastructure_support       = var.infrastructure_support
   performance_insights_enabled = true
 
   rds_family = "postgres16"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
@@ -1,11 +1,14 @@
 module "court_data_adaptor_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  namespace     = var.namespace
-  team_name     = "laa-crime-apps-team"
-  business_unit = "Crime Apps"
-  application   = "laa-court-data-adaptor"
-  is_production = "false"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  namespace            = var.namespace
+  team_name            = "laa-crime-apps-team"
+  business_unit        = "Crime Apps"
+  application          = "laa-court-data-adaptor"
+  is_production        = "false"
 
   environment_name       = "dev"
   infrastructure_support = var.infrastructure_support

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-prod/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,9 +44,12 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
-  vpc_name               = var.vpc_name
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-test/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,9 +44,12 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
 
-  vpc_name               = var.vpc_name
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-prod/resources/rds-postgresql.tf
@@ -6,7 +6,10 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -65,7 +68,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/rds-postgresql.tf
@@ -6,7 +6,10 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -48,7 +51,7 @@ module "rds" {
 
   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
   enable_rds_auto_start_stop = true
-  maintenance_window          = "Mon:21:00-Mon:22:00"
+  maintenance_window         = "Mon:21:00-Mon:22:00"
 
   # This will rotate the db password. Update the value to the current date.
   # db_password_rotated_date  = "dd-mm-yyyy"
@@ -66,7 +69,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-prod/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +44,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -44,7 +47,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/rds.tf
@@ -6,7 +6,10 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -62,7 +65,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/rds-postgresql.tf
@@ -5,7 +5,10 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
@@ -1,5 +1,8 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/postgresql.tf
@@ -3,7 +3,10 @@
 ##
 
 module "make_recall_decision_api_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   enable_rds_auto_start_stop = true
   vpc_name                   = var.vpc_name
   namespace                  = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/rds-postgres14.tf
@@ -1,5 +1,8 @@
 module "pact_broker_rds_postgres14" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
@@ -4,7 +4,10 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -23,7 +26,7 @@ module "peoplefinder_rds" {
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade = "false"
+  prepare_for_major_upgrade   = "false"
 
   providers = {
     aws = aws.london
@@ -31,7 +34,10 @@ module "peoplefinder_rds" {
 }
 
 module "peoplefinder_rds_replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -1,5 +1,8 @@
 module "drupal_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
@@ -1,5 +1,8 @@
 module "slmtp_api_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
@@ -1,5 +1,8 @@
 module "slmtp_api_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
@@ -4,7 +4,10 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
@@ -4,7 +4,10 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/rds-postgresql.tf
@@ -1,5 +1,8 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -33,7 +36,10 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/rds.tf
@@ -1,5 +1,8 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit


### PR DESCRIPTION
- bump `7.2.2` rds to `8.0.1` batch 2
- no ops for user
- relates to https://github.com/ministryofjustice/cloud-platform/issues/6606