### PR TITLE
CRIMAPP-1711 Finish Postgres 16 upgrade on Crime Apply production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/rds.tf
@@ -27,7 +27,7 @@ module "rds" {
   db_instance_class = "db.t4g.small"
 
   # use "prepare_for_major_upgrade" when upgrading the major version of an engine
-  prepare_for_major_upgrade = true
+  prepare_for_major_upgrade = false
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Turn off `prepare_for_major_upgrade` now that Postgres is upgraded to v16. Upgrade to v17 to follow.