### PR TITLE
CRIMAPP-1679 Reporting infrastructure for crime review production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/04-networkpolicy.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: review-criminal-legal-aid-web-production
+      metrics-target: laa-review-criminal-legal-aid-production-metrics-target
   policyTypes:
   - Ingress
   ingress:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/07-prometheus-sidekiq.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/07-prometheus-sidekiq.yaml
@@ -1,0 +1,74 @@
+# Prometheus Alerts
+#
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html
+#
+# Note: we are using a regex in the namespace to filter and trigger alerts
+# in both, staging and production environments.
+#
+# To see the current alerts in this namespace:
+#   kubectl describe prometheusrule -n laa-review-criminal-legal-aid-production
+#
+# Alerts will be sent to the slack channel: #laa-crime-apply-alerts
+#
+# The rules below are copied from laa-assess-crime-forms
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-rules-sidekiq
+  namespace: laa-review-criminal-legal-aid-production
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: sidekiq-rules
+    rules:
+    - alert: CrimeReview-Production-Sidekiq-DeadJobThresholdReached
+      expr: |-
+        # Any dead jobs added in past 2 minutes
+        #
+        # We use average because each worker pod will report the same number of dead jobs.
+        #
+        # To find those added in the last 2 minutes we take current dead jobs and take away either the number
+        # of dead jobs 2 minutes ago, or the current number minus 1 (to force a diff where there were no dead
+        # jobs previously, because no dead jobs will be represented by an empty value, {}, rather than 0).
+        # 
+        # If the resulting number is greater than 0 then a dead job has been added to the queue. It should be noted
+        # that the number could be less than 0 if dead jobs are cleared/deleted.
+        #
+        avg(ruby_sidekiq_stats_dead_size{namespace="laa-review-criminal-legal-aid-production"})
+         - (
+             avg(ruby_sidekiq_stats_dead_size{namespace="laa-review-criminal-legal-aid-production"} offset 2m)
+             or 
+             avg(ruby_sidekiq_stats_dead_size{namespace="laa-review-criminal-legal-aid-production"}) - 1
+           )
+          > 0
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Crime Review production - One or more Sidekiq jobs moved to dead
+
+    - alert: CrimeReview-Production-Sidekiq-QueueSizeThresholdReached
+      expr: |-
+        # We exclude queues named sidekiq-alive* as these are purely used to test liveness.
+        #
+        # We use `sum by` to "group [counts] by" queue name and `avg by` to divide by the number of worker pods
+        # from which the stats are produced (which are duplicating stats).
+        #
+        # Example: If there are 2 workers and queue1 has size 1 and queue2 has 2 then total queue size is (1+2) * 2 = 6.
+        #          The sum by and avg by "should" result in (6/2)/2 = 1.5
+        #
+        # This is based on guesswork as it is hard to test and we can refine it if we start to see alerts that are not
+        # an issue.
+        #
+        avg by (pod) (
+          sum by (queue) (
+            ruby_sidekiq_queue_backlog{namespace="laa-review-criminal-legal-aid-production", queue!~"sidekiq-alive.*"}
+          )
+        ) > 2
+      for: 1m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Crime Review production - Total Sidekiq queue sizes are more than 2

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/elasticache.tf
@@ -1,0 +1,36 @@
+module "redis" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # Redis cluster configuration
+  node_type               = "cache.t4g.small"
+  engine_version          = "7.0"
+  parameter_group_name    = "default.redis7"
+  # auth_token_rotated_date = "2023-07-04" # Uncomment to rotate the auth token
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "redis_secrets" {
+  metadata {
+    name      = "ec-cluster-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.redis.primary_endpoint_address
+    member_clusters          = jsonencode(module.redis.member_clusters)
+    auth_token               = module.redis.auth_token
+    replication_group_id     = module.redis.replication_group_id
+    url                      = "rediss://:${module.redis.auth_token}@${module.redis.primary_endpoint_address}:6379"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/irsa.tf
@@ -1,0 +1,25 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "${var.namespace}-service"
+  namespace            = var.namespace
+
+  # Attach the approprate policies using a key => value map
+  # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
+  # provide an output called `irsa_policy_arn` that can be used.
+  role_policy_arns = {
+    s3  = module.s3_bucket.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/s3.tf
@@ -1,0 +1,27 @@
+module "s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.2.0"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "s3_bucket" {
+  metadata {
+    name      = "s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.s3_bucket.bucket_arn
+    bucket_name = module.s3_bucket.bucket_name
+  }
+}


### PR DESCRIPTION
This PR makes the following changes in the `laa-review-criminal-legal-aid-production` namespace:
- Adds an ElastiCache (Redis) cluster
- Adds an S3 bucket
- Adds an IRSA module to allow access to S3
- Updates the network policy for Prometheus to target pods by a new label - `laa-review-criminal-legal-aid-production-metrics-target`
- Adds Prometheus alerts to monitor Sidekiq