### PR TITLE
Fix: rds version mismatch in court-probation-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/variables.tf
@@ -43,7 +43,7 @@ variable "db_engine" {
 }
 
 variable "db_engine_version" {
-  default = "14.13"
+  default = "14.17"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `court-probation-dev`

```
module.court_case_service_rds: downgrade from 14.17 to 14.13
```