### PR TITLE
✨ Add Cert For `github-community.service.justice.gov.uk`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-prod/05-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: github-community-prod-cert
+  namespace: github-community-prod
+spec:
+  secretName: github-community-prod-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - github-community.service.justice.gov.uk


### PR DESCRIPTION
## 👀 Purpose

- To add TLS encryption for Web Server

## ♻️ What's changed

- Added a TLS Certificate for `github-community.service.justice.gov.uk`

## 📝 Notes

- Folloiwng this guidance https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/custom-domain-cert.html#obtaining-a-certificate