### PR TITLE
APG-1235 Update RBAC group name for hmpps-manage-and-deliver-accredited-programmes-preprod namespace - preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-manage-and-deliver-accredited-programmes-preprod
 subjects:
   - kind: Group
-    name: "github:hmpps-accredited-programmes-manage-and-deliver-devs"
+    name: "github:hmpps-accredited-programmes-live"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"


### PR DESCRIPTION
Updated the RBAC group configuration for the `hmpps-manage-and-deliver-accredited-programmes-preprod` namespace in pre-prod. 