### PR TITLE
Create namespace for laa-ccms-dev

### DIFF
--- a/.checksum
+++ b/.checksum
@@ -1,3 +1,3 @@
 #This file is used by the auto pr github action. Please commit
-cdn-production
-h1:5QFuue404ZNsX2Xm46olbuhTWDkCl60AzZG9BhnbkIc=
+laa-ccms-dev
+h1:uVjyROVVlXSlCuW6NQVs3AaA0bssiY/k8JznIcACSxs=

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "laa-ccms-dev"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/slack-channel: "laa-ccms-support"
+    cloud-platform.justice.gov.uk/application: "client and cost management system"
+    cloud-platform.justice.gov.uk/owner: "CCMS: ccmspuimodernisation@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-ccms-provider-details-api"
+    cloud-platform.justice.gov.uk/team-name: "laa-ccms-devs"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-ccms-dev-admin
+  namespace: laa-ccms-dev
+subjects:
+  - kind: Group
+    name: "github:laa-ccms-devs"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-ccms-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-ccms-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-ccms-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-ccms-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/ecr.tf
@@ -1,0 +1,120 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+
+  # REQUIRED: Repository configuration
+  team_name = var.team_name
+  repo_name = "${var.namespace}-ecr"
+  namespace = var.namespace
+
+  # REQUIRED: OIDC providers to configure, either "github", "circleci", or both
+  oidc_providers = ["github"]
+
+  # REQUIRED: GitHub repositories that push to this container repository
+  github_repositories = ["laa-ccms-provider-details-api"]
+
+  # Lifecycle policies
+  lifecycle_policy = <<EOF
+    {
+      "rules": [
+        {
+          "rulePriority": 1,
+          "description": "Keep last 10 production images",
+          "selection": {
+            "tagStatus": "tagged",
+            "tagPatternList": ["production*"],
+            "countType": "imageCountMoreThan",
+            "countNumber": 10
+          },
+          "action": {
+            "type": "expire"
+          }
+        },
+        {
+          "rulePriority": 2,
+          "description": "Keep last 60 release images for rollbacks",
+          "selection": {
+            "tagStatus": "tagged",
+            "tagPatternList": ["release*"],
+            "countType": "imageCountMoreThan",
+            "countNumber": 60
+          },
+          "action": {
+            "type": "expire"
+          }
+        },
+        {
+          "rulePriority": 3,
+          "description": "Keep last 10 pre-production images",
+          "selection": {
+            "tagStatus": "tagged",
+            "tagPatternList": ["preprod*"],
+            "countType": "imageCountMoreThan",
+            "countNumber": 10
+          },
+          "action": {
+            "type": "expire"
+          }
+        },
+        {
+          "rulePriority": 4,
+          "description": "Keep last 10 test images",
+          "selection": {
+            "tagStatus": "tagged",
+            "tagPatternList": ["test*"],
+            "countType": "imageCountMoreThan",
+            "countNumber": 10
+          },
+          "action": {
+            "type": "expire"
+          }
+        },
+        {
+          "rulePriority": 5,
+          "description": "Keep last 10 development images",
+          "selection": {
+            "tagStatus": "tagged",
+            "tagPatternList": ["development*"],
+            "countType": "imageCountMoreThan",
+            "countNumber": 10
+          },
+          "action": {
+            "type": "expire"
+          }
+        },
+        {
+          "rulePriority": 6,
+          "description": "Keep the newest 100 images",
+          "selection": {
+            "tagStatus": "any",
+            "countType": "imageCountMoreThan",
+            "countNumber": 100
+          },
+          "action": {
+            "type": "expire"
+          }
+        }
+      ]
+    }
+    EOF
+
+
+  # OPTIONAL: Add deletion_protection = false parameter if you are planning on either deleting your environment namespace or ECR resource.
+  # IMPORTANT: It is the PR owners responsibility to ensure that no other environments are sharing this ECR registry.
+  # This flag will allow a non-empty ECR to be deleted.
+  # Defaults to true
+
+  # deletion_protection = false
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/irsa.tf
@@ -1,0 +1,45 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = var.namespace
+  namespace            = var.namespace # this is also used as a tag
+
+  # Attach the approprate policies using a key => value map
+  # If you're using Cloud Platform provided modules (e.g. SNS, S3), these
+  # provide an output called `irsa_policy_arn` that can be used.
+  role_policy_arns = {
+    ecr = module.ecr.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "${var.namespace}-irsa"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+    rolearn        = module.irsa.role_arn
+  }
+}
+
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.0" # use the latest release
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name # this uses the service account name from the irsa module
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/secret.tf
@@ -1,0 +1,19 @@
+module "secrets_manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "laa-ccms-provider-details-api-secrets" = {
+      description             = "Secrets for provider details api",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-ccms-provider-details-api-secrets"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/serviceaccount.tf
@@ -1,0 +1,93 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories                  = ["laa-ccms-provider-details-api"]
+  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
+  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
+
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "pods/log",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "policy",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "poddisruptionbudgets",
+        "networkpolicies",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "prometheusrules",
+        "servicemonitors",
+      ]
+      verbs = [
+        "*",
+      ]
+    },
+    {
+      api_groups = [
+        "autoscaling",
+      ]
+      resources = [
+        "hpa",
+        "horizontalpodautoscalers",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+      ]
+    },
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/variables.tf
@@ -1,0 +1,115 @@
+variable "eks_cluster_name" {
+  description = "The name of the cluster (eg.: cloud-platform-live-0)"
+  type        = string
+  default     = "example_name"
+}
+
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "client and cost management system"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "laa-ccms-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "LAA"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "laa-ccms-devs"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "ccmspuimodernisation@justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "laa-ccms-support"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the kubernetes cluster name"
+  default     = "KUBE_CLUSTER_DEV"
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  default     = "KUBE_NAMESPACE_DEV"
+}
+
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  default     = "KUBE_CERT_DEV"
+}
+
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  default     = "KUBE_TOKEN_DEV"
+}
+
+variable "github_actions_secret_ecr_name" {
+  description = "The name of the github actions secret containing the ECR name"
+  default     = "ECR_NAME_DEV"
+}
+
+variable "github_actions_secret_ecr_url" {
+  description = "The name of the github actions secret containing the ECR URL"
+  default     = "ECR_URL_DEV"
+}
+
+variable "github_actions_secret_ecr_access_key" {
+  description = "The name of the github actions secret containing the ECR AWS access key"
+  default     = "ECR_AWS_ACCESS_KEY_ID_DEV"
+}
+
+variable "github_actions_secret_ecr_secret_key" {
+  description = "The name of the github actions secret containing the ECR AWS secret key"
+  default     = "ECR_AWS_SECRET_ACCESS_KEY_DEV"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.39.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
New namespace for all ccms applications being migrated from LZ to CP.
This PR is initially for ccms-pda. Further apps to be added in future PRs.