### PR TITLE
LCAM 1484 Add Component Label to Maat Functional Tests

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/00-namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: laa-crime-maat-test
   labels:
+    component: "laa-crime-maat-test"
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "test"
     pod-security.kubernetes.io/enforce: restricted


### PR DESCRIPTION
- Adding component label to maat functional tests so that we can later add a new network policy to crown-court-proceedings service to allow the functional tests to call it.