### PR TITLE
Add IP allowlist secret for test Hardship Service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-hardship-test/resources/secret.tf
@@ -45,5 +45,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "sentry-dsn"
     },
+    "ingress_internal_allowlist_source_range" = {
+      description             = "Internal IP allowlist for Hardship Test",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "ingress-internal-allowlist-source-range"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a new secret for the IP allowlist for the test Hardship Service.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4143)