### PR TITLE
Add Sentry DSN secret for InfoX Dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-development/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-development/resources/secrets.tf
@@ -40,6 +40,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "infox-libra-client-secret"
     },
-
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for InfoX Dev",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "sentry-dsn"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a secret to store the Sentry DSN for InfoX Dev, so that it can be moved out of app configuration. Whilst Sentry DSN values are technically not secret values [according to Sentry](https://sentry.zendesk.com/hc/en-us/articles/26741783759899-My-DSN-key-is-publicly-visible-is-this-a-security-vulnerability), they do allow events to be sent to Sentry without authentication, so ideally should be kept private.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4170)