### PR TITLE
Fix: rds version mismatch in court-probation-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/rds-pre-sentence-service.tf
@@ -12,7 +12,7 @@ module "pre_sentence_service_rds" {
   is_production                = var.is_production
   rds_family                   = "postgres14"
   db_instance_class            = "db.t4g.small"
-  db_engine_version            = "14.13"
+  db_engine_version            = "14.17"
   allow_major_version_upgrade  = false
   prepare_for_major_upgrade    = false
   performance_insights_enabled = true

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/variables.tf
@@ -51,7 +51,7 @@ variable "rds-family" {
 }
 
 variable "db_engine_version" {
-  default = "14.13"
+  default = "14.17"
 }
 
 variable "number_cache_clusters" {


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `court-probation-prod`

```
module.court_case_service_rds: downgrade from 14.17 to 14.13
module.pre_sentence_service_rds: downgrade from 14.17 to 14.13
```