### PR TITLE
Rename DB secret in Infox Test environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/secrets.tf
@@ -10,40 +10,40 @@ module "secrets_manager" {
   eks_cluster_name       = var.eks_cluster_name
 
   secrets = {
-    "laa-infox-db-password" = {
-      description             = "InfoX Soap user database password", # Required
-      recovery_window_in_days = 7,                                   # Required - number of days that AWS Secrets Manager waits before it can delete the secret
-      k8s_secret_name         = "laa-infox-db-password-test"         # The name of the secret in k8s
+    "laa-infox-db-credentials" = {
+      description             = "InfoX Soap database credentials (URL, username, password)",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-infox-db-credentials"
     },
     "laa-infox-mtls-certs" = {
-      description             = "InfoX MTLS Certificates (base64-encoded). These certificates are used to secure the Libra endpoint.", # Required
-      recovery_window_in_days = 7,                                                                                                     # Required - number of days that AWS Secrets Manager waits before it can delete the secret
-      k8s_secret_name         = "app-libra-mtls-certs"                                                                                 # The name of the secret in k8s
+      description             = "InfoX MTLS Certificates (base64-encoded). These certificates are used to secure the Libra endpoint.",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "app-libra-mtls-certs"
     },
     "laa-infox-keystore-password" = {
-      description             = "InfoX Keystore password [test].",   # Required
-      recovery_window_in_days = 7,                            # Required - number of days that AWS Secrets Manager waits before it can delete the secret
-      k8s_secret_name         = "laa-infox-keystore-password-test" # The name of the secret in k8s
+      description             = "InfoX Keystore password [test].",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-infox-keystore-password-test"
     },
     "laa-infox-private-key-password" = {
-      description             = "InfoX private key password [test].",   # Required
-      recovery_window_in_days = 7,                      # Required - number of days that AWS Secrets Manager waits before it can delete the secret
-      k8s_secret_name         = "laa-infox-private-key-password-test" # The name of the secret in k8s
+      description             = "InfoX private key password [test].",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-infox-private-key-password-test"
     },
     "infox-mlra-client-secret" = {
-      description             = "Client Secret used by MLRA",        # Required
-      recovery_window_in_days = 7,                                   # Required - number of days that AWS Secrets Manager waits before it can delete the secret
-      k8s_secret_name         = "infox-mlra-client-secret"          # The name of the secret in k8s
+      description             = "Client Secret used by MLRA",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "infox-mlra-client-secret"
     },
     "infox-nolasa-client-secret" = {
-      description             = "Client Secret used by NoLASA",        # Required
-      recovery_window_in_days = 7,                                   # Required - number of days that AWS Secrets Manager waits before it can delete the secret
-      k8s_secret_name         = "infox-nolasa-client-secret"          # The name of the secret in k8s
+      description             = "Client Secret used by NoLASA",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "infox-nolasa-client-secret"
     },
     "infox-libra-client-secret" = {
-      description             = "Client Secret used by LIBRA",        # Required
-      recovery_window_in_days = 7,                                   # Required - number of days that AWS Secrets Manager waits before it can delete the secret
-      k8s_secret_name         = "infox-libra-client-secret"          # The name of the secret in k8s
+      description             = "Client Secret used by LIBRA",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "infox-libra-client-secret"
     }
   }
 }


### PR DESCRIPTION
Renamed secret from `laa-infox-db_password` to `laa-infox-db-credentials` in `secrets.tf` and updated the description. This will now be used to store all the DB credentials and not just the password.