### PR TITLE
CAS API - Remove deploy branch restriction for test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-api.tf
@@ -5,8 +5,8 @@ module "hmpps_approved_premises_api" {
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
   reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation", "hmpps-community-accommodation-devs"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline
-  # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
+  # selected_branch_patterns      = ["*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline
+  protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
   source_template_repo          = "hmpps-template-kotlin"


### PR DESCRIPTION
The test environment deployment pipeline is completely decoupled from other environments. As such, no deployment to test can be promoted or pushed to any other environments, and it is safe to deploy experimental builds from branches.