### PR TITLE
CRIMAPP-1679 Update network policy in crime review staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/04-networkpolicy.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: review-criminal-legal-aid-web-staging
+      metrics-target: laa-review-criminal-legal-aid-staging-metrics-target
   policyTypes:
   - Ingress
   ingress:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/07-prometheus-sidekiq.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/07-prometheus-sidekiq.yaml
@@ -1,0 +1,76 @@
+# Prometheus Alerts
+#
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html
+#
+# Note: we are using a regex in the namespace to filter and trigger alerts
+# in both, staging and production environments.
+#
+# To see the current alerts in this namespace:
+#   kubectl describe prometheusrule -n laa-review-criminal-legal-aid-staging
+#
+# Alerts will be sent to the slack channel: #laa-crime-apply-alerts
+#
+# The rules below are copied from laa-assess-crime-forms
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-rules-sidekiq
+  namespace: laa-review-criminal-legal-aid-staging
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: sidekiq-rules
+    rules:
+    - alert: CrimeReview-Staging-Sidekiq-DeadJobThresholdReached
+      expr: |-
+        # Any dead jobs added in past 2 minutes
+        #
+        # We use average because each worker pod will report the same number of dead jobs.
+        #
+        # To find those added in the last 2 minutes we take current dead jobs and take away either the number
+        # of dead jobs 2 minutes ago, or the current number minus 1 (to force a diff where there were no dead
+        # jobs previously, because no dead jobs will be represented by an empty value, {}, rather than 0).
+        # 
+        # If the resulting number is greater than 0 then a dead job has been added to the queue. It should be noted
+        # that the number could be less than 0 if dead jobs are cleared/deleted.
+        #
+        avg(ruby_sidekiq_stats_dead_size{namespace="laa-review-criminal-legal-aid-staging"})
+         - (
+             avg(ruby_sidekiq_stats_dead_size{namespace="laa-review-criminal-legal-aid-staging"} offset 2m)
+             or 
+             avg(ruby_sidekiq_stats_dead_size{namespace="laa-review-criminal-legal-aid-staging"}) - 1
+           )
+          > 0
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Crime Review staging - One or more Sidekiq jobs moved to dead
+        dashboard_url: https://staging.review-criminal-legal-aid.service.justice.gov.uk/sidekiq/
+
+    - alert: CrimeReview-Staging-Sidekiq-QueueSizeThresholdReached
+      expr: |-
+        # We exclude queues named sidekiq-alive* as these are purely used to test liveness.
+        #
+        # We use `sum by` to "group [counts] by" queue name and `avg by` to divide by the number of worker pods
+        # from which the stats are produced (which are duplicating stats).
+        #
+        # Example: If there are 2 workers and queue1 has size 1 and queue2 has 2 then total queue size is (1+2) * 2 = 6.
+        #          The sum by and avg by "should" result in (6/2)/2 = 1.5
+        #
+        # This is based on guesswork as it is hard to test and we can refine it if we start to see alerts that are not
+        # an issue.
+        #
+        avg by (pod) (
+          sum by (queue) (
+            ruby_sidekiq_queue_backlog{namespace="laa-review-criminal-legal-aid-staging", queue!~"sidekiq-alive.*"}
+          )
+        ) > 2
+      for: 1m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Crime Review staging - Total Sidekiq queue sizes are more than 2
+        dashboard_url: https://staging.review-criminal-legal-aid.service.justice.gov.uk/sidekiq/


### PR DESCRIPTION
This change updates the Prometheus network policy for `laa-review-criminal-legal-aid-staging` by changing the selector to `metrics-target: laa-review-criminal-legal-aid-staging-metrics-target`, which should now select both the web app pods and the new worker pods.

This also adds a couple of Prometheus rules for Sidekiq.