### PR TITLE
chore: 🤖 poc s3 release bump and fix aurora drift

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/aurora.tf
@@ -7,7 +7,7 @@ module "aurora_db" {
 
   # Database configuration
   engine         = "aurora-postgresql"
-  engine_version = "14.9"
+  engine_version = "14.15"
   engine_mode    = "provisioned"
   instance_type  = "db.t4g.medium"
   replica_count  = 1

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/abundant-namespace-dev/resources/opensearch.tf
@@ -1,5 +1,5 @@
 module "opensearch_snapshot_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
 
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
we have a bunch of 5.1.0 s3 modules to bump as well as 5.2.0 when rolling out 5.3.0. this change will show additional IAM permissions across the board. PR demonstrates this bump is non-destructive

releases:

[5.3.0](https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/releases/tag/5.3.0)

[5.2.0](https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket/releases/tag/5.2.0)