### PR TITLE
Fix: rds version mismatch in formbuilder-platform-live-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -11,7 +11,7 @@ module "user-datastore-rds-instance-2" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.7"
+  db_engine_version = "15.8"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
   db_allocated_storage       = "100"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: formbuilder-platform-live-production

- user-datastore-rds-instance-2: 15.7 → 15.8

Automatically generated by rds-drift-bot.