### PR TITLE
Bumping rds module version for prod and remaining namespaces to remove unused irsa policies

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/analytical-platform-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "grafana_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   db_engine                = "postgres"
   db_engine_version        = "17"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-production/resources/rds.tf
@@ -3,7 +3,7 @@
 ########################################
 
 module "rds-instance" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cdpt-deploys-dashboard/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cdpt-deploys-dashboard/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/check-my-diary-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "checkmydiary_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-production/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact-moj_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   vpc_name                   = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = var.db_allocated_storage
   storage_type         = var.storage_type
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dex-mi-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dex-mi-production/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "dex_mi_production_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   vpc_name                   = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/disclosure-checker-production/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/family-mediators-api-production/resources/rds.tf
@@ -3,7 +3,7 @@
 ############################################
 
 module "rds-instance" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-unclaimed-court-money-production/resources/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage      = 10
   storage_type              = "gp2"
   vpc_name                  = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/submitter.tf
@@ -1,5 +1,5 @@
 module "submitter-rds-instance-2" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_submitter

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-production/resources/user-datastore.tf
@@ -1,5 +1,5 @@
 module "user-datastore-rds-instance-2" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_user_datastore

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/editor.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/editor.tf
@@ -1,5 +1,5 @@
 module "editor-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-saas-live/resources/metadata_api.tf
@@ -1,5 +1,5 @@
 module "metadata-api-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-prod/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "dps_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage      = 10
   storage_type              = "gp2"
   vpc_name                  = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hwpv_sqlserver" {
-  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type             = "gp2"
   vpc_name                 = var.vpc_name
   team_name                = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmcts-complaints-formbuilder-adapter-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmcts-complaints-adapter-rds-instance" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                   = var.vpc_name
   db_backup_retention_period = var.db_backup_retention_period_hmcts_complaints_adapter

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "adjustments_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage      = 10
   storage_type              = "gp2"
   vpc_name                  = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-prod/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "hmpps_assess_risks_and_needs_integrations_prod_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_audit_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-stage/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-demo/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-demo/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
@@ -24,7 +24,7 @@ module "rds" {
 
 module "read_replica" {
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name
@@ -24,7 +24,7 @@ module "rds" {
 
 module "read_replica" {
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-production/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
   vpc_name             = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds_alfresco" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-stage/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds_alfresco" {
-  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type = "gp2"
 
   # VPC configuration

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-prod/resources/gdpr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-prod/resources/gdpr.tf
@@ -1,5 +1,5 @@
 module "gdpr_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-prod/resources/merge.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-prod/resources/merge.tf
@@ -1,5 +1,5 @@
 module "merge_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-document-management-prod/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds_postgres" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dps-reconciliation-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dps-reconciliation-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_dps_reconciliation_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 20
   storage_type               = "gp3"
   vpc_name                   = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "edu_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-prod/resources/rds-postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-prod/resources/rds-postgres.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -44,7 +44,7 @@ resource "kubernetes_secret" "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-prod/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "grafana_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
   vpc_name             = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/rds-postgres14.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -41,7 +41,7 @@ resource "kubernetes_secret" "rds" {
 
 
 #module "rds_replica" {
-#  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+#  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 #  vpc_name               = var.vpc_name
 #  team_name              = var.team_name
 #  business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "historical_prisoner_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name
   business_unit             = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "identify_remand_periods_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/rds.tf
@@ -4,7 +4,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -39,7 +39,7 @@ module "dps_rds" {
 module "dps_rds_replica" {
   # default off
   count  = 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
@@ -4,7 +4,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -68,7 +68,7 @@ module "dps_rds" {
 module "dps_rds_replica" {
   # default off
   count  = 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/rds_postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/rds_postgres.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -53,7 +53,7 @@ resource "kubernetes_secret" "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-prod/resources/rds-postgres14.tf
@@ -1,5 +1,5 @@
 module "hmpps_interventions_postgres14" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -40,7 +40,7 @@ resource "kubernetes_secret" "hmpps_interventions_postgres14" {
 }
 
 module "hmpps_interventions_postgres14_replica" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-integration-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-integration-prod/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -31,7 +31,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -42,7 +42,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/rds-launchpad-auth-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-prod/resources/rds-launchpad-auth-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type = "gp2"
 
   # VPC configuration

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-learner-records-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-learner-records-prod/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/rds.tf
@@ -4,7 +4,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -36,7 +36,7 @@ module "dps_rds" {
 module "dps_rds_replica" {
   # default off
   count  = 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-train/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "ma_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-custody-mailbox-register-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-custody-mailbox-register-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "manage_offences_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-prod/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-prod/resources/flipt.tf
@@ -1,5 +1,5 @@
 module "flipt-db" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-prisoner-apps-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-prisoner-apps-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -40,7 +40,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-nomis-mapping-service-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name                  = var.vpc_name
   team_name                 = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
@@ -4,7 +4,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -37,7 +37,7 @@ module "dps_rds" {
 module "dps_rds_replica" {
   # default off
   count  = 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-one-plan-prod/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -34,7 +34,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-organisations-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-organisations-prod/resources/rds-postgresql.tf
@@ -9,7 +9,7 @@ data "aws_security_group" "mp_dps_sg" {
   name = var.mp_dps_sg_name
 }
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -44,7 +44,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-personal-relationships-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-personal-relationships-prod/resources/rds-postgresql.tf
@@ -9,7 +9,7 @@ data "aws_security_group" "mp_dps_sg" {
   name = var.mp_dps_sg_name
 }
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_service_catalogue" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-stage/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-stage/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_service_catalogue" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "nomis_migration_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-search-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_prisoner_search_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/flipt.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/flipt.tf
@@ -1,5 +1,5 @@
 module "flipt-db" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage         = 10
   storage_type                 = "gp2"
   vpc_name                     = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/hcmts-data-ingestion-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/hcmts-data-ingestion-rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-prod/resources/rds.tf
@@ -4,7 +4,7 @@ data "aws_security_group" "mp_dps_sg" {
 }
 
 module "prisons_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -37,7 +37,7 @@ module "prisons_rds" {
 module "dps_rds_replica" {
   # default off
   count  = 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-api-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rp_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-prod/resources/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -60,7 +60,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-prod/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "hmpps_strengths_based_needs_assessments_prod_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "subject_access_request_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name                     = var.vpc_name
   team_name                    = var.team_name
   business_unit                = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "hmpps_user_preferences_rds" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                    = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage      = 10
   storage_type              = "gp2"
   vpc_name                  = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/iac-fees-prod/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -32,7 +32,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-demo/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-demo/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-demo/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-demo/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
   vpc_name             = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name      = var.vpc_name
   team_name     = var.team_name
   business_unit = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   application            = var.application
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assess-crime-forms-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -43,7 +43,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-prod/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-ccms-prod/resources/rds-mysql.tf
@@ -1,5 +1,5 @@
 module "opa_hub_db" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-check-client-qualifies-production/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -66,7 +66,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-production/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -44,7 +44,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-production/resources/rds.tf
@@ -6,7 +6,7 @@
  */
 
 module "lcdui_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-prod/resources/rds-mssql.tf
@@ -5,7 +5,7 @@
  *
 */
 module "rds_mssql" {
-  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type = "gp2"
 
   # VPC configuration

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-metabase/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "migrated-rds-instance" {
-  source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source   = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name = var.vpc_name
 
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-pact-broker/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-pact-broker/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-stewardship-access-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-stewardship-access-prod/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -42,7 +42,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-prd/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-landing-page-prd/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-review-criminal-legal-aid-production/resources/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   application            = var.application
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-production/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/legal-framework-api-production/resources/rds.tf
@@ -1,6 +1,6 @@
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage        = 10
   storage_type                = "gp2"
   vpc_name                    = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-prod/resources/postgresql.tf
@@ -3,7 +3,7 @@
 ##
 
 module "make_recall_decision_api_rds" {
-  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type = "gp2"
 
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/rds-metabase.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/rds-metabase.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds_metabase" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -45,7 +45,7 @@ module "read_replica_metabase" {
 
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/metabase-example/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 
@@ -44,7 +44,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/migration-link-exchange-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/migration-link-exchange-prod/resources/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 20
   storage_type           = "gp3"
   vpc_name               = var.vpc_name
@@ -66,7 +66,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count                = 0
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 20
   storage_type         = "gp3"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-production/resources/rds.tf
@@ -5,7 +5,7 @@
  *
  */
 module "allocation-rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pact-broker-prod/resources/rds-postgres14.tf
@@ -1,5 +1,5 @@
 module "pact_broker_rds_postgres14" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-production/resources/rds.tf
@@ -20,7 +20,7 @@ module "rds_instance" {
   db_name                    = "parliamentary_questions_production"
   rds_family                 = "postgres16"
   db_backup_retention_period = var.db_backup_retention_period
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   prepare_for_major_upgrade  = false

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/peoplefinder-production/resources/rds.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "peoplefinder_rds" {
-  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage       = 10
   storage_type               = "gp2"
   vpc_name                   = var.vpc_name
@@ -34,7 +34,7 @@ module "peoplefinder_rds" {
 }
 
 module "peoplefinder_rds_replica" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage = 10
   storage_type         = "gp2"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/polygraph-offender-management/resources/rds-postgresql.tf
@@ -1,6 +1,6 @@
 
 module "rds_postgresql" {
-  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type  = "gp2"
   vpc_name      = var.vpc_name
   team_name     = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/rds-prison-visits.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-production/resources/rds-prison-visits.tf
@@ -6,7 +6,7 @@
  */
 
 module "prison-visits-rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = "prison-visits-booking"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds-feedback.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-production/resources/rds-feedback.tf
@@ -1,5 +1,5 @@
 module "prisoner_feedback_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # turn off the db overnight (between 22:00 and 06:00)
   enable_rds_auto_start_stop = false
@@ -46,7 +46,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/request-personal-information-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/request-personal-information-production/resources/rds-postgresql.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "slmtp_api_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/rds-mysql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sjpr-prod/resources/rds-mysql.tf
@@ -6,7 +6,7 @@
 */
 
 module "rds_mysql" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   db_allocated_storage   = 10
   storage_type           = "gp2"
   vpc_name               = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/stg-track-my-case-service-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/stg-track-my-case-service-prod/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
 
   vpc_name               = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/whereabouts-api-prod/resources/rds.tf
@@ -1,5 +1,5 @@
 module "dps_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=8.1.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
   storage_type           = "gp2"
   vpc_name               = var.vpc_name
   team_name              = var.team_name


### PR DESCRIPTION
Bumping rds-instance module to 9.0.0, this will destroy unused irsa policies. Running for all production and remaining namespaces.
Done as a part of [#7509](https://github.com/ministryofjustice/cloud-platform/issues/7509)

[Release notes for change](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/releases/tag/9.0.0)