### PR TITLE
Update all resettlement-passport repos to support github workflows

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/hmpps-person-on-probation-user-service-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/hmpps-person-on-probation-user-service-github.tf
@@ -1,0 +1,15 @@
+module "hmpps-person-on-probation-user-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-person-on-probation-user-api"
+  application                   = "hmpps-person-on-probation-user-api"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/variables.tf
@@ -35,7 +35,7 @@ variable "team_name" {
 variable "environment" {
   description = "Name of the environment type for this service"
   type        = string
-  default     = "development"
+  default     = "dev"
 }
 
 variable "infrastructure_support" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = ">= 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/hmpps-person-on-probation-user-service-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/hmpps-person-on-probation-user-service-github.tf
@@ -1,0 +1,16 @@
+module "hmpps-person-on-probation-user-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-person-on-probation-user-api"
+  application                   = "hmpps-person-on-probation-user-api"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = ">= 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/hmpps-person-on-probation-user-service-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/hmpps-person-on-probation-user-service-github.tf
@@ -1,0 +1,16 @@
+module "hmpps-person-on-probation-user-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-person-on-probation-user-api"
+  application                   = "hmpps-person-on-probation-user-api"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = ">= 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/hmpps-resettlement-passport-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/hmpps-resettlement-passport-github.tf
@@ -1,0 +1,47 @@
+module "hmpps_resettlement-passport-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-api"
+  application                   = "hmpps-resettlement-passport-api"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+}
+
+module "hmpps-resettlement-passport-ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-ui"
+  application                   = "hmpps-resettlement-passport-ui"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+}
+
+module "hmpps-resettlement-passport-person-on-probation-ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-person-on-probation-ui"
+  application                   = "hmpps-resettlement-passport-person-on-probation-ui"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  is_production                 = var.is_production
+  selected_branch_patterns      = ["main"]
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/variables.tf
@@ -35,7 +35,7 @@ variable "team_name" {
 variable "environment" {
   description = "Name of the environment type for this service"
   type        = string
-  default     = "development"
+  default     = "dev"
 }
 
 variable "infrastructure_support" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = ">= 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/hmpps-resettlement-passport-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/hmpps-resettlement-passport-github.tf
@@ -1,0 +1,50 @@
+module "hmpps_resettlement-passport-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-api"
+  application                   = "hmpps-resettlement-passport-api"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}
+
+module "hmpps-resettlement-passport-ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-ui"
+  application                   = "hmpps-resettlement-passport-ui"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}
+
+module "hmpps-resettlement-passport-person-on-probation-ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-person-on-probation-ui"
+  application                   = "hmpps-resettlement-passport-person-on-probation-ui"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  is_production                 = var.is_production
+  selected_branch_patterns      = ["main"]
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-preprod/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = ">= 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/hmpps-resettlement-passport-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/hmpps-resettlement-passport-github.tf
@@ -1,0 +1,50 @@
+module "hmpps_resettlement-passport-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-api"
+  application                   = "hmpps-resettlement-passport-api"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}
+
+module "hmpps-resettlement-passport-ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-ui"
+  application                   = "hmpps-resettlement-passport-ui"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}
+
+module "hmpps-resettlement-passport-person-on-probation-ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  github_repo                   = "hmpps-resettlement-passport-person-on-probation-ui"
+  application                   = "hmpps-resettlement-passport-person-on-probation-ui"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  is_production                 = var.is_production
+  selected_branch_patterns      = ["main"]
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-prod/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = ">= 6.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Added github configuration for the following repos, following instructions in https://tech-docs.hmpps.service.justice.gov.uk/shared-tooling/migrating-to-GHA/

- hmpps-resettlement-passport-ui
- hmpps-resettlement-passport-api
- hmpps-resettlement-passport-person-on-probation-ui
- hmpps-person-on-probation-user-api