### PR TITLE
Fix: rds version mismatch in hmpps-resettlement-passport-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/rds-postgresql.tf
@@ -23,7 +23,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.13"
+  db_engine_version = "14.17"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.small"
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-resettlement-passport-prod`

```
module.rds: downgrade from 14.17 to 14.13
```