### PR TITLE
Update service_account_name in irsa

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/fraud-and-corruption-insights-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/fraud-and-corruption-insights-prod/resources/irsa.tf
@@ -5,7 +5,7 @@ module "irsa" {
   eks_cluster_name = var.eks_cluster_name
 
   # IRSA configuration
-  service_account_name = "fraud-and-corruption-insights-prod-sa"
+  service_account_name = "${var.team_name}-${var.environment}"
   namespace            = var.namespace
 
   role_policy_arns = {


### PR DESCRIPTION
Got an `Error: serviceaccounts "fraud-and-corruption-insights-prod-sa" already exists` error when adding the IRSA from [this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/35215).

This update attempts to build this properly in the correct service account.