### PR TITLE
Fix: rds version mismatch in certificated-bailiffs-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-dev/resources/apex-rds-oracle.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/certificated-bailiffs-dev/resources/apex-rds-oracle.tf
@@ -23,7 +23,7 @@ module "rds_apex" {
 
   # Oracle specifics
   db_engine                = "oracle-se2"
-  db_engine_version        = "19.0.0.0.ru-2025-01.rur-2025-01.r1"
+  db_engine_version        = "19.0.0.0.ru-2025-01.rur-2025-02.r1"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.small"
   storage_type             = "gp2"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `certificated-bailiffs-dev`

```
module.rds_apex: downgrade from 19.0.0.0.ru-2025-01.rur-2025-02.r1 to 19.0.0.0.ru-2025-01.rur-2025-01.r1
```