### PR TITLE
Add redis to care arrangement plan dev environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-dev/resources/elasticache.tf
@@ -1,0 +1,35 @@
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # Redis cluster configuration
+  node_type               = "cache.t4g.micro"
+  engine_version          = "7.1"
+  parameter_group_name    = "default.redis7"
+  auth_token_rotated_date = "2025-03-24"
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    replication_group_id     = module.elasticache_redis.replication_group_id
+  }
+}


### PR DESCRIPTION
Adding redis for the Care Arrangement Plan - https://github.com/ministryofjustice/care-arrangement-plan.
