### PR TITLE
HMAI-556 Restrict API Gateway logging in development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/api_gateway.tf
@@ -253,6 +253,6 @@ resource "aws_api_gateway_method_settings" "all" {
   settings {
     metrics_enabled    = true
     logging_level      = "INFO"
-    data_trace_enabled = true
+    data_trace_enabled = false
   }
 }


### PR DESCRIPTION
Our API Gateway logs contain PII and other Personal data. This is not ideal and we hope that changing data_trace_enabled to false will resolve this.