### PR TITLE
Fix: rds version mismatch in hmpps-staff-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-dev/resources/rds-postgresql.tf
@@ -25,7 +25,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "15.5"
+  db_engine_version = "15.7"
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.small"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-staff-dev`

```
module.rds: downgrade from 15.5 to 15.7
```