### PR TITLE
Update CAS2 UI environment protection rules - dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/hmpps-community-accommodation-tier-2-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/hmpps-community-accommodation-tier-2-ui.tf
@@ -3,10 +3,10 @@ module "hmpps_community_accommodation_tier_2_ui" {
   github_repo = "hmpps-community-accommodation-tier-2-ui"
   application = "hmpps-community-accommodation-tier-2-ui"
   github_team = "hmpps-community-accommodation"
-  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
-  reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["main", "feature-dev/*"] # Optional
-  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
+  # reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation"] # Optional team that should review deployments to this environment.
+  # selected_branch_patterns      = ["main", "feature-dev/*"] # Optional
+  protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
   source_template_repo          = "hmpps-template-typescript"


### PR DESCRIPTION
`development`: auto-deploys from pipeline, only main branch

Follows [similar change done on CAS1](https://github.com/ministryofjustice/cloud-platform-environments/pull/32228)