### PR TITLE
Allow ingress access to laa-cwa-submissions-api-test from laa-cwa-bulk-upload-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/00-namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: "laa-cwa-submissions-api-test"
   labels:
+    cloud-platform.justice.gov.uk/namespace: "laa-cwa-submissions-api-test"
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "test"
     pod-security.kubernetes.io/enforce: restricted

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-source-namespace
+  namespace: laa-cwa-submissions-api-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: "laa-cwa-bulk-upload-dev"


### PR DESCRIPTION
Following the documentation I labelled my namespace and added an ingress rule so that another namespace can have access to resources running in laa-cwa-submissions-api-test.