### PR TITLE
Fix: rds version mismatch in formbuilder-platform-test-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/submitter.tf
@@ -14,6 +14,8 @@ module "submitter-rds-instance-2" {
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 
+  allow_minor_version_upgrade = true
+
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
Fix Terraform RDS version drift. Here are the RDS version mismatches:

downgrade from 15.8 to 15.7

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/11171#L674b88cf:23