### PR TITLE
Remove superfluous base64 encoding of some secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
@@ -85,7 +85,7 @@ resource "kubernetes_secret" "athena_roles" {
   }
   type = "Opaque"
   data = {
-    general_role_arn = base64encode(local.athena_roles.test_general)
-    specials_role_arn = base64encode(local.athena_roles.test_specials)
+    general_role_arn = local.athena_roles.test_general
+    specials_role_arn = local.athena_roles.test_specials
   }
 }


### PR DESCRIPTION
Remove superfluous base64 encoding of secrets in `hmpps-electronic-monitoring-datastore-dev`.