### PR TITLE
Change default value of deletion protection for RDS instance to false

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-prod/resources/variables.tf
@@ -122,7 +122,7 @@ variable prepare_for_major_upgrade {
 variable "deletion_protection" {
   description = "Whether to enable deletion protection for the RDS instance"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "performance_insights_enabled" {


### PR DESCRIPTION
Removes deletion protection as appears to be required as per the concourse build failure of previous PR - https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/12166