### PR TITLE
Add IP allowlist secret for test Application Tracking Service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-test/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-tracking-service-test/resources/secret.tf
@@ -20,5 +20,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "sentry-dsn"
     },
+    "ingress_internal_allowlist_source_range" = {
+      description             = "Internal IP allowlist for ATS Test",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "ingress-internal-allowlist-source-range"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a new secret for the IP allowlist for the test Application Tracking Service.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4147)