### PR TITLE
Create Prometheus rules and new Grafana dashboard for MAAT Data API

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/05-prometheus-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/05-prometheus-rules.yaml
@@ -1,0 +1,166 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-maat-data-api-prod
+  labels:
+    role: alert-rules
+  name: prometheus-custom-rules-laa-maat-data-api
+spec:
+  groups:
+    - name: application-rules
+      rules:
+        - alert: Client Response Errors (excluding 400 and 401)
+          expr: sum(increase(http_server_requests_seconds_count{namespace="laa-maat-data-api-prod",outcome="CLIENT_ERROR",status!~"4(00|01)"}[10m])) > 1
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: There has been an increase in client error responses (excluding 400 and 401) in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Client Response Errors - 401 Unauthorised
+          expr: sum(increase(http_server_requests_seconds_count{status="401",outcome="CLIENT_ERROR",namespace="laa-maat-data-api-prod"}[10m])) > 1
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: There has been an increase in Unauthorised requests in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Client Response Errors - 400 Bad request
+          expr: sum(increase(http_server_requests_seconds_count{status="400",outcome="CLIENT_ERROR",namespace="laa-maat-data-api-prod"}[10m])) > 10
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: There has been an increase in Bad Request Errors in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: MAAT Data API Rollback Error
+          expr: sum(increase(http_server_requests_seconds_count{status="555", namespace="laa-maat-data-api-prod"}[10m])) > 10
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: There has been an increase in rollbacks from the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with the server processing client requests - likely a bug.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Server Response Error
+          expr: sum(increase(http_server_requests_seconds_count{outcome="SERVER_ERROR", namespace="laa-maat-data-api-prod"}[10m])) > 1
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: There has been an increase in server error response from the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with the server processing client requests - likely a bug.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: JVM CPU Usage
+          expr: (process_cpu_usage{namespace="laa-maat-data-api-prod"} * 100) > 95
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: The MAAT Data API service running on a production pod has been using over 95% of the CPU for a minute. This may indicate the pods running this application require more CPU resources.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: System CPU Usage
+          expr: (system_cpu_usage{namespace="laa-maat-data-api-prod"} * 100) > 95
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: A pod that runs the MAAT Data API service on production has been using over 95% of the pod's CPU for a minute. This may indicate there is some underlying process other than our application on the pod that is using up all the CPU resources and warrants further investigation.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Object Heap Memory Usage - Tenured Gen
+          expr: ((jvm_memory_used_bytes{area="heap", id="Tenured Gen", namespace="laa-maat-data-api-prod"}/jvm_memory_max_bytes{area="heap", id="Tenured Gen", namespace="laa-maat-data-api-prod"})*100) > 95
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: Over 95% of the "Tenured Gen" object heap memory on a production pod had been used. This may indicate our application needs more object heap memory or we have a memory resource leak in our application.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Object Heap Memory Usage - Survivor Space
+          expr: ((jvm_memory_used_bytes{area="heap", id="Survivor Space", namespace="laa-maat-data-api-prod"}/jvm_memory_max_bytes{area="heap", id="Survivor Space", namespace="laa-maat-data-api-prod"})*100) > 95
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: Over 95% of the "Survivor Space" object heap memory on a production pod had been used. This may indicate our application needs more object heap memory or we have a memory resource leak in our application.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Object Heap Memory Usage - Eden Space
+          expr: ((jvm_memory_used_bytes{area="heap", id="Eden Space", namespace="laa-maat-data-api-prod"}/jvm_memory_max_bytes{area="heap", id="Eden Space", namespace="laa-maat-data-api-prod"})*100) > 95
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: Over 95% of the "Eden Space" object heap memory on a production pod had been used. This may indicate our application needs more object heap memory or we have a memory resource leak in our application.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Response Time Excessive
+          expr: (sum(http_server_requests_seconds_sum{outcome="SUCCESS", namespace="laa-maat-data-api-prod"})/sum(http_server_requests_seconds_count{outcome="SUCCESS", namespace="laa-maat-data-api-prod"})) > 5
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: The response time for successful responses on production is taking on average over five seconds. This indicates responses to our clients is taking too long.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Logging Error
+          expr: sum(increase(logback_events_total{level="error", namespace="$namespace"}[10m])) > 1
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: There had been an error in the logs of the MAAT Data API in the past 10 minutes. This indicates that there may be a bug with the application.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Instance-Down
+          expr: absent(up{namespace="laa-maat-data-api-prod"}) == 1
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: The production instance of the MAAT Data API has been down for >1m.
+        - alert: Quota-Exceeded
+          expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-maat-data-api-prod"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-maat-data-api-prod"} > 0) > 90
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+        - alert: KubePodCrashLooping
+          expr: round(rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="laa-maat-data-api-prod"}[10m]) * 60 * 10) > 1
+          for: 5m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+        - alert: Increase in 403 Blocked Requests
+          expr: sum(increase(nginx_ingress_controller_requests{exported_namespace="laa-maat-data-api-prod", ingress="laa-maat-data-api", status="403"}[5m])) > 1
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-alerts-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: The rate of requests blocked by the internal ingress has been increasing over the past 5 minutes.
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?orgId=1&var-namespace=laa-maat-data-api-prod&var-ingress=laa-maat-data-api

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/06-grafana.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/06-grafana.yaml
@@ -1,0 +1,648 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: laa-maat-data-api-dashboard
+  namespace: laa-maat-data-api-prod
+  labels:
+    grafana_dashboard: "laa-maat-data-api"
+data:
+  laa-maat-data-api-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "limit": 100,
+            "name": "Annotations & Alerts",
+            "showIn": 0,
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": 107,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 23,
+          "title": "MAAT Data API Metrics",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "% of Object Heap Type Memory Used",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 17,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(jvm_memory_used_bytes{area=\"heap\", id=\"Tenured Gen\", namespace=\"$namespace\"}/jvm_memory_max_bytes{area=\"heap\", id=\"Tenured Gen\", namespace=\"$namespace\"})*100",
+              "legendFormat": "Tenured Gen Object Heap Usage for Pod: {{pod}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(jvm_memory_used_bytes{area=\"heap\", id=\"Survivor Space\", namespace=\"$namespace\"}/jvm_memory_max_bytes{area=\"heap\", id=\"Survivor Space\", namespace=\"$namespace\"})*100",
+              "hide": false,
+              "legendFormat": "Survivor Space Object Heap Usage for Pod: {{pod}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(jvm_memory_used_bytes{area=\"heap\", id=\"Eden Space\", namespace=\"$namespace\"}/jvm_memory_max_bytes{area=\"heap\", id=\"Eden Space\", namespace=\"$namespace\"})*100",
+              "hide": false,
+              "legendFormat": "Eden Space Object Heap Usage for Pod: {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Object Heap Memory Used",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "% CPU Usage",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 25,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "process_cpu_usage{namespace=\"$namespace\"} * 100",
+              "legendFormat": "JVM Process CPU Usage for Pod: {{pod}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "system_cpu_usage{namespace=\"$namespace\"} * 100",
+              "hide": false,
+              "legendFormat": "System CPU Usage for Pod: {{pod}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "JVM and System CPU Usage for Pods",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Time in Seconds",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 27,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(http_server_requests_seconds_sum{outcome=\"SUCCESS\", namespace=\"$namespace\"})/\nsum(http_server_requests_seconds_count{outcome=\"SUCCESS\", namespace=\"$namespace\"})",
+              "legendFormat": "Average Successful Response Time",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Average Successful Response Time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Increase in Errors",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 29,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(http_server_requests_seconds_count{outcome=\"SERVER_ERROR\", namespace=\"$namespace\"}[10m]))",
+              "legendFormat": "Increase in server errors over the past 10 minutes",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(http_server_requests_seconds_count{outcome=\"CLIENT_ERROR\", namespace=\"$namespace\"}[10m]))",
+              "hide": false,
+              "legendFormat": "Increase in client errors over the past 10 minutes",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Increases in Client and Server Error Responses",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Number of logs",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "id": 31,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(logback_events_total{level=\"error\", namespace=\"$namespace\"}[10m]))",
+              "legendFormat": "Increase in error level logs in the past 10 minutes",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(logback_events_total{level=\"info\", namespace=\"$namespace\"}[10m]))",
+              "hide": false,
+              "legendFormat": "Increase in info level logs in the past 10 minutes",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Increases in logs in past 10 minutes (error and info level)",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": [
+        "laa-maat-data-api"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": true,
+              "text": "laa-maat-data-api-prod",
+              "value": "laa-maat-data-api-prod"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(kube_deployment_metadata_generation, namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_deployment_metadata_generation, namespace)",
+              "refId": "Prometheus-namespace-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "/^laa-maat-data-api-/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "browser",
+      "title": "LAA MAAT Data API",
+      "uid": "fd62dc4d9129290e7730434a55d0594d",
+      "version": 2,
+      "weekStart": ""
+    }


### PR DESCRIPTION
This PR creates a set of Prometheus rules for use by AlertManager to send alerts to Slack, as well as a Grafana dashboard to visualise the availability and performance of the application.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4275)