### PR TITLE
Fix: rds version mismatch in hmpps-registers-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-preprod/resources/rds.tf
@@ -15,7 +15,7 @@ module "prisons_rds" {
   db_instance_class           = "db.t4g.micro"
   rds_family                  = "postgres16"
   db_engine                   = "postgres"
-  db_engine_version           = "16.3"
+  db_engine_version = "16.4"
   deletion_protection         = true
   allow_major_version_upgrade = "false"
 


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: hmpps-registers-preprod

- prisons_rds: 16.3 → 16.4

Automatically generated by rds-drift-bot.