### PR TITLE
Fix: rds version mismatch in find-unclaimed-court-money-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/rds-postgresql.tf
@@ -28,7 +28,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.small"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `find-unclaimed-court-money-production`

```
module.rds: downgrade from 16.8 to 16.4
```