### PR TITLE
Fix: rds version mismatch in licences-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
@@ -14,7 +14,7 @@ module "dps_rds" {
   allow_major_version_upgrade = false
   prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.small"
-  db_engine_version = "15.8"
+  db_engine_version = "15.12"
   rds_family                  = "postgres15"
   db_password_rotated_date    = "14-02-2023"
   enable_rds_auto_start_stop  = true


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `licences-dev`

```
module.dps_rds: downgrade from 15.12 to 15.8
```