### PR TITLE
Fix: rds version mismatch in calculate-release-dates-api-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-prod/resources/rds.tf
@@ -15,7 +15,7 @@ module "calculate_release_dates_api_rds" {
   # Database configuration
   db_max_allocated_storage     = "250"
   db_engine              = "postgres"
-  db_engine_version      = "16.3"
+  db_engine_version      = "16.4"
   rds_family             = "postgres16"
   
   prepare_for_major_upgrade = false


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.4 to 16.3
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-a