### PR TITLE
Fix: rds version mismatch in hmpps-interventions-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
@@ -11,7 +11,7 @@ module "hmpps_interventions_postgres14" {
   infrastructure_support = var.infrastructure_support
 
   rds_family                   = "postgres14"
-  db_engine_version            = "14.12"
+  db_engine_version = "14.13"
   db_instance_class            = "db.m6g.2xlarge"
   db_allocated_storage         = "50"
   allow_major_version_upgrade  = "false"
@@ -53,7 +53,7 @@ module "hmpps_interventions_postgres14_replica" {
   infrastructure_support = var.infrastructure_support
 
   rds_family                   = "postgres14"
-  db_engine_version            = "14.12"
+  db_engine_version = "14.13"
   db_instance_class            = "db.m6g.2xlarge"
   allow_major_version_upgrade  = "false"
   db_max_allocated_storage     = "50"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: hmpps-interventions-prod

- hmpps_interventions_postgres14: 14.12 → 14.13

Automatically generated by rds-drift-bot.