### PR TITLE
Added millsike github group to visit-scheduler rbac

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/01-rbac.yaml
@@ -11,6 +11,9 @@ subjects:
   - kind: Group
     name: "github:hmpps-sre"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-millsike-integration"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
We require a local dev instance of visit-scheduler in order to support our implementation of a queue between hmpps-int-api and the scheduler