### PR TITLE
CAS-1681: Removed dupe RBAC for SRE and added Live CAS group

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/01-rbac.yaml
@@ -5,15 +5,15 @@ metadata:
   name: hmpps-community-accommodation-preprod-admin
   namespace: hmpps-community-accommodation-preprod
 subjects:
-  - kind: Group
-    name: "github:hmpps-sre"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: "github:hmpps-community-accommodation"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: "github:hmpps-sre"
-    apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-sre"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-community-accommodation"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-community-accommodation-live"
+  apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
- Added `hmpps-community-accommodation-live` to preproduction namespace
- cleaned up duplicate SRE entry.