### PR TITLE
Tag untagged resources

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
@@ -69,10 +69,10 @@ resource "aws_db_option_group" "sqlserver_backup_rds_option_group" {
 
   tags = {
     application            = var.application
-    business_unit          = var.business_unit
-    environment_name       = var.environment
-    infrastructure_support = var.infrastructure_support
-    is_production          = var.is_production
+    business-unit          = var.business_unit
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    is-production          = var.is_production
     namespace              = var.namespace
     team_name              = var.team_name
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
@@ -67,6 +67,16 @@ resource "aws_db_option_group" "sqlserver_backup_rds_option_group" {
   engine_name              = "sqlserver-web"
   major_engine_version     = "15.00"
 
+  tags = {
+    application            = var.application
+    business_unit          = var.business_unit
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+    is_production          = var.is_production
+    namespace              = var.namespace
+    team_name              = var.team_name
+  }
+
   option {
     option_name = "SQLSERVER_BACKUP_RESTORE"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/rds-mssql.tf
@@ -69,10 +69,10 @@ resource "aws_db_option_group" "sqlserver_backup_rds_option_group" {
 
   tags = {
     application            = var.application
-    business_unit          = var.business_unit
-    environment_name       = var.environment
-    infrastructure_support = var.infrastructure_support
-    is_production          = var.is_production
+    business-unit          = var.business_unit
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    is-production          = var.is_production
     namespace              = var.namespace
     team_name              = var.team_name
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-db-analysis/resources/rds-mssql.tf
@@ -67,6 +67,16 @@ resource "aws_db_option_group" "sqlserver_backup_rds_option_group" {
   engine_name              = "sqlserver-web"
   major_engine_version     = "16.00"
 
+  tags = {
+    application            = var.application
+    business_unit          = var.business_unit
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+    is_production          = var.is_production
+    namespace              = var.namespace
+    team_name              = var.team_name
+  }
+
   option {
     option_name = "SQLSERVER_BACKUP_RESTORE"
 


### PR DESCRIPTION
Adding mandatory tags as a part of mandatory tagging work to untagged RDS options groups - [#6972](https://github.com/ministryofjustice/cloud-platform/issues/6972)

Tags copied from existing RDS instances that use the options groups 