### PR TITLE
Add app secret for Benefit Checker Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/secrets.tf
@@ -1,0 +1,19 @@
+module "secrets_manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "aws-secrets" = {
+      description             = "laa-benefit-checker-prod aws-secrets",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "aws-secrets"
+    },
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/variables.tf
@@ -72,3 +72,7 @@ variable "github_token" {
   description = "Required by the GitHub Terraform provider"
   default     = ""
 }
+
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}


### PR DESCRIPTION
This PR adds a new secret for Benefit Checker in production, to store application-level secrets.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4195)