### PR TITLE
Fix: rds version mismatch in laa-crime-application-store-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-production/resources/rds-postgresql.tf
@@ -60,7 +60,7 @@ module "read_replica" {
 
   # PostgreSQL specifics
   db_engine                 = "postgres"
-  db_engine_version         = "16.4"
+  db_engine_version         = "16.8"
   rds_family                = "postgres16"
   db_instance_class         = "db.t4g.micro"
   db_max_allocated_storage  = "1000"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `laa-crime-application-store-production`

```
module.read_replica: downgrade from 16.8 to 16.4
```