### PR TITLE
HMAI-332 - Add visit write queue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
@@ -6,7 +6,7 @@ locals {
   sqs_queues = {
     "Digital-Prison-Services-dev-hmpps_audit_queue"                           = "hmpps-audit-dev",
     "education-skills-work-employment-dev-hmpps_jobs_board_integration_queue" = "hmpps-jobs-board-integration-dev",
-    "book-a-prison-visit-dev_hmpps_prison_visits_write_events_queue"          = "visit-someone-in-prison-backend-svc-dev"
+    "hmpps_prison_visits_write_events_index_queue"                            = "visit-someone-in-prison-backend-svc-dev"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
   sns_topics = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
@@ -5,7 +5,8 @@ locals {
   # The names of the queues used and the namespace which created them
   sqs_queues = {
     "Digital-Prison-Services-dev-hmpps_audit_queue"                           = "hmpps-audit-dev",
-    "education-skills-work-employment-dev-hmpps_jobs_board_integration_queue" = "hmpps-jobs-board-integration-dev"
+    "education-skills-work-employment-dev-hmpps_jobs_board_integration_queue" = "hmpps-jobs-board-integration-dev",
+    "book-a-prison-visit-dev_hmpps_prison_visits_write_events_queue"          = "visit-someone-in-prison-backend-svc-dev"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
   sns_topics = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
@@ -6,7 +6,7 @@ locals {
   sqs_queues = {
     "Digital-Prison-Services-dev-hmpps_audit_queue"                           = "hmpps-audit-dev",
     "education-skills-work-employment-dev-hmpps_jobs_board_integration_queue" = "hmpps-jobs-board-integration-dev",
-    "hmpps_prison_visits_write_events_queue"          = "visit-someone-in-prison-backend-svc-dev"
+    "hmpps_prison_visits_write_events_queue"                                  = "visit-someone-in-prison-backend-svc-dev"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
   sns_topics = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
@@ -5,8 +5,7 @@ locals {
   # The names of the queues used and the namespace which created them
   sqs_queues = {
     "Digital-Prison-Services-dev-hmpps_audit_queue"                           = "hmpps-audit-dev",
-    "education-skills-work-employment-dev-hmpps_jobs_board_integration_queue" = "hmpps-jobs-board-integration-dev",
-    "hmpps_prison_visits_write_events_queue"                                  = "visit-someone-in-prison-backend-svc-dev"
+    "education-skills-work-employment-dev-hmpps_jobs_board_integration_queue" = "hmpps-jobs-board-integration-dev"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
   sns_topics = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
@@ -6,12 +6,11 @@ locals {
   sqs_queues = {
     "Digital-Prison-Services-dev-hmpps_audit_queue"                           = "hmpps-audit-dev",
     "education-skills-work-employment-dev-hmpps_jobs_board_integration_queue" = "hmpps-jobs-board-integration-dev",
-    "hmpps_prison_visits_write_events_index_queue"                            = "visit-someone-in-prison-backend-svc-dev"
+    "hmpps_prison_visits_write_events_queue"          = "visit-someone-in-prison-backend-svc-dev"
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
   sns_topics = {
     "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev"
-
   }
   sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
@@ -10,6 +10,7 @@ locals {
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
   sns_topics = {
     "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev"
+
   }
   sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-integration-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-integration-api.tf
@@ -1,0 +1,12 @@
+resource "kubernetes_secret" "integration-api-secret" {
+  metadata {
+    name      = "sqs-hmpps-prison-visits-write-events-secret"
+    namespace = "hmpps-integration-api-dev"
+  }
+
+  data = {
+    sqs_queue_url  = module.hmpps_prison_visits_write_events_queue.sqs_id
+    sqs_queue_arn  = module.hmpps_prison_visits_write_events_queue.sqs_arn
+    sqs_queue_name = module.hmpps_prison_visits_write_events_queue.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-write-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-write-events.tf
@@ -36,7 +36,7 @@ module "hmpps_prison_visits_write_events_dead_letter_queue" {
   # Queue configuration
   sqs_name        = "hmpps_prison_visits_write_events_dlq"
   encrypt_sqs_kms = "true"
-  message_retention_seconds  = 21600 # 6 hours
+  message_retention_seconds  = 604800 # 7 days
   visibility_timeout_seconds = 120 # 2 minutes
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-write-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-write-events.tf
@@ -1,0 +1,86 @@
+# Prison visits write events for visit someone in prison
+
+module "hmpps_prison_visits_write_events_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
+
+  # Queue configuration
+  sqs_name                   = "hmpps_prison_visits_write_events_queue"
+  encrypt_sqs_kms            = "true"
+  message_retention_seconds  = 43200 # 12 hours
+  visibility_timeout_seconds = 120 # 2 minutess
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.hmpps_prison_visits_write_events_dead_letter_queue.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the queue
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+# Dead letter queue
+
+module "hmpps_prison_visits_write_events_dead_letter_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
+
+  # Queue configuration
+  sqs_name        = "hmpps_prison_visits_write_events_dlq"
+  encrypt_sqs_kms = "true"
+  message_retention_seconds  = 21600 # 6 hours
+  visibility_timeout_seconds = 120 # 2 minutes
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the queue
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+# Secrets
+
+resource "kubernetes_secret" "hmpps_prison_visits_write_events_queue" {
+  ## For metadata use - not _
+  metadata {
+    name = "sqs-hmpps-prison-visits-write-events-secret"
+    ## Name space where the listening service is found
+    namespace = "visit-someone-in-prison-backend-svc-dev"
+  }
+
+  data = {
+    sqs_queue_url  = module.hmpps_prison_visits_write_events_queue.sqs_id
+    sqs_queue_arn  = module.hmpps_prison_visits_write_events_queue.sqs_arn
+    sqs_queue_name = module.hmpps_prison_visits_write_events_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "hmpps_prison_visits_write_events_dead_letter_queue" {
+  ## For metadata use - not _
+  metadata {
+    name = "sqs-hmpps-prison-visits-write-events-dlq-secret"
+    ## Name space where the listening service is found
+    namespace = "visit-someone-in-prison-backend-svc-dev"
+  }
+
+  data = {
+    sqs_queue_url  = module.hmpps_prison_visits_write_events_dead_letter_queue.sqs_id
+    sqs_queue_arn  = module.hmpps_prison_visits_write_events_dead_letter_queue.sqs_arn
+    sqs_queue_name = module.hmpps_prison_visits_write_events_dead_letter_queue.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-write-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/hmpps-prison-visits-write-events.tf
@@ -1,7 +1,7 @@
 # Prison visits write events for visit someone in prison
 
 module "hmpps_prison_visits_write_events_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.0"
 
   # Queue configuration
   sqs_name                   = "hmpps_prison_visits_write_events_queue"
@@ -31,7 +31,7 @@ module "hmpps_prison_visits_write_events_queue" {
 # Dead letter queue
 
 module "hmpps_prison_visits_write_events_dead_letter_queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.0"
 
   # Queue configuration
   sqs_name        = "hmpps_prison_visits_write_events_dlq"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
@@ -13,10 +13,6 @@ locals {
     visit_allocation_rds = module.visit_allocation_rds.irsa_policy_arn
   }
 
-  sqs_queues = {
-    "book-a-prison-visit-dev_hmpps_prison_visits_write_events_queue"          = "visit-someone-in-prison-backend-svc-dev"
-  }
-
   all_policies = merge(
     {
       hmpps_prison_visits_event_index_queue                                   = module.hmpps_prison_visits_event_queue.irsa_policy_arn,

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
@@ -25,8 +25,8 @@ locals {
       hmpps_prison_visits_allocation_processing_job_index_dead_letter_queue   = module.hmpps_prison_visits_allocation_processing_job_dead_letter_queue.irsa_policy_arn,
       hmpps_prison_visits_allocation_prisoner_retry_index_queue               = module.hmpps_prison_visits_allocation_prisoner_retry_queue.irsa_policy_arn,
       hmpps_prison_visits_allocation_prisoner_retry_index_dead_letter_queue   = module.hmpps_prison_visits_allocation_prisoner_retry_dead_letter_queue.irsa_policy_arn,
-      hmpps_prison_visits_write_events_index_queue                            = module.hmpps_prison_visits_write_events_queue.irsa_policy_arn,
-      hmpps_prison_visits_write_events_index_dead_letter_queue                = module.hmpps_prison_visits_write_events_dead_letter_queue.irsa_policy_arn,
+      (module.hmpps_prison_visits_write_events_queue.sqs_name)                = module.hmpps_prison_visits_write_events_queue.irsa_policy_arn
+      (module.hmpps_prison_visits_write_events_dead_letter_queue.sqs_name)    = module.hmpps_prison_visits_write_events_dead_letter_queue.irsa_policy_arn
     },
     local.sns_policies,
     local.rds_policies

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
@@ -12,7 +12,11 @@ locals {
     prison_visit_booker_registry_rds = module.prison_visit_booker_registry_rds.irsa_policy_arn,
     visit_allocation_rds = module.visit_allocation_rds.irsa_policy_arn
   }
-  
+
+  sqs_queues = {
+    "book-a-prison-visit-dev_hmpps_prison_visits_write_events_queue"          = "visit-someone-in-prison-backend-svc-dev"
+  }
+
   all_policies = merge(
     {
       hmpps_prison_visits_event_index_queue                                   = module.hmpps_prison_visits_event_queue.irsa_policy_arn,
@@ -37,7 +41,6 @@ data "aws_ssm_parameter" "irsa_policy_arns_sns" {
   for_each = local.sns_topics
   name     = "/${each.value}/sns/${each.key}/irsa-policy-arn"
 }
-
 
 module "irsa" {
   source               = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/irsa.tf
@@ -25,6 +25,8 @@ locals {
       hmpps_prison_visits_allocation_processing_job_index_dead_letter_queue   = module.hmpps_prison_visits_allocation_processing_job_dead_letter_queue.irsa_policy_arn,
       hmpps_prison_visits_allocation_prisoner_retry_index_queue               = module.hmpps_prison_visits_allocation_prisoner_retry_queue.irsa_policy_arn,
       hmpps_prison_visits_allocation_prisoner_retry_index_dead_letter_queue   = module.hmpps_prison_visits_allocation_prisoner_retry_dead_letter_queue.irsa_policy_arn,
+      hmpps_prison_visits_write_events_index_queue                            = module.hmpps_prison_visits_write_events_queue.irsa_policy_arn,
+      hmpps_prison_visits_write_events_index_dead_letter_queue                = module.hmpps_prison_visits_write_events_dead_letter_queue.irsa_policy_arn,
     },
     local.sns_policies,
     local.rds_policies

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/ssm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/ssm.tf
@@ -1,0 +1,14 @@
+# Add outputs that need to be consumed in other namespaces here.
+
+locals {
+  sqs_irsa_policies = {
+    (module.hmpps_prison_visits_write_events_queue.sqs_name) = module.hmpps_prison_visits_write_events_queue.irsa_policy_arn,
+  }
+}
+
+resource "aws_ssm_parameter" "tf-outputs-sqs-irsa-policies" {
+  for_each = local.sqs_irsa_policies
+  type     = "String"
+  name     = "/${var.namespace}/sqs/${each.key}/irsa-policy-arn"
+  value    = each.value
+}


### PR DESCRIPTION
The purpose of this PR:

* Add a new queue + dead letter queue to the `visit-someone-in-prison-backend-svc-*` namespaces for visit writes
* We will be listening to this queue in `manage-prison-visits-orchestation` or `visits-scheduler` service
* Allow the HMPPS Integration API to write to this queue