### PR TITLE
Revert "[CTSKF 1311] Add rule to block all egress on CCR uat"

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-uat/04-networkpolicy.yaml
@@ -40,16 +40,3 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: monitoring
----
-kind: NetworkPolicy
-apiVersion: projectcalico.org/v3
-metadata:
-  name: block-egress
-  namespace: laa-crown-court-remuneration-uat
-spec:
-  order: 50.0
-  selector: all()
-  egress:
-  - action: Deny
-  types:
-  - Egress


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-environments#34753

This isn't working as expected. I'm reverting the change in this environment while I try to fix it in the dev environment.