### PR TITLE
Fix: rds version mismatch in visit-someone-in-prison-backend-svc-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-staging/resources/rds.tf
@@ -12,7 +12,7 @@ module "visit_scheduler_rds" {
   allow_major_version_upgrade = "false"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "15.8"
+  db_engine_version           = "15.12"
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.micro"
   db_max_allocated_storage    = "500"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `visit-someone-in-prison-backend-svc-staging`

```
module.visit_scheduler_rds: downgrade from 15.12 to 15.8
```