### PR TITLE
allow resource itself for ListObject

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-preprod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-preprod/resources/s3.tf
@@ -66,6 +66,7 @@ data "aws_iam_policy_document" "dso_user_s3_access_policy" {
     ]
 
     resources = [
+      module.hmpps-prisoner-location_s3_bucket.bucket_arn,
       "${module.hmpps-prisoner-location_s3_bucket.bucket_arn}/*"
     ]
   }


### PR DESCRIPTION
hmpps-prisoner-location-preprod

- without the bucket's actual arn in the allowed resources list s3:ListBucket won't work
- s3:PutObject works because it's acting on arn/* i.e. the contents of the bucket

Required to check whether the new file has already been uploaded to make the workflow running the file upload idempotent
It's going to be called at 02:20 a.m. and again at 03:20 a.m. to deal with GMT/BST

Offloc file upload to the source bucket elsewhere runs at 23:20 and 00:20 UTC for the same reason