### PR TITLE
Bump rds-instance modules to 9.0.0 for dev namespaces

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-development/resources/rds.tf
@@ -1,5 +1,5 @@
 module "grafana_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   db_engine                = "postgres"
   db_engine_version        = "17"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-dev/resources/rds.tf
@@ -3,7 +3,7 @@
 ########################################
 
 module "rds-instance" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact-moj_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   vpc_name                   = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-development/resources/simulated-data-producer-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-development/resources/simulated-data-producer-rds.tf
@@ -1,5 +1,5 @@
 module "simulated_data_producer_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/submitter.tf
@@ -1,5 +1,5 @@
 module "submitter-rds-instance-2" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_submitter

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance-2" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_user_datastore

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/submitter.tf
@@ -1,5 +1,5 @@
 module "submitter-rds-instance-2" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_submitter

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance-2" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_user_datastore

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/gdavies-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/gdavies-dev/resources/rds.tf
@@ -1,7 +1,7 @@
 # PostgreSQL
 
 module "rds_postgresql" {
-  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type = "gp2"
 
   # VPC configuration

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name
@@ -68,7 +68,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hwpv_sqlserver" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "adjustments_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-for-early-release-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-for-early-release-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "assess-for-early-release_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-dev/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "hmpps_assess_risks_and_needs_integrations_dev_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_audit_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
@@ -60,7 +60,7 @@ resource "kubernetes_secret" "dps_rds_external_users_api" {
 
 module "hmpps_authorization_rds" {
 
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
@@ -24,7 +24,7 @@ module "rds" {
 
 module "read_replica" {
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-dev/resources/gdpr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-dev/resources/gdpr.tf
@@ -1,5 +1,5 @@
 module "gdpr_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-dev/resources/merge.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-dev/resources/merge.tf
@@ -1,5 +1,5 @@
 module "merge_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-dev/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds_postgres" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dps-reconciliation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dps-reconciliation-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_dps_reconciliation_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 20
   storage_type               = "gp3"
   vpc_name                   = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/rds.tf
@@ -4,7 +4,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "edu_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/rds-postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/rds-postgres.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -47,7 +47,7 @@ resource "kubernetes_secret" "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-feature-flags-dev/resources/hmpps-feature-flags.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-feature-flags-dev/resources/hmpps-feature-flags.tf
@@ -14,7 +14,7 @@ module "hmpps-feature-flags" {
 
 
 module "flipt-db" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-dev/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-dev/resources/rds-postgres14.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -41,7 +41,7 @@ resource "kubernetes_secret" "rds" {
 
 
 #module "rds_replica" {
-#  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+#  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 #  vpc_name               = var.vpc_name
 #  team_name              = var.team_name
 #  business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "historical_prisoner_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "identify_remand_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/rds.tf
@@ -4,7 +4,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -67,7 +67,7 @@ module "dps_rds" {
 module "read_replica" {
   # default off
   count  = 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/rds_postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/rds_postgres.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -53,7 +53,7 @@ resource "kubernetes_secret" "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/rds-postgres14.tf
@@ -1,5 +1,5 @@
 module "hmpps_interventions_postgres14" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -39,7 +39,7 @@ resource "kubernetes_secret" "hmpps_interventions_postgres14" {
 
 
 module "hmpps_interventions_postgres14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-integration-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-integration-dev/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/rds-launchpad-auth-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/rds-launchpad-auth-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-learner-records-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-learner-records-dev/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "ma_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-custody-mailbox-register-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-custody-mailbox-register-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "manage_offences_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-dev/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-dev/resources/flipt.tf
@@ -1,5 +1,5 @@
 module "flipt-db" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-prisoner-apps-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-prisoner-apps-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -44,7 +44,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-organisations-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-organisations-dev/resources/rds-postgresql.tf
@@ -10,7 +10,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -44,7 +44,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-personal-relationships-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-personal-relationships-dev/resources/rds-postgresql.tf
@@ -10,7 +10,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_service_catalogue" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-finance-poc-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-finance-poc-dev/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 20
   storage_type         = "gp3"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "nomis_migration_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_prisoner_search_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/flipt.tf
@@ -1,5 +1,5 @@
 module "flipt-db" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/hcmts-data-ingestion-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/hcmts-data-ingestion-rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "prisons_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rp_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name
@@ -63,7 +63,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_strengths_based_needs_assessments_dev_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "subject_access_request_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_user_preferences_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage      = 10
   storage_type              = "gp2"
   vpc_name                  = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-vcms-notification-poc-dev/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-vcms-notification-poc-dev/resources/rds-mysql.tf
@@ -6,7 +6,7 @@
 */
 
 module "rds_mysql" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/rds-history.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/rds-history.tf
@@ -1,5 +1,5 @@
 module "rds-history" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/rds-live.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/rds-live.tf
@@ -1,5 +1,5 @@
 module "rds-live" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-dev/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -32,7 +32,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-dev/resources/rds-mysql.tf
@@ -1,5 +1,5 @@
 module "opa_hub_db" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccw-fees-service-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccw-fees-service-dev/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -44,7 +44,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "lcdui_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds-mtn" {
-  source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name = var.vpc_name
 
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -42,7 +42,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-dev/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -42,7 +42,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-link-service-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-link-service-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds_instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/rds.tf
@@ -3,7 +3,7 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage     = 10
   storage_type             = "gp2"
   vpc_name                 = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/migration-link-exchange-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/migration-link-exchange-dev/resources/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name
@@ -63,7 +63,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/rds.tf
@@ -3,7 +3,7 @@
 #############################################
 
 module "rds_instance" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   application                = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/rds.tf
@@ -3,7 +3,7 @@ resource "random_id" "id" {
 }
 
 module "dps_rds" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage     = 10
   storage_type             = "gp2"
   vpc_name                 = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-development/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   vpc_name                   = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "prison-visits-rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds-feedback.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/rds-feedback.tf
@@ -1,5 +1,5 @@
 module "prisoner_feedback_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # turn off the db overnight (between 22:00 and 06:00)
   enable_rds_auto_start_stop = false
@@ -46,7 +46,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "slmtp_api_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   vpc_name                   = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/srikanth-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/srikanth-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/stg-track-my-case-service-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/stg-track-my-case-service-dev/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/tim-development/resources/rds.tf
@@ -6,7 +6,7 @@
 #  *
 #  */
 # module "rds" {
-#   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+#   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
 #   # VPC configuration
 #   vpc_name = var.vpc_name
@@ -37,7 +37,7 @@
 
 
 # module "rds_2" {
-#   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+#   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
 #   # VPC configuration
 #   vpc_name = var.vpc_name
@@ -72,7 +72,7 @@
 # # module "read_replica" {
 # #   # default off
 # #   count  = 1
-# #   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+# #   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
 # #   vpc_name               = var.vpc_name
 
@@ -115,7 +115,7 @@
 # # }
 
 # module "rds_3" {
-#   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+#   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
 #   # VPC configuration
 #   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   vpc_name                   = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-dev/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/rds-allocation.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/rds-allocation.tf
@@ -1,5 +1,5 @@
 module "rds-allocation" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit


### PR DESCRIPTION
Bump rds-instance modules to 9.0.0 for dev namespaces to remove unused irsa policies.
Done as a part of [#7509](https://github.com/ministryofjustice/cloud-platform/issues/7509)

[Module release notes](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/releases/tag/9.0.0)