### PR TITLE
[CRIMAPP-1823] Update datastore staging egress network policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/04-networkpolicy.yaml
@@ -127,5 +127,3 @@ spec:
   podSelector: {}
   policyTypes:
   - Egress
-  egress:
-  - {}


### PR DESCRIPTION
This change updates egress config to the network policy on laa-criminal-applications-datastore-staging.