### PR TITLE
ESWE-1356: add slack alert channel- preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-preprod/00-namespace.yaml
@@ -9,8 +9,9 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HMPPS"
     cloud-platform.justice.gov.uk/slack-channel: "prison-education"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "education-skills-work-employment-dev"
     cloud-platform.justice.gov.uk/application: "Jobs Board"
     cloud-platform.justice.gov.uk/owner: "Education Skills Work and Employment: managing.eswe@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-jobs-board-api"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-jobs-board-ui.git"
     cloud-platform.justice.gov.uk/team-name: "hmpps-education-skills-and-work"
     cloud-platform.justice.gov.uk/review-after: ""


### PR DESCRIPTION
This PR adds a missing slack alert channel to the repo.