### PR TITLE
DSTEW-100: override default service-account permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/serviceaccount.tf
@@ -42,6 +42,7 @@ module "serviceaccount" {
         "jobs",
         "replicasets",
         "statefulsets",
+        "persistentvolumeclaims",
         "poddisruptionbudgets",
         "networkpolicies"
       ],


### PR DESCRIPTION
override default service-account permissions to add persistentvolumeclaims API actions.