### PR TITLE
Fix: rds version mismatch in hmpps-candidate-matching-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-candidate-matching-prod/resources/rds.tf
@@ -15,7 +15,7 @@ module "candidate_matching_rds" {
   prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "10000"
-  db_engine_version           = "16.4"
+  db_engine_version           = "16.8"
   deletion_protection         = true
 
   providers = {


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-candidate-matching-prod`

```
module.candidate_matching_rds: downgrade from 16.8 to 16.4
```