### PR TITLE
Remove SQS policies from integration events

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/irsa.tf
@@ -45,7 +45,6 @@ module "hmpps-integration-event-irsa" {
   namespace            = var.namespace
   service_account_name = "hmpps-integration-event"
   role_policy_arns = merge(
-    local.sqs_policies,
     {
       integration_api_domain_events_queue             = module.integration_api_domain_events_queue.irsa_policy_arn,
       integration_api_domain_events_dead_letter_queue = module.integration_api_domain_events_dead_letter_queue.irsa_policy_arn,


### PR DESCRIPTION
I don't believe that the events service needs any access to the SQS policies as these queues are only used in the HMPPS Integration API