### PR TITLE
Update rds instance in cfe-civil-productionrds.tf file

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/rds.tf
@@ -24,7 +24,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "14.13"
+  db_engine_version = "14.17"
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.small"
@@ -80,7 +80,7 @@ module "read_replica" {
   # add them to the replica
 
   rds_family = "postgres14"
-  db_engine_version = "14.13"
+  db_engine_version = "14.17"
   db_instance_class = "db.t4g.small"
   # It is mandatory to set the below values to create read replica instance
 


### PR DESCRIPTION
This was out of date of date because of version drift and did not reflect the version in the cfe-civil-production namespace.

This caused concourse to fail when removing a skipfile