### PR TITLE
EPT-199: added hmpps template ts

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/template-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/template-ui.tf
@@ -1,0 +1,14 @@
+module "hmpps_template_typescript" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo = "hmpps-electronic-monitoring-data-insights-ui"
+  application = "hmpps-electronic-monitoring-data-insights-ui"
+  github_team = "hmpps-em-probation"
+  environment = var.environment 
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = ">= 6.5.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
Deploying the hmpps-electronic-monitoring-data-insights-ui application to the dev environment currently fails due to `AUTH_CODE_CLIENT_ID not found in the secret ` Been told  the typescript hmpps-template is needed in the namespace, to generate the default secrets files.