### PR TITLE
[CRIMAPP-1823] Amend block egress from datstore staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/04-networkpolicy.yaml
@@ -127,3 +127,5 @@ spec:
   podSelector: {}
   policyTypes:
   - Egress
+  egress:
+  - {}


### PR DESCRIPTION
This change adds the missing egress config to the network policy on `laa-criminal-applications-datastore-staging`.