### PR TITLE
Fix: rds version mismatch in hmpps-book-secure-move-api-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/rds.tf
@@ -20,7 +20,7 @@ module "rds-instance" {
   db_instance_class    = "db.t4g.2xlarge"
 
   db_engine         = "postgres"
-  db_engine_version = "16.1"
+  db_engine_version = "16.8"
   rds_family        = "postgres16"
 
   prepare_for_major_upgrade = false


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-book-secure-move-api-production`

```
module.rds-instance: downgrade from 16.8 to 16.1
```