### PR TITLE
Fix: rds version mismatch in hmpps-activities-management-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/rds.tf
@@ -104,7 +104,7 @@ module "activities_rds_read_replica" {
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"
   db_instance_class           = "db.t4g.small"
-  db_engine_version           = "17.2"
+  db_engine_version           = "17.4"
   storage_type                = "gp3"
   db_max_allocated_storage    = "50"
   replicate_source_db         = module.activities_rds.db_identifier


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-activities-management-dev`

```
module.activities_rds_read_replica: downgrade from 17.4 to 17.2
```