### PR TITLE
Fix: rds version mismatch in utiac-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-staging/resources/rds-postgresql.tf
@@ -14,7 +14,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.12"
+  db_engine_version = "14.13"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.medium"
 


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: utiac-staging

- rds: 14.12 → 14.13

Automatically generated by rds-drift-bot.