### PR TITLE
ci: add pr stale bot

### DIFF
--- a/.github/workflows/pr-stale.yaml
+++ b/.github/workflows/pr-stale.yaml
@@ -1,0 +1,22 @@
+name: 'Stale and close PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity.'
+          close-pr-message: 'This PR has been closed due to no response in 7 days.'
+          exempt-pr-labels: dependencies
+          days-before-stale: 90
+          days-before-close: 7
+          debug-only: true


### PR DESCRIPTION
## 👀 Purpose

- Marks PRs as stale after 90 days
- Closes PRs as stale 90 days + 7 days if no response.
- Runs in dry-run only mode so we can test