### PR TITLE
CAS - Allow branch names that include a slash for deployments to test environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-api.tf
@@ -5,7 +5,7 @@ module "hmpps_approved_premises_api" {
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
   reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation", "hmpps-community-accommodation-devs"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline
+  selected_branch_patterns      = ["*", "*/*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline.
   # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-approved-premises-ui.tf
@@ -5,7 +5,7 @@ module "hmpps_approved_premises_ui" {
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
   reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation","hmpps-community-accommodation-devs"] # Optional, team that should review deployments to this environment.
-  selected_branch_patterns      = ["*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline
+  selected_branch_patterns      = ["*", "*/*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline.
   # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-community-accommodation-tier-2-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-community-accommodation-tier-2-ui.tf
@@ -5,7 +5,7 @@ module "hmpps_community_accommodation_tier_2_ui" {
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
   reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation","hmpps-community-accommodation-devs"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline
+  selected_branch_patterns      = ["*", "*/*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline.
   # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-temporary-accommodation-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-temporary-accommodation-ui.tf
@@ -5,7 +5,7 @@ module "hmpps_temporary_accommodation_ui" {
   github_team = "hmpps-community-accommodation"
   environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
   reviewer_teams                = ["hmpps-temporary-accommodation", "hmpps-community-accommodation","hmpps-community-accommodation-devs"] # Optional team that should review deployments to this environment.
-  selected_branch_patterns      = ["*"] # Optional
+  selected_branch_patterns      = ["*", "*/*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline.
   # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"


### PR DESCRIPTION
A single wildcard does not match branch names that contain slashes [1]. This change ensures that branch names with one slash are a match for the pattern.

[1] https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#deployment-branches-and-tags