### PR TITLE
Allow MCC to communicate with CCA's UAT namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-uat/04-networkpolicy.yaml
@@ -39,9 +39,6 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-production
-    - namespaceSelector:
-        matchLabels:
           cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-staging
     - namespaceSelector:
         matchLabels:


### PR DESCRIPTION
Allow Manage your Civil Cases to communicate with Civil Case API's UAT namespace