### PR TITLE
Add route53 custom domain for use with SES

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dex-mi-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dex-mi-production/resources/route53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = "cdpt-metabase.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_sec" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.route53_zone.zone_id
+  }
+}


### PR DESCRIPTION
Add custom domain for dex-mi-production namespace. 

This is for use with amazon SES config cc @sj-williams.