### PR TITLE
Fix: rds version mismatch in hmpps-workload-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-live.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-live.tf
@@ -18,7 +18,7 @@ module "rds-live" {
 
   # change the postgres version as you see fit.
   prepare_for_major_upgrade = false
-  db_engine_version         = "15.7"
+  db_engine_version         = "15.8"
 
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d