### PR TITLE
LNP-1180: Adding prisoner auditing to launchpad ui

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/irsa.tf
@@ -3,7 +3,7 @@
 # This information is used to collect the IAM policies which are used by the IRSA module.
 locals {
   sqs_queues = {
-    "Digital-Prison-Services-dev-hmpps_audit_queue" = "hmpps-audit-dev",
+    "Digital-Prison-Services-dev-hmpps_prisoner_audit_queue" = "hmpps-audit-dev",
   }
   sqs_policies = { for item in data.aws_ssm_parameter.irsa_policy_arns_sqs : item.name => item.value }
 }


### PR DESCRIPTION
Updated the key for `sqs_queues` in `irsa.tf` to match the sqs queue name we are attempting to push to (as configured in [hmpps-prisoner-audit-queue.tf](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/hmpps-prisoner-audit-queue.tf))