### PR TITLE
Fix: rds version mismatch in soc-reporting-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/soc-reporting-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/soc-reporting-dev/resources/rds.tf
@@ -13,7 +13,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version      = "14.12"
+  db_engine_version = "14.13"
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: soc-reporting-dev

- rds: 14.12 → 14.13

Automatically generated by rds-drift-bot.