### PR TITLE
Fix: rds version mismatch in hmpps-book-secure-move-api-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -92,7 +92,7 @@ module "rds-read-replica" {
   db_backup_retention_period = 0
 
   prepare_for_major_upgrade = false
-  db_engine_version         = "16.4"
+  db_engine_version         = "16.8"
   rds_family                = "postgres16"
 
   providers = {


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-book-secure-move-api-production`

```
module.rds-read-replica: downgrade from 16.8 to 16.4
```