### PR TITLE
MO-1682 Remove MPC test topic reference

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/variables.tf
@@ -40,7 +40,6 @@ variable "additional_topic_clients" {
     "hmpps-tier-dev",
     "hmpps-workload-dev",
     "offender-management-staging",
-    "offender-management-test",
     "visit-someone-in-prison-backend-svc-dev",
   ]
 }


### PR DESCRIPTION
We will be decommissioning the `offender-management-test` namespace soon. Cleaning up any references found in other namespaces.