### PR TITLE
hmpps-electronic-monitoring-datastore-dev: Service pod SSM config

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/cross-iam-role-sa.tf
@@ -1,18 +1,3 @@
-
-locals {
-  # The names of the queues used and the namespace which created them
-  sqs_queues = {
-    "Digital-Prison-Services-dev-hmpps_audit_queue" = "hmpps-audit-dev"
-
-  }
-  sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
-
-  athena_roles = {
-    test_general  = "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
-    test_specials = "arn:aws:iam::396913731313:role/specials_cmt_read_emds_data_test",
-  }
-}
-
 module "irsa" {
   source               = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
   eks_cluster_name     = var.eks_cluster_name
@@ -21,7 +6,8 @@ module "irsa" {
   role_policy_arns = merge(
     local.sqs_policies,
     {
-      athena = aws_iam_policy.athena_access.arn
+      athena = aws_iam_policy.athena_access.arn,
+      ssm = aws_iam_policy.ssm_access.arn
     }
   )
 
@@ -32,54 +18,4 @@ module "irsa" {
   team_name              = var.team_name
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
-}
-
-data "aws_iam_policy_document" "document" {
-  # Provide list of permissions and target AWS account resources to allow access to
-  statement {
-    actions = [
-      "sts:AssumeRole"
-    ]
-    resources = [
-      local.athena_roles.test_general,
-      local.athena_roles.test_specials,
-    ]
-  }
-}
-
-data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
-  for_each = local.sqs_queues
-  name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
-}
-
-resource "aws_iam_policy" "athena_access" {
-  name   = "${var.namespace}-athena-policy-general"
-  policy = data.aws_iam_policy_document.document.json
-
-  tags = local.tags
-}
-resource "kubernetes_secret" "irsa" {
-  metadata {
-    name      = "${var.namespace}-irsa-output"
-    namespace = var.namespace
-  }
-  data = {
-    role           = module.irsa.role_name
-    serviceaccount = module.irsa.service_account.name
-  }
-}
-
-resource "kubernetes_secret" "athena_roles" {
-  metadata {
-    name      = "${var.namespace}-athena-roles"
-    namespace = var.namespace
-  }
-  type = "Opaque"
-  data = {
-    general_role_arn = local.athena_roles.test_general
-    specials_role_arn = local.athena_roles.test_specials
-
-    test_ssm_general_role_arn = aws_ssm_parameter.athena_general_role_arn.value
-    test_ssm_specials_role_arn = aws_ssm_parameter.athena_specials_role_arn.value
-  }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/iam-policies.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/iam-policies.tf
@@ -1,0 +1,38 @@
+data "aws_iam_policy_document" "athena_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = [
+      local.athena_roles.test_general,
+      local.athena_roles.test_specials,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "athena_access" {
+  name   = "${var.namespace}-athena-policy-general"
+  policy = data.aws_iam_policy_document.athena_policy.json
+  tags = local.tags
+}
+
+
+data "aws_iam_policy_document" "ssm_policy" {
+  statement {
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:PutParameter"
+    ]
+    resources = [
+      "arn:aws:ssm:eu-west-2:754256621582:parameter/${var.namespace}/athena_specials_role_arn",
+      "arn:aws:ssm:eu-west-2:754256621582:parameter/${var.namespace}/athena_general_role_arn"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ssm_access" {
+  name   = "${var.namespace}-ssm-policy"
+  policy = data.aws_iam_policy_document.ssm_policy.json
+  tags = local.tags
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/kubernetes-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/kubernetes-secrets.tf
@@ -1,0 +1,25 @@
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "${var.namespace}-irsa-output"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+  }
+}
+
+resource "kubernetes_secret" "athena_roles" {
+  metadata {
+    name      = "${var.namespace}-athena-roles"
+    namespace = var.namespace
+  }
+  type = "Opaque"
+  data = {
+    general_role_arn = local.athena_roles.test_general
+    specials_role_arn = local.athena_roles.test_specials
+
+    test_ssm_general_role_arn = aws_ssm_parameter.athena_general_role_arn.value
+    test_ssm_specials_role_arn = aws_ssm_parameter.athena_specials_role_arn.value
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/locals.tf
@@ -1,0 +1,22 @@
+locals {
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    owner                  = var.team_name
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+  
+  sqs_queues = {
+    "Digital-Prison-Services-dev-hmpps_audit_queue" = "hmpps-audit-dev"
+  }
+
+  sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
+
+  athena_roles = {
+    test_general  = "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
+    test_specials = "arn:aws:iam::396913731313:role/specials_cmt_read_emds_data_test",
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/main.tf
@@ -44,15 +44,3 @@ provider "github" {
 }
 
 provider "kubernetes" {}
-
-locals {
-  tags = {
-    business-unit          = var.business_unit
-    application            = var.application
-    is-production          = var.is_production
-    owner                  = var.team_name
-    environment-name       = var.environment
-    infrastructure-support = var.infrastructure_support
-    namespace              = var.namespace
-  }
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/ssm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/ssm.tf
@@ -27,3 +27,8 @@ resource "aws_ssm_parameter" "athena_specials_role_arn" {
     ]
   }
 }
+
+data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
+  for_each = local.sqs_queues
+  name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
+}


### PR DESCRIPTION
In `hmpps-electronic-monitoring-datastore-dev`:
- Give the service pod SSM parameter permissions
- Refactor the service pod config for ease of maintenance