### PR TITLE
BAVL-1058: Update GH actions integration version

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/versions.tf
@@ -6,8 +6,8 @@ terraform {
       version = "~> 5.78.0"
     }
     github = {
-      source  = "integrations/github"
-      version = "~> 5.39.0"
+       source  = "integrations/github"
+       version = "~> 6.6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Update GH actions integration from v5.39.0 to v6.6.0. 