### PR TITLE
Add appinsights to allow CAS2 Bail preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/appinsights.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/appinsights.tf
@@ -1,0 +1,25 @@
+########################### IMPORTANT ##################################
+## This parameter determines which application insights account is used
+## so you will need to change depending on environment
+
+data "aws_ssm_parameter" "application_insights_key" {
+
+## dev (t3) = /application_insights/key-dev
+## preprod  = /application_insights/key-preprod
+## prod     = /application_insights/key-prod
+
+  name = "/application_insights/key-preprod"
+}
+
+########################################################################
+
+resource "kubernetes_secret" "application-insights" {
+  metadata {
+    name      = "application-insights"
+    namespace = var.namespace
+  }
+  data = {
+    APPINSIGHTS_INSTRUMENTATIONKEY = data.aws_ssm_parameter.application_insights_key.value
+    APPLICATIONINSIGHTS_CONNECTION_STRING = format("%s%s","InstrumentationKey=",data.aws_ssm_parameter.application_insights_key.value)
+  }
+}


### PR DESCRIPTION
The appinsights secret was missing and deployment is failing. It looks like this file needs to be added for the Github Actions deployments