### PR TITLE
CPR-629 Scale up rds to support migration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-prod/resources/person-match-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-prod/resources/person-match-rds.tf
@@ -9,6 +9,7 @@ module "hmpps_person_match_rds" {
   environment_name            = var.environment
   infrastructure_support      = var.infrastructure_support
   db_max_allocated_storage    = "500"
+  db_allocated_storage        = "90"
   rds_family                  = "postgres16"
   db_instance_class           = "db.r6g.xlarge"
   db_engine                   = "postgres"


### PR DESCRIPTION
* Increase to 90GiB allocated mem to support migration, Will revert to auto scaling after migration