### PR TITLE
Fix: rds version mismatch in peoplefinder-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
@@ -17,7 +17,7 @@ module "peoplefinder_rds" {
   db_max_allocated_storage   = "10000"
   db_engine                  = "postgres"
   rds_family                 = "postgres16"
-  db_engine_version          = "16.4"
+  db_engine_version          = "16.8"
   db_backup_retention_period = "7"
   db_name                    = "peoplefinder_production"
   environment_name           = var.environment


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `peoplefinder-production`

```
module.peoplefinder_rds: downgrade from 16.8 to 16.4
```