### PR TITLE
Fix: rds version mismatch in hmpps-person-record-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-prod/resources/rds.tf
@@ -11,7 +11,7 @@ module "hmpps_person_record_rds" {
   rds_family                   = "postgres17"
   db_instance_class            = "db.r6g.2xlarge"
   db_engine                    = "postgres"
-  db_engine_version            = "17.1"
+  db_engine_version            = "17.4"
   prepare_for_major_upgrade    = false
   performance_insights_enabled = true
   allow_major_version_upgrade  = "true"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-person-record-prod`

```
module.hmpps_person_record_rds: downgrade from 17.4 to 17.1
```