### PR TITLE
Disable ECR deletion protection for laa-crime-validation-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-validation-dev/resources/ecr.tf
@@ -7,6 +7,8 @@
 module "ecr" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
 
+  deletion_protection = false
+
   # REQUIRED: Repository configuration
   repo_name = var.namespace
 


### PR DESCRIPTION
This PR disables ECR deletion protection for `laa-crime-validation-dev` to enable the namespace and all contained resources to be deleted, as the decision has been made that the service is no longer required.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4123)