### PR TITLE
Test: Turn on s3 object versioning in the laa-sds-dev namespace to investigate rollback mechanisms

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/irsa.tf
@@ -8,7 +8,8 @@ module "irsa" {
   role_policy_arns = merge(
     {
       dynamodb         = aws_iam_policy.auditdb_policy.arn,
-      s3 = module.s3_bucket.irsa_policy_arn
+      s3 = module.s3_bucket.irsa_policy_arn,
+      s3_versioning     = aws_iam_policy.s3_versioning_policy.arn
     },
     { for name, module in module.s3_buckets : name => module.irsa_policy_arn }
   )
@@ -39,6 +40,39 @@ module "cross-irsa" {
   infrastructure_support = var.infrastructure_support
 }
 
+data "aws_iam_policy_document" "s3_versioning_policy" {
+  # Required to call boto3's list_object_versions()
+  statement {
+    actions = ["s3:ListBucketVersions"]
+    resources = [
+      for name in var.bucket_names :
+      "arn:aws:s3:::${name}-${var.environment}"
+    ]
+  }
+
+  # Required to delete specific object versions
+  statement {
+    actions = ["s3:DeleteObjectVersion"]
+    resources = [
+      for name in var.bucket_names :
+      "arn:aws:s3:::${name}-${var.environment}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "s3_versioning_policy" {
+  name   = "s3_versioning_policy"
+  policy = data.aws_iam_policy_document.s3_versioning_policy.json
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
 
 data "aws_iam_policy_document" "s3_migrate_policy" {
   # List & location for source & destination S3 bucket.
@@ -86,7 +120,7 @@ resource "aws_iam_policy" "s3_migrate_policy" {
     infrastructure-support = var.infrastructure_support
   }
 }
-
+ 
 # store irsa rolearn in k8s secret for retrieving to provide within source bucket policy
 resource "kubernetes_secret" "cross_irsa" {
   metadata {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/s3.tf
@@ -28,6 +28,7 @@ module "s3_buckets" {
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
   bucket_name            = "${each.value}-${var.environment}"
+  versioning             = true
 }
 
 


### PR DESCRIPTION
This PR enables S3 object versioning on both buckets in the laa-sds-dev namespace (laa-sds-internal-dev and laa-sds-equiniti-dev). 

It also adds the necessary IAM permissions (s3:ListBucketVersions and s3:DeleteObjectVersion) to support versioned operations.

This work is part of testing and documenting S3 rollback mechanisms for the SDS API.