### PR TITLE
Fix: rds version mismatch in sif-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sif-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sif-staging/resources/rds.tf
@@ -26,7 +26,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
 
   # change the instance class as you see fit.
   db_instance_class        = "db.t4g.micro"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `sif-staging`

```
module.rds: downgrade from 16.8 to 16.4
```