### PR TITLE
Fix: rds version mismatch in hmpps-vcms-notification-poc-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-vcms-notification-poc-dev/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-vcms-notification-poc-dev/resources/rds-mysql.tf
@@ -26,7 +26,7 @@ module "rds_mysql" {
 
   # using mysql
   db_engine         = "mysql"
-  db_engine_version = "8.0.35"
+  db_engine_version = "8.0.40"
   rds_family        = "mysql8.0"
   db_instance_class = "db.t4g.small"
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-vcms-notification-poc-dev`

```
module.rds_mysql: downgrade from 8.0.40 to 8.0.35
```