### PR TITLE
Fix: rds version mismatch in c100-application-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/variables.tf
@@ -33,7 +33,7 @@ variable "repo_name" {
 # Database
 
 variable "db_engine_version" {
-  default = "14.17"
+  default = "14.19"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `c100-application-staging`

```
module.rds-instance: downgrade from 14.19 to 14.17
```