### PR TITLE
Fix: rds version mismatch in calculate-journey-variable-payments-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-journey-variable-payments-dev/resources/rds.tf
@@ -14,7 +14,7 @@ module "rds-instance" {
   enable_rds_auto_start_stop = true
 
   db_engine         = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   db_instance_class = "db.t4g.small"
 
   rds_family = "postgres16"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `calculate-journey-variable-payments-dev`

```
module.rds-instance: downgrade from 16.8 to 16.4
```