### PR TITLE
Fix: rds version mismatch in soc-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/soc-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/soc-staging/resources/rds.tf
@@ -26,7 +26,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "14.12"
+  db_engine_version = "14.13"
 
   # change the instance class as you see fit.
   db_instance_class        = "db.t4g.micro"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: soc-staging

- rds: 14.12 → 14.13

Automatically generated by rds-drift-bot.