### PR TITLE
CRIMAPP-1823 View calico network policies in datastore staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/01-rbac.yaml
@@ -11,3 +11,17 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-criminal-applications-datastore-staging-calico-np-access
+  namespace: laa-criminal-applications-datastore-staging
+subjects:
+  - kind: Group
+    name: "github:laa-crime-apply"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: calico-network-policy-access
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Adds role binding to view calico network policies in datastore staging namespace as per [user guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/block-egress-traffic.html#viewing-calico-network-policies-in-my-namespace)