### PR TITLE
Fix: rds version mismatch in hmpps-book-secure-move-api-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/rds.tf
@@ -16,7 +16,7 @@ module "rds-instance" {
 
   db_instance_class = "db.t4g.small"
   db_engine         = "postgres"
-  db_engine_version = "16.8"
+  db_engine_version = "16.9"
   rds_family        = "postgres16"
 
   prepare_for_major_upgrade = false


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-book-secure-move-api-uat`

```
module.rds-instance: downgrade from 16.9 to 16.8
```