### PR TITLE
Add new policy ARN to IRSA module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/fraud-and-corruption-insights-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/fraud-and-corruption-insights-dev/resources/irsa.tf
@@ -10,6 +10,7 @@ module "irsa" {
 
   role_policy_arns = {
     dynamodb                = module.dynamodb-cluster.irsa_policy_arn
+    dynamodb_dev            = module.dynamodb-fci-dev.irsa_policy_arn
     xaccounts3              = aws_iam_policy.access_ap_s3_policy.arn
   }
 


### PR DESCRIPTION
Add the new dynamodb module policy ARN to the IRSA module in the fraud-and-corruption-insights-dev namespace.