### PR TITLE
Fix: rds version mismatch in intranet-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-staging/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
 
   # general options
   db_engine                   = "mariadb"
-  db_engine_version           = "10.11.6"
+  db_engine_version = "10.11.8"
   rds_family                  = "mariadb10.11"
   db_instance_class           = "db.t4g.large"
   environment_name            = var.environment


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `intranet-staging`

```
module.rds: downgrade from 10.11.6 to 10.11.8
```