### PR TITLE
Opensearch 2.19 upgrade dc dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/opensearch.tf
@@ -12,23 +12,23 @@ module "opensearch_snapshot_bucket" {
 }
 
 module "opensearch" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-opensearch?ref=1.6.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-opensearch?ref=1.8.0"
 
   # VPC/EKS configuration
   vpc_name         = var.vpc_name
   eks_cluster_name = var.eks_cluster_name
 
   # Cluster configuration
-  engine_version      = "OpenSearch_2.9"
+  engine_version      = var.opensearch_engine_version
   snapshot_bucket_arn = module.opensearch_snapshot_bucket.bucket_arn
 
   cluster_config = {
-    instance_count = 3
-    instance_type  = "t3.medium.search"
+    instance_count = var.opensearch_instance_count
+    instance_type  = var.opensearch_instance_type
   }
 
   ebs_options = {
-    volume_size = 50
+    volume_size = var.opensearch_ebs_volume_size
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/variables.tf
@@ -169,3 +169,28 @@ variable "deletion_protection" {
   type        = bool
   default     = true
 }
+
+variable "opensearch_engine_version" {
+  description = "The OpenSearch engine version to use"
+  type        = string
+  default     = "OpenSearch_2.19"
+}
+
+variable "opensearch_instance_type" {
+  description = "The instance type to use for the OpenSearch cluster"
+  type        = string
+  default     = "t3.medium.search"
+}
+
+variable "opensearch_instance_count" {
+  description = "The number of instances to use for the OpenSearch cluster"
+  type        = number
+  default     = 3
+}
+
+variable "opensearch_ebs_volume_size" {
+  description = "The EBS volume size to use for the OpenSearch cluster"
+  type        = number
+  default     = 50
+  
+}


### PR DESCRIPTION
- Add's variables for key opensearch values
- Upgrades the Opensearch Engine version from 2.9 to 2.19