### PR TITLE
add ecr deletion protection as prep to delete my namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/emma-cloud-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/emma-cloud-test/resources/ecr.tf
@@ -16,5 +16,6 @@ module "ecr" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }
 


### PR DESCRIPTION
This pr is to deletion protection ready to test the deletion of my dev namespace on the slack alerts it is part of issue https://github.com/ministryofjustice/cloud-platform/issues/6929