### PR TITLE
Fix: rds version mismatch in claim-criminal-injuries-compensation-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-prod/resources/rds-postgresql.tf
@@ -22,7 +22,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.12"
+  db_engine_version = "14.13"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.micro"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-dev/resources/rds-postgresql.tf
@@ -22,7 +22,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.12"
+  db_engine_version = "14.13"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.medium"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/civil-appeal-case-tracker-prod/resources/rds-postgresql.tf
@@ -22,7 +22,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.12"
+  db_engine_version = "14.13"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.medium"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
   infrastructure_support = var.email
 
   db_engine                    = "postgres"
-  db_engine_version            = "14.12"
+  db_engine_version            = "14.13"
   db_instance_class            = "db.t4g.small"
   db_allocated_storage         = "10"
   db_name                      = "datacaptureservice"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
   infrastructure_support = var.email
 
   db_engine                    = "postgres"
-  db_engine_version            = "14.12"
+  db_engine_version            = "14.13"
   db_instance_class            = "db.t4g.micro"
   db_allocated_storage         = "50"
   db_max_allocated_storage     = "500"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
   infrastructure_support = var.email
 
   db_engine                    = "postgres"
-  db_engine_version            = "14.12"
+  db_engine_version            = "14.13"
   db_instance_class            = "db.t4g.small"
   db_allocated_storage         = "5"
   db_max_allocated_storage     = "500"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
@@ -18,7 +18,7 @@ module "contact-moj_rds" {
   db_instance_class          = "db.t4g.small"
   db_max_allocated_storage   = "10000"
   db_engine                  = "postgres"
-  db_engine_version          = "16.3"
+  db_engine_version          = "16.4"
   rds_family                 = "postgres16"
   db_backup_retention_period = "7"
   db_name                    = "contact_moj_production"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: claim-criminal-injuries-compensation-uat

- rds: 14.12 → 14.13

Automatically generated by rds-drift-bot.