### PR TITLE
Fix: rds version mismatch in send-legal-mail-to-prisons-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-preprod/resources/rds.tf
@@ -17,7 +17,7 @@ module "slmtp_api_rds" {
   db_max_allocated_storage    = "500"
   db_engine                   = "postgres"
   rds_family                  = "postgres15"
-  db_engine_version           = "15.7"
+  db_engine_version = "15.8"
   db_password_rotated_date    = "2023-03-22"
 
   snapshot_identifier = "rds:cloud-platform-16854fceeeaf4ba2-2022-03-11-01-23"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: send-legal-mail-to-prisons-preprod

- slmtp_api_rds: 15.7 → 15.8

Automatically generated by rds-drift-bot.