### PR TITLE
Fix: rds version mismatch in workforce-management-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/rds-allocation.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/rds-allocation.tf
@@ -17,7 +17,7 @@ module "rds-allocation" {
   db_instance_class = "db.t4g.small"
 
   # change the postgres version as you see fit.
-  db_engine_version      = "15.5"
+  db_engine_version      = "15.12"
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `workforce-management-dev`

```
module.rds-allocation: downgrade from 15.12 to 15.5
```