### PR TITLE
Fix: rds version mismatch in laa-court-data-adaptor-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds-instance.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/rds-instance.tf
@@ -12,7 +12,7 @@ module "court_data_adaptor_rds" {
   environment_name       = "prod"
   infrastructure_support = var.infrastructure_support
   rds_family             = "postgres14"
-  db_engine_version      = "14.13"
+  db_engine_version      = "14.17"
 
   allow_major_version_upgrade = "true"
   db_instance_class           = "db.t4g.small"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `laa-court-data-adaptor-prod`

```
module.court_data_adaptor_rds: downgrade from 14.17 to 14.13
```