### PR TITLE
CAS1 UI - Allow deployment to test from any branch

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-ui.tf
@@ -5,8 +5,8 @@ module "hmpps_approved_premises_ui" {
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
   reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation"] # Optional, team that should review deployments to this environment.
-  # selected_branch_patterns      = ["main", "feature-test/*"] # Optional
-  protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
+  selected_branch_patterns      = ["*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline
+  # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
   source_template_repo          = "hmpps-template-typescript"


### PR DESCRIPTION
The Test environment for CAS1 is fully decoupled from the main pipeline, so no deployment to test can be promoted to preprod or prod.