### PR TITLE
Add access credentials for MAAT Scheduled Tasks dev bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-dev/resources/s3.tf
@@ -212,5 +212,7 @@ resource "kubernetes_secret" "s3_bucket" {
   data = {
     bucket_arn  = module.s3_bucket.bucket_arn
     bucket_name = module.s3_bucket.bucket_name
+    access_key_id = module.s3_bucket.access_key_id
+    secret_access_key = module.s3_bucket.secret_access_key
   }
 }


### PR DESCRIPTION
This PR adds access credentials for the MAAT Scheduled Tasks dev bucket, to enable data to be uploaded for testing and also for use by the service in Cloud Platform.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4273)