### PR TITLE
CCR dev - Add alert for new payment_get_errors

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/05-prometheus.yaml
@@ -150,3 +150,12 @@ spec:
         message: CCR DEV - {{ $labels.pod }} is restarting excessively
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/AAC/pages/3160014895/Crown+Court+Remuneration+CCR+Runbook#Monitoring-and-Alerting"
         dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/application-alerts/application-alerts?orgId=1&var-namespace=laa-crown-court-remuneration-dev"
+
+    - alert: CCR-Payment-Get-Errors
+      expr: expr: increase(payment_get_errors_total{namespace="laa-crown-court-remuneration-dev"}[5m]) > 0
+      labels:
+        severity: laa_crown_court_renumeration_alerts_dev
+      annotations:
+        message: CCR DEV - {{ printf "%0.0f" $value }} new payment get errors in the last 5 minutes.
+        runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/AAC/pages/3160014895/Crown+Court+Remuneration+CCR+Runbook#Monitoring-and-Alerting"
+        dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/application-alerts/application-alerts?orgId=1&var-namespace=laa-crown-court-remuneration-dev"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/05-prometheus.yaml
@@ -152,7 +152,7 @@ spec:
         dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/application-alerts/application-alerts?orgId=1&var-namespace=laa-crown-court-remuneration-dev"
 
     - alert: CCR-Payment-Get-Errors
-      expr: expr: increase(payment_get_errors_total{namespace="laa-crown-court-remuneration-dev"}[5m]) > 0
+      expr: increase(payment_get_errors_total{namespace="laa-crown-court-remuneration-dev"}[5m]) > 0
       labels:
         severity: laa_crown_court_renumeration_alerts_dev
       annotations:


### PR DESCRIPTION
Added an alert so that when there's an increase in the amount of errors scraped over one minute, an alert is raised