### PR TITLE
Fix: rds version mismatch in offender-categorisation-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/rds.tf
@@ -13,7 +13,7 @@ module "dps_rds" {
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "10000"
   db_engine                   = "postgres"
-  db_engine_version           = "16"
+  db_engine_version = "17.2"
   allow_major_version_upgrade = "true"
   prepare_for_major_upgrade   = true
   enable_rds_auto_start_stop  = true


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: offender-categorisation-dev

- dps_rds: 16 → 17.2

Automatically generated by rds-drift-bot.