### PR TITLE
Fix: rds version mismatch in contact-moj-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
@@ -18,7 +18,7 @@ module "contact-moj_rds" {
   db_instance_class          = "db.t4g.small"
   db_max_allocated_storage   = "10000"
   db_engine                  = "postgres"
-  db_engine_version          = "16.3"
+  db_engine_version          = "16.4"
   rds_family                 = "postgres16"
   db_backup_retention_period = "7"
   db_name                    = "contact_moj_production"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: contact-moj-production

- contact-moj_rds: 16.3 → 16.4

Automatically generated by rds-drift-bot.