### PR TITLE
Fix: rds version mismatch in hmpps-registers-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/rds.tf
@@ -16,7 +16,7 @@ module "prisons_rds" {
 
   db_instance_class         = "db.t4g.small"
   db_engine                 = "postgres"
-  db_engine_version         = "16.4"
+  db_engine_version         = "16.8"
   rds_family                = "postgres16"
   db_max_allocated_storage  = "10000"
     # use "allow_major_version_upgrade" when upgrading the major version of an engine


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-registers-prod`

```
module.prisons_rds: downgrade from 16.8 to 16.4
```