### PR TITLE
Allow IRSA service account to assume role in external account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/cross-iam-role-sa.tf
@@ -1,0 +1,22 @@
+data "aws_iam_policy_document" "assume_rekognition_role" {
+  statement {
+    sid = "AssumeRekognitionRole"
+    actions = ["sts:AssumeRole"]
+    effect = "Allow"
+    resources = [var.rekognition_role_arn]
+  }
+}
+
+resource "aws_iam_policy" "assume_rekognition_policy" {
+  name = "${var.namespace}-allow-assume-rekognition"
+  policy = data.aws_iam_policy_document.assume_rekognition_role.json
+
+  tags = {
+    business-unit = var.business_unit
+    application = var.application
+    is-production = var.is_production
+    environment-name = var.environment
+    owner = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }  
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/irsa.tf
@@ -8,6 +8,7 @@ module "irsa" {
   service_account_name = "hmpps-esupervision-api"
   role_policy_arns = {
     s3 = module.s3_data_bucket.irsa_policy_arn
+    rekognition = aws_iam_policy.assume_rekognition_policy.arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/variables.tf
@@ -81,3 +81,9 @@ variable "postgres_instance_class" {
   description = "Class of the postgres instance"
   default = "db.t4g.micro"
 }
+
+variable "rekognition_role_arn" {
+  type = string
+  description = "ARN of the role to assume for Rekognition operations"
+  default = "arn:aws:iam::514115671816:role/rekognition-role"
+}


### PR DESCRIPTION
A role has been defined within an external AWS account (within the modernisation platform) with permissions required for the AWS Rekognition service used within the esupervision application.

Allow the service account permission to assume this role.