### PR TITLE
Add servicemonitor for ccr dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/06-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/06-servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: laa-crown-court-remuneration-app
+  namespace: laa-crown-court-remuneration-dev
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: laa-crown-court-remuneration-dev
+      app.kubernetes.io/name: laa-crown-court-remuneration-app
+  endpoints:
+  - port: metrics
+    interval: 30s


### PR DESCRIPTION
Adding a service monitor for ccr-dev which has the name matching what you get with the command

`kubectl get service laa-crown-court-remuneration-app -n laa-crown-court-remuneration-dev -o yaml`

