### PR TITLE
Put the serviceaccount_name setting back to what it was 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/serviceaccount.tf
@@ -3,6 +3,7 @@ module "serviceaccount" {
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
+  serviceaccount_name = var.serviceaccount_name
   serviceaccount_rules = [
     {
       "api_groups": [


### PR DESCRIPTION
Put the serviceaccount_name setting back to what it was before the last PR because the pipeline depends on the name.