### PR TITLE
HIA-790 Restrict API Gateway logging in prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/api_gateway.tf
@@ -253,6 +253,6 @@ resource "aws_api_gateway_method_settings" "all" {
   settings {
     metrics_enabled    = true
     logging_level      = "INFO"
-    data_trace_enabled = true
+    data_trace_enabled = false
   }
 }


### PR DESCRIPTION
Change `data_trace_enabled` to `false` to remove PII from logs