### PR TITLE
Fix: rds version mismatch in c100-application-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/variables.tf
@@ -29,7 +29,7 @@ variable "namespace" {
 # Database
 
 variable "db_engine_version" {
-  default = "14.12"
+  default = "14.13"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: c100-application-production

- rds-instance: 14.12 → 14.13

Automatically generated by rds-drift-bot.