### PR TITLE
LFSP-60: Add networkpolicy and servicemonitor (laa-fee-scheme-api-dev)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-dev/04-networkpolicy.yaml
@@ -25,3 +25,20 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scraping
+  namespace: laa-fee-scheme-api-dev
+spec:
+  podSelector:
+    matchLabels:
+      app: laa-fee-scheme-api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: monitoring

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-dev/05-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-dev/05-servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: laa-fee-scheme-api-service-monitor
+  namespace: laa-fee-scheme-api-dev
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: laa-fee-scheme-api-dev
+  namespaceSelector:
+    matchNames:
+      - laa-fee-scheme-api-dev
+  endpoints:
+    - port: actuator
+      interval: 15s


### PR DESCRIPTION
**Changes made:**

- Added network policy to allow Prometheus scraping
- Added service monitor for actuator