### PR TITLE
Fix: rds version mismatch in peoplefinder-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
@@ -48,7 +48,7 @@ module "peoplefinder_rds_replica" {
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000"
   rds_family               = "postgres16"
-  db_engine_version        = "16.4"
+  db_engine_version        = "16.8"
   namespace                = var.namespace
   business_unit            = var.business_unit
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `peoplefinder-production`

```
module.peoplefinder_rds_replica: downgrade from 16.8 to 16.4
```