### PR TITLE
build: set deletion_protection to false for computer-webapp-xhibit

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-xhibit-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-app-commuter-webapp-xhibit-prod/resources/ecr.tf
@@ -73,6 +73,7 @@ EOF
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }
 
 


### PR DESCRIPTION
Preparing to remove an unneeded namespace, following the instructions [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/cleaning-up.html#preparation)