### PR TITLE
Add ServiceMonitor for ccr dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/06-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/06-servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: laa-crown-court-remuneration
+  namespace: laa-crown-court-remuneration-dev
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: laa-crown-court-remuneration-dev
+      app.kubernetes.io/name: laa-crown-court-remuneration-app
+  endpoints:
+  - port: metrics
+    interval: 30s


### PR DESCRIPTION
I want a service monitor added for the ccr dev environment to enable Prometheus scraping