### PR TITLE
Fix: rds version mismatch in hmpps-registers-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/rds.tf
@@ -56,7 +56,7 @@ module "dps_rds_replica" {
   # PostgreSQL specifics
   prepare_for_major_upgrade   = false
   db_engine         = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.small"
   allow_minor_version_upgrade = true


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-registers-prod`

```
module.dps_rds_replica: downgrade from 16.8 to 16.4
```