### PR TITLE
Update secret name to store JKS content PRE-PROD

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-preproduction/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-preproduction/resources/secrets.tf
@@ -40,10 +40,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "infox-libra-client-secret"
     },
-    "laa-infox-keystore-location" = {
-      description             = "Location of Keystore",
+    "laa-infox-keystore" = {
+      description             = "JKS Keystore",
       recovery_window_in_days = 7,
-      k8s_secret_name         = "laa-infox-keystore-location-preprod"
+      k8s_secret_name         = "laa-infox-keystore-preprod"
     }
   }
 }


### PR DESCRIPTION
Renamed the secret from `laa-infox-keystore-location` to `laa-infox-keystore` to reflect the change from storing a file path to storing the actual JKS file content in AWS Secrets Manager.

This prepares the service to load the keystore directly from the secret instead of relying on a mounted file location.