### PR TITLE
configuring audit for hmpps-interventions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/hmpps-audit-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/hmpps-audit-queue.tf
@@ -5,7 +5,7 @@ resource "kubernetes_secret" "hmpps_audit_secret" {
   }
 
   data = {
-    sqs_queue_name = "Digital-Prison-Services-${var.environment-name}-hmpps_audit_queue"
-    sqs_queue_url = "https://sqs.eu-west-2.amazonaws.com/754256621582/Digital-Prison-Services-${var.environment-name}-hmpps_audit_queue"
+    sqs_queue_name = "Digital-Prison-Services-${var.environment_name}-hmpps_audit_queue"
+    sqs_queue_url = "https://sqs.eu-west-2.amazonaws.com/754256621582/Digital-Prison-Services-${var.environment_name}-hmpps_audit_queue"
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/hmpps-audit-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/hmpps-audit-queue.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_secret" "hmpps_audit_secret" {
+  metadata {
+    name      = "sqs-hmpps-audit-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    sqs_queue_name = "Digital-Prison-Services-${var.environment-name}-hmpps_audit_queue"
+    sqs_queue_url = "https://sqs.eu-west-2.amazonaws.com/754256621582/Digital-Prison-Services-${var.environment-name}-hmpps_audit_queue"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/irsa.tf
@@ -2,7 +2,13 @@ locals {
   sns_local = {
     "cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573" = "hmpps-domain-events-dev"
   }
-  sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns : item.name => item.value }
+  sns_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sns : item.name => item.value }
+  sqs_queues = {
+    #"Digital-Prison-Services-dev-hmpps_audit_queue" = "hmpps-audit-dev",
+    "Digital-Prison-Services-${var.environment_name}-hmpps_audit_queue" = "hmpps-audit-${var.environment_name}",
+  }
+  # The names of the SNS topics used and the namespace which created them
+  sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
 }
 
 module "irsa" {
@@ -17,7 +23,9 @@ module "irsa" {
   role_policy_arns = merge(local.sns_policies, {
     s3 = module.interventions_s3_bucket.irsa_policy_arn
     elasticache = module.hmpps_interventions_elasticache_redis.irsa_policy_arn
-  })
+  },
+    local.sqs_policies
+  )
 
   # Tags
   business_unit          = var.business_unit
@@ -28,7 +36,12 @@ module "irsa" {
   infrastructure_support = var.infrastructure_support
 }
 
-data "aws_ssm_parameter" "irsa_policy_arns" {
+data "aws_ssm_parameter" "irsa_policy_arns_sns" {
   for_each = local.sns_local
   name     = "/${each.value}/sns/${each.key}/irsa-policy-arn"
+}
+
+data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
+  for_each = local.sqs_queues
+  name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/variables.tf
@@ -27,8 +27,15 @@ variable "team_name" {
 }
 
 variable "environment" {
-  description = "The type of environment you're deploying to."
+  description = "Name of the environment type for this service"
+  type        = string
   default     = "development"
+}
+
+variable "environment_name" {
+  description = "The type of environment you're deploying to."
+  type        = string
+  default     = "dev"
 }
 
 variable "infrastructure_support" {


### PR DESCRIPTION
configure refer and monitor interventions to enable audit in dev so that we can trace call to search for CRN