### PR TITLE
Fix: rds version mismatch in utiac-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-prod/resources/rds-postgresql.tf
@@ -14,7 +14,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "14.13"
+  db_engine_version = "14.17"
   rds_family        = "postgres14"
   db_instance_class = "db.t4g.medium"
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `utiac-prod`

```
module.rds: downgrade from 14.17 to 14.13
```