### PR TITLE
VB-5327 - Revert allow_major_version_upgrade and prepare_for_major_upgrade flags to false - PROD

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
@@ -93,8 +93,8 @@ module "visit_allocation_rds" {
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
 
-  allow_major_version_upgrade = "true"
-  prepare_for_major_upgrade   = true
+  allow_major_version_upgrade = "false"
+  prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "17.4"
   rds_family                  = "postgres17"


### PR DESCRIPTION
VB-5327 - Revert allow_major_version_upgrade and prepare_for_major_upgrade flags to false for visit_allocation_rds on visit-someone-in-prison-backend-svc-prod namespace.