### PR TITLE
Fix: rds version mismatch in hmpps-interventions-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
@@ -11,7 +11,7 @@ module "hmpps_interventions_postgres14" {
   infrastructure_support = var.infrastructure_support
 
   rds_family                   = "postgres14"
-  db_engine_version            = "14.12"
+  db_engine_version = "14.13"
   db_instance_class            = "db.m5.large"
   db_allocated_storage         = 20
   allow_major_version_upgrade  = "false"
@@ -70,7 +70,7 @@ module "hmpps_interventions_postgres14_replica" {
   infrastructure_support = var.infrastructure_support
 
   rds_family                  = "postgres14"
-  db_engine_version           = "14.12"
+  db_engine_version = "14.13"
   db_instance_class           = "db.m5.large"
   db_allocated_storage        = 20
   allow_major_version_upgrade = "false"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: hmpps-interventions-preprod

- hmpps_interventions_postgres14: 14.12 → 14.13

Automatically generated by rds-drift-bot.