### PR TITLE
CRIMAPP-1711 Upgrade Postgres to v16 on Crime Datastore production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/rds.tf
@@ -22,9 +22,12 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "15"
-  rds_family        = "postgres15"
+  db_engine_version = "16"
+  rds_family        = "postgres16"
   db_instance_class = "db.t4g.small"
+
+  # use "prepare_for_major_upgrade" when upgrading the major version of an engine
+  prepare_for_major_upgrade = true
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Upgrade RDS Postgres version to 16 for `laa-criminal-applications-datastore-production`.
Upgrade to version 17 to follow.