### PR TITLE
Add MCC production namespace to CCA UAT NetworkPolicy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-uat/04-networkpolicy.yaml
@@ -43,3 +43,6 @@ spec:
     - namespaceSelector:
         matchLabels:
           cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-uat
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-production


### PR DESCRIPTION
- Allow laa-manage-your-civil-cases-production to access laa-civil-case-api-uat
- Fixes EL-1942/EL-2598: MCC Production access to CCA UAT
- Production namespace was missing from the allow-source-namespace NetworkPolicy