### PR TITLE
Fix: rds version mismatch in hmpps-complexity-of-need-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-staging/resources/rds.tf
@@ -23,7 +23,7 @@ module "complexity-of-need-rds" {
   db_name                    = "hmpps_complexity_of_need"
   enable_rds_auto_start_stop = true
 
-  db_engine_version           = "15.6"
+  db_engine_version           = "15.12"
   rds_family                  = "postgres15"
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-complexity-of-need-staging`

```
module.complexity-of-need-rds: downgrade from 15.12 to 15.6
```