### PR TITLE
Fix: rds version mismatch in tim-development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/rds.tf
@@ -21,7 +21,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.8"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  db_engine_version = "16.9"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `tim-development`

```
module.rds: downgrade from 16.9 to 16.8
```