### PR TITLE
LAA Cyber Security Team Self Hosted Runner

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cst-self-hosted-runners/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cst-self-hosted-runners/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: laa-cst-self-hosted-runners
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/slack-channel: "cyber-security-team-laad"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "ask-laad-cyber-team"
+    cloud-platform.justice.gov.uk/application: "LAA CST Self Hosted Runners"
+    cloud-platform.justice.gov.uk/owner: "LAA CST"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-cst-self-hosted-runners.git"
+    cloud-platform.justice.gov.uk/team-name: "laa-cst"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cst-self-hosted-runners/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cst-self-hosted-runners/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-cst-self-hosted-runners-admin
+  namespace: laa-cst-self-hosted-runners
+subjects:
+  - kind: Group
+    name: "github:laa-cyber-security-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cst-self-hosted-runners/02-secret.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cst-self-hosted-runners/02-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: laa-cst-self-hosted-runners-secret
+  namespace: laa-cst-self-hosted-runners
+type: Opaque
+data:
+  github_app_id: <base64-app-id>
+  github_app_installation_id: <base64-installation-id>
+  github_app_private_key: <base64-private-key>

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cst-self-hosted-runners/03-helmrelease.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cst-self-hosted-runners/03-helmrelease.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: laa-cst-self-hosted-runners
+  namespace: laa-cst-self-hosted-runners
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: ./helm_deploy/laa-cst-self-hosted-runners
+      sourceRef:
+        kind: GitRepository
+        name: laa-cst-self-hosted-runners
+        namespace: flux-system
+  values:
+    runnerScaleSet:
+      githubConfigSecret: laa-cst-self-hosted-runners-secret
+      minRunners: 0
+      maxRunners: 5
+      labels:
+        - cst-ephemeral-aws


### PR DESCRIPTION
Creates a namespace for ephemeral github runners to be used as part of DAST.