### PR TITLE
Fix: rds version mismatch in send-legal-mail-to-prisons-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
@@ -14,7 +14,7 @@ module "slmtp_api_rds" {
   allow_major_version_upgrade = "false"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "15.8"
+  db_engine_version           = "15.12"
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
   db_max_allocated_storage    = "10000"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `send-legal-mail-to-prisons-prod`

```
module.slmtp_api_rds: downgrade from 15.12 to 15.8
```