### PR TITLE
Fix: rds version mismatch in hmpps-welcome-to-prison-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-prod/resources/rds.tf
@@ -25,7 +25,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11, postgres12, postgres13
   # Pick the one that defines the postgres version the best


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-welcome-to-prison-prod`

```
module.rds: downgrade from 16.8 to 16.4
```