### PR TITLE
Update laa-landing-page-test network policy to allow monitoring

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-test/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: laa-landing-page-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring


### PR DESCRIPTION
Allow traffic from Prometheus in the monitoring namespace.