### PR TITLE
Update CAS3 UI environment protection rules - test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-temporary-accommodation-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-temporary-accommodation-ui.tf
@@ -5,8 +5,8 @@ module "hmpps_temporary_accommodation_ui" {
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
   reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["main", "feature-test/*"] # Optional
-  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  selected_branch_patterns      = ["*"] # Optional
+  # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
   source_template_repo          = "hmpps-template-typescript"


### PR DESCRIPTION
`test`: deploy review from separate 'Deploy to test' workflow, for any branch

Follows [similar change done on CAS1](https://github.com/ministryofjustice/cloud-platform-environments/pull/32230)