### PR TITLE
MO-1682 Remove MPC test references

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/elasticache.tf
@@ -31,16 +31,3 @@ resource "kubernetes_secret" "redis-staging" {
     url                      = "rediss://:${module.ec-cluster-offender-management-allocation-manager.auth_token}@${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}:6379"
   }
 }
-
-resource "kubernetes_secret" "redis-test" {
-  metadata {
-    name      = "allocation-elasticache-redis"
-    namespace = "offender-management-test"
-  }
-
-  data = {
-    primary_endpoint_address = module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address
-    auth_token               = module.ec-cluster-offender-management-allocation-manager.auth_token
-    url                      = "rediss://:${module.ec-cluster-offender-management-allocation-manager.auth_token}@${module.ec-cluster-offender-management-allocation-manager.primary_endpoint_address}:6379"
-  }
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-staging/resources/rds.tf
@@ -54,25 +54,6 @@ resource "kubernetes_secret" "allocation-rds" {
   }
 }
 
-resource "kubernetes_secret" "allocation-rds-test" {
-  metadata {
-    name      = "allocation-rds-instance-output"
-    namespace = "offender-management-test"
-  }
-
-  data = {
-    rds_instance_endpoint = module.allocation-rds.rds_instance_endpoint
-    rds_instance_address  = module.allocation-rds.rds_instance_address
-    database_name         = module.allocation-rds.database_name
-    database_username     = module.allocation-rds.database_username
-    database_password     = module.allocation-rds.database_password
-    postgres_name         = module.allocation-rds.database_name
-    postgres_host         = module.allocation-rds.rds_instance_address
-    postgres_user         = module.allocation-rds.database_username
-    postgres_password     = module.allocation-rds.database_password
-  }
-}
-
 ###############################################
 ### Inject RDS creds into new MPC namespace ###
 ###############################################


### PR DESCRIPTION
We will be decommissioning the `offender-management-test namespace` soon. Cleaning up any references found in other namespaces.