### PR TITLE
`intranet-production` Add DNS for old JAC intranet domain

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/route53-alt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/route53-alt.tf
@@ -1,0 +1,26 @@
+# This file contains the Route53 resources related to domains other than intranet.justice.gov.uk
+resource "aws_route53_zone" "jac_intranet_service_justice_gov_uk_zone" {
+  name = "jac.intranet.service.justice.gov.uk"
+
+  tags = {
+    business_unit          = var.business_unit
+    application            = var.application
+    is_production          = var.is_production
+    team_name              = var.team_name
+    namespace              = var.namespace
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "route53_alt_zone_sec" {
+  metadata {
+    name      = "route53-alt-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    jac_zone_id      = aws_route53_zone.jac_intranet_service_justice_gov_uk_zone.zone_id
+    jac_name_servers = join("\n", aws_route53_zone.jac_intranet_service_justice_gov_uk_zone.name_servers)
+  }
+}


### PR DESCRIPTION
Hi @wilson1000 , can I get some input on this?

Currently there is a service that is redirecting visitors from the old JAC intranet

The old domain is jac.intranet.service.justice.gov.uk 
And the repo is at https://github.com/ministryofjustice/wp-intranet-jac

With this PR and an update to DNS records, we could bring the redirect into `intranet-production`'s ingress with a rule like 

```
# If the host is jac.intranet.service.justice.gov.uk then
# redirect to the https://intranet.justice.gov.uk/?agency=jac
if ($host = "jac.intranet.service.justice.gov.uk") {
    return 301 https://intranet.justice.gov.uk/?agency=jac;
}
```

Then we could safely archive the JAC repo, and remove it from wherever it is hosted. Ultimately reducing our surface area for security attacks.