### PR TITLE
🔥 Remove ECR Deletion Protection in `operations-engineering-find-a-github-repository-owner-dev`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-find-a-github-repository-owner-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/operations-engineering-find-a-github-repository-owner-dev/resources/ecr.tf
@@ -41,4 +41,5 @@ EOF
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/github-community/issues/27
- To prepare the removal of the namespace

## ♻️ What's changed

- Removed ECR deletion protection