### PR TITLE
Fix: rds version mismatch in claim-criminal-injuries-compensation-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
   infrastructure_support = var.email
 
   db_engine                    = "postgres"
-  db_engine_version            = "14.12"
+  db_engine_version            = "14.13"
   db_instance_class            = "db.t3.small"
   db_allocated_storage         = "5"
   db_name                      = "datacaptureservice"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
   infrastructure_support = var.email
 
   db_engine                    = "postgres"
-  db_engine_version            = "14.12"
+  db_engine_version            = "14.13"
   db_instance_class            = "db.t4g.small"
   db_allocated_storage         = "5"
   db_max_allocated_storage     = "500"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: claim-criminal-injuries-compensation-uat

- rds: 14.12 → 14.13

Automatically generated by rds-drift-bot.