### PR TITLE
Fix: rds version mismatch in justice-gov-uk-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
 
   # general options
   db_engine                   = "mariadb"
-  db_engine_version = "10.11.10"
+  db_engine_version = "10.11.11"
   rds_family                  = "mariadb10.11"
   db_instance_class           = "db.t4g.medium"
   db_allocated_storage        = "20"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `justice-gov-uk-production`

```
module.rds: downgrade from 10.11.11 to 10.11.10
```