### PR TITLE
mcc prod label to enable network rules.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cloud-platform.justice.gov.uk/is-production: "true"
     cloud-platform.justice.gov.uk/environment-name: "production"
+    cloud-platform.justice.gov.uk/namespace: "laa-manage-your-civil-cases-production"
     component: allow-laa-civil-case-api-uat
     pod-security.kubernetes.io/enforce: restricted
   annotations:


### PR DESCRIPTION
Summary
Add missing cloud-platform.justice.gov.uk/namespace label to MCC production namespace to enable network connectivity to CCA UAT.
