### PR TITLE
Remove bmadley API client

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
@@ -20,7 +20,6 @@ locals {
     "maspin",
     "kilco",
     "meganexus",
-    "bmadley",
     "serco",
     "unilink",
     "prisonerfacing",


### PR DESCRIPTION
This is so it can be re-added to rotate the API Key attached to the bmadley consumer