### PR TITLE
🛂 Extend SA resource access

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-development/resources/serviceacount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-development/resources/serviceacount.tf
@@ -3,4 +3,84 @@ module "serviceaccount" {
 
   kubernetes_cluster = var.kubernetes_cluster
   namespace          = var.namespace
+
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+        "persistentvolumeclaims",
+        "serviceaccounts",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "policy",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "poddisruptionbudgets",
+        "networkpolicies",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "prometheusrules",
+        "servicemonitors",
+      ]
+      verbs = [
+        "*",
+      ]
+    },
+    {
+      api_groups = [
+        "autoscaling",
+      ]
+      resources = [
+        "hpa",
+        "horizontalpodautoscalers",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+      ]
+    },
+  ]
 }


### PR DESCRIPTION
## Proposed Changes

- Extend default `serviceaccount_rules` with `persistentvolumeclaims` and `serviceaccounts`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>