### PR TITLE
Create service pod for laa-maat-scheduled-tasks-dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-dev/resources/irsa.tf
@@ -24,6 +24,14 @@ module "irsa" {
   infrastructure_support = var.infrastructure_support
 }
 
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.0"
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name
+}
+
 resource "kubernetes_secret" "irsa" {
   metadata {
     name      = "${var.namespace}-irsa"


### PR DESCRIPTION
This PR creates a service pod for the `laa-maat-scheduled-tasks-dev` namespace to be able to test against the S3 bucket associated with this namespace.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4273)