### PR TITLE
CRIMAPP-1821 Add SQS queue and subscription to Crime Datastore staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/irsa.tf
@@ -15,7 +15,8 @@ module "irsa" {
     rds = module.rds.irsa_policy_arn
     s3  = module.s3_bucket.irsa_policy_arn
     sns = module.application-events-sns-topic.irsa_policy_arn
-    sqs = module.application-events-dlq.irsa_policy_arn
+    sqs = module.application-events-queue.irsa_policy_arn
+    sqs_dlq = module.application-events-dlq.irsa_policy_arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sns-application-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sns-application-events.tf
@@ -36,6 +36,19 @@ resource "kubernetes_secret" "application-events-sns-topic" {
 ########### SNS subscriptions ###########
 ###
 
+resource "aws_sns_topic_subscription" "application-events-queue-subscription" {
+  provider  = aws.london
+  topic_arn = module.application-events-sns-topic.topic_arn
+  endpoint  = module.application-events-queue.sqs_arn
+  protocol  = "sqs"
+
+  filter_policy = jsonencode({
+    event_name = [
+      "apply.submission"
+    ]
+  })
+}
+
 resource "aws_sns_topic_subscription" "events-review-subscription" {
   topic_arn = module.application-events-sns-topic.topic_arn
   endpoint  = "https://staging.review-criminal-legal-aid.service.justice.gov.uk/api/events"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sqs-application-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sqs-application-events.tf
@@ -1,0 +1,65 @@
+module "application-events-queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  # Queue configuration
+  sqs_name        = "application-events"
+  encrypt_sqs_kms = true
+  message_retention_seconds = 1209600
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the queue
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  redrive_policy = <<EOF
+  {
+    "deadLetterTargetArn": "${module.application-events-dlq.sqs_arn}","maxReceiveCount": 1
+  }
+  EOF
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "application-events-queue" {
+  metadata {
+    name      = "application-events-queue"
+    namespace = var.namespace
+  }
+
+  data = {
+    sqs_id   = module.application-events-queue.sqs_id
+    sqs_name = module.application-events-queue.sqs_name
+    sqs_arn  = module.application-events-queue.sqs_arn
+  }
+}
+
+resource "aws_sqs_queue_policy" "events-sns-to-application-events-queue-policy" {
+  queue_url = module.application-events-queue.sqs_id
+
+  policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "${module.application-events-queue.sqs_arn}/SQSDefaultPolicy",
+    "Statement":
+      [
+        {
+          "Effect": "Allow",
+          "Principal": { "Service": "sns.amazonaws.com" },
+          "Resource": "${module.application-events-queue.sqs_arn}",
+          "Action": "SQS:SendMessage",
+          "Condition": {
+            "ArnEquals": {
+              "aws:SourceArn": "${module.application-events-sns-topic.topic_arn}"
+            }
+          }
+        }
+      ]
+  }
+  EOF
+}


### PR DESCRIPTION
This change adds a new SQS queue to `laa-criminal-applications-datastore-staging`. This queue is linked to the existing dead-letter queue and subscribed to the SNS topic.