### PR TITLE
Fix: rds version mismatch in laa-court-data-ui-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
@@ -20,7 +20,7 @@ module "lcdui_rds" {
   db_max_allocated_storage    = "500"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "14.12"
+  db_engine_version           = "14.13"
   rds_family                  = "postgres14"
   allow_major_version_upgrade = "true"
 


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 14.13 to 14.12
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-d