### PR TITLE
BAVL-914 subscribe to the prisoner received at prison domain event for the BVLS API to process in prod.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-prod/resources/domain-events-queue-bvls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-prod/resources/domain-events-queue-bvls.tf
@@ -116,6 +116,7 @@ resource "aws_sns_topic_subscription" "hmpps_book_a_video_link_domain_subscripti
       "prison-offender-events.prisoner.merged",
       "prison-offender-events.prisoner.video-appointment.cancelled",
       "prison-offender-events.prisoner.appointments-changed",
+      "prisoner-offender-search.prisoner.received",
     ]
   })
 }


### PR DESCRIPTION
Same as PREPROD PR [here](https://github.com/ministryofjustice/cloud-platform-environments/pull/33947) but for PROD.

When a prisoner is received into a prison this event is fired.

When this event is fired the book a video link service needs check if it impacts any of its bookings and take the appropriate action if it does.