### PR TITLE
CRIMAPP-1711 Upgrade Postgres to v17 on Crime Apply staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/rds.tf
@@ -15,17 +15,17 @@ module "rds" {
 
   # change the postgres version as you see fit.
   db_engine         = "postgres"
-  db_engine_version = "15"
+  db_engine_version = "17"
 
   # change the instance class as you see fit.
   db_instance_class        = "db.t4g.micro"
   db_max_allocated_storage = "500"
 
   # Pick the one that defines the postgres version the best
-  rds_family = "postgres15"
+  rds_family = "postgres17"
 
   # use "prepare_for_major_upgrade" when upgrading the major version of an engine
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade = true
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Upgrade RDS Postgres version to 17 for `laa-apply-for-criminal-legal-aid-staging`.