### PR TITLE
PIC-3705 remove court-list-splitter references in DEV

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/07-certificate.yaml
@@ -10,7 +10,6 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - court-list-splitter-preprod.hmpps.service.justice.gov.uk
     - court-hearing-event-receiver-preprod.hmpps.service.justice.gov.uk
     - pre-sentence-service-preprod.hmpps.service.justice.gov.uk
     - pre-sentence-service-wproofreader-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This is because court-list-splitter has been archived and no longer in use.