### PR TITLE
changing the db max allocated storage of postgres replica to 20

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds-postgres14.tf
@@ -53,7 +53,7 @@ module "hmpps_interventions_postgres14_replica" {
   db_engine_version           = "14.17"
   db_instance_class           = "db.t4g.small"
   allow_major_version_upgrade = "false"
-  db_max_allocated_storage    = "10"
+  db_max_allocated_storage    = "20"
 
   db_name             = null # "db_name": conflicts with replicate_source_db
   replicate_source_db = module.hmpps_interventions_postgres14.db_identifier


### PR DESCRIPTION
In Refer and Monitor dev terraform plan, we need to change the db max allocated storage to 20