### PR TITLE
Define postgres instance for HMPPS esupervision test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/resources/rds.tf
@@ -1,0 +1,56 @@
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = false
+  db_max_allocated_storage     = "500"
+  enable_rds_auto_start_stop   = !var.is_production
+  # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
+
+  # PostgreSQL specifics
+  db_engine         = "postgres"
+  db_engine_version = "17"
+  rds_family        = "postgres17"
+  db_instance_class = var.postgres_instance_class
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "hmpps-esupervision-rds-settings"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+}
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/resources/variables.tf
@@ -76,3 +76,9 @@ variable "number_cache_clusters" {
   default = "2"
 }
 
+variable "postgres_instance_class" {
+  type = string
+  description = "Class of the postgres instance"
+  default = "db.t4g.micro"
+}
+


### PR DESCRIPTION
Add definition for a postgres instance and associated secrets for the db connection to the HMPPS esupervision test namespace.