### PR TITLE
Add S3 buckets for media uploads in HMMPS esupervision preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-preprod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-preprod/resources/s3.tf
@@ -1,0 +1,34 @@
+module "s3_data_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  cors_rule =[
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET", "PUT"]
+      allowed_origins = ["https://esupervision-preprod.hmpps.service.justice.gov.uk"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    }
+  ]
+}
+
+# info about the bucket
+resource "kubernetes_secret" "s3_bucket" {
+  metadata {
+    name      = "hmpps-esupervision-data-s3-bucket"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.s3_data_bucket.bucket_arn
+    bucket_name = module.s3_data_bucket.bucket_name
+  }
+}


### PR DESCRIPTION
Add S3 bucket to the HMPPS esupervision preprod environment. This is used to store image and video uploads for the application.