### PR TITLE
Fix: rds version mismatch in pathfinder-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-preprod/resources/rds.tf
@@ -12,7 +12,7 @@ module "dps_rds" {
   namespace                = var.namespace
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000" # maximum storage for autoscaling
-  db_engine_version        = "15.7"
+  db_engine_version        = "15.8"
   environment_name         = var.environment_name
   infrastructure_support   = var.infrastructure_support
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
@@ -8,7 +8,7 @@ module "dps_rds" {
   namespace                = var.namespace
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000" # maximum storage for autoscaling
-  db_engine_version        = "15.7"
+  db_engine_version        = "15.8"
   environment_name         = var.environment_name
   infrastructure_support   = var.infrastructure_support
 


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-e