### PR TITLE
Fix: rds version mismatch in money-to-prisoners-test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -18,7 +18,7 @@ module "rds" {
 
   rds_family           = "postgres16"
   db_engine            = "postgres"
-  db_engine_version    = "16.8"
+  db_engine_version    = "16.9"
   db_instance_class    = "db.t4g.small"
   db_allocated_storage = 20
   db_name              = "mtp_api"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `money-to-prisoners-test`

```
module.rds: downgrade from 16.9 to 16.8
```