### PR TITLE
LAA Check if you can get legal aid DNS certificate Update

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/06-certificate.yaml
@@ -10,3 +10,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
   - staging.checklegalaid.service.gov.uk
+  - beta.checklegalaid.service.gov.uk


### PR DESCRIPTION
Adds the beta environment to the public dns certificate.