### PR TITLE
LASB 4309 Remove MAAT Credentials from MAAT Scheduled Tasks Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-prod/resources/cognito.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-prod/resources/cognito.tf
@@ -10,18 +10,6 @@ resource "aws_cognito_user_pool" "pool" {
 }
 
 #To add a new client to the user pool, copy line 13 - 23 with new 'cognito_user_pool_client_name'
-resource "aws_cognito_user_pool_client" "maat" {
-  name                                 = var.cognito_user_pool_client_name_maat
-  user_pool_id                         = aws_cognito_user_pool.pool.id
-  explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH"]
-  allowed_oauth_flows                  = ["client_credentials"]
-  allowed_oauth_flows_user_pool_client = true
-  allowed_oauth_scopes                 = aws_cognito_resource_server.resource.scope_identifiers
-  prevent_user_existence_errors        = "ENABLED"
-  supported_identity_providers         = ["COGNITO"]
-  generate_secret                      = true
-}
-
 resource "aws_cognito_user_pool_client" "billing" {
   name                                 = var.cognito_user_pool_client_name_billing
   user_pool_id                         = aws_cognito_user_pool.pool.id
@@ -57,8 +45,6 @@ resource "kubernetes_secret" "aws_cognito_user_pool_client" {
   }
 
   data = {
-    maat_id     = aws_cognito_user_pool_client.maat.id
-    maat_secret = aws_cognito_user_pool_client.maat.client_secret
     billing_id     = aws_cognito_user_pool_client.billing.id
     billing_secret = aws_cognito_user_pool_client.billing.client_secret
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-prod/resources/variables.tf
@@ -77,11 +77,6 @@ variable "user_pool_name" {
   default     = "maat-scheduled-tasks-prod-userpool"
 }
 
-variable "cognito_user_pool_client_name_maat" {
-  description = "Cognito user pool client - MAAT"
-  default     = "maat-prod"
-}
-
 variable "cognito_user_pool_client_name_billing" {
   description = "Cognito user pool client - Billing"
   default     = "billing-prod"


### PR DESCRIPTION
The intention was for these credentials to be used for manual testing which will not be done in prod so best to remove unwanted credentials.