### PR TITLE
Fix: rds version mismatch in hmcts-complaints-formbuilder-adapter-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
@@ -11,7 +11,7 @@ module "hmcts-complaints-adapter-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
 
-  db_engine_version    = "14.12"
+  db_engine_version = "14.13"
   rds_family           = "postgres14"
   db_instance_class    = "db.t4g.medium"
   db_allocated_storage = "100"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: hmcts-complaints-formbuilder-adapter-production

- hmcts-complaints-adapter-rds-instance: 14.12 → 14.13

Automatically generated by rds-drift-bot.