### PR TITLE
LCAM 1484 Enable Integration Between Functional Tests and CCP

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-proceeding-test/04-networkpolicy.yaml
@@ -40,4 +40,19 @@ spec:
         - namespaceSelector:
             matchLabels:
               component: laa-maat-orchestration-test
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-laa-crime-maat-test
+  namespace: laa-crown-court-proceeding-test
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: laa-crime-maat-test
 


### PR DESCRIPTION
- Added network policy to CCP to enable cross namespace integration with functional tests.