### PR TITLE
Allow MCC to communicate with CCA's development namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-dev/04-networkpolicy.yaml
@@ -39,10 +39,4 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-production
-    - namespaceSelector:
-        matchLabels:
-          cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-staging
-    - namespaceSelector:
-        matchLabels:
           cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-uat


### PR DESCRIPTION
Allow Mange your Civil Cases to communicate with Civil Case API's development namespace