### PR TITLE
Adds bucket policy for AP ingestion account access.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-dev/resources/s3.tf
@@ -197,7 +197,7 @@ data "aws_iam_policy_document" "ap_ingestion" {
 
 # Attach the policy to the bucket as its own resource
 resource "aws_s3_bucket_policy" "ap_ingestion" {
-  bucket = module.s3_bucket.bucket_id
+  bucket = module.s3_bucket.bucket_name
   policy = data.aws_iam_policy_document.ap_ingestion.json
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-dev/resources/s3.tf
@@ -118,31 +118,34 @@ module "s3_bucket" {
    *
    */
 
-  /*
-   * Allow a user (foobar) from another account (012345678901) to get objects from
-   * this bucket.
-   *
+
 
    bucket_policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::012345678901:user/foobar"
-      },
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "$${bucket_arn}/*"
-      ]
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowAnalyticalPlatformIngestionService",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::730335344807:role/transfer"
+            },
+            "Action": [
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:PutObjectTagging"
+            ],
+            "Resource": [
+                "${module.s3_bucket.bucket_arn}",
+                "${module.s3_bucket.bucket_arn}/*"
+            ]
+        }
+    ]
 }
 EOF
-*/
 
   /*
    * OIDC for GitHub Actions


### PR DESCRIPTION
As per title, allows AP ingestion dev to access the s3 bucket in laa-maat-scheduled-tasks-dev.