### PR TITLE
hmpps-electronic-monitoring-datastore-preprod: Correct source code reference

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-preprod/00-namespace.yaml
@@ -11,6 +11,6 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "em-engineers-moj-madetech"
     cloud-platform.justice.gov.uk/application: "Electronic Monitoring Datastore"
     cloud-platform.justice.gov.uk/owner: "Electronic Monitoring Datastore: hmpps-ems-platform-team@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/tst-em-example-app-jkn.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-electronic-monitoring-datastore-ui"
     cloud-platform.justice.gov.uk/team-name: "hmpps-electronic-monitoring"
     cloud-platform.justice.gov.uk/review-after: "2024-12-10"


### PR DESCRIPTION
In `hmpps-electronic-monitoring-datastore-preprod`,
correct the `source-code` metadata property in `00-namespace.yaml`.