### PR TITLE
CRIMAPP-1679 Add S3 bucket to crime review staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/s3.tf
@@ -1,0 +1,27 @@
+module "s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.2.0"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "s3_bucket" {
+  metadata {
+    name      = "s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.s3_bucket.bucket_arn
+    bucket_name = module.s3_bucket.bucket_name
+  }
+}


### PR DESCRIPTION
This change adds an S3 bucket resource to `laa-review-criminal-legal-aid-staging`.