### PR TITLE
CRIMAPP-1821 Remove SNS HTTPS subscription from Crime Datastore staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sns-application-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/sns-application-events.tf
@@ -48,37 +48,3 @@ resource "aws_sns_topic_subscription" "application-events-queue-subscription" {
     ]
   })
 }
-
-resource "aws_sns_topic_subscription" "events-review-subscription" {
-  topic_arn = module.application-events-sns-topic.topic_arn
-  endpoint  = "https://staging.review-criminal-legal-aid.service.justice.gov.uk/api/events"
-  protocol  = "https"
-
-  raw_message_delivery   = false
-  endpoint_auto_confirms = true
-
-  redrive_policy = jsonencode({
-    deadLetterTargetArn = module.application-events-dlq.sqs_arn
-  })
-
-  delivery_policy = jsonencode({
-    "healthyRetryPolicy" = {
-      "backoffFunction"    = "exponential"
-      "numRetries"         = 30
-      "minDelayTarget"     = 5
-      "maxDelayTarget"     = 120
-      "numNoDelayRetries"  = 3
-      "numMinDelayRetries" = 2
-      "numMaxDelayRetries" = 15
-    }
-    "throttlePolicy" = {
-      "maxReceivesPerSecond" = 10
-    }
-  })
-
-  filter_policy = jsonencode({
-    event_name = [
-      "apply.submission"
-    ]
-  })
-}


### PR DESCRIPTION
This change removes the SNS HTTPS subscription from `laa-criminal-applications-datastore-staging`, leaving only the SQS subscription.