### PR TITLE
Fix: rds version mismatch in hmpps-accredited-programmes-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/rds-postgresql.tf
@@ -21,7 +21,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-accredited-programmes-dev`

```
module.rds: downgrade from 16.8 to 16.4
```