### PR TITLE
Sds stg turn on versioning

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-stg/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-stg/resources/irsa.tf
@@ -7,7 +7,8 @@ module "irsa" {
   role_policy_arns = merge(
     {
       dynamodb         = aws_iam_policy.auditdb_policy.arn,
-      s3 = module.laa_sds_equiniti.irsa_policy_arn
+      s3 = module.laa_sds_equiniti.irsa_policy_arn,
+      s3_versioning     = aws_iam_policy.s3_versioning_policy.arn
     },
     { for name, module in module.s3_buckets : name => module.irsa_policy_arn }
   )
@@ -38,6 +39,37 @@ module "cross-irsa" {
   infrastructure_support = var.infrastructure_support
 }
 
+data "aws_iam_policy_document" "s3_versioning_policy" {
+  # Required to call boto3's list_object_versions()
+  statement {
+    actions = ["s3:ListBucketVersions"]
+    resources = [
+      for name in var.bucket_names :
+      "arn:aws:s3:::${name}-${var.environment}"
+    ]
+  }
+
+  # Required to get/hard-delete specific object versions
+  statement {
+    actions = ["s3:GetObjectVersion", "s3:DeleteObjectVersion"]
+    resources = [
+      for name in var.bucket_names :
+      "arn:aws:s3:::${name}-${var.environment}/*"
+    ]
+  }
+}
+resource "aws_iam_policy" "s3_versioning_policy" {
+  name   = "s3_versioning_policy"
+  policy = data.aws_iam_policy_document.s3_versioning_policy.json
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
 
 data "aws_iam_policy_document" "s3_migrate_policy" {
   # List & location for source & destination S3 bucket.

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-stg/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-stg/resources/s3.tf
@@ -15,6 +15,7 @@ module "laa_sds_equiniti" {
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
   bucket_name            = "laa-sds-equiniti-${var.environment}"
+  versioning             = true
 }
 
 module "s3_buckets" {
@@ -29,6 +30,7 @@ module "s3_buckets" {
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
   bucket_name            = "${each.value}-${var.environment}"
+  versioning             = true
 }
 
 


### PR DESCRIPTION
Following a successful [PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/34467) enabling S3 bucket versioning in the `dev` environment for the LAA Secure Document Storage (SDS) API, tests have confirmed the feature behaves as expected and meets product requirements.

The SDS team now intends to enable versioning on all buckets across the SDS namespaces.

This PR enables versioning on all buckets in the `laa-sds-stg` namespace and updates the IRSA policy to include the necessary permissions for the AWS/boto3 actions required by the service.