### PR TITLE
Add alert handling for CCR production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: laa-crown-court-remuneration-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/05-prometheus.yaml
@@ -150,3 +150,21 @@ spec:
         message: CCR PRODUCTION - {{ $labels.pod }} is restarting excessively
         runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/AAC/pages/3160014895/Crown+Court+Remuneration+CCR+Runbook#Monitoring-and-Alerting"
         dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/application-alerts/application-alerts?orgId=1&var-namespace=laa-crown-court-remuneration-production"
+
+    - alert: CCR-Payment-Get-Errors
+      expr: increase(payment_get_errors_total{namespace="laa-crown-court-remuneration-production"}[5m]) > 0
+      labels:
+        severity: laa-crown-court-remuneration-production
+      annotations:
+        message: CCR PRODUCTION - {{ printf "%0.0f" $value }} new payment get errors in the last 5 minutes.
+        runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/AAC/pages/3160014895/Crown+Court+Remuneration+CCR+Runbook#Monitoring-and-Alerting"
+        dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/application-alerts/application-alerts?orgId=1&var-namespace=laa-crown-court-remuneration-production"
+
+    - alert: CCR-Payment-Post-Errors
+      expr: increase(payment_post_errors_total{namespace="laa-crown-court-remuneration-production"}[5m]) > 0
+      labels:
+        severity: laa-crown-court-remuneration-production
+      annotations:
+        message: CCR PRODUCTION - {{ printf "%0.0f" $value }} new payment post errors in the last 5 minutes.
+        runbook_url: "https://dsdmoj.atlassian.net/wiki/spaces/AAC/pages/3160014895/Crown+Court+Remuneration+CCR+Runbook#Monitoring-and-Alerting"
+        dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/application-alerts/application-alerts?orgId=1&var-namespace=laa-crown-court-remuneration-production"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/06-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/06-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: laa-crown-court-remuneration-app
+  namespace: laa-crown-court-remuneration-production
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: laa-crown-court-remuneration-production
+      app.kubernetes.io/name: laa-crown-court-remuneration-app
+  endpoints:
+  - port: http
+    path: /ccr/metrics 
+    interval: 30s


### PR DESCRIPTION
Add support for scraping of our metrics endpoint `ccr/metrics` and configure Prometheus alerts based on possible error scenarios