### PR TITLE
AP-6166: Update cfe-civil staging database config

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/rds.tf
@@ -23,18 +23,16 @@ module "rds" {
   # enable performance insights
   performance_insights_enabled = true
 
-  # change the postgres version as you see fit.
-  prepare_for_major_upgrade = true
-  db_engine = "postgres"
-  db_engine_version = "17.16"
-
-  # change the instance class as you see fit.
-  db_instance_class        = "db.t4g.micro"
-  db_max_allocated_storage = "500"
-
-  # rds_family should be one of: postgres10, postgres11, postgres12, postgres13, postgres14
-  # Pick the one that defines the postgres version the best
-  rds_family = "postgres17"
+  # Database configuration
+  prepare_for_major_upgrade   = true
+  db_engine                   = "postgres"
+  db_engine_version           = "17.6"
+  rds_family                  = "postgres17"
+  db_instance_class           = "db.t4g.micro"
+  allow_minor_version_upgrade = "true"
+  allow_major_version_upgrade = "false"
+  enable_rds_auto_start_stop  = true
+  db_max_allocated_storage    = "500"
 
   # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".
@@ -46,17 +44,10 @@ module "rds" {
   #   }
   # ]
 
-  # use "allow_major_version_upgrade" when upgrading the major version of an engine
-  allow_major_version_upgrade = "false"
-
-  # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
-  # enable_rds_auto_start_stop  = true
-
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
-
 
   enable_irsa = true
 }


### PR DESCRIPTION
Change version to v17.6. 
Tidy up config. 
Enable auto start stop. 
Allow minor version upgrades