### PR TITLE
bump cloud-platform-terraform-hmpps-template version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/template-kotlin.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/template-kotlin.tf
@@ -1,5 +1,5 @@
 module "hmpps_template_kotlin" {
-  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.1.0"
   github_repo = "hmpps-template-kotlin"
   application = "hmpps-template-kotlin"
   github_team = "hmpps-sre"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/template-typescript.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/template-typescript.tf
@@ -1,5 +1,5 @@
 module "hmpps_template_typescript" {
-  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.0.0"
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.1.0"
   github_repo = "hmpps-template-typescript"
   application = "hmpps-template-typescript"
   github_team = "hmpps-sre"


### PR DESCRIPTION
Match the latest version in the template, so new projects don't run afoul of the version check.