### PR TITLE
Update CAS1 UI environment protection rules

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/hmpps-approved-premises-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/hmpps-approved-premises-ui.tf
@@ -3,10 +3,10 @@ module "hmpps_approved_premises_ui" {
   github_repo = "hmpps-approved-premises-ui"
   application = "hmpps-approved-premises-ui"
   github_team = "hmpps-community-accommodation"
-  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
-  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["main", "feature-dev/*"] # Optional
-  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
+  # reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
+  # selected_branch_patterns      = ["main", "feature-dev/*"] # Optional
+  protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
   source_template_repo          = "hmpps-template-typescript"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-approved-premises-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-approved-premises-ui.tf
@@ -3,9 +3,9 @@ module "hmpps_approved_premises_ui" {
   github_repo = "hmpps-approved-premises-ui"
   application = "hmpps-approved-premises-ui"
   github_team = "hmpps-community-accommodation"
-  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
   reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["main"] # Optional
+  # selected_branch_patterns      = ["main"] # Optional
   protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "preprod" # Either "dev", "preprod" or "prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-approved-premises-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/hmpps-approved-premises-ui.tf
@@ -3,9 +3,9 @@ module "hmpps_approved_premises_ui" {
   github_repo = "hmpps-approved-premises-ui"
   application = "hmpps-approved-premises-ui"
   github_team = "hmpps-community-accommodation"
-  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
   reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["main"] # Optional
+  # selected_branch_patterns      = ["main"] # Optional
   protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "prod" # Either "dev", "preprod" or "prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-ui.tf
@@ -3,10 +3,10 @@ module "hmpps_approved_premises_ui" {
   github_repo = "hmpps-approved-premises-ui"
   application = "hmpps-approved-premises-ui"
   github_team = "hmpps-community-accommodation"
-  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
-  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["main", "feature-test/*"] # Optional
-  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
+  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional, team that should review deployments to this environment.
+  # selected_branch_patterns      = ["main", "feature-test/*"] # Optional
+  protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
   source_template_repo          = "hmpps-template-typescript"


### PR DESCRIPTION
This updates the Github Environments protection rules for [the CAS1 UI repository](https://github.com/ministryofjustice/hmpps-approved-premises-ui/settings/environments):

- `development`: auto-deploys from pipeline, only main branch
- `preprod`: deploy review from pipeline, only main branch
- `prod`: deploy review from pipeline, only main branch
- `test`: deploy review from separate 'Deploy to test' workflow, for any branch