### PR TITLE
Remove event-service from Integration API to delete api-key.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
@@ -14,7 +14,7 @@ locals {
     "heartbeat",
     "ctrlo",
     "pnd",
-    "event-service",
+    # "event-service",
     "mryall",
     "moj-pes",
     "maspin",


### PR DESCRIPTION
This is to allow us to generate a new key.