### PR TITLE
Fix: rds version mismatch in hmpps-book-secure-move-api-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds-instance" {
   enable_rds_auto_start_stop = true
 
   db_engine         = "postgres"
-  db_engine_version = "16.3"
+  db_engine_version = "16.8"
   db_instance_class = "db.t4g.small"
 
   rds_family = "postgres16"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-book-secure-move-api-staging`

```
module.rds-instance: downgrade from 16.8 to 16.3
```