### PR TITLE
Temporarily turn off RDS start/stop

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-dev/resources/rds.tf
@@ -7,7 +7,8 @@ module "rds" {
   vpc_name = var.vpc_name
 
   # Turn off over night
-  enable_rds_auto_start_stop = true
+  # Turn this back on after go live
+  enable_rds_auto_start_stop = false
 
   # RDS configuration
   allow_minor_version_upgrade  = true


### PR DESCRIPTION
Testers are working early/late in approach to go live - makes sense to leave this up for now. I have created a ticket to turn this back on post go live.