### PR TITLE
Update egress rules

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/04-networkpolicy.yaml
@@ -70,18 +70,23 @@ spec:
   types:
     - Egress
 ---
-kind: NetworkPolicy
 apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
 metadata:
   name: allow-egress-hostnames
   namespace: laa-crown-court-remuneration-dev
 spec:
   order: 48.0
   selector: all()
+  types:
+    - Egress
   egress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - 443
     - action: Allow
       destination:
         domains:
-          - "*.injest.sentry.io"
-  types:
-    - Egress
+          - '*.inject.sentry.io'


### PR DESCRIPTION
A second attempt at creating an egress rule based on domain name as the previous version failed with an error. This time the rule is copied form https://docs.tigera.io/calico-cloud/tutorials/applications/egress-controls#use-wildcards-in-domain-names and modified accordingly.

Notable differences;
* Port is explicitly given as 443 (https)
* The domain name is in single quotes instead of double quotes