### PR TITLE
EL-2598: Enable MCC Production to access CCA (Civil Case API) UAT via cross namespace network access

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
+    component: allow-laa-civil-case-api-uat
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "LAA"
@@ -14,3 +15,4 @@ metadata:
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-manage-your-civil-cases"
     cloud-platform.justice.gov.uk/team-name: "check-client-qualifies"
     cloud-platform.justice.gov.uk/review-after: ""
+    cloud-platform.justice.gov.uk/namespace: "laa-manage-your-civil-cases-production"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/04-networkpolicy.yaml
@@ -25,3 +25,21 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-laa-civil-case-api-uat
+  namespace: laa-manage-your-civil-cases-production
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: laa-civil-case-api-uat
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: laa-civil-case-api-uat


### PR DESCRIPTION
If applied, this should allow cross namespace network access between MCC Production & CCA UAT.