### PR TITLE
EL-2597: MCC staging access to CAA UAT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-staging/00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cloud-platform.justice.gov.uk/is-production: "false"
     cloud-platform.justice.gov.uk/environment-name: "staging"
+    cloud-platform.justice.gov.uk/namespace: "laa-manage-your-civil-cases-staging"
     component: allow-laa-civil-case-api-uat
     pod-security.kubernetes.io/enforce: restricted
   annotations:


### PR DESCRIPTION

- Add cloud-platform.justice.gov.uk/namespace label to MCC staging namespace
- This label is required by NetworkPolicy in CCA UAT for cross-namespace access
- Matches the pattern from working MCC UAT environment
- Resolves connectivity timeout between MCC staging and CCA UAT mock endpoints

Root cause: NetworkPolicy selectors match labels only, not annotations. MCC staging had the identifier as annotation but not label, preventing the allow-source-namespace policy from