### PR TITLE
Add ECR repo for Benefit Checker Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/ecr.tf
@@ -1,0 +1,25 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+
+  # Repository configuration
+  repo_name = var.namespace
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = [var.repo_name]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/variables.tf
@@ -73,6 +73,12 @@ variable "github_token" {
   default     = ""
 }
 
+variable "repo_name" {
+  type = string
+  description = "The name of github repo AND ecr repo"
+  default = "laa-benefitchecker-1.0-big"
+}
+
 variable "eks_cluster_name" {
   description = "The name of the eks cluster to retrieve the OIDC information"
 }


### PR DESCRIPTION
This PR adds a new ECR repo to store the images to be deployed as part of the CD pipeline to `laa-benefit-checker-prod`.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4195)