### PR TITLE
Fix: rds version mismatch in hmpps-workload-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-history.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-prod/resources/rds-history.tf
@@ -19,7 +19,7 @@ module "rds-history" {
 
   # change the postgres version as you see fit.
   prepare_for_major_upgrade = false
-  db_engine_version         = "15.8"
+  db_engine_version         = "15.12"
 
   environment_name          = var.environment
   infrastructure_support    = var.infrastructure_support


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-workload-prod`

```
module.rds-history: downgrade from 15.12 to 15.8
```