### PR TITLE
Change environment name in dev namespace for esupervision

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/variables.tf
@@ -35,7 +35,7 @@ variable "team_name" {
 variable "environment" {
   description = "Name of the environment type for this service"
   type        = string
-  default     = "development"
+  default     = "dev"
 }
 
 variable "infrastructure_support" {


### PR DESCRIPTION
Various build components expect the environment name to be 'dev' instead of 'development' so update the name to match.