### PR TITLE
Add session secret for CAS2 Bail preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/ui-session-secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/ui-session-secret.tf
@@ -1,0 +1,17 @@
+# Generate a secure random session secret
+resource "random_password" "session_secret" {
+  length  = 32
+  special = false
+  upper   = true
+  lower   = true
+  number  = true
+}
+resource "kubernetes_secret" "session_secret" {
+  metadata {
+    name      = "session-secret"
+    namespace = var.namespace
+  }
+  data = {
+    SESSION_SECRET = random_password.session_secret.result
+  }
+}


### PR DESCRIPTION
Deployments to preprod are not working for CAS2 Bail. The build says we're missing the session secret so after digging through older commits and threads I found a file that we needed to add due to the change in build process