### PR TITLE
add s3:GetObjectVersion permission to fetch object versions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/irsa.tf
@@ -50,9 +50,9 @@ data "aws_iam_policy_document" "s3_versioning_policy" {
     ]
   }
 
-  # Required to delete specific object versions
+  # Required to get/hard delete specific object versions
   statement {
-    actions = ["s3:DeleteObjectVersion"]
+    actions = ["s3:GetObjectVersion", "s3:DeleteObjectVersion"]
     resources = [
       for name in var.bucket_names :
       "arn:aws:s3:::${name}-${var.environment}/*"


### PR DESCRIPTION
Further to a [previous PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/34467) to turn on versioning for buckets in the laa-sds-dev namespace, this PR adds the `s3:GetObjectVersion` permission to the `s3_versioning_policy`. This is to enable users to fetch the content of specific object versions.