### PR TITLE
Fix: rds version mismatch in c100-application-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/variables.tf
@@ -29,7 +29,7 @@ variable "namespace" {
 # Database
 
 variable "db_engine_version" {
-  default = "14.13"
+  default = "14.17"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `c100-application-production`

```
module.rds-instance: downgrade from 14.17 to 14.13
```