### PR TITLE
BAVL-752 subscribe to the appointments changed domain event for the BVLS API to process.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-preprod/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-preprod/resources/domain-events-queue-bvls.tf
@@ -115,6 +115,7 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
       "prisoner-offender-search.prisoner.released",
       "prison-offender-events.prisoner.merged",
       "prison-offender-events.prisoner.video-appointment.cancelled",
+      "prison-offender-events.prisoner.appointments-changed",
     ]
   })
 }


### PR DESCRIPTION
Change to subscribe to the appointments changed domain event in preprod.

This is so the BVLS API can take the appropriate action for any video bookings affected by the prisoners appointments related to this event.

Associated API PR [here](https://github.com/ministryofjustice/hmpps-book-a-video-link-api/pull/459).