### PR TITLE
CRIMAPP-1711 Upgrade Postgres to v17 on Crime Review production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/rds.tf
@@ -22,12 +22,12 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16"
-  rds_family        = "postgres16"
+  db_engine_version = "17"
+  rds_family        = "postgres17"
   db_instance_class = "db.t4g.small"
 
   # use "prepare_for_major_upgrade" when upgrading the major version of an engine
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade = true
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"


### PR DESCRIPTION
Upgrade RDS Postgres version to 17 for `laa-review-criminal-legal-aid-production`.