### PR TITLE
`hmpps-incentives-preprod`: Set up for GH Actions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/github.tf
@@ -1,0 +1,33 @@
+module "hmpps-incentives-ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-incentives-ui"
+  application                   = "hmpps-incentives-ui"
+  github_team                   = var.team_name
+  environment                   = var.deployment_environment
+  is_production                 = var.is_production
+  protected_branches_only       = true
+  reviewer_teams                = [var.team_name]
+  application_insights_instance = var.deployment_environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+}
+
+module "hmpps-incentives-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-incentives-api"
+  application                   = "hmpps-incentives-api"
+  github_team                   = var.team_name
+  environment                   = var.deployment_environment
+  is_production                 = var.is_production
+  protected_branches_only       = true
+  reviewer_teams                = [var.team_name]
+  application_insights_instance = var.deployment_environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/variables.tf
@@ -30,6 +30,12 @@ variable "environment" {
   default     = "preprod"
 }
 
+variable "deployment_environment" {
+  type = string
+  description = "Environment code used when deploying, e.g. dev, preprod or prod"
+  default = "preprod"
+}
+
 variable "infrastructure_support" {
   description = "The team responsible for managing the infrastructure. Should be of the form team-email."
   default     = "dps-hmpps@digital.justice.gov.uk"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = "~> 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Added two instances of the `cloud-platform-terraform-hmpps-template` module, one for the UI and the other for the API.