### PR TITLE
Fix: rds version mismatch in hmpps-manage-people-on-probation-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-prod/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-prod/resources/flipt.tf
@@ -12,7 +12,7 @@ module "flipt-db" {
   namespace                    = var.namespace
   rds_name                     = "manage-people-on-probation-flipt-db-${var.environment}"
   rds_family                   = "postgres16"
-  db_engine_version            = "16.4"
+  db_engine_version            = "16.8"
   db_instance_class            = "db.t4g.small"
   prepare_for_major_upgrade    = false
   allow_major_version_upgrade  = true


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-manage-people-on-probation-prod`

```
module.flipt-db: downgrade from 16.8 to 16.4
```