### PR TITLE
fix(hmpps-accredited-programmes): Separate out development and live data for Accredited Programmes with separate GH teams.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/00-namespace.yaml
@@ -12,4 +12,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Accredited Programmes"
     cloud-platform.justice.gov.uk/owner: "Accredited Programmes: team.acp@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-accredited-programmes-ui,https://github.com/ministryofjustice/hmpps-accredited-programmes-api"
-    cloud-platform.justice.gov.uk/team-name: "accredited-programmes-team"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-accredited-programmes-devs"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-accredited-programmes-dev
 subjects:
   - kind: Group
-    name: "github:accredited-programmes-team"
+    name: "github:hmpps-accredited-programmes-devs"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/variables.tf
@@ -24,7 +24,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "accredited-programmes-team"
+  default     = "hmpps-accredited-programmes-devs"
 }
 
 variable "environment" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/00-namespace.yaml
@@ -12,5 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Accredited Programmes"
     cloud-platform.justice.gov.uk/owner: "Accredited Programmes: team.acp@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-accredited-programmes-ui,https://github.com/ministryofjustice/hmpps-accredited-programmes-api"
-    cloud-platform.justice.gov.uk/team-name: "accredited-programmes-team"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-accredited-programmes-live"
     cloud-platform.justice.gov.uk/slack-alert-channel: "accredited-programmes-events"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-accredited-programmes-preprod
 subjects:
   - kind: Group
-    name: "github:accredited-programmes-team"
+    name: "github:hmpps-accredited-programmes-live"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/variables.tf
@@ -24,7 +24,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "accredited-programmes-team"
+  default     = "hmpps-accredited-programmes-live"
 }
 
 variable "environment" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/00-namespace.yaml
@@ -12,5 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Accredited Programmes"
     cloud-platform.justice.gov.uk/owner: "Accredited Programmes: team.acp@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-accredited-programmes-ui,https://github.com/ministryofjustice/hmpps-accredited-programmes-api"
-    cloud-platform.justice.gov.uk/team-name: "accredited-programmes-team"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-accredited-programmes-live"
     cloud-platform.justice.gov.uk/slack-alert-channel: "accredited-programmes-events"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-accredited-programmes-prod
 subjects:
   - kind: Group
-    name: "github:accredited-programmes-team"
+    name: "github:hmpps-accredited-programmes-live"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/resources/variables.tf
@@ -24,7 +24,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "accredited-programmes-team"
+  default     = "hmpps-accredited-programmes-live"
 }
 
 variable "environment" {


### PR DESCRIPTION
**WHAT**

The HMPPS-Accredited Programmes team recently discovered that their namespaces do not permit access to live vs. development data.  This PR separates out one previous team (`accredited-programmes-team`) into separate teams for non/live environments:

- `hmpps-accredited-programmes-devs`
- `hmpps-accredited-programmes-live`