### PR TITLE
[ESWE-1386] update integration_api_domain_events_queue filtering 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/hmpps-domain-event-subscription.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/hmpps-domain-event-subscription.tf
@@ -117,6 +117,7 @@ resource "aws_sns_topic_subscription" "integration_api_domain_events_subscriptio
       "prison-offender-events.prisoner.person-restriction.deleted",
       "prison-offender-events.prisoner.non-association-detail.changed",
       "prison-offender-events.prisoner.received",
+      "prison-offender-events.prisoner.merged",
       "calculate-release-dates.prisoner.changed",
       "risk-assessment.scores.ogrs.determined",
       "risk-assessment.scores.rsr.determined",


### PR DESCRIPTION
Updates queue filter to include `prison-offender-events.prisoner.merged` domain event (Dev only).