### PR TITLE
ap-6128: add external secret to cfe-civil-production namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/main.tf
@@ -5,16 +5,34 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = "laa-apply-for-legal-aid"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      GithubTeam = "laa-apply-for-legal-aid"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      GithubTeam = "laa-apply-for-legal-aid"
+    }
+  }
 }
 
 provider "github" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/secret.tf
@@ -1,0 +1,19 @@
+module "secrets" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.4"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "cfe-civil-secrets" = {
+      description             = "cfe-civil-production secrets",
+      recovery_window_in_days = 7
+      k8s_secret_name         = "cfe-civil-secrets"
+    },
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/variables.tf
@@ -53,3 +53,7 @@ variable "github_token" {
   description = "Required by the Github Terraform provider"
   default     = ""
 }
+
+variable "eks_cluster_name" {
+  description = "EKS cluster name"
+}


### PR DESCRIPTION
Add default tags to allow secret to be viewed by laa-apply-for-legalaid team in console