### PR TITLE
Fix: rds version mismatch in manage-soc-cases-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-preprod/resources/rds.tf
@@ -12,7 +12,7 @@ module "dps_rds" {
   application              = var.application
   is_production            = var.is_production
   namespace                = var.namespace
-  db_engine_version        = "15.8"
+  db_engine_version        = "15.12"
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000" # maximum storage for autoscaling
   environment_name         = var.environment_name


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `manage-soc-cases-preprod`

```
module.dps_rds: downgrade from 15.12 to 15.8
```