### PR TITLE
Comment out visit events in staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/hmpps-prison-visits-allocation-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/hmpps-prison-visits-allocation-events.tf
@@ -13,7 +13,7 @@ resource "aws_sns_topic_subscription" "hmpps_prison_visits_allocation_events_sub
       "prisoner-offender-search.prisoner.received",
       "prison-offender-events.prisoner.released",
       "prison-offender-events.prisoner.merged",
-      "prison-offender-events.prisoner.booking.moved",
+      "prison-offender-events.prisoner.booking.moved"
 
       # visit events don't get published on staging environment. Commenting out because although we don't subscribe to them here,
       # we still process them on the service, but the messages get added to the SQS via the testing-helper-api by our e2e tests for staging.


### PR DESCRIPTION
## Issue
Most of DPS doesn't have a staging environment but the Visits space does. This causes an issue when visit events are published, because they are published onto the domain-events topic, which only exists for the dev environment. This results in staging SQS consuming dev messages, and failing because they cannot find the information on the staging visits databases.

## Solution
We're commenting out the visit events (booked / cancelled) on staging. Instead of getting these messages from the domain-events topic (which causes the issue), we will manually put onto the staging SQS queue, the visit-booked messages via the e2e testing suites & testing-helper-api. This stops staging seeing any dev related messages for visits, and avoids DLQ spamming.