### PR TITLE
MAP-2608 Update default deployment environment to 'train' for HMPPS Locations Inside Prison train configuration.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/github.tf
@@ -7,7 +7,7 @@ module "hmpps-locations-inside-prison-api" {
   environment                   = var.deployment_environment
   is_production                 = var.is_production
   protected_branches_only       = true
-  application_insights_instance = var.deployment_environment
+  application_insights_instance = "preprod"
   source_template_repo          = "hmpps-template-kotlin"
   github_token                  = var.github_token
   namespace                     = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/variables.tf
@@ -31,7 +31,7 @@ variable "environment" {
 variable "deployment_environment" {
   type = string
   description = "Environment code used when deploying, e.g. dev, preprod or prod"
-  default = "train"
+  default = "preprod"
 }
 
 variable "infrastructure_support" {


### PR DESCRIPTION
The pull request updates the default deployment environment configuration to 'train' for HMPPS Locations Inside Prison, aligning it with the desired train environment setup.