### PR TITLE
Fix: rds version mismatch in pathfinder-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prod/resources/rds.tf
@@ -10,7 +10,7 @@ module "dps_rds" {
   namespace                = var.namespace
   db_instance_class        = "db.t4g.small"
   db_max_allocated_storage = "10000" # maximum storage for autoscaling
-  db_engine_version        = "15.8"
+  db_engine_version        = "15.12"
   environment_name         = var.environment_name
   infrastructure_support   = var.infrastructure_support
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `pathfinder-prod`

```
module.dps_rds: downgrade from 15.12 to 15.8
```