### PR TITLE
Create certificates for HMPPS esupervision test environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/06-certificate.yaml
@@ -1,0 +1,25 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-esupervision-api-cert
+  namespace: hmpps-esupervision-test
+spec:
+  secretName: hmpps-esupervision-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - esupervision-api-test.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-esupervision-ui-cert
+  namespace: hmpps-esupervision-test
+spec:
+  secretName: hmpps-esupervision-ui-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - esupervision-test.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Add certificates for esupervision-test and esupervision-api-test subdomains within the HMPPS esuperivsion test namespace.