### PR TITLE
Add missing GithubTeam tag for Benefit Checker Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-prod/resources/main.tf
@@ -10,6 +10,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
+      GithubTeam = var.team_name
     }
   }
 }
@@ -22,6 +23,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
+      GithubTeam = var.team_name
     }
   }
 }
@@ -34,6 +36,7 @@ provider "aws" {
     tags = {
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
+      GithubTeam = var.team_name
     }
   }
 }


### PR DESCRIPTION
This PR adds the missing `GithubTeam` tag for Benefit Checker Prod to the existing Terraform providers set-up for this namespace.