### PR TITLE
AP-6161: Add civil apply team to rbac [CFE UAT]

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/01-rbac.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: Group
     name: "github:laa-eligibility-platform"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:laa-apply-for-legal-aid"
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
Add civil apply team to rbac

For k8s access without being a a member of the laa-eligibility-team