### PR TITLE
[APG-536] Upgrade PostgreSQL version for Accredited Programmes in Pre-Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/rds-postgresql.tf
@@ -17,11 +17,12 @@ module "rds" {
   db_max_allocated_storage     = "500"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
+  prepare_for_major_upgrade = true
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.13"
-  rds_family        = "postgres14"
+  db_engine_version = "16.4"
+  rds_family        = "postgres16"
   db_instance_class = "db.t4g.medium"
 
   # Tags


### PR DESCRIPTION
- Updated the RDS configuration to upgrade PostgreSQL from version 14.13 to 16.4.
- Adjusted the RDS family and set the `prepare_for_major_upgrade` to true