### PR TITLE
BAVL-914 subscribe to the prisoner received at prison domain event for the BVLS API to process.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/domain-events-queue-bvls.tf
@@ -117,6 +117,7 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
       "prison-offender-events.prisoner.merged",
       "prison-offender-events.prisoner.video-appointment.cancelled",
       "prison-offender-events.prisoner.appointments-changed",
+      "prisoner-offender-search.prisoner.received",
     ]
   })
 }


### PR DESCRIPTION
When this event occurs the book a video link service needs check if it impacts any of its bookings and take the appropriate action if it does.