### PR TITLE
BAVL-695 add app insights key to fix app insights warnings in PROD.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-prod/resources/appinsights.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-prod/resources/appinsights.tf
@@ -1,0 +1,14 @@
+data "aws_ssm_parameter" "application_insights_key" {
+  name = "/application_insights/key-${var.environment}"
+}
+
+resource "kubernetes_secret" "application-insights" {
+  metadata {
+    name      = "application-insights"
+    namespace = var.namespace
+  }
+  data = {
+    APPINSIGHTS_INSTRUMENTATIONKEY        = data.aws_ssm_parameter.application_insights_key.value
+    APPLICATIONINSIGHTS_CONNECTION_STRING = "InstrumentationKey=${data.aws_ssm_parameter.application_insights_key.value};IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
+  }
+}


### PR DESCRIPTION
This change is needed on the back of an issue identified [here](https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/7.x.md#710).