### PR TITLE
Fix: rds version mismatch in workforce-management-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-prod/resources/rds-allocation.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-prod/resources/rds-allocation.tf
@@ -19,7 +19,7 @@ module "rds-allocation" {
 
   # change the postgres version as you see fit.
   prepare_for_major_upgrade = false
-  db_engine_version = "15.8"
+  db_engine_version = "15.12"
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `workforce-management-prod`

```
module.rds-allocation: downgrade from 15.12 to 15.8
```