### PR TITLE
Fix: rds version mismatch in hmpps-activities-management-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-prod/resources/rds.tf
@@ -18,7 +18,7 @@ module "activities_api_rds" {
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"
   db_instance_class           = "db.t4g.medium"
-  db_engine_version           = "17.2"
+  db_engine_version           = "17.4"
   db_engine                   = "postgres"
   performance_insights_enabled = true
   deletion_protection         = true


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-activities-management-prod`

```
module.activities_api_rds: downgrade from 17.4 to 17.2
```