### PR TITLE
Reconfigure WAF to only record suspect requests in HMPPS test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/07-ingress.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/07-ingress.yaml
@@ -8,7 +8,8 @@ metadata:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleEngine On
+      SecRuleEngine DetectionOnly
+      SecAuditEngine RelevantOnly
       SecDefaultAction "phase:2,pass,log,tag:github_team=stg-pathfinders"
 spec:
   ingressClassName: modsec-non-prod


### PR DESCRIPTION
Reconfigure the modsecurity WAF to only record suspect requests within the HMPPS test environment. Only suspect requests should be added to the audit log.