### PR TITLE
DSTEW-100: override default service-account permissions 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/serviceaccount.tf
@@ -15,6 +15,7 @@ module "serviceaccount" {
         "secrets",
         "services",
         "configmaps",
+        "persistentvolumeclaims",
         "pods"
       ],
       "verbs": [
@@ -42,7 +43,6 @@ module "serviceaccount" {
         "jobs",
         "replicasets",
         "statefulsets",
-        "persistentvolumeclaims",
         "poddisruptionbudgets",
         "networkpolicies"
       ],


### PR DESCRIPTION
Move persistentvolumeclaims to the generic API actions.