### PR TITLE
CRIMAPP-1821 Add SQS role policy from Datastore to Review staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/irsa.tf
@@ -1,3 +1,11 @@
+# SQS policy ARN secret created in Datastore staging
+data "kubernetes_secret" "sqs-policy-arn-cross-namespace" {
+  metadata {
+    name      = "application-events-queue-policy-arn"
+    namespace = var.namespace
+  }
+}
+
 module "irsa" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
 
@@ -13,6 +21,7 @@ module "irsa" {
   # provide an output called `irsa_policy_arn` that can be used.
   role_policy_arns = {
     s3  = module.s3_bucket.irsa_policy_arn
+    sqs = data.kubernetes_secret.sqs-policy-arn-cross-namespace.data.sqs_irsa_policy_arn
   }
 
   # Tags


### PR DESCRIPTION
This change adds the SQS policy ARN for the SQS queue in the `laa-criminal-applications-datastore-staging` namespace, created in that namespace and stored in this one as a secret.