### PR TITLE
Define S3 bucket and IRSA configuration for esupervision app

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/irsa.tf
@@ -1,0 +1,34 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "hmpps-esupervision-api"
+  role_policy_arns = {
+    s3 = module.s3_data_bucket.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+# IRSA role used to authenticate bucket requests
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "hmpps-esupervision-api-irsa"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/s3.tf
@@ -1,0 +1,50 @@
+module "s3_data_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.2.0"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+
+  /*
+   * NOTE: CORS config might be required in future
+   * The following example can be used if you need to define CORS rules for your s3 bucket.
+   *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-cors"
+   *
+
+  cors_rule =[
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET"]
+      allowed_origins = ["https://s3-website-test.hashicorp.com"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    },
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["PUT"]
+      allowed_origins = ["https://s3-website-test.hashicorp.com"]
+      expose_headers  = [""]
+      max_age_seconds = 3000
+    },
+  ]
+
+  */
+}
+
+# info about the bucket
+resource "kubernetes_secret" "s3_bucket" {
+  metadata {
+    name      = "hmpps-esupervision-data-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.s3_data_bucket.bucket_arn
+    bucket_name = module.s3_data_bucket.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/variables.tf
@@ -8,6 +8,10 @@ variable "kubernetes_cluster" {
   type        = string
 }
 
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}
+
 variable "application" {
   description = "Name of the application you are deploying"
   type        = string


### PR DESCRIPTION
Define an S3 data bucket with the default access policy for the HMPPS esupervision application. Add an IRSA role to the namespace so the API pod can access the bucket.