### PR TITLE
Fix naming of IAM policy (laa-sds-production env)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-production/resources/irsa.tf
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "s3_versioning_policy" {
   }
 }
 resource "aws_iam_policy" "s3_versioning_policy" {
-  name   = "s3_versioning_policy"
+  name   = "s3_versioning_policy_${var.environment}"
   policy = data.aws_iam_policy_document.s3_versioning_policy.json
   tags = {
     business-unit          = var.business_unit


### PR DESCRIPTION
## What this PR does

- Fixes a build error caused by a globally named IAM policy (`s3_versioning_policy`) already existing.
- Updates the policy name to include `${var.environment}` to avoid name collisions across environments.
- No functional change to permissions — this is a fix for deployment compatibility.