### PR TITLE
LAA Access Civil Legal Aid - Add TLS Certificate

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-access-civil-legal-aid-staging/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-access-civil-legal-aid-staging/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: laa-access-civil-legal-aid-staging-cert
+  namespace: laa-access-civil-legal-aid-staging
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - beta.checklegalaid.service.gov.uk


### PR DESCRIPTION
Adds a TLS certificate to the staging environment of Access Civil Legal Aid