### PR TITLE
Add Sentry DSN secret for InfoX Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/secrets.tf
@@ -49,6 +49,11 @@ module "secrets_manager" {
       description             = "Information Exchange Slack Webhook",
       recovery_window_in_days = 7,
       k8s_secret_name         = "infox-slack-webhook"
-    }
+    },
+    "sentry_dsn" = {
+      description             = "Sentry Data Source Name (DSN) for InfoX Prod",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "sentry-dsn"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a secret to store the Sentry DSN for InfoX Prod, so that it can be moved out of app configuration. Whilst Sentry DSN values are technically not secret values [according to Sentry](https://sentry.zendesk.com/hc/en-us/articles/26741783759899-My-DSN-key-is-publicly-visible-is-this-a-security-vulnerability), they do allow events to be sent to Sentry without authentication, so ideally should be kept private.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4170)