### PR TITLE
CPR-769 reinstate dev circleCI serviceaccount

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/person-match-score-circleci-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/person-match-score-circleci-serviceaccount.tf
@@ -1,0 +1,10 @@
+module "serviceaccount_circleci" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  serviceaccount_name = "circleci-migrated"
+}


### PR DESCRIPTION
Deleted when migrating a project to github actions, but we still have another one which uses circleci