### PR TITLE
Fix: rds version mismatch in hmpps-probation-integration-services-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/flipt.tf
@@ -12,7 +12,7 @@ module "flipt-db" {
   namespace                    = var.namespace
   rds_name                     = "probation-integration-flipt-db-${var.environment_name}"
   rds_family                   = "postgres16"
-  db_engine_version            = "16.4"
+  db_engine_version            = "16.8"
   db_instance_class            = "db.t4g.small"
   prepare_for_major_upgrade    = false
   allow_major_version_upgrade  = true


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-probation-integration-services-preprod`

```
module.flipt-db: downgrade from 16.8 to 16.4
```