### PR TITLE
Fix: rds version mismatch in visit-someone-in-prison-backend-svc-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-prod/resources/rds.tf
@@ -68,7 +68,7 @@ module "prison_visit_booker_reg_rds" {
   namespace              = var.namespace
 
   db_engine                    = "postgres"
-  db_engine_version            = "15.8"
+  db_engine_version            = "15.12"
   rds_family                   = "postgres15"
   db_instance_class            = "db.t4g.small"
   db_max_allocated_storage     = "50"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `visit-someone-in-prison-backend-svc-prod`

```
module.prison_visit_booker_reg_rds: downgrade from 15.12 to 15.8
module.visit_scheduler_pg_rds: downgrade from 15.12 to 15.8
```