### PR TITLE
Add Sentry DSN secret for InfoX Test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-test/resources/secrets.tf
@@ -44,6 +44,11 @@ module "secrets_manager" {
       description             = "Client Secret used by LIBRA",
       recovery_window_in_days = 7,
       k8s_secret_name         = "infox-libra-client-secret"
-    }
+    },
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for InfoX Test",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "sentry-dsn"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a secret to store the Sentry DSN for InfoX Test, so that it can be moved out of app configuration. Whilst Sentry DSN values are technically not secret values according to Sentry, they do allow events to be sent to Sentry without authentication, so ideally should be kept private.