### PR TITLE
CAS-1681 - Add new dev group to dev rbac. will test with one dev first

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/01-rbac.yaml
@@ -5,15 +5,18 @@ metadata:
   name: hmpps-community-accommodation-dev-admin
   namespace: hmpps-community-accommodation-dev
 subjects:
-  - kind: Group
-    name: "github:hmpps-sre"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: "github:hmpps-community-accommodation"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: "github:hmpps-sre"
-    apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-sre"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-community-accommodation"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-community-accommodation-devs"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-sre"
+  apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
This work is to unblock one of our developers in the first instance, who needs access to dev namespace.