### PR TITLE
hmpps-electronic-monitoring-datastore-dev: Update IRSA account roles

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
@@ -38,6 +38,7 @@ data "aws_iam_policy_document" "document" {
     ]
     resources = [
       "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
+      "arn:aws:iam::396913731313:role/specials_cmt_read_emds_data_test",
       "arn:aws:iam::800964199911:role/cmt_read_emds_data_dev",
     ]
   }


### PR DESCRIPTION
Add an assumable role to hmpps-electronic-monitoring-datastore-dev.
This role allows testing of role based access to restricted data (using test data).