### PR TITLE
Create clusterrole to enable management of calico network policies

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/user-roles.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/user-roles.yaml
@@ -82,4 +82,12 @@ rules:
   - tzcronjobs
   verbs:
   - '*'
-
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-network-policy-access
+rules:
+- apiGroups: ["crd.projectcalico.org"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "list", "describe", "create", "delete", "watch", "update"]


### PR DESCRIPTION
This will create a ClusterRole that will allow users to manage Calico network policies.
This will require a RoleBinding in namespaces that want to use it to work.

Tested clusterrole by manually applying the role and blinding it in tom-namespace-dev to a group that contains the dummy user. Tested to ensure the dummy user could only get calico networkpolicies from the namespace and accessing other namespaces calico NPs are forbidden.