### PR TITLE
Fix: rds version mismatch in manage-soc-cases-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prod/resources/rds.tf
@@ -10,7 +10,7 @@ module "dps_rds" {
   application              = var.application
   is_production            = var.is_production
   namespace                = var.namespace
-  db_engine_version        = "15.7"
+  db_engine_version        = "15.8"
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000" # maximum storage for autoscaling
   environment_name         = var.environment_name


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-e