### PR TITLE
RST-7307: Adding a empty db param to avoid the force ssl being made on oracle

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-dev/resources/apex-rds-oracle.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-dev/resources/apex-rds-oracle.tf
@@ -34,6 +34,9 @@ module "rds_apex" {
   character_set_name       = "WE8MSWIN1252"
   option_group_name        = aws_db_option_group.oracle_apex.name
 
+  # Avoid default parameters set my MOJ ( rds.force_ssl)
+  db_parameter = []
+
   # Tags
   application            = local.application
   business_unit          = var.business_unit


### PR DESCRIPTION
MOJ rds module sets the default db param to "rds.force_ssl" and this is not applicable in Oracle db. Want to have the default set so working around