### PR TITLE
ACD-499: Upgrade RDS instance type

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds_new.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-mock-api-dev/resources/rds_new.tf
@@ -15,7 +15,8 @@ module "hmcts_mock_api_rds_instance" {
   rds_family             = "postgres14"
 
   allow_major_version_upgrade = "true"
-  db_instance_class           = "db.t3.small"
+  db_instance_class           = "db.t4g.small"
+  db_max_allocated_storage    = "500"
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
This is a non-prod DB, so 500 seems an appropriate max storage. However, as the instance type was already "small" I don't want to downgrade to micro.