### PR TITLE
hmpps-electronic-monitoring-datastore-dev: Replace hardcoded ARNs with SSM parameters.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/iam-policies.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/iam-policies.tf
@@ -4,8 +4,8 @@ data "aws_iam_policy_document" "athena_policy" {
       "sts:AssumeRole"
     ]
     resources = [
-      local.athena_roles.test_general,
-      local.athena_roles.test_specials,
+      data.aws_ssm_parameter.athena_general_role_arn.value,
+      data.aws_ssm_parameter.athena_specials_role_arn.value
     ]
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/kubernetes-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/kubernetes-secrets.tf
@@ -16,10 +16,7 @@ resource "kubernetes_secret" "athena_roles" {
   }
   type = "Opaque"
   data = {
-    general_role_arn = local.athena_roles.test_general
-    specials_role_arn = local.athena_roles.test_specials
-
-    test_ssm_general_role_arn = data.aws_ssm_parameter.athena_general_role_arn.value
-    test_ssm_specials_role_arn = data.aws_ssm_parameter.athena_specials_role_arn.value
+    general_role_arn = data.aws_ssm_parameter.athena_general_role_arn.value
+    specials_role_arn = data.aws_ssm_parameter.athena_specials_role_arn.value
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/locals.tf
@@ -14,9 +14,4 @@ locals {
   }
 
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
-
-  athena_roles = {
-    test_general  = "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
-    test_specials = "arn:aws:iam::396913731313:role/specials_cmt_read_emds_data_test",
-  }
 }


### PR DESCRIPTION
In hmpps-electronic-monitoring-datastore-dev: 
- Remove hardcoded ARNs from the namespace
- Use SSM parameters instead
- Remove some obsolete test content