### PR TITLE
🔥 Remove ECR Deletion Protection in `operations-engineering-reports-prod`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-dev/resources/ecr.tf
@@ -41,4 +41,5 @@ EOF
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
## 👀 Purpose

- To enable the deletion of the namespace

## ♻️ What's changed

- Disabled ECR Deletion protection