### PR TITLE
Accredited Programmes: Update the dev GitHub Team Name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/00-namespace.yaml
@@ -12,4 +12,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "Accredited Programmes"
     cloud-platform.justice.gov.uk/owner: "Accredited Programmes: team.acp@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-accredited-programmes-ui,https://github.com/ministryofjustice/hmpps-accredited-programmes-api"
-    cloud-platform.justice.gov.uk/team-name: "accredited-programmes-team"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-accredited-programmes-devs"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-accredited-programmes-dev
 subjects:
   - kind: Group
-    name: "github:accredited-programmes-team"
+    name: "github:hmpps-accredited-programmes-devs"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/variables.tf
@@ -24,7 +24,7 @@ variable "business_unit" {
 variable "team_name" {
   description = "Name of the development team responsible for this service"
   type        = string
-  default     = "accredited-programmes-team"
+  default     = "hmpps-accredited-programmes-devs"
 }
 
 variable "environment" {


### PR DESCRIPTION
**DO NOT MERGE THIS PR**

The HMPPS Accredited Programmes team recently discovered two issues with the roles across their name spaces:

1. There was no way to to distinguish access to live vs. non-live data
2. The naming convention of the teams does not follow best practices.

This PR needs to be deployed after the following PR in hmpps-github-teams repository: 

https://github.com/ministryofjustice/hmpps-github-teams/pull/457

The above PR (457) will create the required teams:

- `hmpps-accredited-programmes-dev`
- `hmpps-accredited-programmes-live`

That PR does not remove the current team (`accredited-programmes-team`) from any users.  We will gradually swap out the roles, on a per-namespace basis, before we are able to remove the `accredited-programmes-team` role completely.