### PR TITLE
fix: require actions write permission for cache

### DIFF
--- a/.github/workflows/pr-stale.yaml
+++ b/.github/workflows/pr-stale.yaml
@@ -7,6 +7,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   stale:


### PR DESCRIPTION
## 👀 Purpose

- Allows the bot to override the actions cache and close issues