### PR TITLE
Allow the HAAR admin team access to HMPPS esupervision preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-preprod/05-rbac-haar-client-admin-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-preprod/05-rbac-haar-client-admin-team.yaml
@@ -1,0 +1,39 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-esupervision-preprod
+rules:
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "issuers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["", "extensions"]
+    resources: ["services", "ingresses", "configmaps", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-esupervision-preprod
+subjects:
+  - kind: Group
+    name: "github:hmpps-haar-client-admin"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: hmpps-haar-client-admin-team
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Add a role allowing the HMPPS HAAR client admin team permission to various objects within the HMPPS esupervision preprod namespace. This is required to allow them to configure HMPPS auth client secrets and access deployments.