### PR TITLE
CCR dev - Fix port name in service monitor

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/06-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/06-servicemonitor.yaml
@@ -9,5 +9,5 @@ spec:
       app.kubernetes.io/instance: laa-crown-court-remuneration-dev
       app.kubernetes.io/name: laa-crown-court-remuneration-app
   endpoints:
-  - port: metrics
+  - port: http
     interval: 30s


### PR DESCRIPTION
The exposed port name of ccr-dev is "http" which is not what is listed in the service monitor.

You can see the name by command `kubectl -n laa-crown-court-remuneration-dev get svc laa-crown-court-remuneration-app -o jsonpath='{range .spec}{"Name: "}{.ports[*].name}{"\nPort: "}{@.ports[*].port}{"\n"}{end}'
`