### PR TITLE
Enable prometheus scraping for laa ccr dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/04-networkpolicy.yaml
@@ -25,3 +25,19 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: laa-crown-court-remuneration-dev
+spec:
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/04-networkpolicy.yaml
@@ -32,7 +32,6 @@ metadata:
   name: allow-prometheus-scraping
   namespace: laa-crown-court-remuneration-dev
 spec:
-spec:
   podSelector: {}
   policyTypes:
   - Ingress


### PR DESCRIPTION
I want to enable Prometheus scraping of metrics for laa-crown-court-remuneration-dev