### PR TITLE
Add Route53 hosted zone for Benefit Checker UAT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-uat/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-uat/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "laa_benefit_checker_uat_route53_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.github_owner
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "laa_benefit_checker_uat_route53_zone_sec" {
+  metadata {
+    name      = "laa-benefit-checker-uat-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.laa_benefit_checker_uat_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.laa_benefit_checker_uat_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-uat/resources/variables.tf
@@ -50,6 +50,11 @@ variable "is_production" {
   default     = "false"
 }
 
+variable "domain" {
+  default = "uat.laa-benefit-checker.service.justice.gov.uk"
+  type    = string
+}
+
 variable "slack_channel" {
   description = "Slack channel name for your team, if we need to contact you about this service"
   type        = string


### PR DESCRIPTION
This PR adds a Route53 hosted zone for the UAT environment of Benefit Checker, to enable a certificate to be separately created with a Common Name of less than 64 characters (which is the limit).

Note: the `laa-benefit-checker.service.justice.gov.uk` hostname defined in this PR does not yet exist, so I'm not sure if creating the subdomain defined in this PR will be possible until it does. If this is the case, I will get the PR for the live environment merged in first to create this hostname (https://github.com/ministryofjustice/cloud-platform-environments/pull/33445).