### PR TITLE
Update Team Metadata in Information Exchange Production Namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/00-namespace.yaml
@@ -8,9 +8,9 @@ metadata:
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
-    cloud-platform.justice.gov.uk/slack-channel: "laa-ops-team"
+    cloud-platform.justice.gov.uk/slack-channel: "laa-crimeapps"
     cloud-platform.justice.gov.uk/application: "Information Exchange"
-    cloud-platform.justice.gov.uk/owner: "LAA OPS: laa_ops@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "laa-crime-apps-team: laa-crime-apps@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-infox-application"
-    cloud-platform.justice.gov.uk/team-name: "laa-aws-infrastructure"
+    cloud-platform.justice.gov.uk/team-name: "laa-crime-apps-team"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam = "laa-aws-infrastructure"
+      GithubTeam = var.team_name
     }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/variables.tf
@@ -29,7 +29,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "laa-aws-infrastructure"
+  default     = "laa-crime-apps-team"
 }
 
 variable "environment" {
@@ -41,7 +41,7 @@ variable "environment" {
 variable "infrastructure_support" {
   description = "Email address of the team responsible this service"
   type        = string
-  default     = "laa_ops@digital.justice.gov.uk"
+  default     = "laa-crime-apps@digital.justice.gov.uk"
 }
 
 variable "is_production" {
@@ -53,7 +53,7 @@ variable "is_production" {
 variable "slack_channel" {
   description = "Slack channel name for your team, if we need to contact you about this service"
   type        = string
-  default     = "laa-ops-team"
+  default     = "laa-crimeapps"
 }
 
 variable "github_owner" {


### PR DESCRIPTION
Update team ownership to `crime-apps-team` from `laa-ops` so that we can migrate the service over from the LAA LZ.