### PR TITLE
Fix: rds version mismatch in calculate-release-dates-api-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-preprod/resources/rds.tf
@@ -11,7 +11,7 @@ module "calculate_release_dates_api_rds" {
   infrastructure_support = var.infrastructure_support
   db_max_allocated_storage     = "250"
   db_engine              = "postgres"
-  db_engine_version      = "16.3"
+  db_engine_version      = "16.4"
   rds_family             = "postgres16"
   prepare_for_major_upgrade = false
   allow_minor_version_upgrade = true


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.4 to 16.3
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-a