### PR TITLE
chore: 🤖 allow calico-network-policy-access role in conftest

### DIFF
--- a/policy/rolebinding.rego
+++ b/policy/rolebinding.rego
@@ -5,5 +5,6 @@ deny_rolebinding[msg]  {
   input.kind == "RoleBinding"
   input.roleRef.kind == "ClusterRole"
   input.roleRef.name != "admin"
+  input.roleRef.name != "calico-network-policy-access"
   msg := sprintf("ClusterRole %v is not allowed", [input.roleRef.name])
 }


### PR DESCRIPTION
this PR updates rolebinding conftest check to permit namespaced calico network policy resources