### PR TITLE
add cwa-test-provider-api repo to the serviceaccount module for laa-cwa-feature-tests-uat namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-feature-tests-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-feature-tests-uat/resources/serviceaccount.tf
@@ -6,7 +6,7 @@ module "serviceaccount" {
 
   serviceaccount_token_rotated_date = "28-03-2025"
 
-  github_repositories = ["laa-cwa-feature-tests"]
+  github_repositories = ["laa-cwa-feature-tests","cwa-test-provider-api"]
   github_environments = ["uat"]
   serviceaccount_rules = [
     {


### PR DESCRIPTION
add the cwa-test-provider-api repo to the serviceaccount for this namespace so I can inject secrets into the repo and deploy via github actions