### PR TITLE
🔥 Remove ECR Protection in `operations-engineering-reports-dev`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-dev/resources/ecr.tf
@@ -41,4 +41,5 @@ EOF
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
## 👀 Purpose

- blocking #30713 
- To enable the deletion of the namespace

## ♻️ What's changed

- Disabled deletion protection on the ECR Resource