### PR TITLE
Add required config parameter to ingress in HMPPS esupervision test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/07-ingress.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/07-ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: hmpps-esupervision-test
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: ui-internet-modsec-hmpps-esupervision-test-green
+    external-dns.alpha.kubernetes.io/aws-weight: '100'
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On


### PR DESCRIPTION
Add required aws-weight parameter to the ingress in the HMPPS esupervision test namespace.