### PR TITLE
Add groups to hmpps-esupervision-test environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/01-rbac.yaml
@@ -7,6 +7,12 @@ subjects:
   - kind: Group
     name: "github:stg-pathfinders"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-haar-client-admin"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
Add the HMPPS SRE and HAAR groups to the permissions for the HMPPS esupervision test environment.