### PR TITLE
fix: explicitly define a custom param group name 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-rds-namespace/resources/rds-postgresql.tf
@@ -63,7 +63,8 @@ module "read_replica" {
 
   # If any other inputs of the RDS is passed in the source db which are different from defaults,
   # add them to the replica
-  db_name                = "replica"
+  # Explicitly set a unique parameter group name
+  db_parameter_group_name = "cloud-platform-a8439a865056bd57-replica"
   # PostgreSQL specifics
   db_engine         = "postgres"
   db_engine_version = "17.4"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type


### PR DESCRIPTION
Fixes https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/12527#L67db9764:23