### PR TITLE
chore: 🤖 bump all remaining 7.1.1 ecr modules calls to latest

### DIFF
--- a/namespace-resources-cli-template/resources/prototype/ecr.tf
+++ b/namespace-resources-cli-template/resources/prototype/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module/resources/ecr.tf
+++ b/namespaces/live-2.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   repo_name = "${var.namespace}-ecr"
 
   /*

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/accessibility-book-club/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/accessibility-book-club/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/accredited-programmes-community-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/accredited-programmes-community-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/accredited-programmes-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/accredited-programmes-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/aminur-sandbox/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/aminur-sandbox/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ap-app-poc-bde/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ap-app-poc-bde/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-compensation-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/apply-for-legal-aid-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/approved-premises-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/categorisation-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/categorisation-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cdpt-av/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cdpt-av/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cdpt-deploys-dashboard/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cdpt-deploys-dashboard/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-apply-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-apply-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-experian-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "cica-experian-uat"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-information-extraction-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-information-extraction-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cjs-dashboard-demo/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name             = "${var.namespace}-ecr"
   github_repositories   = ["cjs-dashboard"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cla-reform-design/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cla-reform-design/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cla-reform-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cla-reform-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-non-standard-magistrate-fee-high-fidelity/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-non-standard-magistrate-fee-high-fidelity/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-containers/resources/ecr_delete_oldsnapshots.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-containers/resources/ecr_delete_oldsnapshots.tf
@@ -1,5 +1,5 @@
 module "delete_oldsnapshots" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0" # use the latest release
 
   # Repository configuration
   repo_name = "delete-oldsnapshots"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-example-application/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-example-application/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # REQUIRED: Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-hammer-bot/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-hammer-bot/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   repo_name = "${var.namespace}-ecr"
 
   /*

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-metrics/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-metrics/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-prototype-demo/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-prototype-demo/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-service-pod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-service-pod/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # REQUIRED: Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/core-person-record-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/core-person-record-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/courtfines-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name           = var.team_name
   repo_name           = "${var.namespace}-ecr"
   oidc_providers      = ["circleci"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/crmfour-proto/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/crmfour-proto/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cvl-improvements-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cvl-improvements-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-science-asset-register/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-science-asset-register/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dave-learning/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dave-learning/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-reporting-mi-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-reporting-mi-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = var.repo_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dwf-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dwf-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/eligibility-estimate/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/eligibility-estimate/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/evidencelibrary-test/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-staging/resources/ecr.tf
@@ -3,7 +3,7 @@
 #####################################
 
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = var.repo_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-repos/resources/repos.tf
@@ -1,7 +1,7 @@
 # Publisher ECR Repos
 
 module "ecr-repo-fb-publisher-base" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-publisher-base"
@@ -36,7 +36,7 @@ resource "kubernetes_secret" "ecr-repo-fb-publisher-base" {
 }
 
 module "ecr-repo-fb-publisher-web" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-publisher-web"
@@ -71,7 +71,7 @@ resource "kubernetes_secret" "ecr-repo-fb-publisher-web" {
 }
 
 module "ecr-repo-fb-publisher-worker" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-publisher-worker"
@@ -109,7 +109,7 @@ resource "kubernetes_secret" "ecr-repo-fb-publisher-worker" {
 
 # Runner Node ECR Repos
 module "ecr-repo-fb-runner-node" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-runner-node"
@@ -147,7 +147,7 @@ resource "kubernetes_secret" "ecr-repo-fb-runner-node" {
 
 # Service Token Cache ECR Repos
 module "ecr-repo-fb-service-token-cache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-service-token-cache"
@@ -185,7 +185,7 @@ resource "kubernetes_secret" "ecr-repo-fb-service-token-cache" {
 
 # Submitter ECR Repos
 module "ecr-repo-fb-submitter-base" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-submitter-base"
@@ -217,7 +217,7 @@ resource "kubernetes_secret" "ecr-repo-fb-submitter-base" {
 }
 
 module "ecr-repo-fb-submitter-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-submitter-api"
@@ -252,7 +252,7 @@ resource "kubernetes_secret" "ecr-repo-fb-submitter-api" {
 }
 
 module "ecr-repo-fb-submitter-workers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-submitter-workers"
@@ -291,7 +291,7 @@ resource "kubernetes_secret" "ecr-repo-fb-submitter-workers" {
 
 # User Datastore ECR Repos
 module "ecr-repo-fb-user-datastore-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-user-datastore-api"
@@ -329,7 +329,7 @@ resource "kubernetes_secret" "ecr-repo-fb-user-datastore-api" {
 
 # User Filestore ECR Repos
 module "ecr-repo-fb-user-filestore-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-user-filestore-api"
@@ -367,7 +367,7 @@ resource "kubernetes_secret" "ecr-repo-fb-user-filestore-api" {
 
 # AV (Anti Virus) ECR Repos
 module "ecr-repo-fb-av" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-av"
@@ -405,7 +405,7 @@ resource "kubernetes_secret" "ecr-repo-fb-av" {
 
 # fb-builder - docker image used to build form builder components
 module "ecr-repo-fb-builder" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-builder"
@@ -443,7 +443,7 @@ resource "kubernetes_secret" "ecr-repo-fb-builder" {
 ##################################################
 
 module "ecr-repo-fb-pdf-generator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-pdf-generator"
@@ -476,7 +476,7 @@ resource "kubernetes_secret" "ecr-repo-fb-pdf-generator" {
 ##################################################
 
 module "ecr-repo-fb-base-adapter" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-base-adapter"
@@ -509,7 +509,7 @@ resource "kubernetes_secret" "ecr-repo-fb-base-adapter" {
 ##################################################
 
 module "ecr-repo-hmcts-complaints-formbuilder-adapter-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "hmcts-complaints-formbuilder-adapter-api"
@@ -544,7 +544,7 @@ resource "kubernetes_secret" "ecr-repo-hmcts-complaints-formbuilder-adapter-api"
 }
 
 module "ecr-repo-hmcts-complaints-formbuilder-adapter-worker" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "hmcts-complaints-formbuilder-adapter-worker"
@@ -581,7 +581,7 @@ resource "kubernetes_secret" "ecr-repo-hmcts-complaints-formbuilder-adapter-work
 ##################################################
 
 module "ecr-repo-fb-metadata-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-metadata-api"
@@ -614,7 +614,7 @@ resource "kubernetes_secret" "ecr-repo-fb-metadata-api" {
 ##################################################
 
 module "ecr-repo-fb-editor-web" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-editor-web"
@@ -646,7 +646,7 @@ resource "kubernetes_secret" "ecr-repo-fb-editor-web" {
 }
 
 module "ecr-repo-fb-editor-workers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-editor-workers"
@@ -679,7 +679,7 @@ resource "kubernetes_secret" "ecr-repo-fb-editor-workers" {
 ##################################################
 
 module "ecr-repo-fb-runner" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "form-builder"
   repo_name = "fb-runner"
@@ -712,7 +712,7 @@ resource "kubernetes_secret" "ecr-repo-fb-runner" {
 ##################################################
 
 module "ecr-repo-fb-maintenance-page" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-maintenance-page"
@@ -745,7 +745,7 @@ resource "kubernetes_secret" "ecr-repo-fb-maintenance-page" {
 ##################################################
 
 module "ecr-repo-fb-adapter-template-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-adapter-template-api"
@@ -780,7 +780,7 @@ resource "kubernetes_secret" "ecr-repo-fb-adapter-template-api" {
 }
 
 module "ecr-repo-fb-adapter-template-worker" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = "formbuilder"
   repo_name = "fb-adapter-template-worker"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/gov-collab-library/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/gov-collab-library/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source         = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source         = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name      = var.team_name
   repo_name      = "${var.namespace}-ecr"
   oidc_providers = ["circleci"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/haar-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/haar-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hdc-cvl-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hdc-cvl-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-child-arrangements-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr_credentials" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activity-management-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activity-management-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-afer-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-afer-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-prison-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-prison-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prototypes/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-prototypes/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr-repo-datasette.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr-repo-datasette.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-datasette" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = "ecr-repo-datasette"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = var.repo_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-tier-2-bail-prototypes/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-tier-2-bail-prototypes/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-tier-2-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-tier-2-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-design/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-design/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cvl-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cvl-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-shared/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-shared/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "alfresco-content-ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "alfresco-content-repository"
@@ -26,7 +26,7 @@ module "alfresco-content-ecr" {
 }
 
 module "alfresco-share-ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "alfresco-share"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-tool/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-tool/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-vision/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-vision/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-recalls-prototype-history/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-recalls-prototype-history/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-recalls-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-recalls-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-supervisions-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-behaviour-prototyping/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-behaviour-prototyping/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-matching-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-matching-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-official-visits-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-official-visits-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prepare-a-case-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prepare-a-case-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-education/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-education/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-design-history/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-design-history/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-rap-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-single-accommodation-service-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-single-accommodation-service-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-services-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-temporary-accommodation-services-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-uof-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-uof-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-visit-someone-in-prison-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-visit-someone-in-prison-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/housing-disrepair-oss-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/housing-disrepair-oss-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = var.namespace
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/interventions-design-history/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/interventions-design-history/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justicedata-test/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/kristian-helloworld/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/kristian-helloworld/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-architect-info/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-architect-info/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-a-claim-frontend-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-a-claim-frontend-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-a-claim-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-a-claim-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-aws-control/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-aws-control/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-benefit-checker-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-billing-alpha-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-billing-alpha-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-billing-controlled-work-proto/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-billing-controlled-work-proto/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-staging-api-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-staging-api-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-staging-file-upload-api-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-staging-file-upload-api-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-user-management-api-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-user-management-api-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-end-to-end-tests/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-end-to-end-tests/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "cla_frontend_app_credentials" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name
@@ -37,7 +37,7 @@ resource "kubernetes_secret" "cla_frontend_app_credentials" {
 }
 
 module "cla_frontend_socket_server_credentials" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = "cla_frontend_socket_server"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-high-fidelity-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-claim-non-standard-magistrate-fee-high-fidelity-prototype/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-apply-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-maat-test/resources/ecr.tf
@@ -9,7 +9,7 @@ module "ecr_credentials" {
   # enable the oidc implementation for GitHub
   oidc_providers = ["github"]
 
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # REQUIRED: Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-review-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-review-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-deployments-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-deployments-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # REQUIRED: Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-feature-tests-stg/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-feature-tests-stg/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   deletion_protection = false
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-submissions-api-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # REQUIRED: Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-users-api-stg/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-users-api-stg/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-users-api-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cwa-users-api-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  * Making a dummy change.
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-pact-broker/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-pact-broker/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-provider-data-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-provider-data-uat/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-stewardship-access-resources/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-stewardship-access-resources/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-dummy-drc-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-dummy-drc-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-decide-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-end-to-end/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-end-to-end/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fala-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "laa_fee_caclulator_team_ecr_credentials" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = var.repo_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name           = "${var.namespace}-ecr"
   oidc_providers      = ["circleci"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-prd/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-prd/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-api" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-means-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-means-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-mnm-onelogin-spike-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-mnm-onelogin-spike-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-portal/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-portal/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = var.repo_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-stg/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-stg/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-test-viewer/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-test-viewer/resources/ecr.tf
@@ -8,7 +8,7 @@ module "ecr_credentials" {
   # enable the oidc implementation for GitHub
   oidc_providers = ["github"]
 
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # REQUIRED: Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-zap-dast/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-zap-dast/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/launchpad-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/launchpad-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-uat/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name           = "${var.namespace}-ecr"
   oidc_providers      = ["circleci"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makerecall-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makerecall-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/makerecalldecisions-design-history/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/makerecalldecisions-design-history/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-a-workforce/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-a-workforce/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-people-on-probation-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-people-on-probation-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-pom-cases-design-history/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-pom-cases-design-history/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-supervisions-design-history/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-supervisions-design-history/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/managing-apps-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/managing-apps-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mikebell-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mikebell-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/moj-frontend/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/moj-frontend/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mpc-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mpc-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/mrd-proto/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/mrd-proto/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/nettest/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/nettest/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/opg-lpa-fd-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/opg-lpa-fd-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/opg-sirius-prototypes/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/opg-sirius-prototypes/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/philpayne-sandbox/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/philpayne-sandbox/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pre-sentence-service-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pre-sentence-service-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prepare-a-case-for-sentence-design-history/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prepare-a-case-for-sentence-design-history/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-public.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-public.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-prison-visits-public" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name           = "prison-visits-public"
   oidc_providers      = ["circleci"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-staff.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-staff.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-prison-visits-staff" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name           = "prison-visits-staff"
   oidc_providers      = ["circleci"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-tests.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-staging/resources/ecr-prison-visits-tests.tf
@@ -1,5 +1,5 @@
 module "ecr-repo-prison-visits-tests" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name           = "prison-visits-integration-tests"
   oidc_providers      = ["circleci"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/probation-template/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/probation-template/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prototype-kit-training/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prototype-kit-training/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/psr-ai-design-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/psr-ai-design-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rajinder-pocs/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rajinder-pocs/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # REQUIRED: Repository configuration
   team_name = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-entra-test/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-entra-test/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-exercise/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-exercise/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-sighting/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/record-a-goose-sighting/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/request-info-from-moj/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/request-info-from-moj/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/request-personal-information-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/request-personal-information-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rp-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rp-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sentence-and-offence-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sentence-and-offence-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name = "${var.namespace}-ecr"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/specialist-provider-proto/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/specialist-provider-proto/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/stg-tmc-example/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/stg-tmc-example/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/stg-track-my-case-ui-demo/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/stg-track-my-case-ui-demo/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/trevors-sandbox/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/trevors-sandbox/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/unpaid-work-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/unpaid-work-prototype/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/utiac-staging/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr" {
-  source         = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source         = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
   repo_name      = var.namespace
   oidc_providers = ["circleci"]
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/verification-report-pilot/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/verification-report-pilot/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/victims-pathfinder/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/victims-pathfinder/resources/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = "${var.namespace}-ecr"


### PR DESCRIPTION
[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/releases/tag/8.0.0)

relates to https://github.com/ministryofjustice/cloud-platform/issues/7508