### PR TITLE
DPR2-1777: Add MP DPS security group to calculate_release_dates_api_rds

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-preprod/resources/rds.tf
@@ -29,7 +29,7 @@ module "calculate_release_dates_api_rds" {
     aws = aws.london
   }
 
-  vpc_security_group_ids     = [aws_security_group.data_catalogue_access_sg.id]
+  vpc_security_group_ids     = [aws_security_group.data_catalogue_access_sg.id, data.aws_security_group.mp_dps_sg.id]
 
   db_parameter = [
     {


### PR DESCRIPTION
This PR adds the MP DPS security group to `calculate_release_dates_api_rds`so that the primary database instance is also accessible to the DPR service.