### PR TITLE
Add new CNAME value for hmicfrs.justiceinspectorates.gov.uk

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/justiceinspectorates.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/justiceinspectorates.tf
@@ -35,7 +35,7 @@ resource "aws_route53_record" "justiceinspectorates_route53_cname_record_hmicfrs
   name    = "hmicfrs.justiceinspectorates.gov.uk"
   type    = "CNAME"
   ttl     = "60"
-  records = ["web-1202467189.eu-west-2.elb.amazonaws.com"]
+  records = ["hmicfrs.b-cdn.net"]
 }
 
 resource "aws_route53_record" "justiceinspectorates_route53_cname_record_hmiprobationeforms" {


### PR DESCRIPTION
Stakeholder has requested a new value for their CNAME to send traffic to.