### PR TITLE
Fix: rds version mismatch in calculate-journey-variable-payments-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-prod/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds-instance" {
   business_unit          = var.business_unit
 
   db_engine         = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   db_instance_class = "db.t4g.large"
 
   rds_family = "postgres16"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `calculate-journey-variable-payments-prod`

```
module.rds-instance: downgrade from 16.8 to 16.4
```