### PR TITLE
Fix: rds version mismatch in laa-crime-validation-test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-test/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-test/resources/rds-postgresql.tf
@@ -22,7 +22,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.7"
+  db_engine_version = "14.13"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.micro"
 
@@ -67,7 +67,7 @@ module "read_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.7"
+  db_engine_version = "14.13"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.micro"
   # It is mandatory to set the below values to create read replica instance


### PR DESCRIPTION
Fix Terraform RDS version drift for namespace: laa-crime-validation-test

- rds: 14.7 → 14.13

Automatically generated by rds-drift-bot.