### PR TITLE
PIC-3705 remove court-list-splitter references in DEV

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/07-certificate.yaml
@@ -9,7 +9,6 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - court-list-splitter-dev.hmpps.service.justice.gov.uk
     - court-hearing-event-receiver-dev.hmpps.service.justice.gov.uk
     - court-case-test-app-dev.hmpps.service.justice.gov.uk
     - pre-sentence-service-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Remove this in dev

This is because court-list-splitter has been archived and no longer in use.