### PR TITLE
Fix: rds version mismatch in create-and-vary-a-licence-test1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test1/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-test1/resources/rds.tf
@@ -13,7 +13,7 @@ module "create_and_vary_a_licence_api_rds" {
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false
   db_instance_class           = "db.t4g.small"
-  db_engine_version           = "15.7"
+  db_engine_version = "15.8"
   rds_family                  = "postgres15"
   prepare_for_major_upgrade   = false
   db_password_rotated_date    = "14-02-2023"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `create-and-vary-a-licence-test1`

```
module.create_and_vary_a_licence_api_rds: downgrade from 15.7 to 15.8
```