### PR TITLE
Fix: rds version mismatch in hmpps-welcome-to-prison-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-dev/resources/rds.tf
@@ -24,7 +24,7 @@ module "rds" {
   # enable performance insights
   performance_insights_enabled = true
 
-  db_engine_version = "16.1"
+  db_engine_version = "16.8"
 
   rds_family = "postgres16"
   enable_rds_auto_start_stop = true


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-welcome-to-prison-dev`

```
module.rds: downgrade from 16.8 to 16.1
```