### PR TITLE
Fix: rds version mismatch in laa-crown-court-litigator-fees-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-staging/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds-instance-migrated" {
 
   # Database configuration
   db_engine                = "oracle-se2"
-  db_engine_version        = "19.0.0.0.ru-2024-10.rur-2024-10.r1"
+  db_engine_version = "19.0.0.0.ru-2025-01.rur-2025-01.r1"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.medium"
   db_allocated_storage     = "300"


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: laa-crown-court-litigator-fees-staging

- rds-instance-migrated: 19.0.0.0.ru-2024-10.rur-2024-10.r1 → 19.0.0.0.ru-2025-01.rur-2025-01.r1

Automatically generated by rds-drift-bot.