### PR TITLE
hmpps-electronic-monitoring-datastore-dev: Configure SSM

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
@@ -6,12 +6,6 @@ locals {
 
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
-
-  athena_roles = {
-    dev_general   = "arn:aws:iam::800964199911:role/cmt_read_emds_data_dev",
-    test_general  = "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
-    test_specials = "arn:aws:iam::396913731313:role/specials_cmt_read_emds_data_test",
-  }
 }
 
 module "irsa" {
@@ -42,9 +36,8 @@ data "aws_iam_policy_document" "document" {
       "sts:AssumeRole"
     ]
     resources = [
-      local.athena_roles.dev_general,
-      local.athena_roles.test_general,
-      local.athena_roles.test_specials,
+      data.aws_ssm_parameter.athena_general_role_arn.value,
+      data.aws_ssm_parameter.athena_specials_role_arn.value,
     ]
   }
 }
@@ -58,14 +51,7 @@ resource "aws_iam_policy" "athena_access" {
   name   = "${var.namespace}-athena-policy-general"
   policy = data.aws_iam_policy_document.document.json
 
-  tags = {
-    business-unit          = var.business_unit
-    application            = var.application
-    is-production          = var.is_production
-    environment-name       = var.environment
-    owner                  = var.team_name
-    infrastructure-support = var.infrastructure_support
-  }
+  tags = local.tags
 }
 resource "kubernetes_secret" "irsa" {
   metadata {
@@ -85,7 +71,7 @@ resource "kubernetes_secret" "athena_roles" {
   }
   type = "Opaque"
   data = {
-    general_role_arn = local.athena_roles.test_general
-    specials_role_arn = local.athena_roles.test_specials
+    general_role_arn = data.aws_ssm_parameter.athena_general_role_arn.value
+    specials_role_arn = data.aws_ssm_parameter.athena_specials_role_arn.value
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
@@ -36,8 +36,8 @@ data "aws_iam_policy_document" "document" {
       "sts:AssumeRole"
     ]
     resources = [
-      data.aws_ssm_parameter.athena_general_role_arn.value,
-      data.aws_ssm_parameter.athena_specials_role_arn.value,
+      aws_ssm_parameter.athena_general_role_arn.value,
+      aws_ssm_parameter.athena_specials_role_arn.value,
     ]
   }
 }
@@ -71,7 +71,7 @@ resource "kubernetes_secret" "athena_roles" {
   }
   type = "Opaque"
   data = {
-    general_role_arn = data.aws_ssm_parameter.athena_general_role_arn.value
-    specials_role_arn = data.aws_ssm_parameter.athena_specials_role_arn.value
+    general_role_arn = aws_ssm_parameter.athena_general_role_arn.value
+    specials_role_arn = aws_ssm_parameter.athena_specials_role_arn.value
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/main.tf
@@ -44,3 +44,15 @@ provider "github" {
 }
 
 provider "kubernetes" {}
+
+locals {
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    owner                  = var.team_name
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/ssm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/ssm.tf
@@ -13,10 +13,6 @@ resource "aws_ssm_parameter" "athena_general_role_arn" {
   }
 }
 
-data "aws_ssm_parameter" "athena_general_role_arn" {
-  name = "/${var.namespace}/athena_general_role_arn"
-}
-
 resource "aws_ssm_parameter" "athena_specials_role_arn" {
   name        = "/${var.namespace}/athena_specials_role_arn"
   type        = "SecureString"
@@ -30,8 +26,4 @@ resource "aws_ssm_parameter" "athena_specials_role_arn" {
       value
     ]
   }
-}
-
-data "aws_ssm_parameter" "athena_specials_role_arn" {
-  name = "/${var.namespace}/athena_specials_role_arn"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/ssm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/ssm.tf
@@ -1,0 +1,37 @@
+resource "aws_ssm_parameter" "athena_general_role_arn" {
+  name        = "/${var.namespace}/athena_general_role_arn"
+  type        = "SecureString"
+  # This value must be replaced with a genuine role ARN using AWS CLI
+  value       = "arn:aws:iam::0000000000000:role/general-placeholder"
+  description = "ARN of the role used to query Athena for general EM order data"
+  overwrite   = false
+  tags        = local.tags
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
+}
+
+data "aws_ssm_parameter" "athena_general_role_arn" {
+  name = "/${var.namespace}/athena_general_role_arn"
+}
+
+resource "aws_ssm_parameter" "athena_specials_role_arn" {
+  name        = "/${var.namespace}/athena_specials_role_arn"
+  type        = "SecureString"
+  # This value must be replaced with a genuine role ARN using AWS CLI
+  value       = "arn:aws:iam::0000000000000:role/specials-placeholder"
+  description = "ARN of the role used to query Athena for general & specials EM order data"
+  overwrite   = false 
+  tags        = local.tags
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
+}
+
+data "aws_ssm_parameter" "athena_specials_role_arn" {
+  name = "/${var.namespace}/athena_specials_role_arn"
+}


### PR DESCRIPTION
In namespace `hmpps-electronic-monitoring-datastore-dev`:
- configure SSM for storing role ARNs
- remove a superfluous ARN
- parameterise `tags` for convenient reuse.