### PR TITLE
Add cognito config to cclf-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/cognito.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/cognito.tf
@@ -1,0 +1,50 @@
+resource "aws_cognito_user_pool" "pool" {
+  name = var.user_pool_name
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "admin_only"
+      priority = 1
+    }
+  }
+}
+
+resource "aws_cognito_user_pool_client" "postman_client_dev" {
+  name                                 = var.cognito_user_pool_client_name
+  user_pool_id                         = aws_cognito_user_pool.pool.id
+  explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH"]
+  allowed_oauth_flows                  = ["client_credentials"]
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_scopes                 = aws_cognito_resource_server.resource.scope_identifiers
+  prevent_user_existence_errors        = "ENABLED"
+  supported_identity_providers         = ["COGNITO"]
+  generate_secret                      = true
+}
+
+resource "aws_cognito_resource_server" "resource" {
+  identifier = var.resource_server_identifier
+  name       = var.resource_server_name
+
+  scope {
+    scope_name        = var.resource_server_scope_name
+    scope_description = var.resource_server_scope_description
+  }
+  user_pool_id = aws_cognito_user_pool.pool.id
+}
+
+resource "aws_cognito_user_pool_domain" "domain" {
+  domain       = var.cognito_user_pool_domain_name
+  user_pool_id = aws_cognito_user_pool.pool.id
+}
+
+resource "kubernetes_secret" "aws_cognito_user_pool_client" {
+  metadata {
+    name      = "caa-cognito-client-secret-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    postman_client_id     = aws_cognito_user_pool_client.postman_client_dev.id
+    postman_client_secret = aws_cognito_user_pool_client.postman_client_dev.client_secret
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/variables.tf
@@ -127,3 +127,35 @@ variable "serviceaccount_rules" {
   ]
 }
 
+variable "user_pool_name" {
+  description = "Cognito user pool name"
+  default     = "cclf-dev-userpool"
+}
+
+variable "cognito_user_pool_client_name" {
+  description = "Cognito user pool client name"
+  default     = "postman"
+}
+
+variable "resource_server_identifier" {
+  description = "Cognito resource server identifier"
+  default     = "cclf-dev"
+}
+
+variable "resource_server_name" {
+  description = "Cognito resource server name"
+  default     = "cclf-dev-resource-server"
+}
+
+variable "resource_server_scope_name" {
+  description = "Resource server scope name"
+  default     = "standard"
+}
+
+variable "resource_server_scope_description" {
+  default = "Standard scope"
+}
+
+variable "cognito_user_pool_domain_name" {
+  default = "cclf-dev"
+}


### PR DESCRIPTION
As part of a spike to add authentication to an API within CCLF, this creates a Cognito user pool for us to test with.