### PR TITLE
CAS pre-prod database: increase db_allocated_storage from 10 to 50 for rds module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/rds.tf
@@ -25,7 +25,7 @@ module "rds" {
 module "read_replica" {
   count                = 0
   source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
-  db_allocated_storage = 10
+  db_allocated_storage = 50
   storage_type         = "gp2"
 
   vpc_name               = var.vpc_name


### PR DESCRIPTION
Pre-Prod: increase db_allocated_storage from 10 to 50 for read_replica module

See related PR (already done) to increase storage for the rds module: https://github.com/ministryofjustice/cloud-platform-environments/pull/30366