### PR TITLE
Fix: rds version mismatch in hmpps-launchpad-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/rds-launchpad-auth-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/rds-launchpad-auth-postgresql.tf
@@ -21,7 +21,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   rds_family        = "postgres16"
   backup_window     = "02:00-04:00"
   db_instance_class = "db.t4g.large"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-launchpad-prod`

```
module.rds: downgrade from 16.8 to 16.4
```