### PR TITLE
Change certificate path so that the path matches other environments

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/s3_truststore.tf
@@ -93,7 +93,7 @@ resource "kubernetes_secret" "certificate_backup_secret" {
   }
   data = {
     bucket_name                        = module.certificate_backup.bucket_name
-    event_service_certificate_path     = "event-service/client-debug.p12"
+    event_service_certificate_path     = "event-service/client.p12"
     event_service_certificate_password = random_password.event_service_certificate_password.result
   }
 }


### PR DESCRIPTION
This is to avoid us having to have special cases in the uploadp12 script in Integration API