### PR TITLE
✨ Add Domain Name for GitHub Community

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/route53.tf
@@ -19,7 +19,7 @@ resource "kubernetes_secret" "route53_zone_output" {
   }
 
   data = {
-    zone_id     = aws_route53_zone.example_team_route53_zone.zone_id
-    nameservers = join("\n", aws_route53_zone.example_team_route53_zone.name_servers)
+    zone_id     = aws_route53_zone.route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.route53_zone.name_servers)
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = "github-community.service.justice.gov.uk"
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_output" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.example_team_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.example_team_route53_zone.name_servers)
+  }
+}


### PR DESCRIPTION
## 👀 Purpose

- To give the github community a production domain name to serve the new Repository Standards project

## ♻️ What's changed

- Added a hosted zone for `github-community.service.justice.gov.uk`