### PR TITLE
CAS-1681 - additional - add dev team to the CAS2 Bail prototype

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-tier-2-bail-prototypes/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-tier-2-bail-prototypes/01-rbac.yaml
@@ -4,9 +4,12 @@ metadata:
   name: hmpps-community-accommodation-tier-2-bail-prototypes-admin
   namespace: hmpps-community-accommodation-tier-2-bail-prototypes
 subjects:
-  - kind: Group
-    name: "github:hmpps-cas-bail-alpha"
-    apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-cas-bail-alpha"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "github:hmpps-community-accommodation-devs"
+  apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
add the CAS Devs to the team which should allow pushes to the prototype.