### PR TITLE
Allow E-supervision prod environment to assume Rekognition role

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/cross-iam-role-sa.tf
@@ -1,0 +1,22 @@
+data "aws_iam_policy_document" "assume_rekognition_role" {
+  statement {
+    sid = "AssumeRekognitionRole"
+    actions = ["sts:AssumeRole"]
+    effect = "Allow"
+    resources = [var.rekognition_role_arn]
+  }
+}
+
+resource "aws_iam_policy" "assume_rekognition_policy" {
+  name = "${var.namespace}-allow-assume-rekognition"
+  policy = data.aws_iam_policy_document.assume_rekognition_role.json
+
+  tags = {
+    business-unit = var.business_unit
+    application = var.application
+    is-production = var.is_production
+    environment-name = var.environment
+    owner = var.team_name
+    infrastructure-support = var.infrastructure_support
+  } 
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/irsa.tf
@@ -8,6 +8,7 @@ module "irsa" {
   service_account_name = "hmpps-esupervision-api"
   role_policy_arns = {
     s3 = module.s3_data_bucket.irsa_policy_arn
+    rekognition = aws_iam_policy.assume_rekognition_policy.arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/variables.tf
@@ -87,3 +87,10 @@ variable "domain_esupervision_api" {
   type        = string
   default     = "esupervision.hmpps.service.justice.gov.uk"
 }
+
+variable "rekognition_role_arn" {
+  type = string
+  description = "ARN of the role to assume for Rekognition operations"
+  default = "arn:aws:iam::398497927247:role/rekognition-role"
+}
+


### PR DESCRIPTION
Allow the service account within the E-supervision prod namespace to assume the role used for Rekognition operations.