### PR TITLE
Fix: rds version mismatch in track-a-query-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/rds.tf
@@ -51,7 +51,7 @@ module "track_a_query_rds_replica" {
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000"
   rds_family               = "postgres16"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
 
   replicate_source_db = module.track_a_query_rds.db_identifier
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `track-a-query-production`

```
module.track_a_query_rds_replica: downgrade from 16.8 to 16.4
```