### PR TITLE
Fix: rds version mismatch in hmpps-tier-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/rds.tf
@@ -10,7 +10,7 @@ module "rds" {
   namespace                    = var.namespace
   rds_name                     = "hmpps-tier-${var.environment_name}"
   rds_family                   = "postgres16"
-  db_engine_version            = "16.4"
+  db_engine_version            = "16.8"
   db_instance_class            = "db.t4g.small"
   prepare_for_major_upgrade    = false
   performance_insights_enabled = true


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-tier-prod`

```
module.rds: downgrade from 16.8 to 16.4
```