### PR TITLE
[CCLF Production] Remove rds access, given last week

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-production/resources/rds.tf
@@ -85,15 +85,6 @@ resource "aws_security_group_rule" "rule1" {
   security_group_id = aws_security_group.rds.id
 }
 
-resource "aws_security_group_rule" "windows_server_laa_stg" {
-  cidr_blocks       = ["10.204.2.94/32"]
-  type              = "ingress"
-  protocol          = "tcp"
-  from_port         = 1521
-  to_port           = 1521
-  security_group_id = aws_security_group.rds.id
-}
-
 resource "aws_security_group_rule" "rule2" {
   cidr_blocks       = ["10.205.0.0/20"]
   type              = "egress"


### PR DESCRIPTION
Reverting this commit, as access is no longer needed - https://github.com/ministryofjustice/cloud-platform-environments/commit/e71108da0a276072a377e9bcabac1e3047831ed2