### PR TITLE
hmpps-electronic-monitoring-datastore-prod: Create SSM parameters for Athena access role ARNs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/cross-iam-role-sa.tf
@@ -1,73 +1,21 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+  eks_cluster_name      = var.eks_cluster_name
+  service_account_name  = "${var.namespace-short}-athena"
+  namespace             = var.namespace
+  role_policy_arns = merge(
+    local.sqs_policies,
+    {
+      athena = aws_iam_policy.athena_access.arn
+      ssm = aws_iam_policy.ssm_access.arn
+    }
+  )
 
-locals {
-  # The names of the queues used and the namespace which created them
-  sqs_queues = {
-    "Digital-Prison-Services-prod-hmpps_audit_queue" = "hmpps-audit-prod"
-
-  }
-  sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
-
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
 }
-
-    module "irsa" {
-      source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
-      eks_cluster_name      = var.eks_cluster_name
-      service_account_name  = "${var.namespace-short}-athena"
-      namespace             = var.namespace
-      role_policy_arns = merge(
-        local.sqs_policies,
-        {
-          athena = aws_iam_policy.athena_access.arn
-        }
-      )
-
-      # Tags
-      business_unit          = var.business_unit
-      application            = var.application
-      is_production          = var.is_production
-      team_name              = var.team_name
-      environment_name       = var.environment
-      infrastructure_support = var.infrastructure_support
-    }
-
-    data "aws_iam_policy_document" "document" {
-      # Provide list of permissions and target AWS account resources to allow access to
-      statement {
-        actions = [
-          "sts:AssumeRole"
-        ]
-        resources = [
-          "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
-        ]
-      }
-    }
-
-
-data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
-  for_each = local.sqs_queues
-  name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
-}
-
-    resource "aws_iam_policy" "athena_access" {
-      name   = "${var.namespace}-athena-policy-general"
-      policy = data.aws_iam_policy_document.document.json
-
-      tags = {
-        business-unit          = var.business_unit
-        application            = var.application
-        is-production          = var.is_production
-        environment-name       = var.environment
-        owner                  = var.team_name
-        infrastructure-support = var.infrastructure_support
-      }
-    }
-    resource "kubernetes_secret" "irsa" {
-      metadata {
-        name      = "${var.namespace}-irsa-output"
-        namespace = var.namespace
-      }
-      data = {
-        role = module.irsa.role_name
-        serviceaccount = module.irsa.service_account.name
-      }
-    }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/iam-policies.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/iam-policies.tf
@@ -1,0 +1,37 @@
+data "aws_iam_policy_document" "athena_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = [
+      aws_ssm_parameter.athena_general_role_arn.value,
+      aws_ssm_parameter.athena_specials_role_arn.value,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "athena_access" {
+  name   = "${var.namespace}-athena-policy-general"
+  policy = data.aws_iam_policy_document.athena_policy.json
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "ssm_policy" {
+  statement {
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:PutParameter"
+    ]
+    resources = [
+      "arn:aws:ssm:eu-west-2:754256621582:parameter/${var.namespace}/athena_specials_role_arn",
+      "arn:aws:ssm:eu-west-2:754256621582:parameter/${var.namespace}/athena_general_role_arn"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ssm_access" {
+  name   = "${var.namespace}-ssm-policy"
+  policy = data.aws_iam_policy_document.ssm_policy.json
+  tags = local.tags
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/kubernetes-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/kubernetes-secrets.tf
@@ -1,0 +1,22 @@
+resource "kubernetes_secret" "athena_roles" {
+  metadata {
+    name      = "athena-roles"
+    namespace = var.namespace
+  }
+  type = "Opaque"
+  data = {
+    general_role_arn = aws_ssm_parameter.athena_general_role_arn.value
+    specials_role_arn = aws_ssm_parameter.athena_specials_role_arn.value
+  }
+}
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "${var.namespace}-irsa-output"
+    namespace = var.namespace
+  }
+  data = {
+    role = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/locals.tf
@@ -1,0 +1,18 @@
+locals {
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+
+  sqs_queues = {
+    "Digital-Prison-Services-prod-hmpps_audit_queue" = "hmpps-audit-prod"
+  }
+
+  sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/ssm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-prod/resources/ssm.tf
@@ -1,0 +1,32 @@
+resource "aws_ssm_parameter" "athena_general_role_arn" {
+  name        = "/${var.namespace}/athena_general_role_arn"
+  type        = "SecureString"
+  # This value must be replaced with a genuine role ARN using AWS CLI
+  value       = "arn:aws:iam::0000000000000:role/general-placeholder"
+  description = "ARN of the role used to query Athena for general EM order data"
+  tags        = local.tags
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "athena_specials_role_arn" {
+  name        = "/${var.namespace}/athena_specials_role_arn"
+  type        = "SecureString"
+  # This value must be replaced with a genuine role ARN using AWS CLI
+  value       = "arn:aws:iam::0000000000000:role/specials-placeholder"
+  description = "ARN of the role used to query Athena for general & specials EM order data"
+  tags        = local.tags
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
+}
+
+data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
+  for_each = local.sqs_queues
+  name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
+}


### PR DESCRIPTION
In `hmpps-electronic-monitoring-datastore-prod`:
- Create SSM parameters for storage of Athena access role ARNs
- Provide these as kubernetes secrets in the namespace
- Refactor the namespace directory for ease of use and maintenance
