### PR TITLE
Fix: rds version mismatch in hmpps-person-record-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/hmpps-person-record-read-replica-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/hmpps-person-record-read-replica-rds.tf
@@ -11,7 +11,7 @@ module "hmpps_person_record_rds_read_replica" {
   rds_family                  = "postgres17"
   db_instance_class           = "db.t4g.small"
   db_engine                   = "postgres"
-  db_engine_version           = "17.1"
+  db_engine_version           = "17.4"
   prepare_for_major_upgrade   = false
   allow_major_version_upgrade = "true"
   enable_rds_auto_start_stop  = true


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-person-record-preprod`

```
module.hmpps_person_record_rds_read_replica: downgrade from 17.4 to 17.1
```