### PR TITLE
network policy re-instate

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/04-networkpolicy.yaml
@@ -25,18 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-# ---
-# kind: NetworkPolicy
-# apiVersion: networking.k8s.io/v1
-# metadata:
-#   name: allow-source-namespace
-#   namespace: laa-cwa-submissions-api-test
-# spec:
-#   podSelector: {}
-#   policyTypes:
-#   - Ingress
-#   ingress:
-#   - from:
-#     - namespaceSelector:
-#         matchLabels:
-#           cloud-platform.justice.gov.uk/namespace: "laa-cwa-bulk-upload-dev"
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-source-namespace
+  namespace: laa-cwa-submissions-api-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: "laa-cwa-bulk-upload-dev"


### PR DESCRIPTION
Re-instate a network policy to allow ingress from another cp namespace.