### PR TITLE
Update LAA LFA slack channel

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/00-namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
-    cloud-platform.justice.gov.uk/slack-channel: "applyprivatebeta"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "legal-framework-api"
     cloud-platform.justice.gov.uk/owner: "Apply for Legal Aid: apply-for-civil-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/legal-framework-api"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-staging/00-namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
-    cloud-platform.justice.gov.uk/slack-channel: "applyprivatebeta"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "legal-framework-api"
     cloud-platform.justice.gov.uk/owner: "Apply for Legal Aid: apply-for-civil-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/legal-framework-api"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/00-namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
-    cloud-platform.justice.gov.uk/slack-channel: "applyprivatebeta"
+    cloud-platform.justice.gov.uk/slack-channel: "apply-dev"
     cloud-platform.justice.gov.uk/application: "Legal Framework API"
     cloud-platform.justice.gov.uk/owner: "Apply for Legal Aid: apply-for-civil-legal-aid@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/legal-framework-api"


### PR DESCRIPTION

The channel `applyprivatebeta` does not exist, therefore this PR updates LAA LFA slack channel from `applyprivatebeta` to `apply-dev`
