### PR TITLE
Update MAAT Data API Prod dashboard id

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/06-grafana.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/06-grafana.yaml
@@ -642,7 +642,7 @@ data:
       },
       "timezone": "browser",
       "title": "LAA MAAT Data API",
-      "uid": "fd62dc4d9129290e7730434a55d0594d",
+      "uid": "3c878b0d42914a8fa421f798cfb3ba8f",
       "version": 2,
       "weekStart": ""
     }


### PR DESCRIPTION
This PR fixes the MAAT Data API Prod dashboard id to the intended id, as it currently conflicts with the existing MAAT Orchestration Service Prod dashboard id.