### PR TITLE
Fix: rds version mismatch in hmpps-subject-access-request-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/rds.tf
@@ -11,10 +11,11 @@ module "subject_access_request_rds" {
   infrastructure_support      = var.infrastructure_support
   db_instance_class           = "db.t4g.small"
   db_engine                   = "postgres"
-  db_engine_version           = "15.7"
+  db_engine_version           = "15.8"
   rds_family                  = "postgres15"
   prepare_for_major_upgrade   = true
   allow_major_version_upgrade = true
+  allow_minor_version_upgrade = true
   deletion_protection         = true
 
   providers = {


### PR DESCRIPTION
Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/11125.1