### PR TITLE
add cwa-test-provider-api repo to serviceaccount module for laa-cwa-feature-tests-test namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-feature-tests-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-feature-tests-test/resources/serviceaccount.tf
@@ -6,7 +6,7 @@ module "serviceaccount" {
 
   serviceaccount_token_rotated_date = "28-03-2025"
 
-  github_repositories = ["laa-cwa-feature-tests"]
+  github_repositories = ["laa-cwa-feature-tests","cwa-test-provider-api"]
   github_environments = ["test"]
   serviceaccount_rules = [
     {


### PR DESCRIPTION
Need to inject secrets into the cwa-test-provider-api repo for the laa-cwa-feature-tests-test namespace.