### PR TITLE
Fix: rds version mismatch in hmpps-user-preferences-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/rds.tf
@@ -9,7 +9,7 @@ module "hmpps_user_preferences_rds" {
   is_production             = var.is_production
   namespace                 = var.namespace
   db_engine                 = "postgres"
-  db_engine_version         = "14.13"
+  db_engine_version         = "14.17"
   rds_family                = "postgres14"
   db_instance_class         = "db.t4g.small"
   environment_name          = var.environment


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-user-preferences-preprod`

```
module.hmpps_user_preferences_rds: downgrade from 14.17 to 14.13
```