### PR TITLE
Fix: rds version mismatch in track-a-query-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-production/resources/rds.tf
@@ -18,7 +18,7 @@ module "track_a_query_rds" {
   db_instance_class          = "db.t4g.medium"
   db_max_allocated_storage   = "10000"
   db_engine                  = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   db_backup_retention_period = "7"
   db_name                    = "track_a_query_production"
   prepare_for_major_upgrade  = false


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `track-a-query-production`

```
module.track_a_query_rds: downgrade from 16.8 to 16.4
```