### PR TITLE
Add dblink extension to SAN database

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -15,7 +15,7 @@ module "hmpps_strengths_based_needs_assessments_dev_rds" {
   db_engine_version      = "16"
 
   allow_major_version_upgrade = "true"
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade   = false
 
   providers = {
     aws = aws.london
@@ -36,4 +36,20 @@ resource "kubernetes_secret" "hmpps_strengths_based_needs_assessments_dev_rds_se
     rds_instance_address  = module.hmpps_strengths_based_needs_assessments_dev_rds.rds_instance_address
     url                   = "postgres://${module.hmpps_strengths_based_needs_assessments_dev_rds.database_username}:${module.hmpps_strengths_based_needs_assessments_dev_rds.database_password}@${module.hmpps_strengths_based_needs_assessments_dev_rds.rds_instance_endpoint}/${module.hmpps_strengths_based_needs_assessments_dev_rds.database_name}"
   }
+}
+
+provider "postgresql" {
+  database         = "postgres"
+  host             = module.hmpps_strengths_based_needs_assessments_dev_rds.rds_instance_address
+  port             = module.hmpps_strengths_based_needs_assessments_dev_rds.rds_instance_port
+  username         = module.hmpps_strengths_based_needs_assessments_dev_rds.database_username
+  password         = module.hmpps_strengths_based_needs_assessments_dev_rds.database_password
+  expected_version = "16"
+  sslmode          = "require"
+  superuser        = false
+}
+
+# Installs postgres dblink extension
+resource "postgresql_extension" "dblink" {
+  name = "dblink"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/versions.tf
@@ -17,5 +17,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6.0"
     }
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "~> 1.25.0"
+    }
   }
 }


### PR DESCRIPTION
Terraform to add the `dblink` extension to the SAN `dev` database.