### PR TITLE
Fix: rds version mismatch in licences-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
@@ -14,7 +14,7 @@ module "dps_rds" {
   allow_major_version_upgrade = false
   prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.small"
-  db_engine_version           = "15.8"
+  db_engine_version           = "15.12"
   rds_family                  = "postgres15"
   db_password_rotated_date    = "23-09-2024"
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `licences-prod`

```
module.dps_rds: downgrade from 15.12 to 15.8
```