### PR TITLE
Fix: rds version mismatch in hmpps-education-employment-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/rds.tf
@@ -13,7 +13,7 @@ module "edu_rds" {
   allow_major_version_upgrade = false
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "10000"
-  db_engine_version           = "16.3"
+  db_engine_version           = "16.4"
   deletion_protection         = true
 
   providers = {


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.4 to 16.3
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-c