### PR TITLE
Fix: rds version mismatch in visit-someone-in-prison-backend-svc-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
@@ -27,7 +27,7 @@ module "visit_scheduler_pg_rds" {
   allow_major_version_upgrade  = "false"
   prepare_for_major_upgrade    = false
   db_engine                    = "postgres"
-  db_engine_version            = "15.7"
+  db_engine_version            = "15.8"
   rds_family                   = "postgres15"
   db_instance_class            = "db.t4g.small"
   db_max_allocated_storage     = "200"
@@ -68,7 +68,7 @@ module "prison_visit_booker_reg_rds" {
   namespace              = var.namespace
 
   db_engine                    = "postgres"
-  db_engine_version            = "15.7"
+  db_engine_version            = "15.8"
   rds_family                   = "postgres15"
   db_instance_class            = "db.t4g.small"
   db_max_allocated_storage     = "50"
@@ -96,7 +96,7 @@ module "visit_allocation_rds" {
   allow_major_version_upgrade = "false"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "15.7"
+  db_engine_version           = "15.8"
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "50"


### PR DESCRIPTION


``` Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
downgrade from 15.8 to 15.7
Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
Fix Terraform RDS version drift. Here are the RDS version mismatches: 

Fix Terraform RDS version drift. Here are the RDS version mismatches: 

downgrade from 15.8 to 15.7
downgrade from 15.8 to 15.7
downgrade from 15.8 to 15.7
 ```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live-e