### PR TITLE
Fix: rds version mismatch in hmpps-dpr-fake-dps-service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/rds-postgresql.tf
@@ -26,7 +26,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine              = "postgres"
-  db_engine_version      = "16.2"
+  db_engine_version      = "16.8"
   rds_family             = "postgres16"
   db_instance_class      = "db.t4g.micro"
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-dpr-fake-dps-service`

```
module.rds: downgrade from 16.8 to 16.2
```