### PR TITLE
rds auto-start-stop flag turned to false temporarily

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-dev/resources/rds.tf
@@ -15,7 +15,7 @@ module "rds" {
   allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
-  enable_rds_auto_start_stop   = true # non-prod db, so turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
+  enable_rds_auto_start_stop   = false # non-prod db, so turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # PostgreSQL specifics


### PR DESCRIPTION
**enable_rds_auto_start_stop** turned to false temporarily. Once other environments like QA,UAT & Prod are configured and then I will enable this flag