### PR TITLE
fixing the concorse build failure

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
@@ -10,7 +10,7 @@ module "dps_rds" {
   namespace                = var.namespace
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000" # maximum storage for autoscaling
-  db_engine_version        = "15.7"
+  db_engine_version        = "15.8"
   environment_name         = var.environment_name
   infrastructure_support   = var.infrastructure_support
 


### PR DESCRIPTION
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/11276 < failure is here, seems to be trying to downgrade a postgres version, followed instructions on slack in #ask-cloud-platform channel.