### PR TITLE
Fix: rds version mismatch in hmpps-electronic-monitoring-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-preprod/resources/rds.tf
@@ -15,7 +15,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.7"
+  db_engine_version = "14.13"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.micro"
 


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: hmpps-electronic-monitoring-preprod

- rds: 14.7 → 14.13

Automatically generated by rds-drift-bot.