### PR TITLE
ci: remove debug mode from pr stale bot

### DIFF
--- a/.github/workflows/pr-stale.yaml
+++ b/.github/workflows/pr-stale.yaml
@@ -19,4 +19,3 @@ jobs:
           exempt-pr-labels: dependencies
           days-before-stale: 90
           days-before-close: 7
-          debug-only: true


### PR DESCRIPTION
## 👀 Purpose

- Removes the debug only option from the PR stale bot