### PR TITLE
move github action secrets to github environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mbpr-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mbpr-dev/resources/serviceaccount.tf
@@ -9,4 +9,5 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["mbpr-test"]
+  github_environments = [var.environment]
 }


### PR DESCRIPTION
move github actions secrets to be stored per github environment rather than repository level