### PR TITLE
Fix: rds version mismatch in make-recall-decision-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/postgresql.tf
@@ -18,7 +18,7 @@ module "make_recall_decision_api_rds" {
   rds_name             = "make-recall-decision-${var.environment}"
   rds_family           = "postgres13"
   db_engine            = "postgres"
-  db_engine_version    = "13.16"
+  db_engine_version    = "13.20"
   db_instance_class    = "db.t3.small"
   db_name              = "make_recall_decision"
   db_allocated_storage = 30


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `make-recall-decision-prod`

```
module.make_recall_decision_api_rds: downgrade from 13.20 to 13.16
```