### PR TITLE
EL-2597: Enable MCC Staging to access CCA (Civil Case API) UAT via cross namespace network access

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-staging/00-namespace.yaml
@@ -15,3 +15,4 @@ metadata:
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-manage-your-civil-cases"
     cloud-platform.justice.gov.uk/team-name: "check-client-qualifies"
     cloud-platform.justice.gov.uk/review-after: ""
+    cloud-platform.justice.gov.uk/namespace: "laa-manage-your-civil-cases-staging"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-staging/04-networkpolicy.yaml
@@ -30,7 +30,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-laa-civil-case-api-uat
-  namespace: laa-manage-your-civil-cases-uat
+  namespace: laa-manage-your-civil-cases-staging
 spec:
   podSelector: {}
   policyTypes:


### PR DESCRIPTION
If applied, this should allow cross namespace network access between MCC Staging & CCA UAT.