### PR TITLE
Fix: rds version mismatch in send-legal-mail-to-prisons-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
@@ -18,7 +18,7 @@ module "slmtp_api_rds" {
   db_max_allocated_storage    = "500"
   db_engine                   = "postgres"
   rds_family                  = "postgres15"
-  db_engine_version           = "15.8"
+  db_engine_version           = "15.12"
   db_password_rotated_date    = "2023-03-22"
 
   providers = {


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `send-legal-mail-to-prisons-dev`

```
module.slmtp_api_rds: downgrade from 15.12 to 15.8
```