### PR TITLE
Fix: rds version mismatch in hmpps-staff-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-staff-preprod/resources/rds-postgresql.tf
@@ -25,7 +25,7 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "15.5"
+  db_engine_version = "15.12"
 
   # change the instance class as you see fit.
   db_instance_class = "db.t4g.small"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-staff-preprod`

```
module.rds: downgrade from 15.12 to 15.5
```