### PR TITLE
EL-1638: Upgrade Postgres RDS DB on CCQ PROD - Part 4

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
@@ -20,7 +20,7 @@ module "rds" {
   # Changing the RDS name requires the RDS to be re-created (destroy + create)
   rds_name = "ccq-rds-production"
 
-  prepare_for_major_upgrade = true
+  prepare_for_major_upgrade = false
 
   # enable performance insights
   performance_insights_enabled = true


### PR DESCRIPTION
If applied, this resets the namespace now that DB instance has been upgraded.