### PR TITLE
Add Postgres FDW to the Assessments database

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -78,11 +78,11 @@ resource "postgresql_extension" "postgres_fdw" {
 # Create Foreign Server
 resource "postgresql_server" "integrations_rds" {
   server_name = "integrations_rds"
-  fdw_name    = "postgres_fdw"
+  fdw_name    = "postgresql_fdw"
   options = {
     host   = data.aws_ssm_parameter.integrations_rds_instance_address.value # Other server
-    dbname = data.aws_ssm_parameter.integrations_rds_database_name.value # Other DB name
     port   = data.aws_ssm_parameter.integrations_rds_instance_port.value # Other port
+    dbname = data.aws_ssm_parameter.integrations_rds_database_name.value # Other DB name
   }
 
   depends_on = [postgresql_extension.postgres_fdw]
@@ -101,8 +101,3 @@ resource "postgresql_user_mapping" "remote_mapping" {
     password = data.aws_ssm_parameter.integrations_rds_database_password.value # password for other server
   }
 }
-
-# Import Tables
-# data "postgresql_tables" "integrations_tables" {
-#   database = integrations_rds
-# }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -104,5 +104,5 @@ resource "postgresql_user_mapping" "remote_mapping" {
 
 # Import Tables
 data "postgresql_tables" "tables" {
-  database = data.aws_ssm_parameter.integrations_rds_database_name
+  database = data.aws_ssm_parameter.integrations_rds_database_name.value
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -76,8 +76,8 @@ resource "postgresql_extension" "postgres_fdw" {
 }
 
 # Create Foreign Server
-resource "postgresql_server" "myserver_postgres" {
-  server_name = "myserver_postgres"
+resource "postgresql_server" "integrations_rds" {
+  server_name = "integrations_rds"
   fdw_name    = "postgres_fdw"
   options = {
     host   = data.aws_ssm_parameter.integrations_rds_instance_address.value # Other server
@@ -94,7 +94,7 @@ resource "postgresql_role" "remote_role" {
 }
 
 resource "postgresql_user_mapping" "remote_mapping" {
-  server_name = postgresql_server.myserver_postgres.server_name
+  server_name = postgresql_server.integrations_rds.server_name
   user_name   = postgresql_role.remote_role.name
   options = {
     user = data.aws_ssm_parameter.integrations_rds_database_username.value # username for other server
@@ -103,6 +103,6 @@ resource "postgresql_user_mapping" "remote_mapping" {
 }
 
 # Import Tables
-data "postgresql_tables" "tables" {
-  database = data.aws_ssm_parameter.integrations_rds_database_name.value
-}
+# data "postgresql_tables" "integrations_tables" {
+#   database = integrations_rds
+# }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -80,9 +80,9 @@ resource "postgresql_server" "myserver_postgres" {
   server_name = "myserver_postgres"
   fdw_name    = "postgres_fdw"
   options = {
-    host   = data.aws_ssm_parameter.integrations_rds_instance_address # Other server
-    dbname = data.aws_ssm_parameter.integrations_rds_database_name # Other DB name
-    port   = data.aws_ssm_parameter.integrations_rds_instance_port # Other port
+    host   = data.aws_ssm_parameter.integrations_rds_instance_address.value # Other server
+    dbname = data.aws_ssm_parameter.integrations_rds_database_name.value # Other DB name
+    port   = data.aws_ssm_parameter.integrations_rds_instance_port.value # Other port
   }
 
   depends_on = [postgresql_extension.postgres_fdw]
@@ -97,8 +97,8 @@ resource "postgresql_user_mapping" "remote_mapping" {
   server_name = postgresql_server.myserver_postgres.server_name
   user_name   = postgresql_role.remote_role.name
   options = {
-    user = data.aws_ssm_parameter.integrations_rds_database_username # username for other server
-    password = data.aws_ssm_parameter.integrations_rds_database_password # password for other server
+    user = data.aws_ssm_parameter.integrations_rds_database_username.value # username for other server
+    password = data.aws_ssm_parameter.integrations_rds_database_password.value # password for other server
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -1,4 +1,3 @@
-
 module "hmpps_strengths_based_needs_assessments_dev_rds" {
   source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.0.1"
   db_allocated_storage   = 10
@@ -22,7 +21,6 @@ module "hmpps_strengths_based_needs_assessments_dev_rds" {
   providers = {
     aws = aws.london
   }
-
 }
 
 resource "kubernetes_secret" "hmpps_strengths_based_needs_assessments_dev_rds_secret" {
@@ -52,7 +50,59 @@ provider "postgresql" {
   superuser        = false
 }
 
-# Installs postgres dblink extension
-resource "postgresql_extension" "dblink_new" {
-  name = "dblink"
+data "aws_ssm_parameter" "integrations_rds_database_name" {
+  name = "/hmpps-assess-risks-and-needs-integrations-dev/rds-database-name"
+}
+
+data "aws_ssm_parameter" "integrations_rds_database_username" {
+  name = "/hmpps-assess-risks-and-needs-integrations-dev/rds-database-username"
+}
+
+data "aws_ssm_parameter" "integrations_rds_database_password" {
+  name = "/hmpps-assess-risks-and-needs-integrations-dev/rds-database-password"
+}
+
+data "aws_ssm_parameter" "integrations_rds_instance_address" {
+  name = "/hmpps-assess-risks-and-needs-integrations-dev/rds-instance-address"
+}
+
+data "aws_ssm_parameter" "integrations_rds_instance_port" {
+  name = "/hmpps-assess-risks-and-needs-integrations-dev/rds-instance-port"
+}
+
+# Installs postgres_fdw extension
+resource "postgresql_extension" "postgres_fdw" {
+  name = "postgres_fdw"
+}
+
+# Create Foreign Server
+resource "postgresql_server" "myserver_postgres" {
+  server_name = "myserver_postgres"
+  fdw_name    = "postgres_fdw"
+  options = {
+    host   = data.aws_ssm_parameter.integrations_rds_instance_address # Other server
+    dbname = data.aws_ssm_parameter.integrations_rds_database_name # Other DB name
+    port   = data.aws_ssm_parameter.integrations_rds_instance_port # Other port
+  }
+
+  depends_on = [postgresql_extension.postgres_fdw]
+}
+
+# Create User Mapping
+resource "postgresql_role" "remote_role" {
+  name = "remote"
+}
+
+resource "postgresql_user_mapping" "remote_mapping" {
+  server_name = postgresql_server.myserver_postgres.server_name
+  user_name   = postgresql_role.remote_role.name
+  options = {
+    user = data.aws_ssm_parameter.integrations_rds_database_username # username for other server
+    password = data.aws_ssm_parameter.integrations_rds_database_password # password for other server
+  }
+}
+
+# Import Tables
+data "postgresql_tables" "tables" {
+  database = data.aws_ssm_parameter.integrations_rds_database_name
 }


### PR DESCRIPTION
PR to add a Foreign Data Wrapper to the Assessments database using the information exposed by https://github.com/ministryofjustice/cloud-platform-environments/pull/30468/.