### PR TITLE
chore: 🤖 trigger build on no change

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sw-psa-audit-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sw-psa-audit-test/resources/ecr.tf
@@ -20,6 +20,7 @@ module "ecr_credentials" {
   }
   EOF
 
+  # a nothing change
   repo_name = var.namespace
 
   oidc_providers = ["github"]


### PR DESCRIPTION
heres a PR with no changes, and no legacy_naming flag set.

EXPECTING: no change anyway, because of lifecycle ignore change