### PR TITLE
LASB 4309 Renamed MAAT Credentials for MAAT Scheduled Tasks Test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-test/resources/cognito.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-test/resources/cognito.tf
@@ -10,8 +10,8 @@ resource "aws_cognito_user_pool" "pool" {
 }
 
 #To add a new client to the user pool, copy line 13 - 23 with new 'cognito_user_pool_client_name'
-resource "aws_cognito_user_pool_client" "maat" {
-  name                                 = var.cognito_user_pool_client_name_maat
+resource "aws_cognito_user_pool_client" "fts" {
+  name                                 = var.cognito_user_pool_client_name_fts
   user_pool_id                         = aws_cognito_user_pool.pool.id
   explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH"]
   allowed_oauth_flows                  = ["client_credentials"]
@@ -57,8 +57,8 @@ resource "kubernetes_secret" "aws_cognito_user_pool_client" {
   }
 
   data = {
-    maat_id     = aws_cognito_user_pool_client.maat.id
-    maat_secret = aws_cognito_user_pool_client.maat.client_secret
+    fts_id     = aws_cognito_user_pool_client.fts.id
+    fts_secret = aws_cognito_user_pool_client.fts.client_secret
     billing_id     = aws_cognito_user_pool_client.billing.id
     billing_secret = aws_cognito_user_pool_client.billing.client_secret
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-maat-scheduled-tasks-test/resources/variables.tf
@@ -77,9 +77,9 @@ variable "user_pool_name" {
   default     = "maat-scheduled-tasks-test-userpool"
 }
 
-variable "cognito_user_pool_client_name_maat" {
-  description = "Cognito user pool client - MAAT"
-  default     = "maat-test"
+variable "cognito_user_pool_client_name_fts" {
+  description = "Cognito user pool client - Functional Tests"
+  default     = "fts-test"
 }
 
 variable "cognito_user_pool_client_name_billing" {


### PR DESCRIPTION
The original intention was for these credentials to be for manual testing and use in the functional test suite so renaming to make that clearer.