### PR TITLE
Fix: rds version mismatch in create-and-vary-a-licence-api-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-api-prod/resources/rds.tf
@@ -12,7 +12,7 @@ module "create_and_vary_a_licence_api_rds" {
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false
   db_instance_class           = "db.t4g.small"
-  db_engine_version           = "15.7"
+  db_engine_version = "15.8"
   rds_family                  = "postgres15"
   prepare_for_major_upgrade   = false
   db_password_rotated_date    = "23-09-2024"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: create-and-vary-a-licence-api-prod

- create_and_vary_a_licence_api_rds: 15.7 → 15.8

Automatically generated by rds-drift-bot.