### PR TITLE
Revert "Adding CNAMEs for Benefit Checker"

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/route53.tf
@@ -22,35 +22,3 @@ resource "kubernetes_secret" "laa_crime_apps_route53_zone_sec" {
     zone_id = aws_route53_zone.laa_crime_apps_team_route53_zone.zone_id
   }
 }
-
-resource "aws_route53_record" "bc_prod" {
-  name    = "_1t62whbcnt4ej6waw9jbruabyybsj63.laa-benefit-checker.service.justice.gov.uk"
-  zone_id = aws_route53_zone.laa_crime_apps_team_route53_zone.zone_id
-  type    = "CNAME"
-  records = ["dcv.digicert.com"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "bc_prod_ext" {
-  name    = "_1t62whbcnt4ej6waw9jbruabyybsj63.www.laa-benefit-checker.service.justice.gov.uk"
-  zone_id = aws_route53_zone.laa_crime_apps_team_route53_zone.zone_id
-  type    = "CNAME"
-  records = ["dcv.digicert.com"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "bc_uat" {
-  name    = "_2txda07ippujatlt6lwrmtg03o007ne.uat.laa-benefit-checker.service.justice.gov.uk"
-  zone_id = aws_route53_zone.laa_crime_apps_team_route53_zone.zone_id
-  type    = "CNAME"
-  records = ["dcv.digicert.com"]
-  ttl     = "300"
-}
-
-resource "aws_route53_record" "bc_uat_ext" {
-  name    = "_2txda07ippujatlt6lwrmtg03o007ne.www.uat.laa-benefit-checker.service.justice.gov.uk"
-  zone_id = aws_route53_zone.laa_crime_apps_team_route53_zone.zone_id
-  type    = "CNAME"
-  records = ["dcv.digicert.com"]
-  ttl     = "300"
-}


### PR DESCRIPTION
The CNAME's need to be added in the BC, not in Court Data Adaptor.