### PR TITLE
🔥 Remove ECR Deletion Protection in `operations-engineering-reports-prod`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-reports-prod/resources/ecr.tf
@@ -38,4 +38,5 @@ EOF
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/github-community/issues/27
- To prepare the removal of the namespace

## ♻️ What's changed

- Removed ECR deletion proteciton