### PR TITLE
Fix: rds version mismatch in formbuilder-platform-test-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-production/resources/submitter.tf
@@ -10,7 +10,7 @@ module "submitter-rds-instance-2" {
   infrastructure_support     = var.infrastructure_support
   team_name                  = var.team_name
   business_unit              = "Platforms"
-  db_engine_version          = "15.8"
+  db_engine_version          = "15.12"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `formbuilder-platform-test-production`

```
module.submitter-rds-instance-2: downgrade from 15.12 to 15.8
```