### PR TITLE
Fix: rds version mismatch in prison-visits-booking-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/rds.tf
@@ -13,7 +13,7 @@ module "prison-visits-rds" {
   allow_major_version_upgrade = "false"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "15.5"
+  db_engine_version           = "15.12"
   rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
   db_allocated_storage        = "50"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `prison-visits-booking-dev`

```
module.prison-visits-rds: downgrade from 15.12 to 15.5
```