### PR TITLE
[APG-536] Bump up PostgreSQL to 16.4 in Dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/rds-postgresql.tf
@@ -12,16 +12,17 @@ module "rds" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = false
+  allow_major_version_upgrade  = true
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
+  prepare_for_major_upgrade = true
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.13"
-  rds_family        = "postgres14"
+  db_engine_version = "16.4"
+  rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
 
   # Tags


### PR DESCRIPTION
- Allow major version upgrades for RDS instances 
- Upgrade the PostgreSQL version to 16.4. 
- Adjusted the RDS family to match the new version.