### PR TITLE
FRI-967: Add SQS resources for Find and Refer preprod and prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/domain-events-topic.tf
@@ -14,5 +14,5 @@ data "aws_ssm_parameter" "hmpps-domain-events-topic-arn" {
 }
 
 data "aws_sns_topic" "hmpps-domain-events" {
-  name = "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573"
+  name = "cloud-platform-Digital-Prison-Services-15b2b4a6af7714848baeaf5f41c85fcd"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/domain-events-topic.tf
@@ -1,0 +1,18 @@
+resource "kubernetes_secret" "hmpps_find_and_refer_hmpps_domain_events_topic" {
+  metadata {
+    name      = "hmpps-domain-events-topic"
+    namespace = var.namespace
+  }
+
+  data = {
+    topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
+  }
+}
+
+data "aws_ssm_parameter" "hmpps-domain-events-topic-arn" {
+  name = "/hmpps-domain-events-dev/topic-arn"
+}
+
+data "aws_sns_topic" "hmpps-domain-events" {
+  name = "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/isra.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/isra.tf
@@ -3,6 +3,7 @@
 # This information is used to collect the IAM policies which are used by the IRSA module.
 locals {
   sqs_queues = {
+#    "Digital-Prison-Services-dev-hmpps_audit_queue" = "hmpps-audit-dev",
     "Digital-Prison-Services-${var.environment}-hmpps_audit_queue" = "hmpps-audit-${var.environment}",
   }
 
@@ -16,16 +17,24 @@ module "irsa" {
   eks_cluster_name       = var.eks_cluster_name
   namespace              = var.namespace
   service_account_name   = "hmpps-find-and-refer-intervention"
+
   role_policy_arns = merge(
     { elasticache = module.elasticache_redis.irsa_policy_arn },
+    {
+      sqs = module.hmpps_find_and_refer_domain_events_queue.irsa_policy_arn
+    },
+    {
+      sqs_dlq = module.hmpps_find_and_refer_domain_events_dlq.irsa_policy_arn
+    },
     local.sqs_policies,
   )
+
   # Tags
   business_unit          = var.business_unit
   application            = var.application
   is_production          = var.is_production
   team_name              = var.team_name
-  environment_name       = var.environment
+  environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/sqs-domain-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/sqs-domain-events.tf
@@ -1,0 +1,75 @@
+module "hmpps_find_and_refer_domain_events_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name                  = "hmpps_find_and_refer_domain_events_queue"
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.hmpps_find_and_refer_domain_events_dlq.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "aws_sqs_queue_policy" "hmpps_find_and_refer_domain_events_queue_policy" {
+  queue_url = module.hmpps_find_and_refer_domain_events_queue.sqs_id
+  policy    = data.aws_iam_policy_document.sqs_queue_policy_document.json
+}
+
+module "hmpps_find_and_refer_domain_events_dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name        = "hmpps_find_and_refer_domain_events_dlq"
+  message_retention_seconds = 7 * 24 * 3600 # 1 week
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "aws_sns_topic_subscription" "hmpps_find_and_refer_domain_events_subscription" {
+  topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
+  protocol  = "sqs"
+  endpoint  = module.hmpps_find_and_refer_domain_events_queue.sqs_arn
+  filter_policy = jsonencode({
+    eventType = [
+      "probation-case.requirement.created",
+      "probation-case.licence-condition.created"
+    ]
+  })
+}
+
+resource "kubernetes_secret" "hmpps_find_and_refer_domain_events_queue_secret" {
+  metadata {
+    name      = "sqs-domain-events-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    queue_url  = module.hmpps_find_and_refer_domain_events_queue.sqs_id
+    queue_arn  = module.hmpps_find_and_refer_domain_events_queue.sqs_arn
+    queue_name = module.hmpps_find_and_refer_domain_events_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "hmpps_find_and_refer_domain_events_queue_secret_dlq" {
+  metadata {
+    name      = "sqs-domain-events-dlq-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    queue_url  = module.hmpps_find_and_refer_domain_events_dlq.sqs_id
+    queue_arn  = module.hmpps_find_and_refer_domain_events_dlq.sqs_arn
+    queue_name = module.hmpps_find_and_refer_domain_events_dlq.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/sqs-policy.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/sqs-policy.tf
@@ -1,0 +1,18 @@
+# Policy to allow SNS -> SQS
+data "aws_iam_policy_document" "sqs_queue_policy_document" {
+  statement {
+    sid     = "DomainEventsToQueue"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      variable = "aws:SourceArn"
+      test     = "ArnEquals"
+      values   = [data.aws_sns_topic.hmpps-domain-events.arn]
+    }
+    resources = ["*"]
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/domain-events-topic.tf
@@ -14,5 +14,5 @@ data "aws_ssm_parameter" "hmpps-domain-events-topic-arn" {
 }
 
 data "aws_sns_topic" "hmpps-domain-events" {
-  name = "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573"
+  name = "cloud-platform-Digital-Prison-Services-97e6567cf80881a8a52290ff2c269b08"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/domain-events-topic.tf
@@ -1,0 +1,18 @@
+resource "kubernetes_secret" "hmpps_find_and_refer_hmpps_domain_events_topic" {
+  metadata {
+    name      = "hmpps-domain-events-topic"
+    namespace = var.namespace
+  }
+
+  data = {
+    topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
+  }
+}
+
+data "aws_ssm_parameter" "hmpps-domain-events-topic-arn" {
+  name = "/hmpps-domain-events-dev/topic-arn"
+}
+
+data "aws_sns_topic" "hmpps-domain-events" {
+  name = "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/isra.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/isra.tf
@@ -3,6 +3,7 @@
 # This information is used to collect the IAM policies which are used by the IRSA module.
 locals {
   sqs_queues = {
+#    "Digital-Prison-Services-dev-hmpps_audit_queue" = "hmpps-audit-dev",
     "Digital-Prison-Services-${var.environment}-hmpps_audit_queue" = "hmpps-audit-${var.environment}",
   }
 
@@ -16,16 +17,24 @@ module "irsa" {
   eks_cluster_name       = var.eks_cluster_name
   namespace              = var.namespace
   service_account_name   = "hmpps-find-and-refer-intervention"
+
   role_policy_arns = merge(
     { elasticache = module.elasticache_redis.irsa_policy_arn },
+    {
+      sqs = module.hmpps_find_and_refer_domain_events_queue.irsa_policy_arn
+    },
+    {
+      sqs_dlq = module.hmpps_find_and_refer_domain_events_dlq.irsa_policy_arn
+    },
     local.sqs_policies,
   )
+
   # Tags
   business_unit          = var.business_unit
   application            = var.application
   is_production          = var.is_production
   team_name              = var.team_name
-  environment_name       = var.environment
+  environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/sqs-domain-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/sqs-domain-events.tf
@@ -1,0 +1,75 @@
+module "hmpps_find_and_refer_domain_events_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name                  = "hmpps_find_and_refer_domain_events_queue"
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.hmpps_find_and_refer_domain_events_dlq.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "aws_sqs_queue_policy" "hmpps_find_and_refer_domain_events_queue_policy" {
+  queue_url = module.hmpps_find_and_refer_domain_events_queue.sqs_id
+  policy    = data.aws_iam_policy_document.sqs_queue_policy_document.json
+}
+
+module "hmpps_find_and_refer_domain_events_dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name        = "hmpps_find_and_refer_domain_events_dlq"
+  message_retention_seconds = 7 * 24 * 3600 # 1 week
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "aws_sns_topic_subscription" "hmpps_find_and_refer_domain_events_subscription" {
+  topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
+  protocol  = "sqs"
+  endpoint  = module.hmpps_find_and_refer_domain_events_queue.sqs_arn
+  filter_policy = jsonencode({
+    eventType = [
+      "probation-case.requirement.created",
+      "probation-case.licence-condition.created"
+    ]
+  })
+}
+
+resource "kubernetes_secret" "hmpps_find_and_refer_domain_events_queue_secret" {
+  metadata {
+    name      = "sqs-domain-events-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    queue_url  = module.hmpps_find_and_refer_domain_events_queue.sqs_id
+    queue_arn  = module.hmpps_find_and_refer_domain_events_queue.sqs_arn
+    queue_name = module.hmpps_find_and_refer_domain_events_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "hmpps_find_and_refer_domain_events_queue_secret_dlq" {
+  metadata {
+    name      = "sqs-domain-events-dlq-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    queue_url  = module.hmpps_find_and_refer_domain_events_dlq.sqs_id
+    queue_arn  = module.hmpps_find_and_refer_domain_events_dlq.sqs_arn
+    queue_name = module.hmpps_find_and_refer_domain_events_dlq.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/sqs-policy.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/sqs-policy.tf
@@ -1,0 +1,18 @@
+# Policy to allow SNS -> SQS
+data "aws_iam_policy_document" "sqs_queue_policy_document" {
+  statement {
+    sid     = "DomainEventsToQueue"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      variable = "aws:SourceArn"
+      test     = "ArnEquals"
+      values   = [data.aws_sns_topic.hmpps-domain-events.arn]
+    }
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
This PR adds the required config to listen to `Hmpps Domain events` in preprod and prod environments.