### PR TITLE
chore: bump 7.2.2 RDS to 8.0.1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-dev/resources/rds.tf
@@ -3,7 +3,9 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -22,6 +24,7 @@ module "rds-instance" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/rds.tf
@@ -3,7 +3,9 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -22,6 +24,7 @@ module "rds-instance" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/rds.tf
@@ -3,7 +3,9 @@
 ########################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -22,6 +24,7 @@ module "rds-instance" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-dev/resources/rds.tf
@@ -1,17 +1,19 @@
 module "calculate_release_dates_api_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name               = var.vpc_name
-  db_instance_class      = "db.t3.small"
-  team_name              = var.team_name
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  namespace              = var.namespace
-  environment_name       = var.environment
-  infrastructure_support = var.infrastructure_support
-  db_engine              = "postgres"
-  db_engine_version      = "16"
-  rds_family             = "postgres16"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage      = 10
+  storage_type              = "gp2"
+  vpc_name                  = var.vpc_name
+  db_instance_class         = "db.t3.small"
+  team_name                 = var.team_name
+  business_unit             = var.business_unit
+  application               = var.application
+  is_production             = var.is_production
+  namespace                 = var.namespace
+  environment_name          = var.environment
+  infrastructure_support    = var.infrastructure_support
+  db_engine                 = "postgres"
+  db_engine_version         = "16"
+  rds_family                = "postgres16"
   prepare_for_major_upgrade = false
 
   db_password_rotated_date = "14-02-2023"
@@ -20,7 +22,8 @@ module "calculate_release_dates_api_rds" {
     aws = aws.london
   }
 
-  vpc_security_group_ids     = [data.aws_security_group.mp_dps_sg.id]
+
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 
   db_parameter = [
     {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/read_replica.tf
@@ -1,7 +1,8 @@
 module "read_replica" {
   # default off as in count = 0
-  count  = 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count        = 1
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -37,6 +38,7 @@ module "read_replica" {
   skip_final_snapshot        = "true"
   db_backup_retention_period = 0
 }
+
 
 resource "kubernetes_secret" "read_replica" {
   count = 1

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -83,6 +88,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-preprod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -83,6 +88,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -83,6 +88,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/rds.tf
@@ -53,6 +53,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -61,8 +62,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -94,6 +97,7 @@ module "read_replica" {
     aws = aws.london
   }
 
+
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.
 
@@ -118,7 +122,7 @@ resource "kubernetes_secret" "rds" {
     database_username     = module.rds.database_username
     database_password     = module.rds.database_password
     rds_instance_address  = module.rds.rds_instance_address
-    jdbc_url = "jdbc:postgresql://${module.rds.rds_instance_endpoint}/${module.rds.database_name}?user=${module.rds.database_username}&password=${module.rds.database_password}"
+    jdbc_url              = "jdbc:postgresql://${module.rds.rds_instance_endpoint}/${module.rds.database_name}?user=${module.rds.database_username}&password=${module.rds.database_password}"
 
   }
   /* You can replace all of the above with the following, if you prefer to

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging-mtr/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging-mtr/resources/rds.tf
@@ -27,7 +27,7 @@ module "rds" {
   db_engine_version = "14"
 
   # change the instance class as you see fit.
-  db_instance_class = "db.t4g.micro"
+  db_instance_class        = "db.t4g.micro"
   db_max_allocated_storage = "500"
 
   # rds_family should be one of: postgres10, postgres11, postgres12, postgres13, postgres14
@@ -54,6 +54,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -62,8 +63,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -94,6 +97,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/rds.tf
@@ -27,7 +27,7 @@ module "rds" {
   db_engine_version = "14.12"
 
   # change the instance class as you see fit.
-  db_instance_class = "db.t4g.micro"
+  db_instance_class        = "db.t4g.micro"
   db_max_allocated_storage = "500"
 
   # rds_family should be one of: postgres10, postgres11, postgres12, postgres13, postgres14
@@ -54,6 +54,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -62,8 +63,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -95,6 +98,7 @@ module "read_replica" {
     aws = aws.london
   }
 
+
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.
 
@@ -119,7 +123,7 @@ resource "kubernetes_secret" "rds" {
     database_username     = module.rds.database_username
     database_password     = module.rds.database_password
     rds_instance_address  = module.rds.rds_instance_address
-    jdbc_url = "jdbc:postgresql://${module.rds.rds_instance_endpoint}/${module.rds.database_name}?user=${module.rds.database_username}&password=${module.rds.database_password}"
+    jdbc_url              = "jdbc:postgresql://${module.rds.rds_instance_endpoint}/${module.rds.database_name}?user=${module.rds.database_username}&password=${module.rds.database_password}"
 
   }
   /* You can replace all of the above with the following, if you prefer to

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "checkmydiary_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
@@ -22,6 +24,7 @@ module "checkmydiary_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "checkmydiary_rds_secrets" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "checkmydiary_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
@@ -20,6 +22,7 @@ module "checkmydiary_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "checkmydiary_rds_secrets" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -83,6 +88,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-preprod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -83,6 +88,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -83,6 +88,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjse-dev/resources/rds-mssql.tf
@@ -5,7 +5,8 @@
  *
 */
 module "rds_mssql" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -33,6 +34,7 @@ module "rds_mssql" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
   # Tags
@@ -52,8 +54,8 @@ resource "kubernetes_secret" "rds_mssql" {
   }
 
   data = {
-    database_username     = module.rds_mssql.database_username
-    database_password     = module.rds_mssql.database_password
+    database_username = module.rds_mssql.database_username
+    database_password = module.rds_mssql.database_password
   }
 }
 
@@ -88,6 +90,7 @@ resource "kubernetes_config_map" "rds_mssql" {
 #       value        = "1"
 #       apply_method = "pending-reboot"
 #     }
+
 #   ]
 
 #   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
@@ -1,5 +1,6 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -30,6 +31,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -30,6 +31,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
@@ -1,5 +1,6 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -33,6 +34,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/rds.tf
@@ -1,5 +1,6 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -32,6 +33,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "contact-moj_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -28,6 +30,7 @@ module "contact-moj_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "contact-moj_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "contact-moj_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -27,6 +29,7 @@ module "contact-moj_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "contact-moj_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-staging/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "contact-moj_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -29,6 +31,7 @@ module "contact-moj_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "contact-moj_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds-pre-sentence-service.tf
@@ -1,5 +1,7 @@
 module "pre_sentence_service_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -18,6 +20,7 @@ module "pre_sentence_service_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "pre_sentence_service_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "court_case_service_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -18,6 +20,7 @@ module "court_case_service_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "court_case_service_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds-pre-sentence-service.tf
@@ -1,5 +1,7 @@
 module "pre_sentence_service_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -18,6 +20,7 @@ module "pre_sentence_service_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "pre_sentence_service_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "court_case_service_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -22,6 +23,7 @@ module "court_case_service_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "court_case_service_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds-pre-sentence-service.tf
@@ -1,5 +1,7 @@
 module "pre_sentence_service_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -18,6 +20,7 @@ module "pre_sentence_service_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "pre_sentence_service_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "court_case_service_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -19,6 +21,7 @@ module "court_case_service_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "court_case_service_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -72,6 +77,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -72,6 +77,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-staging/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -72,6 +77,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "create_and_vary_a_licence_api_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -15,11 +17,12 @@ module "create_and_vary_a_licence_api_rds" {
   rds_family                  = "postgres15"
   prepare_for_major_upgrade   = false
   db_password_rotated_date    = "14-02-2023"
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop  = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "create_and_vary_a_licence_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-preprod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "create_and_vary_a_licence_api_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -20,6 +21,7 @@ module "create_and_vary_a_licence_api_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "create_and_vary_a_licence_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-prod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "create_and_vary_a_licence_api_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -20,6 +21,7 @@ module "create_and_vary_a_licence_api_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "create_and_vary_a_licence_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test1/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test1/resources/rds.tf
@@ -1,5 +1,7 @@
 module "create_and_vary_a_licence_api_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -15,11 +17,12 @@ module "create_and_vary_a_licence_api_rds" {
   rds_family                  = "postgres15"
   prepare_for_major_upgrade   = false
   db_password_rotated_date    = "14-02-2023"
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop  = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "create_and_vary_a_licence_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test2/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test2/resources/rds.tf
@@ -1,5 +1,7 @@
 module "create_and_vary_a_licence_api_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -15,11 +17,12 @@ module "create_and_vary_a_licence_api_rds" {
   rds_family                  = "postgres15"
   prepare_for_major_upgrade   = false
   db_password_rotated_date    = "14-02-2023"
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop  = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "create_and_vary_a_licence_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -35,14 +37,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -86,6 +91,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-preprod/resources/rds-postgresql.tf
@@ -23,11 +23,14 @@ module "rds_security_group" {
       protocol    = "tcp"
       cidr_blocks = "10.27.96.0/21"
     },
+
   ]
 }
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -61,6 +64,7 @@ module "rds" {
   # granting access from the Cloud Platform
   vpc_security_group_ids = [module.rds_security_group.security_group_id]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -29,6 +31,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-development/resources/simulated-data-producer-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-development/resources/simulated-data-producer-rds.tf
@@ -1,5 +1,7 @@
 module "simulated_data_producer_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -21,6 +23,7 @@ module "simulated_data_producer_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "simulated_data_producer_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -33,6 +35,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-preprod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -33,6 +35,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -15,7 +17,7 @@ module "rds" {
   allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
-  deletion_protection = true
+  deletion_protection          = true
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
@@ -34,6 +36,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-daap-api/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-daap-api/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dex-mi-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dex-mi-production/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "dex_mi_production_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -29,6 +31,7 @@ module "dex_mi_production_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dex_mi_production_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/rds.tf
@@ -3,7 +3,9 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -26,6 +28,7 @@ module "rds-instance" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-qa/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-qa/resources/rds.tf
@@ -3,29 +3,32 @@
 ############################################
 
 module "rds-instance" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                   = var.vpc_name
-  team_name                  = var.team_name
-  business_unit              = var.business_unit
-  application                = var.application
-  is_production              = var.is_production
-  environment_name           = var.environment_name
-  infrastructure_support     = var.infrastructure_support
-  namespace                  = var.namespace
-  db_instance_class          = "db.t4g.micro"
-  db_max_allocated_storage   = "500"
-  db_engine                  = "postgres"
-  db_engine_version          = "16"
-  rds_family                 = "postgres16"
-  backup_window              = "06:00-08:00"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
+  vpc_name                 = var.vpc_name
+  team_name                = var.team_name
+  business_unit            = var.business_unit
+  application              = var.application
+  is_production            = var.is_production
+  environment_name         = var.environment_name
+  infrastructure_support   = var.infrastructure_support
+  namespace                = var.namespace
+  db_instance_class        = "db.t4g.micro"
+  db_max_allocated_storage = "500"
+  db_engine                = "postgres"
+  db_engine_version        = "16"
+  rds_family               = "postgres16"
+  backup_window            = "06:00-08:00"
 
   enable_rds_auto_start_stop = true
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade  = false
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/rds.tf
@@ -3,29 +3,32 @@
 ############################################
 
 module "rds-instance" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                   = var.vpc_name
-  team_name                  = var.team_name
-  business_unit              = var.business_unit
-  application                = var.application
-  is_production              = var.is_production
-  environment_name           = var.environment_name
-  infrastructure_support     = var.infrastructure_support
-  namespace                  = var.namespace
-  db_instance_class          = "db.t4g.micro"
-  db_max_allocated_storage   = "500"
-  db_engine                  = "postgres"
-  db_engine_version          = "16"
-  rds_family                 = "postgres16"
-  backup_window              = "06:00-08:00"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
+  vpc_name                 = var.vpc_name
+  team_name                = var.team_name
+  business_unit            = var.business_unit
+  application              = var.application
+  is_production            = var.is_production
+  environment_name         = var.environment_name
+  infrastructure_support   = var.infrastructure_support
+  namespace                = var.namespace
+  db_instance_class        = "db.t4g.micro"
+  db_max_allocated_storage = "500"
+  db_engine                = "postgres"
+  db_engine_version        = "16"
+  rds_family               = "postgres16"
+  backup_window            = "06:00-08:00"
 
   enable_rds_auto_start_stop = true
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade  = false
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "evidencelibrary_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -44,6 +46,7 @@ module "evidencelibrary_rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "evidencelibrary_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-staging/resources/rds.tf
@@ -1,12 +1,14 @@
 
 module "evidencelibrary_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = var.application
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = var.application
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   # enable performance insights
   performance_insights_enabled = true
@@ -32,6 +34,7 @@ module "evidencelibrary_rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "evidencelibrary_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/rds.tf
@@ -1,12 +1,14 @@
 
 module "evidencelibrary_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = var.application
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = var.application
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   # enable performance insights
   performance_insights_enabled = true
@@ -32,6 +34,7 @@ module "evidencelibrary_rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "evidencelibrary_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
@@ -3,7 +3,9 @@
 ############################################
 
 module "rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -15,16 +17,17 @@ module "rds-instance" {
   namespace              = var.namespace
   team_name              = var.team_name
 
-  db_instance_class        = "db.t4g.small"
-  db_max_allocated_storage = "10000"
-  db_engine                = "postgres"
-  db_engine_version        = "16.4"
-  rds_family               = "postgres16"
+  db_instance_class         = "db.t4g.small"
+  db_max_allocated_storage  = "10000"
+  db_engine                 = "postgres"
+  db_engine_version         = "16.4"
+  rds_family                = "postgres16"
   prepare_for_major_upgrade = false
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/rds.tf
@@ -3,21 +3,23 @@
 ############################################
 
 module "rds-instance" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                   = var.vpc_name
-  team_name                  = var.team_name
-  business_unit              = var.business_unit
-  application                = var.application
-  is_production              = var.is_production
-  environment_name           = var.environment_name
-  infrastructure_support     = var.infrastructure_support
-  namespace                  = var.namespace
-  db_instance_class          = "db.t4g.micro"
-  db_max_allocated_storage   = "500"
-  rds_family                 = "postgres16"
-  db_engine                  = "postgres"
-  db_engine_version          = "16"
-  backup_window              = "06:00-08:00"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
+  vpc_name                 = var.vpc_name
+  team_name                = var.team_name
+  business_unit            = var.business_unit
+  application              = var.application
+  is_production            = var.is_production
+  environment_name         = var.environment_name
+  infrastructure_support   = var.infrastructure_support
+  namespace                = var.namespace
+  db_instance_class        = "db.t4g.micro"
+  db_max_allocated_storage = "500"
+  rds_family               = "postgres16"
+  db_engine                = "postgres"
+  db_engine_version        = "16"
+  backup_window            = "06:00-08:00"
 
   enable_rds_auto_start_stop = true
   prepare_for_major_upgrade  = false
@@ -26,6 +28,7 @@ module "rds-instance" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage      = 10
+  storage_type              = "gp2"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit
@@ -58,6 +60,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-staging/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage      = 10
+  storage_type              = "gp2"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit
@@ -59,6 +61,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/gdavies-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/gdavies-dev/resources/rds.tf
@@ -1,7 +1,8 @@
 # PostgreSQL
 
 module "rds_postgresql" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name                     = var.vpc_name
@@ -32,6 +33,7 @@ module "rds_postgresql" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -56,6 +58,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -64,8 +67,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -96,6 +101,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-preprod/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -25,6 +27,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "dps_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage      = 10
+  storage_type              = "gp2"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit
@@ -25,6 +27,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/rds.tf
@@ -1,5 +1,6 @@
 module "hwpv_sqlserver" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -20,6 +21,7 @@ module "hwpv_sqlserver" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hwpv_sqlserver" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-preprod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "hwpv_sqlserver" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -20,6 +21,7 @@ module "hwpv_sqlserver" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hwpv_sqlserver" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "hwpv_sqlserver" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -20,6 +21,7 @@ module "hwpv_sqlserver" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hwpv_sqlserver" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmcts-complaints-adapter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_hmcts_complaints_adapter
@@ -19,6 +21,7 @@ module "hmcts-complaints-adapter-rds-instance" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmcts-complaints-adapter-rds-instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds_new.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds_new.tf
@@ -1,5 +1,7 @@
 module "hmcts_mock_api_rds_instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = "laa-crime-apps-team"
@@ -18,6 +20,7 @@ module "hmcts_mock_api_rds_instance" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmcts_mock_api_rds_instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "adjustments_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -17,6 +19,7 @@ module "adjustments_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "adjustments_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "adjustments_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -17,6 +19,7 @@ module "adjustments_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "adjustments_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-prod/resources/rds.tf
@@ -1,22 +1,25 @@
 module "adjustments_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                    = var.vpc_name
-  team_name                   = var.team_name
-  business_unit               = var.business_unit
-  application                 = var.application
-  is_production               = var.is_production
-  namespace                   = var.namespace
-  environment_name            = var.environment_name
-  infrastructure_support      = var.infrastructure_support
-  rds_family                  = var.rds_family
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage      = 10
+  storage_type              = "gp2"
+  vpc_name                  = var.vpc_name
+  team_name                 = var.team_name
+  business_unit             = var.business_unit
+  application               = var.application
+  is_production             = var.is_production
+  namespace                 = var.namespace
+  environment_name          = var.environment_name
+  infrastructure_support    = var.infrastructure_support
+  rds_family                = var.rds_family
   prepare_for_major_upgrade = "false"
-  db_instance_class           = "db.t4g.small"
-  db_max_allocated_storage    = "500"
-  db_engine_version           = "14"
+  db_instance_class         = "db.t4g.small"
+  db_max_allocated_storage  = "500"
+  db_engine_version         = "14"
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "adjustments_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-for-early-release-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-for-early-release-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "assess-for-early-release_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -15,11 +17,12 @@ module "assess-for-early-release_rds" {
   rds_family                  = "postgres16"
   prepare_for_major_upgrade   = true
   db_password_rotated_date    = "14-02-2023"
-  enable_rds_auto_start_stop = true
+  enable_rds_auto_start_stop  = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "assess-for-early-release_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_assess_risks_and_needs_dev_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -19,6 +21,7 @@ module "hmpps_assess_risks_and_needs_dev_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_assess_risks_and_needs_dev_rds_secret" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-preprod/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_assess_risks_and_needs_preprod_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -19,6 +21,7 @@ module "hmpps_assess_risks_and_needs_preprod_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_assess_risks_and_needs_preprod_rds_secret" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prod/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_assess_risks_and_needs_prod_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -17,6 +19,7 @@ module "hmpps_assess_risks_and_needs_prod_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_assess_risks_and_needs_prod_rds_secret" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_assessments_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -19,6 +21,7 @@ module "hmpps_assessments_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_assessments_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-preprod/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_assessments_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -19,6 +21,7 @@ module "hmpps_assessments_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_assessments_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_assessments_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -20,6 +22,7 @@ module "hmpps_assessments_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_assessments_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_audit_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -9,19 +11,20 @@ module "hmpps_audit_rds" {
   environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 
-  db_instance_class          = "db.t4g.micro"
-  db_max_allocated_storage   = "500"
-  rds_family                 = "postgres16"
-  db_engine_version          = "16"
-  deletion_protection        = true
-  enable_rds_auto_start_stop = true
-  prepare_for_major_upgrade  = false
-  db_engine                  = "postgres"
-  performance_insights_enabled  = true
+  db_instance_class            = "db.t4g.micro"
+  db_max_allocated_storage     = "500"
+  rds_family                   = "postgres16"
+  db_engine_version            = "16"
+  deletion_protection          = true
+  enable_rds_auto_start_stop   = true
+  prepare_for_major_upgrade    = false
+  db_engine                    = "postgres"
+  performance_insights_enabled = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_audit_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_audit_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -21,6 +23,7 @@ module "hmpps_audit_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_audit_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_audit_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -9,18 +11,19 @@ module "hmpps_audit_rds" {
   environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 
-  db_instance_class         = "db.t4g.small"
-  db_engine                 = "postgres"
-  db_engine_version         = "16"
-  rds_family                = "postgres16"
-  db_max_allocated_storage  = "10000"
-  prepare_for_major_upgrade = false
-  deletion_protection       = true
-  performance_insights_enabled  = true
+  db_instance_class            = "db.t4g.small"
+  db_engine                    = "postgres"
+  db_engine_version            = "16"
+  rds_family                   = "postgres16"
+  db_max_allocated_storage     = "10000"
+  prepare_for_major_upgrade    = false
+  deletion_protection          = true
+  performance_insights_enabled = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_audit_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/resources/rds.tf
@@ -1,25 +1,28 @@
 module "dps_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                  = var.vpc_name
-  team_name                 = var.team_name
-  business_unit             = var.business_unit
-  application               = var.application
-  is_production             = var.is_production
-  namespace                 = var.namespace
-  environment_name          = var.environment-name
-  infrastructure_support    = var.infrastructure_support
-  db_instance_class         = "db.t4g.micro"
-  db_max_allocated_storage  = "500"
-  deletion_protection       = true
-  prepare_for_major_upgrade = false
-  rds_family                = "postgres16"
-  db_engine                 = "postgres"
-  db_engine_version         = "16"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
+  vpc_name                     = var.vpc_name
+  team_name                    = var.team_name
+  business_unit                = var.business_unit
+  application                  = var.application
+  is_production                = var.is_production
+  namespace                    = var.namespace
+  environment_name             = var.environment-name
+  infrastructure_support       = var.infrastructure_support
+  db_instance_class            = "db.t4g.micro"
+  db_max_allocated_storage     = "500"
+  deletion_protection          = true
+  prepare_for_major_upgrade    = false
+  rds_family                   = "postgres16"
+  db_engine                    = "postgres"
+  db_engine_version            = "16"
   performance_insights_enabled = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {
@@ -56,27 +59,30 @@ resource "kubernetes_secret" "dps_rds_external_users_api" {
 
 module "hmpps_authorization_rds" {
 
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                      = var.vpc_name
-  team_name                     = var.team_name
-  business_unit                 = var.business_unit
-  application                   = var.application
-  is_production                 = var.is_production
-  namespace                     = var.namespace
-  environment_name              = var.environment-name
-  infrastructure_support        = var.infrastructure_support
-  db_instance_class             = "db.t4g.micro"
-  db_max_allocated_storage      = "500"
-  deletion_protection           = true
-  prepare_for_major_upgrade     = false
-  rds_family                    = "postgres16"
-  db_engine                     = "postgres"
-  db_engine_version             = "16"
-  performance_insights_enabled  = true
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
+  vpc_name                     = var.vpc_name
+  team_name                    = var.team_name
+  business_unit                = var.business_unit
+  application                  = var.application
+  is_production                = var.is_production
+  namespace                    = var.namespace
+  environment_name             = var.environment-name
+  infrastructure_support       = var.infrastructure_support
+  db_instance_class            = "db.t4g.micro"
+  db_max_allocated_storage     = "500"
+  deletion_protection          = true
+  prepare_for_major_upgrade    = false
+  rds_family                   = "postgres16"
+  db_engine                    = "postgres"
+  db_engine_version            = "16"
+  performance_insights_enabled = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_authorization_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -20,6 +22,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -19,6 +21,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/rds.tf
@@ -1,25 +1,28 @@
 module "dps_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                  = var.vpc_name
-  team_name                 = var.team_name
-  business_unit             = var.business_unit
-  application               = var.application
-  is_production             = var.is_production
-  namespace                 = var.namespace
-  environment_name          = var.environment-name
-  infrastructure_support    = var.infrastructure_support
-  db_instance_class         = "db.t4g.small"
-  db_max_allocated_storage  = "500"
-  deletion_protection       = true
-  prepare_for_major_upgrade = false
-  rds_family                = "postgres16"
-  db_engine                 = "postgres"
-  db_engine_version         = "16"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
+  vpc_name                     = var.vpc_name
+  team_name                    = var.team_name
+  business_unit                = var.business_unit
+  application                  = var.application
+  is_production                = var.is_production
+  namespace                    = var.namespace
+  environment_name             = var.environment-name
+  infrastructure_support       = var.infrastructure_support
+  db_instance_class            = "db.t4g.small"
+  db_max_allocated_storage     = "500"
+  deletion_protection          = true
+  prepare_for_major_upgrade    = false
+  rds_family                   = "postgres16"
+  db_engine                    = "postgres"
+  db_engine_version            = "16"
   performance_insights_enabled = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -34,12 +34,13 @@ module "rds-instance" {
       "name" : "log_min_duration_statement",
       "value" : "2000"
     },
+
     {
       name         = "rds.logical_replication"
       value        = "1"
       apply_method = "pending-reboot"
     },
-     {
+    {
       name         = "shared_preload_libraries"
       value        = "pglogical"
       apply_method = "pending-reboot"
@@ -69,7 +70,8 @@ resource "kubernetes_secret" "rds-instance" {
 }
 
 module "rds-read-replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -90,16 +92,17 @@ module "rds-read-replica" {
   db_backup_retention_period = 0
 
   prepare_for_major_upgrade = false
-  db_engine_version = "16.4"
-  rds_family        = "postgres16"
+  db_engine_version         = "16.4"
+  rds_family                = "postgres16"
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
 
+
   # Add security groups for DPR
-  vpc_security_group_ids     = [data.aws_security_group.mp_dps_sg.id]
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 }
 
 # Retrieve mp_dps_sg_name SG group ID, CP-MP-INGRESS

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "candidate_matching_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "candidate_matching_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "candidate_matching_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "candidate_matching_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "candidate_matching_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "candidate_matching_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "candidate_matching_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "candidate_matching_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "candidate_matching_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-demo/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-demo/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -17,11 +19,14 @@ module "rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 module "read_replica" {
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -40,6 +45,7 @@ module "read_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -17,11 +19,14 @@ module "rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 module "read_replica" {
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -40,6 +45,7 @@ module "read_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -17,11 +19,14 @@ module "rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 module "read_replica" {
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -30,7 +35,7 @@ module "read_replica" {
   infrastructure_support = var.infrastructure_support
   team_name              = var.team_name
   business_unit          = var.business_unit
-  namespace = var.namespace
+  namespace              = var.namespace
   db_name                = null # "db_name": conflicts with replicate_source_db
   replicate_source_db    = module.rds.db_identifier
 
@@ -40,6 +45,7 @@ module "read_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -17,11 +19,14 @@ module "rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 module "read_replica" {
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -40,6 +45,7 @@ module "read_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -17,11 +19,14 @@ module "rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 module "read_replica" {
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -40,6 +45,7 @@ module "read_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/rds.tf
@@ -1,11 +1,13 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = "Complexity of Need microservice"
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = "Complexity of Need microservice"
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   # enable performance insights
   performance_insights_enabled = true
@@ -28,6 +30,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/rds.tf
@@ -1,12 +1,14 @@
 
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = "Complexity of Need microservice"
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = "Complexity of Need microservice"
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   # enable performance insights
   performance_insights_enabled = true
@@ -27,6 +29,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
@@ -5,7 +5,9 @@
  *
  */
 module "complexity-of-need-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                   = var.vpc_name
   db_instance_class          = "db.t4g.micro"
@@ -30,6 +32,7 @@ module "complexity-of-need-rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-register-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-register-dev/resources/rds-postgresql.tf
@@ -1,6 +1,8 @@
 
 module "court-register-api-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -20,6 +22,7 @@ module "court-register-api-rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-register-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-register-preprod/resources/rds-postgresql.tf
@@ -1,6 +1,8 @@
 
 module "court-register-api-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -20,6 +22,7 @@ module "court-register-api-rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-register-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-register-prod/resources/rds-postgresql.tf
@@ -1,6 +1,8 @@
 
 module "court-register-api-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -20,6 +22,7 @@ module "court-register-api-rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-stage/resources/rds.tf
@@ -1,5 +1,6 @@
 module "rds_alfresco" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -31,6 +32,7 @@ module "rds_alfresco" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-test/resources/rds.tf
@@ -1,5 +1,6 @@
 module "rds_alfresco" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -31,6 +32,7 @@ module "rds_alfresco" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds_postgres" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -22,6 +24,7 @@ module "rds_postgres" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
 
 resource "kubernetes_secret" "rds_postgres" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-preprod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds_postgres" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -22,6 +24,7 @@ module "rds_postgres" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
 
 resource "kubernetes_secret" "rds_postgres" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-prod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds_postgres" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -22,6 +24,7 @@ module "rds_postgres" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
 
 resource "kubernetes_secret" "rds_postgres" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -10,7 +10,8 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -35,6 +36,7 @@ module "rds" {
       value        = "1"
       apply_method = "pending-reboot"
     },
+
     {
       name         = "shared_preload_libraries"
       value        = "pglogical"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/rds.tf
@@ -4,7 +4,9 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "edu_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -26,6 +28,7 @@ module "edu_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "edu_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "edu_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "edu_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "edu_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "edu_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "edu_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "edu_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/cemo-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/cemo-rds.tf
@@ -1,5 +1,7 @@
 module "cemo_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -27,6 +29,7 @@ module "cemo_rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "cemo_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -26,6 +28,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -26,6 +28,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/rds-postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/rds-postgres.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -26,6 +28,7 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-postgresql-instance-output"
@@ -43,8 +46,10 @@ resource "kubernetes_secret" "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -53,7 +58,7 @@ module "read_replica" {
   is_production          = var.is_production
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
-  namespace              = var.namespace  
+  namespace              = var.namespace
 
   # Set the database_name of the source db
   db_name = module.rds.database_name
@@ -64,8 +69,9 @@ module "read_replica" {
   # Set to true. No backups or snapshots are created for read replica
   skip_final_snapshot        = "true"
   db_backup_retention_period = 0
-  
+
 }
+
 
 
 # Configmap to store non-sensitive data related to the RDS instance

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/rds.tf
@@ -1,12 +1,14 @@
 
 module "grafana_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = var.application
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = var.application
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   # enable performance insights
   performance_insights_enabled = true
@@ -29,6 +31,7 @@ module "grafana_rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "grafana_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "identify_remand_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -18,6 +20,7 @@ module "identify_remand_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "identify_remand_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "identify_remand_periods_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -18,6 +20,7 @@ module "identify_remand_periods_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "identify_remand_periods_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "identify_remand_periods_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -17,6 +19,7 @@ module "identify_remand_periods_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "identify_remand_periods_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/rds_postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/rds_postgres.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -32,6 +34,7 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-postgresql-instance-output"
@@ -49,8 +52,10 @@ resource "kubernetes_secret" "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -88,6 +93,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "read_replica" {
   # default off

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/rds_postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/rds_postgres.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -32,6 +34,7 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-postgresql-instance-output"
@@ -49,8 +52,10 @@ resource "kubernetes_secret" "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -88,6 +93,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "read_replica" {
   # default off

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/rds_postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/rds_postgres.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -32,6 +34,7 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-postgresql-instance-output"
@@ -49,8 +52,10 @@ resource "kubernetes_secret" "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -88,6 +93,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "read_replica" {
   # default off

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
@@ -1,5 +1,6 @@
 module "hmpps_interventions_postgres14" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -9,16 +10,17 @@ module "hmpps_interventions_postgres14" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 
-  rds_family                  = "postgres14"
-  db_engine_version           = "14.12"
-  db_instance_class           = "db.m5.large"
-  db_allocated_storage        = 20
-  allow_major_version_upgrade = "false"
+  rds_family                   = "postgres14"
+  db_engine_version            = "14.12"
+  db_instance_class            = "db.m5.large"
+  db_allocated_storage         = 20
+  allow_major_version_upgrade  = "false"
   performance_insights_enabled = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_interventions_postgres14" {
@@ -56,7 +58,8 @@ resource "kubernetes_secret" "hmpps_interventions_refresh14_secret" {
 
 
 module "hmpps_interventions_postgres14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -81,6 +84,7 @@ module "hmpps_interventions_postgres14_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_interventions_postgres14_replica" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
@@ -1,5 +1,6 @@
 module "hmpps_interventions_postgres14" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -19,6 +20,7 @@ module "hmpps_interventions_postgres14" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_interventions_postgres14" {
@@ -38,7 +40,9 @@ resource "kubernetes_secret" "hmpps_interventions_postgres14" {
 }
 
 module "hmpps_interventions_postgres14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -64,6 +68,7 @@ module "hmpps_interventions_postgres14_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_interventions_postgres14_replica" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/rds-postgresql.tf
@@ -1,8 +1,10 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # Add security group id
-  vpc_security_group_ids       = [data.aws_security_group.mp_dps_sg.id]
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -32,31 +34,32 @@ module "rds" {
 
   # add parameter group
   db_parameter = [
-      {
-        name         = "rds.logical_replication"
-        value        = "1"
-        apply_method = "pending-reboot"
-      },
-      {
-        name         = "shared_preload_libraries"
-        value        = "pglogical"
-        apply_method = "pending-reboot"
-      },
-      {
-        name         = "max_wal_size"
-        value        = "1024"
-        apply_method = "immediate"
-      },
-      {
-        name         = "wal_sender_timeout"
-        value        = "0"
-        apply_method = "immediate"
-      },
-      {
-        name         = "max_slot_wal_keep_size"
-        value        = "40000"
-        apply_method = "immediate"
-      }
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
   ]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-preprod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -20,7 +22,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  db_engine_version = "16" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
 
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -59,7 +64,7 @@ module "read_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.2"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  db_engine_version = "16.2" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
   # It is mandatory to set the below values to create read replica instance
@@ -82,6 +87,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-dev/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -27,6 +29,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-preprod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -27,6 +29,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-prod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -27,6 +29,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/rds-launchpad-auth-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/rds-launchpad-auth-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -15,7 +17,7 @@ module "rds" {
   allow_major_version_upgrade  = false
   performance_insights_enabled = true
   # db_max_allocated_storage     = "500"
-  enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
+  enable_rds_auto_start_stop = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # PostgreSQL specifics
@@ -33,6 +35,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-preprod/resources/rds-launchpad-auth-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-preprod/resources/rds-launchpad-auth-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -15,7 +17,7 @@ module "rds" {
   allow_major_version_upgrade  = false
   performance_insights_enabled = true
   #db_max_allocated_storage     = "500"
-  enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
+  enable_rds_auto_start_stop = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # PostgreSQL specifics
@@ -33,6 +35,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/rds-launchpad-auth-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/rds-launchpad-auth-postgresql.tf
@@ -5,7 +5,8 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,6 +35,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -21,6 +23,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "ma_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "ma_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-preprod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "ma_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -20,6 +21,7 @@ module "ma_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "ma_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -25,6 +26,7 @@ module "ma_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "manage_offences_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "manage_offences_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "manage_offences_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "manage_offences_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "manage_offences_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "manage_offences_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "manage_offences_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "manage_offences_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "manage_offences_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-preprod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -28,12 +30,15 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -75,6 +80,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-prod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -28,12 +30,15 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -75,6 +80,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-dev/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -27,6 +29,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-preprod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -27,6 +29,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-links-prod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -27,6 +29,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_service_catalogue" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -17,6 +19,7 @@ module "hmpps_service_catalogue" {
   providers = {
     aws = aws.london
   }
+
 }
 
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_service_catalogue" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -17,6 +19,7 @@ module "hmpps_service_catalogue" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_service_catalogue" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "nomis_migration_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
@@ -18,6 +20,7 @@ module "nomis_migration_rds" {
   prepare_for_major_upgrade  = false
   enable_rds_auto_start_stop = true
 }
+
 
 resource "kubernetes_secret" "nomis_migration_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "nomis_migration_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
@@ -18,6 +20,7 @@ module "nomis_migration_rds" {
   prepare_for_major_upgrade  = false
   enable_rds_auto_start_stop = true
 }
+
 
 resource "kubernetes_secret" "nomis_migration_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "nomis_migration_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
@@ -17,6 +19,7 @@ module "nomis_migration_rds" {
   deletion_protection       = true
   prepare_for_major_upgrade = false
 }
+
 
 resource "kubernetes_secret" "nomis_migration_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_prisoner_search_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
@@ -21,6 +23,7 @@ module "hmpps_prisoner_search_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_prisoner_search_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-preprod/resources/rds.tf
@@ -1,25 +1,28 @@
 module "hmpps_prisoner_search_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name                     = var.vpc_name
-  team_name                    = var.team_name
-  business_unit                = var.business_unit
-  application                  = var.application
-  is_production                = var.is_production
-  namespace                    = var.namespace
-  environment_name             = var.environment
-  infrastructure_support       = var.infrastructure_support
-  db_instance_class            = "db.t4g.micro"
-  db_engine                    = "postgres"
-  db_engine_version            = "17"
-  rds_family                   = "postgres17"
-  deletion_protection          = true
-  prepare_for_major_upgrade    = false
-  db_max_allocated_storage     = "500"
+  vpc_name                  = var.vpc_name
+  team_name                 = var.team_name
+  business_unit             = var.business_unit
+  application               = var.application
+  is_production             = var.is_production
+  namespace                 = var.namespace
+  environment_name          = var.environment
+  infrastructure_support    = var.infrastructure_support
+  db_instance_class         = "db.t4g.micro"
+  db_engine                 = "postgres"
+  db_engine_version         = "17"
+  rds_family                = "postgres17"
+  deletion_protection       = true
+  prepare_for_major_upgrade = false
+  db_max_allocated_storage  = "500"
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_prisoner_search_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-prod/resources/rds.tf
@@ -1,25 +1,28 @@
 module "hmpps_prisoner_search_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name                     = var.vpc_name
-  team_name                    = var.team_name
-  business_unit                = var.business_unit
-  application                  = var.application
-  is_production                = var.is_production
-  namespace                    = var.namespace
-  environment_name             = var.environment
-  infrastructure_support       = var.infrastructure_support
-  db_instance_class            = "db.t4g.small"
-  db_engine                    = "postgres"
-  db_engine_version            = "17"
-  rds_family                   = "postgres17"
-  deletion_protection          = true
-  prepare_for_major_upgrade    = false
-  db_max_allocated_storage     = "500"
+  vpc_name                  = var.vpc_name
+  team_name                 = var.team_name
+  business_unit             = var.business_unit
+  application               = var.application
+  is_production             = var.is_production
+  namespace                 = var.namespace
+  environment_name          = var.environment
+  infrastructure_support    = var.infrastructure_support
+  db_instance_class         = "db.t4g.small"
+  db_engine                 = "postgres"
+  db_engine_version         = "17"
+  rds_family                = "postgres17"
+  deletion_protection       = true
+  prepare_for_major_upgrade = false
+  db_max_allocated_storage  = "500"
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_prisoner_search_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/flipt.tf
@@ -1,5 +1,7 @@
 module "flipt-db" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -17,6 +19,7 @@ module "flipt-db" {
   performance_insights_enabled = true
   maintenance_window           = "sun:00:00-sun:03:00"
 }
+
 
 resource "kubernetes_secret" "flipt-db" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/flipt.tf
@@ -1,5 +1,7 @@
 module "flipt-db" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -17,6 +19,7 @@ module "flipt-db" {
   performance_insights_enabled = true
   maintenance_window           = "sun:00:00-sun:03:00"
 }
+
 
 resource "kubernetes_secret" "flipt-db" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/flipt.tf
@@ -1,5 +1,7 @@
 module "flipt-db" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage         = 10
+  storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit
@@ -17,6 +19,7 @@ module "flipt-db" {
   performance_insights_enabled = true
   maintenance_window           = "sun:00:00-sun:03:00"
 }
+
 
 resource "kubernetes_secret" "flipt-db" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-dev/resources/rds-postgresql.tf
@@ -1,16 +1,18 @@
 
 module "remand-and-sentencing-api-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
 
   # PostgreSQL specifics
   prepare_for_major_upgrade = false
-  db_engine         = "postgres"
-  db_engine_version = "16"
-  rds_family        = "postgres16"
-  db_instance_class = "db.t4g.small"
+  db_engine                 = "postgres"
+  db_engine_version         = "16"
+  rds_family                = "postgres16"
+  db_instance_class         = "db.t4g.small"
 
   # Tags
   application            = var.application
@@ -21,6 +23,7 @@ module "remand-and-sentencing-api-rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -72,6 +77,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -74,6 +79,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -35,14 +37,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -75,6 +80,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rp_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
@@ -21,6 +23,7 @@ module "rp_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rp_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
@@ -20,6 +22,7 @@ module "rp_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rp_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
@@ -20,6 +22,7 @@ module "rp_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -53,14 +55,17 @@ module "rds" {
   db_password_rotated_date = "11-04-2023"
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -98,6 +103,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-test/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -53,14 +55,17 @@ module "rds" {
   db_password_rotated_date = "11-04-2023"
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -98,6 +103,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-dev/resources/rds-postgresql.tf
@@ -53,6 +53,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -61,8 +62,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -93,6 +96,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-preprod/resources/rds-postgresql.tf
@@ -53,6 +53,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -61,8 +62,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -93,6 +96,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-prod/resources/rds-postgresql.tf
@@ -45,7 +45,7 @@ module "rds" {
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade   = false
 
   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
   # enable_rds_auto_start_stop  = true
@@ -54,6 +54,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -62,8 +63,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -94,6 +97,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_strengths_based_needs_assessments_dev_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -15,11 +17,12 @@ module "hmpps_strengths_based_needs_assessments_dev_rds" {
   db_engine_version      = "16"
 
   allow_major_version_upgrade = "true"
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade   = false
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_strengths_based_needs_assessments_dev_rds_secret" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-preprod/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_strengths_based_needs_assessments_preprod_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -15,11 +17,12 @@ module "hmpps_strengths_based_needs_assessments_preprod_rds" {
   db_engine_version      = "16"
 
   allow_major_version_upgrade = "true"
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade   = false
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_strengths_based_needs_assessments_preprod_rds_secret" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-prod/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_strengths_based_needs_assessments_prod_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -15,11 +17,12 @@ module "hmpps_strengths_based_needs_assessments_prod_rds" {
   db_engine_version      = "16"
 
   allow_major_version_upgrade = "true"
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade   = false
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_strengths_based_needs_assessments_prod_rds_secret" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-test/resources/rds.tf
@@ -1,6 +1,8 @@
 
 module "hmpps_strengths_based_needs_assessments_test_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -15,11 +17,12 @@ module "hmpps_strengths_based_needs_assessments_test_rds" {
   db_engine_version      = "16"
 
   allow_major_version_upgrade = "true"
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade   = false
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_strengths_based_needs_assessments_test_rds_secret" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "subject_access_request_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
@@ -20,6 +22,7 @@ module "subject_access_request_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "subject_access_request_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "subject_access_request_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -16,6 +18,7 @@ module "subject_access_request_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "subject_access_request_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "subject_access_request_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -16,6 +18,7 @@ module "subject_access_request_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "subject_access_request_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_user_preferences_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage      = 10
+  storage_type              = "gp2"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit
@@ -17,6 +19,7 @@ module "hmpps_user_preferences_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_user_preferences_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_user_preferences_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage      = 10
+  storage_type              = "gp2"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit
@@ -17,6 +19,7 @@ module "hmpps_user_preferences_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_user_preferences_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "hmpps_user_preferences_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage      = 10
+  storage_type              = "gp2"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit
@@ -17,6 +19,7 @@ module "hmpps_user_preferences_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "hmpps_user_preferences_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-dev/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -26,10 +28,13 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -53,6 +58,7 @@ module "read_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-prod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -26,10 +28,13 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -53,6 +58,7 @@ module "read_replica" {
   providers = {
     aws = aws.london
   }
+
 
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-staging/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -26,10 +28,13 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -59,6 +64,7 @@ module "read_replica" {
   providers = {
     aws = aws.london
   }
+
 
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-demo/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-demo/resources/rds.tf
@@ -1,5 +1,6 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -30,6 +31,7 @@ module "rds" {
       value        = "utf8mb4"
       apply_method = "immediate"
     },
+
     {
       name         = "character_set_server"
       value        = "utf8mb4"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-demo/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-demo/resources/rds.tf
@@ -1,11 +1,13 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = var.application
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = var.application
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   # turn off performance insights
   performance_insights_enabled = false
@@ -29,6 +31,7 @@ module "rds" {
       value        = "utf8mb4"
       apply_method = "immediate"
     },
+
     {
       name         = "character_set_server"
       value        = "utf8mb4"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -16,6 +18,7 @@ module "dps_rds" {
   db_password_rotated_date    = "15-02-2023"
   prepare_for_major_upgrade   = false
 }
+
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -16,6 +18,7 @@ module "dps_rds" {
   prepare_for_major_upgrade   = false
   db_password_rotated_date    = "15-02-2023"
 }
+
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/keyworker-api-prod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -20,6 +21,7 @@ module "dps_rds" {
   deletion_protection         = true
   prepare_for_major_upgrade   = false
 }
+
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
@@ -53,6 +53,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -61,8 +62,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -93,6 +96,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-staging/resources/rds.tf
@@ -27,7 +27,7 @@ module "rds" {
   db_engine_version = "14.12"
 
   # change the instance class as you see fit.
-  db_instance_class = "db.t4g.micro"
+  db_instance_class        = "db.t4g.micro"
   db_max_allocated_storage = "500"
 
   # rds_family should be one of: postgres10, postgres11, postgres12, postgres13, postgres14
@@ -54,6 +54,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -62,8 +63,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -94,6 +97,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-production/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-staging/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-uat/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -9,7 +9,8 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds_postgres_14" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -17,10 +18,10 @@ module "cla_backend_rds_postgres_14" {
   is_production = var.is_production
   namespace     = var.namespace
 
-  db_name = "cla_backend"
-  db_instance_class        = "db.t4g.large"
-  db_allocated_storage     = "30"
-  db_max_allocated_storage = "1000"
+  db_name                      = "cla_backend"
+  db_instance_class            = "db.t4g.large"
+  db_allocated_storage         = "30"
+  db_max_allocated_storage     = "1000"
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
@@ -45,6 +46,7 @@ module "cla_backend_rds_postgres_14" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
   providers = {
@@ -54,7 +56,8 @@ module "cla_backend_rds_postgres_14" {
 }
 
 module "cla_backend_rds_postgres_14_replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -94,10 +97,12 @@ module "cla_backend_rds_postgres_14_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 module "cla_backend_metabase_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -105,13 +110,13 @@ module "cla_backend_metabase_rds" {
   is_production = var.is_production
   namespace     = var.namespace
 
-  db_name                  = "metabase"
-  db_engine_version        = "16"
-  db_instance_class        = "db.t4g.micro"
-  db_allocated_storage     = "5"
-  db_max_allocated_storage = "500"
-  environment_name         = var.environment-name
-  infrastructure_support   = var.infrastructure_support
+  db_name                      = "metabase"
+  db_engine_version            = "16"
+  db_instance_class            = "db.t4g.micro"
+  db_allocated_storage         = "5"
+  db_max_allocated_storage     = "500"
+  environment_name             = var.environment-name
+  infrastructure_support       = var.infrastructure_support
   performance_insights_enabled = true
 
   rds_family = "postgres16"
@@ -122,6 +127,7 @@ module "cla_backend_metabase_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "cla_backend_rds_postgres_14" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/rds.tf
@@ -8,7 +8,9 @@
 # IMP NOTE: Updating to module version 5.3, existing database password will be rotated.
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 module "cla_backend_rds_postgres_14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -36,10 +38,12 @@ module "cla_backend_rds_postgres_14_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 module "cla_backend_rds_postgres_14" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -74,6 +78,7 @@ module "cla_backend_rds_postgres_14" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-training/resources/rds.tf
@@ -6,13 +6,15 @@
  */
 
 module "cla_backend_rds_postgres_14" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = var.application
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = var.application
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   db_name = "cla_backend"
   # change the postgres version as you see fit.
@@ -38,6 +40,7 @@ module "cla_backend_rds_postgres_14" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
   providers = {
@@ -47,7 +50,9 @@ module "cla_backend_rds_postgres_14" {
 }
 
 module "cla_backend_rds_postgres_14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -75,10 +80,12 @@ module "cla_backend_rds_postgres_14_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 module "cla_backend_metabase_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -102,6 +109,7 @@ module "cla_backend_metabase_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "cla_backend_rds_postgres_14" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/resources/rds.tf
@@ -9,13 +9,15 @@
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "cla_backend_rds_postgres_14" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = var.application
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = var.application
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   db_name = "cla_backend"
   # change the postgres version as you see fit.
@@ -41,6 +43,7 @@ module "cla_backend_rds_postgres_14" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
   providers = {
@@ -50,13 +53,15 @@ module "cla_backend_rds_postgres_14" {
 }
 
 module "cla_backend_cfe_integration_rds_postgres_14" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = var.application
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = var.application
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   db_name = "cla_backend"
   # change the postgres version as you see fit.
@@ -82,6 +87,7 @@ module "cla_backend_cfe_integration_rds_postgres_14" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
   providers = {
@@ -91,7 +97,8 @@ module "cla_backend_cfe_integration_rds_postgres_14" {
 }
 
 module "cla_backend_metabase_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -115,6 +122,7 @@ module "cla_backend_metabase_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "cla_backend_rds_postgres_14" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/rds-instance.tf
@@ -1,11 +1,13 @@
 module "court_data_adaptor_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  namespace     = var.namespace
-  team_name     = "laa-crime-apps-team"
-  business_unit = "Crime Apps"
-  application   = "laa-court-data-adaptor"
-  is_production = "false"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  namespace            = var.namespace
+  team_name            = "laa-crime-apps-team"
+  business_unit        = "Crime Apps"
+  application          = "laa-court-data-adaptor"
+  is_production        = "false"
 
   environment_name       = "dev"
   infrastructure_support = var.infrastructure_support
@@ -21,6 +23,7 @@ module "court_data_adaptor_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "court_data_adaptor_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds-instance.tf
@@ -1,11 +1,13 @@
 module "court_data_adaptor_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  namespace     = var.namespace
-  team_name     = "laa-crime-apps-team"
-  business_unit = "Crime Apps"
-  application   = "laa-court-data-adaptor"
-  is_production = "true"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  namespace            = var.namespace
+  team_name            = "laa-crime-apps-team"
+  business_unit        = "Crime Apps"
+  application          = "laa-court-data-adaptor"
+  is_production        = "true"
 
   environment_name       = "prod"
   infrastructure_support = var.infrastructure_support
@@ -19,6 +21,7 @@ module "court_data_adaptor_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "court_data_adaptor_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-stage/resources/rds-instance.tf
@@ -1,11 +1,13 @@
 module "court_data_adaptor_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  namespace     = var.namespace
-  team_name     = "laa-crime-apps-team"
-  business_unit = "Crime Apps"
-  application   = "laa-court-data-adaptor"
-  is_production = "false"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  namespace            = var.namespace
+  team_name            = "laa-crime-apps-team"
+  business_unit        = "Crime Apps"
+  application          = "laa-court-data-adaptor"
+  is_production        = "false"
 
   environment_name       = "stage"
   infrastructure_support = var.infrastructure_support
@@ -21,6 +23,7 @@ module "court_data_adaptor_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "court_data_adaptor_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/rds-instance.tf
@@ -1,11 +1,13 @@
 module "court_data_adaptor_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  namespace     = var.namespace
-  team_name     = "laa-crime-apps-team"
-  business_unit = "Crime Apps"
-  application   = "laa-court-data-adaptor"
-  is_production = "false"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  namespace            = var.namespace
+  team_name            = "laa-crime-apps-team"
+  business_unit        = "Crime Apps"
+  application          = "laa-court-data-adaptor"
+  is_production        = "false"
 
   db_engine_version      = "14"
   environment_name       = "test"
@@ -21,6 +23,7 @@ module "court_data_adaptor_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "court_data_adaptor_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/rds-instance.tf
@@ -1,11 +1,13 @@
 module "court_data_adaptor_rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  namespace     = var.namespace
-  team_name     = "laa-crime-apps-team"
-  business_unit = "Crime Apps"
-  application   = "laa-court-data-adaptor"
-  is_production = "false"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  namespace            = var.namespace
+  team_name            = "laa-crime-apps-team"
+  business_unit        = "Crime Apps"
+  application          = "laa-court-data-adaptor"
+  is_production        = "false"
 
   environment_name       = "uat"
   infrastructure_support = var.infrastructure_support
@@ -21,6 +23,7 @@ module "court_data_adaptor_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "court_data_adaptor_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-test/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-uat/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-mock-api-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-mock-api-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,6 +36,7 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-postgresql-instance-output"
@@ -46,7 +49,7 @@ resource "kubernetes_secret" "rds" {
     database_username     = module.rds.database_username
     database_password     = module.rds.database_password
     rds_instance_address  = module.rds.rds_instance_address
-    url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+    url                   = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-mock-api-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-mock-api-test/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,6 +36,7 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-postgresql-instance-output"
@@ -46,7 +49,7 @@ resource "kubernetes_secret" "rds" {
     database_username     = module.rds.database_username
     database_password     = module.rds.database_password
     rds_instance_address  = module.rds.rds_instance_address
-    url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+    url                   = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
@@ -5,7 +5,8 @@
  *
 */
 module "rds_mssql" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,6 +35,7 @@ module "rds_mssql" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-uat/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-uat/resources/rds-mssql.tf
@@ -5,7 +5,8 @@
  *
 */
 module "rds_mssql" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -33,6 +34,7 @@ module "rds_mssql" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-dev/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -48,7 +50,7 @@ module "rds" {
 
   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
   enable_rds_auto_start_stop = true
-  maintenance_window          = "Mon:21:00-Mon:22:00"
+  maintenance_window         = "Mon:21:00-Mon:22:00"
 
   # This will rotate the db password. Update the value to the current date.
   # db_password_rotated_date  = "dd-mm-yyyy"
@@ -57,6 +59,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -65,8 +68,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -97,6 +102,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-prod/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -56,6 +58,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -64,8 +67,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -96,6 +101,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-test/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -48,7 +50,7 @@ module "rds" {
 
   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
   enable_rds_auto_start_stop = true
-  maintenance_window          = "Mon:21:00-Mon:22:00"
+  maintenance_window         = "Mon:21:00-Mon:22:00"
 
   # This will rotate the db password. Update the value to the current date.
   # db_password_rotated_date  = "dd-mm-yyyy"
@@ -57,6 +59,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -65,8 +68,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -97,6 +102,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-evidence-uat/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -48,7 +50,7 @@ module "rds" {
 
   # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
   enable_rds_auto_start_stop = true
-  maintenance_window          = "Mon:21:00-Mon:22:00"
+  maintenance_window         = "Mon:21:00-Mon:22:00"
 
   # This will rotate the db password. Update the value to the current date.
   # db_password_rotated_date  = "dd-mm-yyyy"
@@ -57,6 +59,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -65,8 +68,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -97,6 +102,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -37,14 +39,17 @@ module "rds" {
   enable_rds_auto_start_stop = true
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -75,6 +80,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -72,6 +77,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -37,14 +39,17 @@ module "rds" {
   enable_rds_auto_start_stop = true
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -75,6 +80,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-uat/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -37,14 +39,17 @@ module "rds" {
   enable_rds_auto_start_stop = true
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -75,6 +80,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-dev/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -60,6 +62,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -68,8 +71,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -106,6 +111,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-prod/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -54,6 +56,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -62,8 +65,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -96,6 +101,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-test/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -60,6 +62,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -68,8 +71,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -102,6 +107,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-means-assessment-uat/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -60,6 +62,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -68,8 +71,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -102,6 +107,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -37,14 +39,17 @@ module "rds" {
   enable_rds_auto_start_stop = true
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -88,6 +93,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-prod/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,14 +36,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-test/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -37,14 +39,17 @@ module "rds" {
   enable_rds_auto_start_stop = true
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -88,6 +93,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-uat/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -37,14 +39,17 @@ module "rds" {
   enable_rds_auto_start_stop = true
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -88,6 +93,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -31,6 +33,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-dev/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -56,6 +58,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -64,8 +67,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -96,6 +101,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-prod/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -56,6 +58,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -64,8 +67,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -96,6 +101,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -56,6 +58,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -64,8 +67,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -96,6 +101,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-uat/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -56,6 +58,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -64,8 +67,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -96,6 +101,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-dev/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -53,6 +55,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -61,8 +64,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -93,6 +98,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-prod/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -53,6 +55,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -61,8 +64,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -93,6 +98,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -53,6 +55,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -61,8 +64,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -93,6 +98,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-uat/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -53,6 +55,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -61,8 +64,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -93,6 +98,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-data-migration-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-data-migration-dev/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -37,6 +39,7 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-postgresql-instance-output"
@@ -49,7 +52,7 @@ resource "kubernetes_secret" "rds" {
     database_username     = module.rds.database_username
     database_password     = module.rds.database_password
     rds_instance_address  = module.rds.rds_instance_address
-    url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+    url                   = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/rds-postgresql.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -53,6 +55,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -33,6 +35,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/rds-postgresql.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -33,6 +35,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -20,6 +22,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "random_id" "probation_teams_password" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "random_id" "probation_teams_password" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "random_id" "probation_teams_password" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/postgresql.tf
@@ -3,7 +3,9 @@
 ##
 
 module "make_recall_decision_api_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   enable_rds_auto_start_stop = true
   vpc_name                   = var.vpc_name
   namespace                  = var.namespace
@@ -24,6 +26,7 @@ module "make_recall_decision_api_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "make_recall_decision_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/postgresql.tf
@@ -3,7 +3,8 @@
 ##
 
 module "make_recall_decision_api_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type               = "gp2"
   enable_rds_auto_start_stop = true
   vpc_name                   = var.vpc_name
   namespace                  = var.namespace
@@ -14,17 +15,18 @@ module "make_recall_decision_api_rds" {
   is_production              = var.is_production
   team_name                  = var.team_name
 
-  rds_name          = "make-recall-decision-${var.environment}"
-  rds_family        = "postgres13"
-  db_engine         = "postgres"
-  db_engine_version = "13.15"
-  db_instance_class = "db.t3.small"
-  db_name           = "make_recall_decision"
+  rds_name             = "make-recall-decision-${var.environment}"
+  rds_family           = "postgres13"
+  db_engine            = "postgres"
+  db_engine_version    = "13.15"
+  db_instance_class    = "db.t3.small"
+  db_name              = "make_recall_decision"
   db_allocated_storage = 30
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "make_recall_decision_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/postgresql.tf
@@ -3,7 +3,8 @@
 ##
 
 module "make_recall_decision_api_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type = "gp2"
 
   vpc_name               = var.vpc_name
   namespace              = var.namespace
@@ -14,17 +15,18 @@ module "make_recall_decision_api_rds" {
   is_production          = var.is_production
   team_name              = var.team_name
 
-  rds_name          = "make-recall-decision-${var.environment}"
-  rds_family        = "postgres13"
-  db_engine         = "postgres"
-  db_engine_version = "13.15"
-  db_instance_class = "db.t3.small"
-  db_name           = "make_recall_decision"
+  rds_name             = "make-recall-decision-${var.environment}"
+  rds_family           = "postgres13"
+  db_engine            = "postgres"
+  db_engine_version    = "13.15"
+  db_instance_class    = "db.t3.small"
+  db_name              = "make_recall_decision"
   db_allocated_storage = 30
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "make_recall_decision_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
@@ -3,7 +3,9 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -20,6 +22,7 @@ module "dps_rds" {
   prepare_for_major_upgrade = true
 
 }
+
 
 data "aws_iam_policy_document" "manage_soc_cases_dev_rds_to_s3_export_policy" {
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/rds.tf
@@ -3,7 +3,9 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -20,6 +22,7 @@ module "dps_rds" {
   prepare_for_major_upgrade = false
 
 }
+
 
 data "aws_iam_policy_document" "manage_soc_cases_preprod_rds_to_s3_export_policy" {
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/rds.tf
@@ -3,7 +3,9 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -20,6 +22,7 @@ module "dps_rds" {
   prepare_for_major_upgrade = false
 
 }
+
 
 data "aws_iam_policy_document" "manage_soc_cases_preprod_rds_to_s3_export_policy" {
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/rds-metabase.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/rds-metabase.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds_metabase" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,17 +36,20 @@ module "rds_metabase" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica_metabase" {
-  
-  # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
 
-  vpc_name               = var.vpc_name
+  # default off
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -87,6 +92,7 @@ module "read_replica_metabase" {
   # ]
 }
 
+
 resource "kubernetes_secret" "rds_metabase" {
   metadata {
     name      = "rds-metabase-instance-output"
@@ -99,7 +105,7 @@ resource "kubernetes_secret" "rds_metabase" {
     database_username     = module.rds_metabase.database_username
     database_password     = module.rds_metabase.database_password
     rds_instance_address  = module.rds_metabase.rds_instance_address
-    jdbc_url = "jdbc:postgresql://${module.rds_metabase.rds_instance_endpoint}/${module.rds_metabase.database_name}?user=${module.rds_metabase.database_username}&password=${module.rds_metabase.database_password}"
+    jdbc_url              = "jdbc:postgresql://${module.rds_metabase.rds_instance_endpoint}/${module.rds_metabase.database_name}?user=${module.rds_metabase.database_username}&password=${module.rds_metabase.database_password}"
   }
   /* You can replace all of the above with the following, if you prefer to
      * use a single database URL value in your application code:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/rds.tf
@@ -5,7 +5,9 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -34,16 +36,19 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -85,6 +90,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/rds.tf
@@ -5,25 +5,27 @@
  *
  */
 module "allocation-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name                   = var.vpc_name
-  db_instance_class          = "db.t4g.small"
-  team_name                  = var.team_name
-  business_unit              = var.business_unit
-  application                = var.application
-  is_production              = var.is_production
-  namespace                  = var.namespace
-  environment_name           = var.environment_name
-  infrastructure_support     = var.infrastructure_support
-  db_engine                  = "postgres"
+  vpc_name                    = var.vpc_name
+  db_instance_class           = "db.t4g.small"
+  team_name                   = var.team_name
+  business_unit               = var.business_unit
+  application                 = var.application
+  is_production               = var.is_production
+  namespace                   = var.namespace
+  environment_name            = var.environment_name
+  infrastructure_support      = var.infrastructure_support
+  db_engine                   = "postgres"
   db_engine_version           = "15.6"
   rds_family                  = "postgres15"
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false
   prepare_for_major_upgrade   = false
-  db_name                    = "allocations"
-  enable_rds_auto_start_stop = true
+  db_name                     = "allocations"
+  enable_rds_auto_start_stop  = true
 
 
   db_password_rotated_date = "2023-04-05T11:31:27Z"
@@ -31,6 +33,7 @@ module "allocation-rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "allocation-rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
@@ -5,7 +5,9 @@
  *
  */
 module "allocation-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name                    = var.vpc_name
   db_instance_class           = "db.m5.large"
@@ -29,6 +31,7 @@ module "allocation-rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "allocation-rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds.tf
@@ -5,31 +5,34 @@
  *
  */
 module "allocation-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
-  vpc_name                   = var.vpc_name
-  db_instance_class          = "db.t4g.small"
-  team_name                  = var.team_name
-  business_unit              = var.business_unit
-  application                = var.application
-  is_production              = var.is_production
-  namespace                  = var.namespace
-  environment_name           = var.environment_name
-  infrastructure_support     = var.infrastructure_support
-  db_engine                  = "postgres"
+  vpc_name                    = var.vpc_name
+  db_instance_class           = "db.t4g.small"
+  team_name                   = var.team_name
+  business_unit               = var.business_unit
+  application                 = var.application
+  is_production               = var.is_production
+  namespace                   = var.namespace
+  environment_name            = var.environment_name
+  infrastructure_support      = var.infrastructure_support
+  db_engine                   = "postgres"
   db_engine_version           = "15.6"
   rds_family                  = "postgres15"
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false
   prepare_for_major_upgrade   = false
-  db_name                    = "allocations"
-  enable_rds_auto_start_stop = true
+  db_name                     = "allocations"
+  enable_rds_auto_start_stop  = true
 
   db_password_rotated_date = "2023-04-05T11:31:27Z"
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "allocation-rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-find-a-github-repository-owner-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-find-a-github-repository-owner-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -21,6 +23,7 @@ module "rds" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-kpi-dashboard-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -21,6 +23,7 @@ module "rds" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/rds-postgres14.tf
@@ -1,5 +1,7 @@
 module "pact_broker_rds_postgres14" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -17,6 +19,7 @@ module "pact_broker_rds_postgres14" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "pact_broker_rds_postgres14_secrets" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
@@ -3,7 +3,9 @@
 #############################################
 
 module "rds_instance" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   application                = var.application
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
@@ -22,6 +24,7 @@ module "rds_instance" {
   enable_rds_auto_start_stop = true
   prepare_for_major_upgrade  = false
 }
+
 
 resource "kubernetes_secret" "rds_instance" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/rds.tf
@@ -20,12 +20,15 @@ module "rds_instance" {
   db_name                    = "parliamentary_questions_production"
   rds_family                 = "postgres16"
   db_backup_retention_period = var.db_backup_retention_period
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   prepare_for_major_upgrade  = false
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds_instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-staging/resources/rds.tf
@@ -3,7 +3,9 @@
 #############################################
 
 module "rds_instance" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   application                = var.application
   vpc_name                   = var.vpc_name
   environment_name           = var.environment-name
@@ -27,6 +29,7 @@ module "rds_instance" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds_instance" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -3,7 +3,9 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -19,6 +21,7 @@ module "dps_rds" {
   rds_family                = "postgres15"
   prepare_for_major_upgrade = false
 }
+
 
 data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
@@ -3,7 +3,9 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -19,6 +21,7 @@ module "dps_rds" {
   rds_family                = "postgres15"
   prepare_for_major_upgrade = false
 }
+
 
 data "aws_iam_policy_document" "pathfinder_dev_rds_to_s3_export_policy" {
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -15,6 +17,7 @@ module "dps_rds" {
   rds_family                = "postgres15"
   prepare_for_major_upgrade = false
 }
+
 
 resource "kubernetes_secret" "dps_rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -24,11 +26,12 @@ module "peoplefinder_rds" {
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade = "false"
+  prepare_for_major_upgrade   = "false"
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "peoplefinder_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -23,15 +25,18 @@ module "peoplefinder_rds" {
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade = "false"
+  prepare_for_major_upgrade   = "false"
 
   providers = {
     aws = aws.london
   }
+
 }
 
 module "peoplefinder_rds_replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -56,6 +61,7 @@ module "peoplefinder_rds_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "peoplefinder_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-staging/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -25,11 +27,12 @@ module "peoplefinder_rds" {
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade = "false"
+  prepare_for_major_upgrade   = "false"
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "peoplefinder_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/rds-postgresql.tf
@@ -1,6 +1,7 @@
 
 module "rds_postgresql" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit
@@ -33,6 +34,7 @@ module "rds_postgresql" {
       value        = "1"
       apply_method = "pending-reboot"
     }
+
   ]
 
   providers = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/rds.tf
@@ -1,5 +1,6 @@
 module "prison-visits-rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -20,11 +21,12 @@ module "prison-visits-rds" {
   db_parameter                = [{ name = "rds.force_ssl", value = "0", apply_method = "immediate" }]
   db_password_rotated_date    = "2023-03-22"
 
-  enable_rds_auto_start_stop  = true
+  enable_rds_auto_start_stop = true
 
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "prison-visits-rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/rds-prison-visits.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/rds-prison-visits.tf
@@ -6,21 +6,22 @@
  */
 
 module "prison-visits-rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                 = var.vpc_name
-  team_name                = "prison-visits-booking"
-  business_unit            = "HMPPS"
-  application              = "prison-visits-booking-production"
-  is_production            = var.is_production
-  environment_name         = "production"
-  infrastructure_support   = "pvb-technical-support@digital.justice.gov.uk"
-  namespace                = var.namespace
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type           = "gp2"
+  vpc_name               = var.vpc_name
+  team_name              = "prison-visits-booking"
+  business_unit          = "HMPPS"
+  application            = "prison-visits-booking-production"
+  is_production          = var.is_production
+  environment_name       = "production"
+  infrastructure_support = "pvb-technical-support@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   allow_major_version_upgrade = "false"
-  prepare_for_major_upgrade = false
-  db_engine                = "postgres"
-  db_engine_version        = "15.7"
-  rds_family               = "postgres15"
+  prepare_for_major_upgrade   = false
+  db_engine                   = "postgres"
+  db_engine_version           = "15.7"
+  rds_family                  = "postgres15"
 
   db_instance_class        = "db.m5.xlarge"
   db_allocated_storage     = "50"
@@ -33,6 +34,7 @@ module "prison-visits-rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "prison-visits-rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/rds-prison-visits.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/rds-prison-visits.tf
@@ -1,13 +1,14 @@
 module "prison-visits-rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name                 = var.vpc_name
-  team_name                = "prison-visits-booking"
-  business_unit            = "HMPPS"
-  application              = "prison-visits-booking-staging"
-  is_production            = "false"
-  environment_name         = "staging"
-  infrastructure_support   = "pvb-technical-support@digital.justice.gov.uk"
-  namespace                = var.namespace
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type           = "gp2"
+  vpc_name               = var.vpc_name
+  team_name              = "prison-visits-booking"
+  business_unit          = "HMPPS"
+  application            = "prison-visits-booking-staging"
+  is_production          = "false"
+  environment_name       = "staging"
+  infrastructure_support = "pvb-technical-support@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   allow_major_version_upgrade = "false"
   prepare_for_major_upgrade   = false
@@ -23,6 +24,7 @@ module "prison-visits-rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "prison-visits-rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds.tf
@@ -1,5 +1,7 @@
 module "drupal_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -27,6 +29,7 @@ module "drupal_rds" {
       value        = "READ-COMMITTED"
       apply_method = "immediate"
     }
+
   ]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds.tf
@@ -1,5 +1,7 @@
 module "drupal_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage     = 10
+  storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name
   business_unit            = var.business_unit
@@ -11,9 +13,9 @@ module "drupal_rds" {
   db_instance_class        = "db.t4g.xlarge"
   db_password_rotated_date = "2023-05-15"
 
-  db_engine                 = "mariadb"
-  db_engine_version         = "10.11"
-  rds_family                = "mariadb10.11"
+  db_engine         = "mariadb"
+  db_engine_version = "10.11"
+  rds_family        = "mariadb10.11"
 
   # The recommended transaction isolation level for Drupal is READ-COMMITTED.
   # See https://www.drupal.org/docs/getting-started/system-requirements/setting-the-mysql-transaction-isolation-level
@@ -23,6 +25,7 @@ module "drupal_rds" {
       value        = "READ-COMMITTED"
       apply_method = "immediate"
     }
+
   ]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-staging/resources/rds.tf
@@ -1,5 +1,7 @@
 module "drupal_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -30,6 +32,7 @@ module "drupal_rds" {
       value        = "READ-COMMITTED"
       apply_method = "immediate"
     }
+
   ]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/request-personal-information-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/request-personal-information-staging/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -26,6 +28,7 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "slmtp_api_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -22,6 +24,7 @@ module "slmtp_api_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "slmtp_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "slmtp_api_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -23,6 +25,7 @@ module "slmtp_api_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "slmtp_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "slmtp_api_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -21,6 +23,7 @@ module "slmtp_api_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "slmtp_api_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/rds-mysql.tf
@@ -6,7 +6,9 @@
 */
 
 module "rds_mysql" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -35,6 +37,7 @@ module "rds_mysql" {
       value        = "utf8"
       apply_method = "immediate"
     },
+
     {
       name         = "character_set_server"
       value        = "utf8"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/soc-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/soc-production/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -51,6 +53,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -59,8 +62,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -91,6 +96,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/soc-reporting-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/soc-reporting-dev/resources/rds.tf
@@ -1,11 +1,13 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
-  vpc_name      = var.vpc_name
-  team_name     = var.team_name
-  business_unit = var.business_unit
-  application   = var.application
-  is_production = var.is_production
-  namespace     = var.namespace
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
+  vpc_name             = var.vpc_name
+  team_name            = var.team_name
+  business_unit        = var.business_unit
+  application          = var.application
+  is_production        = var.is_production
+  namespace            = var.namespace
 
   # enable performance insights
   performance_insights_enabled = true
@@ -30,6 +32,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/soc-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/soc-staging/resources/rds.tf
@@ -6,7 +6,9 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage   = 10
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -51,6 +53,7 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -59,8 +62,10 @@ module "rds" {
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -91,6 +96,7 @@ module "read_replica" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
 
   # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -26,6 +28,7 @@ module "track_a_query_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "track_a_query_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -29,10 +31,13 @@ module "track_a_query_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 module "track_a_query_rds_replica" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name = var.vpc_name
 
@@ -57,6 +62,7 @@ module "track_a_query_rds_replica" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "track_a_query_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-qa/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -27,6 +29,7 @@ module "track_a_query_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "track_a_query_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-staging/resources/rds.tf
@@ -4,7 +4,9 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage       = 10
+  storage_type               = "gp2"
   vpc_name                   = var.vpc_name
   team_name                  = var.team_name
   business_unit              = var.business_unit
@@ -27,6 +29,7 @@ module "track_a_query_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "track_a_query_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-dev/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -28,14 +30,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -77,6 +82,7 @@ module "read_replica" {
   #   }
   # ]
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -26,14 +28,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -64,6 +69,7 @@ module "read_replica" {
   skip_final_snapshot        = "true"
   db_backup_retention_period = 0
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-staging/resources/rds-postgresql.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -26,14 +28,17 @@ module "rds" {
   team_name              = var.team_name
 }
 
+
 # To create a read replica, use the below code and update the values to specify the RDS instance
 # from which you are replicating. In this example, we're assuming that rds is the
 # source RDS instance and read-replica is the replica we are creating.
 
 module "read_replica" {
   # default off
-  count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  count                = 0
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage = 10
+  storage_type         = "gp2"
 
   vpc_name               = var.vpc_name
   application            = var.application
@@ -64,6 +69,7 @@ module "read_replica" {
   skip_final_snapshot        = "true"
   db_backup_retention_period = 0
 }
+
 
 resource "kubernetes_secret" "rds" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -20,6 +22,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-preprod/resources/rds.tf
@@ -1,5 +1,7 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  db_allocated_storage        = 10
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -19,6 +21,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/rds.tf
@@ -1,5 +1,6 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.2.2"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
+  storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -24,6 +25,7 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
 }
 
 resource "kubernetes_secret" "dps_rds" {


### PR DESCRIPTION
- bump `7.2.2` RDS to `8.0.1`
- add `storage_type = "gp2"` as they are all using `gp2`
- add `allocated_storage = 10` if there is no `allocated_storage` specified in the original RDS terraform file
- no ops for user
- relates to https://github.com/ministryofjustice/cloud-platform/issues/6606