### PR TITLE
Fix: rds version mismatch in hmcts-complaints-formbuilder-adapter-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-staging/resources/rds.tf
@@ -13,7 +13,7 @@ module "hmcts-complaints-adapter-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
 
-  db_engine_version        = "14.12"
+  db_engine_version = "14.13"
   rds_family               = "postgres14"
   db_instance_class        = "db.t4g.micro"
   db_max_allocated_storage = "500" # maximum storage for autoscaling


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: hmcts-complaints-formbuilder-adapter-staging

- hmcts-complaints-adapter-rds-instance: 14.12 → 14.13

Automatically generated by rds-drift-bot.