### PR TITLE
Fix: rds version mismatch in intranet-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
 
   # general options
   db_engine                   = "mariadb"
-  db_engine_version           = "10.11.9"
+  db_engine_version = "10.11.10"
   rds_family                  = "mariadb10.11"
   db_instance_class           = "db.t4g.xlarge"
   environment_name            = var.environment


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `intranet-production`

```
module.rds: downgrade from 10.11.9 to 10.11.10
```