### PR TITLE
Fix: rds version mismatch in offender-management-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
@@ -19,7 +19,7 @@ module "allocation-rds" {
   environment_name            = "production"
   infrastructure_support      = "manage-pom-cases@digital.justice.gov.uk"
   db_engine                   = "postgres"
-  db_engine_version           = "15.8"
+  db_engine_version           = "15.12"
   rds_family                  = "postgres15"
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `offender-management-production`

```
module.allocation-rds: downgrade from 15.12 to 15.8
```