### PR TITLE
fix: bump the max allocated storage to 550

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-postgresql.tf
@@ -69,6 +69,7 @@ module "read_replica" {
   db_engine_version = "16.7"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
+  db_max_allocated_storage = "550"
   # It is mandatory to set the below values to create read replica instance
 
   # Set the db_identifier of the source db


### PR DESCRIPTION
Fixes https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/12510#L67db91fa:23