### PR TITLE
Fix: rds version mismatch in hmpps-find-and-refer-an-intervention-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/rds-postgres14.tf
@@ -10,7 +10,7 @@ module "rds" {
   infrastructure_support = var.infrastructure_support
 
   rds_family                  = "postgres16"
-  db_engine_version           = "16.3"
+  db_engine_version           = "16.4"
   # db instance class
   db_instance_class           = "db.t4g.small"
   allow_major_version_upgrade = "false"


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 16.4 to 16.3
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-c