### PR TITLE
Fix incorrect team name for ECR permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -681,7 +681,7 @@ resource "kubernetes_secret" "ecr-repo-fb-editor-workers" {
 module "ecr-repo-fb-runner" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
 
-  team_name = "formbuilder"
+  team_name = "form-builder"
   repo_name = "fb-runner"
 
   lifecycle_policy = var.lifecycle_policy


### PR DESCRIPTION
Think team name is wrong because I'm in the team, but can't see any of the ECR images. The team on Github is form-builder