### PR TITLE
Fix: rds version mismatch in hmpps-user-preferences-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/rds.tf
@@ -10,7 +10,7 @@ module "hmpps_user_preferences_rds" {
   namespace                 = var.namespace
   db_instance_class         = "db.t4g.small"
   db_engine                 = "postgres"
-  db_engine_version         = "14.13"
+  db_engine_version         = "14.17"
   rds_family                = "postgres14"
   environment_name          = var.environment
   infrastructure_support    = var.infrastructure_support


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-user-preferences-prod`

```
module.hmpps_user_preferences_rds: downgrade from 14.17 to 14.13
```