### PR TITLE
CPR-802 allow the pre-production service account to access the produc…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/data.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/data.tf
@@ -18,6 +18,7 @@ data "aws_ssm_parameter" "large-court-cases-s3-bucket-name" {
   name = "/court-probation-preprod/large-court-cases-s3-bucket-name"
 }
 
-data "aws_ssm_parameter" "large-court-cases-s3-bucket-arn" {
-  name = "/court-probation-preprod/large-court-cases-s3-bucket-arn"
+data "aws_ssm_parameter" "prod-large-court-cases-s3-bucket-arn" {
+  name = "/court-probation-prod/large-court-cases-s3-bucket-arn"
 }
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-preprod/resources/irsa.tf
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "cross_namespace_s3_access" {
     actions = [
       "s3:GetObject",
     ]
-    resources = ["${data.aws_ssm_parameter.large-court-cases-s3-bucket-arn.value}/*", ]
+    resources = ["${data.aws_ssm_parameter.prod-large-court-cases-s3-bucket-arn.value}/*", ]
   }
 }
 


### PR DESCRIPTION
…tion S3 CHER large message bucket

This is because we have subscribed a preproduction queue to a production topic, and the messages contain a reference to the S3 bucket where large objects are stored. Consequently the preproduction service account needs get-object permission to the production S3 bucket