### PR TITLE
CAS-1681 - add devs team to test namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/01-rbac.yaml
@@ -5,12 +5,15 @@ metadata:
   name: hmpps-community-accommodation-test-admin
   namespace: hmpps-community-accommodation-test
 subjects:
-  - kind: Group
-    name: "github:hmpps-community-accommodation"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: "github:hmpps-sre"
-    apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-community-accommodation"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-community-accommodation-devs"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-sre"
+  apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
Add `hmpps-community-accommodation-devs` github team to `test` namespace