### PR TITLE
disable ecr protection

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-df-bid-shiny-dev/resources/ecr.tf
@@ -1,7 +1,8 @@
 module "ecr_credentials" {
-  source         = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
-  repo_name      = "${var.namespace}-ecr"
-  oidc_providers = ["github"]
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  repo_name           = "${var.namespace}-ecr"
+  oidc_providers      = ["github"]
+  deletion_protection = false
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in


### PR DESCRIPTION
Disables ECR protection in df-bid-shiny dev namespace. 