### PR TITLE
AP-6070: Add service account permissions [Assure Staging]

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/serviceaccount.tf
@@ -10,4 +10,6 @@ module "serviceaccount" {
   github_actions_secret_kube_token     = var.github_actions_secret_kube_token
   github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
   github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+
+  serviceaccount_rules = var.serviceaccount_rules
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/variables.tf
@@ -92,3 +92,67 @@ variable "github_actions_secret_kube_cluster" {
 variable "eks_cluster_name" {
   description = "The name of the eks cluster to retrieve the OIDC information"
 }
+
+variable "serviceaccount_rules" {
+  description = "The capabilities of this serviceaccount"
+
+  type = list(object({
+    api_groups = list(string),
+    resources  = list(string),
+    verbs      = list(string)
+  }))
+
+  # These values are default plus custom to allow for deletion of UAT branches via CI/CD pipeline
+  default = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "configmaps",
+        "persistentvolumeclaims",
+        "serviceaccounts",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "monitoring.coreos.com",
+        "policy",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "replicasets",
+        "statefulsets",
+        "poddisruptionbudgets",
+        "servicemonitors",
+        "prometheusrules",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
+}


### PR DESCRIPTION
Add service account permissions [Assure Staging]

Required for ClamAV PVC and configmaps as well as defaults