### PR TITLE
hmpps-electronic-monitoring-datastore-preprod: Reintroduce ARN data properties.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-preprod/resources/iam-policies.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-preprod/resources/iam-policies.tf
@@ -4,8 +4,8 @@ data "aws_iam_policy_document" "athena_policy" {
       "sts:AssumeRole"
     ]
     resources = [
-      aws_ssm_parameter.athena_general_role_arn.value,
-      aws_ssm_parameter.athena_specials_role_arn.value,
+      data.aws_ssm_parameter.athena_general_role_arn.value,
+      data.aws_ssm_parameter.athena_specials_role_arn.value,
     ]
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-preprod/resources/kubernetes-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-preprod/resources/kubernetes-secrets.tf
@@ -5,8 +5,8 @@ resource "kubernetes_secret" "athena_roles" {
   }
   type = "Opaque"
   data = {
-    general_role_arn = aws_ssm_parameter.athena_general_role_arn.value
-    specials_role_arn = aws_ssm_parameter.athena_specials_role_arn.value
+    general_role_arn = data.aws_ssm_parameter.athena_general_role_arn.value
+    specials_role_arn = data.aws_ssm_parameter.athena_specials_role_arn.value
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-preprod/resources/ssm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-preprod/resources/ssm.tf
@@ -13,6 +13,11 @@ resource "aws_ssm_parameter" "athena_general_role_arn" {
   }
 }
 
+data "aws_ssm_parameter" "athena_general_role_arn" {
+  name = "/${var.namespace}/athena_general_role_arn"
+  with_decryption = true
+}
+
 resource "aws_ssm_parameter" "athena_specials_role_arn" {
   name        = "/${var.namespace}/athena_specials_role_arn"
   type        = "SecureString"
@@ -26,6 +31,11 @@ resource "aws_ssm_parameter" "athena_specials_role_arn" {
       value
     ]
   }
+}
+
+data "aws_ssm_parameter" "athena_specials_role_arn" {
+  name = "/${var.namespace}/athena_specials_role_arn"
+  with_decryption = true
 }
 
 data "aws_ssm_parameter" "irsa_policy_arns_sqs" {


### PR DESCRIPTION
In `hmpps-electronic-monitoring-datastore-preprod`,
reintroduce some data properties that were previously removed.

They were removed as they tried to access AWS SSM parameters that had not yet been created, causing an error.
Now that the SSM parameters have been created the data properties can be reintroduced.