### PR TITLE
adds self hosted runner for CAS ap UI test env

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/08-github-actions-runner.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/08-github-actions-runner.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-actions-runner
+  namespace: hmpps-community-accommodation-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: github-actions-runner
+  template:
+    metadata:
+      labels:
+        app: github-actions-runner
+    spec:
+      serviceAccountName: cd-serviceaccount
+      containers:
+        - name: runner
+          image: quay.io/hmpps/browser-testing-github-actions-runner:latest # Built from https://github.com/ministryofjustice/browser-testing-github-actions-runner
+          resources:
+            limits:
+              memory: 8000Mi
+              cpu: 2000m
+          securityContext:
+            runAsUser: 1001 # 'runner' user
+          env:
+            - name: RUNNER_NAME # Switch this to "RUNNER_NAME_PREFIX" if we start using multiple instances
+              value: hmpps-community-accommodation-test-runner
+            - name: RUNNER_WORKDIR
+              value: '/_work'
+            - name: LABELS
+              value: moj-cloud-platform
+            - name: REPO_URL
+              value: https://github.com/ministryofjustice/hmpps-approved-premises-ui
+            - name: RUN_AS_ROOT
+              value: 'false'
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-actions-runner-token
+                  key: ACCESS_TOKEN


### PR DESCRIPTION
I haven't managed to get my playwright e2e tests running on GH Actions yet.

After chatting to Tom from the ARNS team, he suggested creating a runner - as they did for there project.
This PR copies his: https://github.com/ministryofjustice/cloud-platform-environments/pull/29086

Currently, e2e tests just hang here doing nothing:
<img width="1080" alt="Screenshot 2025-03-26 at 18 33 20" src="https://github.com/user-attachments/assets/f3e1dff7-ef19-4a93-9827-8132159ab6da" />
