### PR TITLE
Fix: rds version mismatch in calculate-release-dates-api-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-api-prod/resources/rds.tf
@@ -15,7 +15,7 @@ module "calculate_release_dates_api_rds" {
   # Database configuration
   db_max_allocated_storage     = "250"
   db_engine              = "postgres"
-  db_engine_version      = "16.4"
+  db_engine_version      = "16.8"
   rds_family             = "postgres16"
   
   prepare_for_major_upgrade = false


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `calculate-release-dates-api-prod`

```
module.calculate_release_dates_api_rds: downgrade from 16.8 to 16.4
```