### PR TITLE
bump limit range to 3GB

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/james-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/james-dev/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
     - default:
         cpu: 2000m
-        memory: 1024Mi
+        memory: 3Gi
       defaultRequest:
         cpu: 10m
         memory: 512Mi


### PR DESCRIPTION
This will help with github actions runners