### PR TITLE
RR-1598 - Set new group name as used in namespace RBAC

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-preprod/00-namespace.yaml
@@ -12,5 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Support Additional Needs"
     cloud-platform.justice.gov.uk/owner: "Digital Prison Services: dps-hmpps@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-support-additional-needs-api"
-    cloud-platform.justice.gov.uk/team-name: "hmpps-farsight-reduce-re-offend"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-support-additional-needs-devs"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-support-additional-needs-preprod
 subjects:
   - kind: Group
-    name: "github:hmpps-farsight-reduce-re-offend"
+    name: "github:hmpps-support-additional-needs-live"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-preprod/resources/variables.tf
@@ -29,7 +29,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "hmpps-farsight-reduce-re-offend"
+  default     = "hmpps-support-additional-needs-devs"
 }
 
 variable "environment" {


### PR DESCRIPTION
PR to change the old group name (`hmpps-farsight-reduce-re-offend`) to the new group name (`hmpps-support-additional-needs-devs`) in respect of the team name, and to `hmpps-support-additional-needs-live` in respect of the RBAC settings for the Support For Additional Needs preprod namespace.