### PR TITLE
Fix: rds version mismatch in hmpps-education-and-work-plan-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prod/resources/rds-postgresql.tf
@@ -20,7 +20,7 @@ module "hmpps_education_work_plan_rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "15.7"
+  db_engine_version = "15.8"
   rds_family        = "postgres15"
   db_instance_class = "db.t4g.micro"
 


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-c