### PR TITLE
Fix: rds version mismatch in hmpps-education-and-work-plan-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/rds-postgresql.tf
@@ -26,7 +26,7 @@ module "hmpps_education_work_plan_rds" {
 
   # PostgreSQL specifics
   db_engine              = "postgres"
-  db_engine_version      = "15.5"
+  db_engine_version      = "15.12"
   rds_family             = "postgres15"
   db_instance_class      = "db.t4g.micro"
 


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-education-and-work-plan-dev`

```
module.hmpps_education_work_plan_rds: downgrade from 15.12 to 15.5
```