### PR TITLE
Updates grafana dashboard url

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/05-prometheus-custom-rules.yaml
@@ -28,4 +28,4 @@ spec:
           annotations:
             message: PRODUCTION environment has fewer than 4 running pods
             runbook_url: https://ministryofjustice.github.io/laa-manage-your-civil-cases/
-            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/djtEK4abc/ccq-ingress-check-if-your-client-qualifies-for-legal-aid?orgId=1&var-namespace=laa-manage-your-civil-cases-production
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/a2ad4e88-e130-46ee-bafa-75cf69a10e72/mcc-ingress-manage-your-civil-cases?var-namespace=laa-manage-your-civil-cases-production&var-ingress=manage-civil-cases-laa-manage-your-civil-cases

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-staging/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-staging/05-prometheus-custom-rules.yaml
@@ -19,4 +19,4 @@ spec:
           annotations:
             message: STAGING ingress {{ $labels.ingress }} is serving 5xx responses.
             runbook_url: https://ministryofjustice.github.io/laa-manage-your-civil-cases/
-            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/djtEK4abc/ccq-ingress-check-if-your-client-qualifies-for-legal-aid?orgId=1&var-namespace=laa-manage-your-civil-cases-staging&var-ingress=check-client-qualifies-laa-estimate-eligibility
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/a2ad4e88-e130-46ee-bafa-75cf69a10e72/mcc-ingress-manage-your-civil-cases?var-namespace=laa-manage-your-civil-cases-staging&var-ingress=manage-civil-cases-laa-manage-your-civil-cases

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-uat/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-uat/05-prometheus-custom-rules.yaml
@@ -19,4 +19,4 @@ spec:
           annotations:
             message: UAT ingress {{ $labels.ingress }} is serving 5xx responses.
             runbook_url: https://ministryofjustice.github.io/laa-manage-your-civil-cases/
-            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/djtEK4abc/ccq-ingress-check-if-your-client-qualifies-for-legal-aid?orgId=1&var-namespace=laa-manage-your-civil-cases-uat&var-ingress=check-client-qualifies-laa-estimate-eligibility
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/a2ad4e88-e130-46ee-bafa-75cf69a10e72/mcc-ingress-manage-your-civil-cases?var-namespace=laa-manage-your-civil-cases-uat&var-ingress=manage-civil-cases-laa-manage-your-civil-cases


### PR DESCRIPTION

This pull request updates the `dashboard_url` annotations in Prometheus custom rules for the production, staging, and UAT environments of the `laa-manage-your-civil-cases` service. The changes ensure that the URLs point to the correct Grafana dashboards for monitoring ingress traffic.
