### PR TITLE
URGENT: Add ppo.gov.uk MTA-STS TLS ACM certificate validation record

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/ppo-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/ppo-route53.tf
@@ -177,3 +177,11 @@ resource "aws_route53_record" "ppo_route53_a_record_mta-sts" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "ppo_route53_cname_mtasts_tls_cert" {
+  zone_id = aws_route53_zone.ppo_route53_zone.zone_id
+  name    = "_c8b092cc5e6b18d6d6b1785824fb5bf4.mta-sts.ppo.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["_708974cacf749aaba82f164334e9e8b4.nhsllhhtvj.acm-validations.aws."]
+}


### PR DESCRIPTION
## 👀 Purpose

- This PR adds an ACM cert validation record to allow the tls cert for the MTA-STS stack to be renewed. This is an urgent PR to fix an issue that might be impacting production email services.

## ♻️ What's changed

- Add CNAME `_c8b092cc5e6b18d6d6b1785824fb5bf4.mta-sts.ppo.gov.uk`

## 📝 Notes

- [Incident thread](https://mojdt.slack.com/archives/C01BUKJSZD4/p1744904313522009)