### PR TITLE
Add new secret to store Slack webhook for MAAT API prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/resources/secret.tf
@@ -15,5 +15,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7
       k8s_secret_name         = "maat-api-env-variables"
     },
+    "maat_api_alert_webhook_prod" = {
+      description             = "MAAT API Slack Webhook",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "maat-api-alert-webhook-prod"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a new secret to store the Slack webhook for MAAT API prod, which will be used to update the relevant Slack channel with alerts from AlertManager.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4275)