### PR TITLE
CRIMAPP-1711 Finish Postgres upgrade on Crime Datastore staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/rds.tf
@@ -25,7 +25,7 @@ module "rds" {
   rds_family = "postgres17"
 
   # use "prepare_for_major_upgrade" when upgrading the major version of an engine
-  prepare_for_major_upgrade = true
+  prepare_for_major_upgrade = false
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Turn off `prepare_for_major_upgrade` now that Postgres is upgraded.