### PR TITLE
Fix: rds version mismatch in hmpps-probation-estate-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-estate-prod/resources/rds.tf
@@ -9,7 +9,7 @@ module "rds" {
 
   performance_insights_enabled = true
   db_instance_class            = "db.t4g.small"
-  db_engine_version            = "15.8"
+  db_engine_version            = "15.12"
   environment_name             = var.environment
   infrastructure_support       = var.infrastructure_support
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-probation-estate-prod`

```
module.rds: downgrade from 15.12 to 15.8
```