### PR TITLE
Add IP allowlist secret for test Contributions Service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-contribution-test/resources/secret.tf
@@ -34,6 +34,11 @@ module "secrets_manager" {
       description             = "Sentry Data Source Name (DSN) for CCC Test",
       recovery_window_in_days = 7
       k8s_secret_name         = "sentry-dsn"
-    }
+    },
+    "ingress_internal_allowlist_source_range" = {
+      description             = "Internal IP allowlist for CCC Test",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "ingress-internal-allowlist-source-range"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a new secret for the IP allowlist for the test Contributions Service.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4145)