### PR TITLE
PRC-570: Increase personal relationships dev DB size

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-personal-relationships-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-personal-relationships-dev/resources/rds-postgresql.tf
@@ -22,7 +22,7 @@ module "rds" {
   db_engine         = "postgres"
   db_engine_version = "16.4"
   rds_family        = "postgres16"
-  db_instance_class = "db.t4g.micro"
+  db_instance_class = "db.t4g.small"
 
   # Tags
   application            = var.application


### PR DESCRIPTION
Increased from db.t4g.micro to db.t4g.small to be able to handle heavy workloads while testing sync and migrate with syscon.