### PR TITLE
Fix: rds version mismatch in hmpps-complexity-of-need-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/rds.tf
@@ -19,7 +19,7 @@ module "rds" {
   environment_name         = var.environment
   infrastructure_support   = var.infrastructure_support
 
-  db_engine_version           = "15.7"
+  db_engine_version = "15.8"
   rds_family                  = "postgres15"
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: hmpps-complexity-of-need-production

- rds: 15.7 → 15.8

Automatically generated by rds-drift-bot.