### PR TITLE
Disable deletion protection on ECR in dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/ecr.tf
@@ -14,6 +14,9 @@ module "ecr" {
   oidc_providers      = ["github"]
   github_repositories = ["hmpps-esupervision-api", "hmpps-esupervision-ui"]
 
+  # disable deletion protection
+  deletion_protection = false
+
   # Tags
   business_unit          = var.business_unit
   application            = var.application


### PR DESCRIPTION
The ECR instance in the HMPPS esupervision dev namespace is no longer required. Disable deletion protection so it can be deleted in a future PR.