### PR TITLE
Avoid DKIM 255 char limit by setting over several strings

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-finucane.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-finucane.tf
@@ -60,13 +60,6 @@ resource "aws_route53_record" "finucane_route53_dkim" {
   type    = "TXT"
   ttl     = 300
   records = [
-    resource "aws_route53_record" "dkim_record" {
-  zone_id = aws_route53_zone.example.zone_id
-  name    = "sophos6ccbafd5a548420e95312e0473634265._domainkey"
-  type    = "TXT"
-  ttl     = 300
-
-  records = [
     "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugfVMdz1tPmlB2oEiIhVLeZnRUzge+doPPTmRvbmhtkPzFGA+mkV49eRXbakmS4pTUgb4DF2A3M5d",
     "uqLDbhxUDG9Jmg7Yavq6qqPYACVai/pPws+mekRMjlUhSxxa6tiqgWRd5Aw+b154uslY4GzaZCrioKd/l0WCKYD3pE2TQlo0u7eev9ViU7NtrieJiEbpfbhAeJx3DkI4zP991sdu",
     "cdz0p7q9Qk4ApuxwDbPnkXiZFWKKcf9KBNu3OYbQkVLAalwjihxKqSMPnbRLZMGbuS3/9DW/cHH9zRoKGS7yJjUVVHJ3clYTn7xzD8PFcwqoFVfPDnCnuOIniLrtgl51QIDAQAB;"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-finucane.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-finucane.tf
@@ -60,7 +60,16 @@ resource "aws_route53_record" "finucane_route53_dkim" {
   type    = "TXT"
   ttl     = 300
   records = [
-    "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugfVMdz1tPmlB2oEiIhVLeZnRUzge+doPPTmRvbmhtkPzFGA+mkV49eRXbakmS4pTUgb4DF2A3M5d\"\"uqLDbhxUDG9Jmg7Yavq6qqPYACVai/pPws+mekRMjlUhSxxa6tiqgWRd5Aw+b154uslY4GzaZCrioKd/l0WCKYD3pE2TQlo0u7eev9ViU7NtrieJiEbpfbhAeJx3DkI4zP991sducdz0p7q9Qk4ApuxwDbPnkXiZFWKKcf9KBNu3OYbQkVLAalwjihxKqSMPnbRLZMGbuS3/9DW/cHH9zRoKGS7yJjUVVHJ3clYTn7xzD8PFcwqoFVfPDnCnuOIniLrtgl51QIDAQAB;"
+    resource "aws_route53_record" "dkim_record" {
+  zone_id = aws_route53_zone.example.zone_id
+  name    = "sophos6ccbafd5a548420e95312e0473634265._domainkey"
+  type    = "TXT"
+  ttl     = 300
+
+  records = [
+    "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugfVMdz1tPmlB2oEiIhVLeZnRUzge+doPPTmRvbmhtkPzFGA+mkV49eRXbakmS4pTUgb4DF2A3M5d",
+    "uqLDbhxUDG9Jmg7Yavq6qqPYACVai/pPws+mekRMjlUhSxxa6tiqgWRd5Aw+b154uslY4GzaZCrioKd/l0WCKYD3pE2TQlo0u7eev9ViU7NtrieJiEbpfbhAeJx3DkI4zP991sdu",
+    "cdz0p7q9Qk4ApuxwDbPnkXiZFWKKcf9KBNu3OYbQkVLAalwjihxKqSMPnbRLZMGbuS3/9DW/cHH9zRoKGS7yJjUVVHJ3clYTn7xzD8PFcwqoFVfPDnCnuOIniLrtgl51QIDAQAB"
   ]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-finucane.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-finucane.tf
@@ -69,7 +69,7 @@ resource "aws_route53_record" "finucane_route53_dkim" {
   records = [
     "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugfVMdz1tPmlB2oEiIhVLeZnRUzge+doPPTmRvbmhtkPzFGA+mkV49eRXbakmS4pTUgb4DF2A3M5d",
     "uqLDbhxUDG9Jmg7Yavq6qqPYACVai/pPws+mekRMjlUhSxxa6tiqgWRd5Aw+b154uslY4GzaZCrioKd/l0WCKYD3pE2TQlo0u7eev9ViU7NtrieJiEbpfbhAeJx3DkI4zP991sdu",
-    "cdz0p7q9Qk4ApuxwDbPnkXiZFWKKcf9KBNu3OYbQkVLAalwjihxKqSMPnbRLZMGbuS3/9DW/cHH9zRoKGS7yJjUVVHJ3clYTn7xzD8PFcwqoFVfPDnCnuOIniLrtgl51QIDAQAB"
+    "cdz0p7q9Qk4ApuxwDbPnkXiZFWKKcf9KBNu3OYbQkVLAalwjihxKqSMPnbRLZMGbuS3/9DW/cHH9zRoKGS7yJjUVVHJ3clYTn7xzD8PFcwqoFVfPDnCnuOIniLrtgl51QIDAQAB;"
   ]
 }
 


### PR DESCRIPTION
Txt DNS must be split into 255 chunks. We have two approaches- either put in a special break `\"\"` or I am trying the approach of putting the value over several strings and letting terraform concatenate together.