### PR TITLE
CRIMAPP-1821 Crime Datastore SQS cross-namespace config

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/irsa.tf
@@ -27,3 +27,15 @@ module "irsa" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
+# Store the SQS policy ARN as a secret in Review staging which polls for messages from SQS
+resource "kubernetes_secret" "datastore-staging-sqs-policy-arn-cross-namespace" {
+  metadata {
+    name      = "application-events-queue-policy-arn"
+    namespace = "laa-review-criminal-legal-aid-staging"
+  }
+
+  data = {
+    sqs_irsa_policy_arn = module.application-events-queue.irsa_policy_arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sqs-application-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sqs-application-events.tf
@@ -39,6 +39,20 @@ resource "kubernetes_secret" "application-events-queue" {
   }
 }
 
+# Duplicate the secret in Review staging which polls for messages from SQS
+resource "kubernetes_secret" "application-events-queue-cross-namespace" {
+  metadata {
+    name      = "application-events-queue"
+    namespace = "laa-review-criminal-legal-aid-staging"
+  }
+
+  data = {
+    sqs_id   = module.application-events-queue.sqs_id
+    sqs_name = module.application-events-queue.sqs_name
+    sqs_arn  = module.application-events-queue.sqs_arn
+  }
+}
+
 resource "aws_sqs_queue_policy" "events-sns-to-application-events-queue-policy" {
   queue_url = module.application-events-queue.sqs_id
 


### PR DESCRIPTION
This change creates secrets with the SQS policy ARN and identifiers in the `laa-review-criminal-legal-aid-staging` namespace so a connection to the SQS queue can be established from there.