### PR TITLE
Fix: rds version mismatch in laa-dces-drc-integration-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-prod/resources/rds-postgresql.tf
@@ -29,7 +29,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine                 = "postgres"
-  db_engine_version         = "16.4"
+  db_engine_version         = "16.8"
   rds_family                = "postgres16"
   db_instance_class         = "db.t4g.micro"
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `laa-dces-drc-integration-prod`

```
module.rds: downgrade from 16.8 to 16.4
```