### PR TITLE
`deletion_protection = false` for ECR

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-daap-api/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-firebreak-daap-api/resources/ecr.tf
@@ -12,6 +12,7 @@ module "ecr" {
   # OpenID Connect configuration
   oidc_providers      = ["github"]
   github_repositories = ["data-platform-firebreak-python-api"]
+  deletion_protection = false
 
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
This namespace is no longer needed and a subsequent PR will be raised to delete it.