### PR TITLE
CAS-1681: remove teams no longer allowed to deploy/access to Preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/01-rbac.yaml
@@ -9,9 +9,6 @@ subjects:
   name: "github:hmpps-sre"
   apiGroup: rbac.authorization.k8s.io
 - kind: Group
-  name: "github:hmpps-community-accommodation"
-  apiGroup: rbac.authorization.k8s.io
-- kind: Group
   name: "github:hmpps-community-accommodation-live"
   apiGroup: rbac.authorization.k8s.io
 roleRef:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-approved-premises-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-approved-premises-api.tf
@@ -4,7 +4,7 @@ module "hmpps_approved_premises_api" {
   application = "hmpps-approved-premises-api"
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
-  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation", "hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
+  reviewer_teams                = ["hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
   # selected_branch_patterns      = ["main"] # Optional
   protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-approved-premises-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-approved-premises-ui.tf
@@ -4,7 +4,7 @@ module "hmpps_approved_premises_ui" {
   application = "hmpps-approved-premises-ui"
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
-  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation","hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
+  reviewer_teams                = ["hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
   # selected_branch_patterns      = ["main"] # Optional
   protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-community-accommodation-tier-2-bail-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-community-accommodation-tier-2-bail-ui.tf
@@ -4,7 +4,7 @@ module "hmpps-community-accommodation-tier-2-bail-ui" {
   application = "hmpps-community-accommodation-tier-2-bail-ui"
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
-  reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation", "hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
+  reviewer_teams                = ["hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
   selected_branch_patterns      = ["main"] # Optional
   protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-community-accommodation-tier-2-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-community-accommodation-tier-2-ui.tf
@@ -4,7 +4,7 @@ module "hmpps_community_accommodation_tier_2_ui" {
   application = "hmpps-community-accommodation-tier-2-ui"
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
-  reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation", "hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
+  reviewer_teams                = ["hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
   # selected_branch_patterns      = ["main"] # Optional
   protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-temporary-accommodation-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-preprod/resources/hmpps-temporary-accommodation-ui.tf
@@ -4,7 +4,7 @@ module "hmpps_community_accommodation" {
   application = "hmpps-temporary-accommodation-ui"
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
-  reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation", "hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
+  reviewer_teams                = [ "hmpps-community-accommodation-live"] # Optional team that should review deployments to this environment.
   # selected_branch_patterns      = ["main"] # Optional
   protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production


### PR DESCRIPTION
This environment is now restricted to GH users within `hmpps-community-accommodation-live` team only.
- Deployments.
- K8s access.