### PR TITLE
Fix: rds version mismatch in formbuilder-platform-live-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
@@ -11,7 +11,7 @@ module "submitter-rds-instance-2" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version          = "15.8"
+  db_engine_version          = "15.12"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -11,7 +11,7 @@ module "user-datastore-rds-instance-2" {
   team_name                  = var.team_name
   business_unit              = "Platforms"
   prepare_for_major_upgrade  = true
-  db_engine_version = "15.8"
+  db_engine_version = "15.12"
   rds_family                 = "postgres15"
   db_instance_class          = var.db_instance_class
   db_allocated_storage       = "100"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `formbuilder-platform-live-production`

```
module.user-datastore-rds-instance-2: downgrade from 15.12 to 15.8
module.submitter-rds-instance-2: downgrade from 15.12 to 15.8
```