### PR TITLE
Add subdomain wildcard for `template-typescript-dev`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/06-certificate.yaml
@@ -25,4 +25,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - template-typescript-dev.hmpps.service.justice.gov.uk
-    - *.template-typescript-dev.hmpps.service.justice.gov.uk
+    - '*.template-typescript-dev.hmpps.service.justice.gov.uk'

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/06-certificate.yaml
@@ -25,3 +25,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - template-typescript-dev.hmpps.service.justice.gov.uk
+    - *.template-typescript-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
As part of ephemeral deployment testing work