### PR TITLE
 [APG-536] Disable major upgrade preparation flag and remove skip file on pre-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/rds-postgresql.tf
@@ -17,7 +17,7 @@ module "rds" {
   db_max_allocated_storage     = "500"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
-  prepare_for_major_upgrade = true
+  prepare_for_major_upgrade = false
 
   # PostgreSQL specifics
   db_engine         = "postgres"


### PR DESCRIPTION
- The `prepare_for_major_upgrade` flag was returned to `false` in the RDS configuration
- The `APPLY_PIPELINE_SKIP_THIS_NAMESPACE` file was removed 