### PR TITLE
Update CAS2 UI environment protection rules - test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-community-accommodation-tier-2-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-community-accommodation-tier-2-ui.tf
@@ -3,10 +3,10 @@ module "hmpps_community_accommodation_tier_2_ui" {
   github_repo = "hmpps-community-accommodation-tier-2-ui"
   application = "hmpps-community-accommodation-tier-2-ui"
   github_team = "hmpps-community-accommodation"
-  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
   reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["main", "feature-test/*"] # Optional
-  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  selected_branch_patterns      = ["*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline
+  # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
   source_template_repo          = "hmpps-template-typescript"


### PR DESCRIPTION
`test`: deploy review from separate 'Deploy to test' workflow, for any branch

Follows [similar change done on CAS1](https://github.com/ministryofjustice/cloud-platform-environments/pull/32230)