### PR TITLE
Fix: rds version mismatch in hmpps-tier-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds" {
   namespace                    = var.namespace
   rds_name                     = "hmpps-tier-${var.environment_name}"
   rds_family                   = "postgres16"
-  db_engine_version            = "16.3"
+  db_engine_version            = "16.4"
   db_instance_class            = "db.t4g.small"
   prepare_for_major_upgrade    = false
   performance_insights_enabled = true


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.4 to 16.3
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d