### PR TITLE
Fix: rds version mismatch in grc-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/rds.tf
@@ -15,7 +15,7 @@ module "dps_rds" {
   application               = var.application
   is_production             = var.is_production
   namespace                 = var.namespace
-  db_engine_version = "14.13"
+  db_engine_version = "14.15"
   db_instance_class         = "db.t4g.medium"
   db_max_allocated_storage  = "500" # maximum storage for autoscaling
   environment_name          = var.environment


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `grc-prod`

```
module.dps_rds: downgrade from 14.15 to 14.13
```