### PR TITLE
Fix: rds version mismatch in hmpps-staff-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-prod/resources/rds-postgresql.tf
@@ -24,7 +24,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "15.7"
+  db_engine_version = "15.8"
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.small"


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d