### PR TITLE
Fix: rds version mismatch in formbuilder-saas-live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
@@ -11,7 +11,7 @@ module "metadata-api-rds-instance" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = false
-  db_engine_version          = "15.8"
+  db_engine_version          = "15.12"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
   db_allocated_storage       = "300"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `formbuilder-saas-live`

```
module.metadata-api-rds-instance: downgrade from 15.12 to 15.8
```