### PR TITLE
PIC-3705 remove court-list-splitter references in Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/07-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/07-certificate.yaml
@@ -10,7 +10,6 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - prepare-case-probation.service.justice.gov.uk
-    - court-list-splitter.hmpps.service.justice.gov.uk
     - pre-sentence-service.hmpps.service.justice.gov.uk
     - pre-sentence-service-wproofreader.hmpps.service.justice.gov.uk
     - court-hearing-event-receiver.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/10-prometheus-k8s-dashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/10-prometheus-k8s-dashboard.yaml
@@ -1509,11 +1509,6 @@ data:
               },
               {
                 "selected": false,
-                "text": "\"court-list-splitter\"",
-                "value": "\"court-list-splitter\""
-              },
-              {
-                "selected": false,
                 "text": "\"court-hearing-event-receiver\"",
                 "value": "\"court-hearing-event-receiver\""
               },
@@ -1533,7 +1528,7 @@ data:
                 "value": "\"pre-sentence-service-wproofreader\""
               }
             ],
-            "query": "\"prepare-a-case\",\"court-case-service\",\"crime-portal-gateway\",\"court-case-matcher\",\"court-list-splitter\",\"court-hearing-event-receiver\",\"pre-sentence-service\",\"pre-sentence-service-gotenberg\",\"pre-sentence-service-wproofreader\"",
+            "query": "\"prepare-a-case\",\"court-case-service\",\"crime-portal-gateway\",\"court-case-matcher\",\"court-hearing-event-receiver\",\"pre-sentence-service\",\"pre-sentence-service-gotenberg\",\"pre-sentence-service-wproofreader\"",
             "queryValue": "",
             "skipUrlSync": false,
             "type": "custom"


### PR DESCRIPTION
This is because court-list-splitter has been archived and no longer in use.