### PR TITLE
Give access to the `laa-cwa-submissions-test` namespace to the `cwa-bulkupload-app-team` GitHub team.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:laa-pcuam"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:cwa-bulkupload-app-team"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
The `cwa-bulkupload-app-team` GitHub team members need access to `laa-cwa-submissions-test`.