### PR TITLE
Maat-Data-Api-Prod - 404 Alert change

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/05-prometheus-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-data-api-prod/05-prometheus-rules.yaml
@@ -9,14 +9,24 @@ spec:
   groups:
     - name: application-rules
       rules:
-        - alert: Client Response Errors (excluding 400 and 401)
-          expr: sum(increase(http_server_requests_seconds_count{namespace="laa-maat-data-api-prod",outcome="CLIENT_ERROR",status!~"4(00|01)"}[10m])) > 1
+        - alert: Client Response Errors (excluding 400, 401, 404)
+          expr: sum(increase(http_server_requests_seconds_count{namespace="laa-maat-data-api-prod",outcome="CLIENT_ERROR",status!~"4(00|01|04)"}[10m])) > 1
           for: 1m
           labels:
             severity: laa-maat-data-api-prod
             namespace: laa-maat-data-api-prod
           annotations:
-            message: There has been an increase in client error responses (excluding 400 and 401) in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
+            message: There has been an increase in client error responses (excluding 400, 401, 404) in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
+        - alert: Client Response Errors - 400 Bad request
+          expr: sum(increase(http_server_requests_seconds_count{status="400",outcome="CLIENT_ERROR",namespace="laa-maat-data-api-prod"}[10m])) > 10
+          for: 1m
+          labels:
+            severity: laa-maat-data-api-prod
+            namespace: laa-maat-data-api-prod
+          annotations:
+            message: There has been an increase in Bad Request Errors in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
             dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
         - alert: Client Response Errors - 401 Unauthorised
@@ -29,14 +39,14 @@ spec:
             message: There has been an increase in Unauthorised requests in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
             dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
-        - alert: Client Response Errors - 400 Bad request
-          expr: sum(increase(http_server_requests_seconds_count{status="400",outcome="CLIENT_ERROR",namespace="laa-maat-data-api-prod"}[10m])) > 10
+        - alert: Client Response Errors (404 Errors)
+          expr: sum(increase(http_server_requests_seconds_count{status="404",outcome="CLIENT_ERROR",namespace="laa-maat-data-api-prod"}[10m])) > 1
           for: 1m
           labels:
             severity: laa-maat-data-api-prod
             namespace: laa-maat-data-api-prod
           annotations:
-            message: There has been an increase in Bad Request Errors in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
+            message: There has been an increase in 404 error responses in the MAAT Data API running on production in the past 10 minutes. This may indicate a problem with clients calling the application - including intrusion attempts.
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
             dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/3c878b0d42914a8fa421f798cfb3ba8f/laa-maat-data-api?var-namespace=laa-maat-data-api-prod
         - alert: MAAT Data API Rollback Error


### PR DESCRIPTION
https://dsdmoj.atlassian.net/jira/software/c/projects/LASB/boards/454/backlog?selectedIssue=LASB-4371

The 404 errors generated from client calls which are completely correct, but do not find anything, are making the generic 4xx alert useless. 
Pulled 404 from the general client alerts.
Added a separate 404 alert for monitoring.
Minor reordering of alerts.

