### PR TITLE
Enable irsa for elasticache modules that use policy output

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfocats-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfocats-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -18,6 +18,8 @@ module "redis" {
   namespace              = var.namespace
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis_secrets" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pac_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name
@@ -20,6 +20,8 @@ module "pac_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "pac_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pac_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name
@@ -20,6 +20,8 @@ module "pac_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "pac_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pac_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name
@@ -20,6 +20,8 @@ module "pac_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "pac_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -17,6 +17,8 @@ module "dps_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "dps_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -17,6 +17,8 @@ module "dps_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "dps_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/digital-prison-services-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -17,6 +17,8 @@ module "dps_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "dps_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -22,6 +22,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -21,6 +21,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -21,6 +21,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-allocate-key-workers-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-allocate-key-workers-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -22,6 +22,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-allocate-key-workers-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-allocate-key-workers-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -22,6 +22,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-allocate-key-workers-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-allocate-key-workers-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -22,6 +22,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assessments_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   team_name               = var.team_name
   namespace               = var.namespace
@@ -16,6 +16,8 @@ module "hmpps_assessments_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "hmpps_assessments_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assessments_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   team_name               = var.team_name
   namespace               = var.namespace
@@ -16,6 +16,8 @@ module "hmpps_assessments_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "hmpps_assessments_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assessments_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   team_name               = var.team_name
   namespace               = var.namespace
@@ -16,6 +16,8 @@ module "hmpps_assessments_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "hmpps_assessments_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 
@@ -20,6 +20,8 @@ module "redis-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 
@@ -20,6 +20,8 @@ module "redis-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 
@@ -20,6 +20,8 @@ module "redis-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 
@@ -20,6 +20,8 @@ module "redis-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-preprod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 
@@ -20,6 +20,8 @@ module "redis-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-production/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 
@@ -20,6 +20,8 @@ module "redis-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-staging/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 
@@ -20,6 +20,8 @@ module "redis-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-frontend-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 
@@ -20,6 +20,8 @@ module "redis-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "redis-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-fake-dps-service/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_dpr_fake_dps_service_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -17,6 +17,8 @@ module "hmpps_dpr_fake_dps_service_ui_ec_cluster" {
   is_production          = var.is_production
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "hmpps_dpr_fake_dps_service_ui_ec_cluster" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -18,6 +18,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -18,6 +18,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-find-and-refer-an-intervention-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -18,6 +18,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_interventions_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment
@@ -21,6 +21,8 @@ module "hmpps_interventions_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "hmpps_interventions_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_manage_adjudications" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -17,6 +17,8 @@ module "hmpps_manage_adjudications" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "hmpps_manage_adjudications" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_manage_adjudications" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -17,6 +17,8 @@ module "hmpps_manage_adjudications" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "hmpps_manage_adjudications" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -22,6 +22,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -22,6 +22,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -22,6 +22,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -12,6 +12,8 @@ module "elasticache" {
   node_type            = "cache.t4g.small"
   engine_version       = "7.0"
   parameter_group_name = "default.redis7"
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -12,6 +12,8 @@ module "elasticache" {
   node_type            = "cache.t4g.small"
   engine_version       = "7.0"
   parameter_group_name = "default.redis7"
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-people-on-probation-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -12,6 +12,8 @@ module "elasticache" {
   node_type            = "cache.t4g.small"
   engine_version       = "7.0"
   parameter_group_name = "default.redis7"
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "mercury_submit_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment
@@ -22,6 +22,8 @@ module "mercury_submit_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "mercury_submit_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "mercury_submit_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment
@@ -22,6 +22,8 @@ module "mercury_submit_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "mercury_submit_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "mercury_submit_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment
@@ -22,6 +22,8 @@ module "mercury_submit_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "mercury_submit_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-mercury-submit-test/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "mercury_submit_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment
@@ -22,6 +22,8 @@ module "mercury_submit_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "mercury_submit_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-frontend-components-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-frontend-components-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment
@@ -16,6 +16,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -12,6 +12,8 @@ module "elasticache" {
   node_type            = "cache.t4g.small"
   engine_version       = "7.0"
   parameter_group_name = "default.redis7"
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -12,6 +12,8 @@ module "elasticache" {
   node_type            = "cache.t4g.micro"
   engine_version       = "7.0"
   parameter_group_name = "default.redis7"
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-search-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit
@@ -12,6 +12,8 @@ module "elasticache" {
   node_type            = "cache.t4g.micro"
   engine_version       = "7.0"
   parameter_group_name = "default.redis7"
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment
@@ -21,6 +21,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment
@@ -20,6 +20,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-welcome-to-prison-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment
@@ -20,6 +20,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   team_name              = "apply-for-legal-aid"
@@ -22,6 +22,8 @@ module "apply-for-legal-aid-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-staging/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "apply-for-legal-aid-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   team_name              = "apply-for-legal-aid"
@@ -22,6 +22,8 @@ module "apply-for-legal-aid-elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "apply-for-legal-aid-elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.application
   namespace              = var.namespace
@@ -15,6 +15,8 @@ module "elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-staging/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.application
   namespace              = var.namespace
@@ -15,6 +15,8 @@ module "elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-uat/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.application
   namespace              = var.namespace
@@ -15,6 +15,8 @@ module "elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-dev/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name
@@ -17,6 +17,8 @@ module "crime_apps_ec_cluster" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "crime_apps_ec_cluster" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-prod/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name
@@ -17,6 +17,8 @@ module "crime_apps_ec_cluster" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "crime_apps_ec_cluster" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-test/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name
@@ -17,6 +17,8 @@ module "crime_apps_ec_cluster" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "crime_apps_ec_cluster" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-adaptor-uat/resources/redis.tf
@@ -1,5 +1,5 @@
 module "crime_apps_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   vpc_name                = var.vpc_name
@@ -17,6 +17,8 @@ module "crime_apps_ec_cluster" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "crime_apps_ec_cluster" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-production/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -22,6 +22,8 @@ module "elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-staging/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-staging/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -22,6 +22,8 @@ module "elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/elasticache.tf
@@ -5,7 +5,7 @@
  *
  */
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   team_name              = var.team_name
@@ -22,6 +22,8 @@ module "elasticache" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment
@@ -17,6 +17,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/make-recall-decision-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment
@@ -17,6 +17,8 @@ module "elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -17,6 +17,8 @@ module "dps_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "dps_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-preprod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -17,6 +17,8 @@ module "dps_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "dps_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-key-workers-prod/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "dps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name
@@ -16,6 +16,8 @@ module "dps_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "dps_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "uof_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -21,6 +21,8 @@ module "uof_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "uof_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-preprod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "uof_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -21,6 +21,8 @@ module "uof_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "uof_elasticache_redis" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/use-of-force-prod/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "uof_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -21,6 +21,8 @@ module "uof_elasticache_redis" {
   providers = {
     aws = aws.london
   }
+
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "uof_elasticache_redis" {


### PR DESCRIPTION
Bumping elasticache module to 8.0.0 and setting enable_irsa=true to ensure creation of irsa policy still happens as policy is in use.
Done as a part of [#7510](https://github.com/ministryofjustice/cloud-platform/issues/7510)

[Release notes for change](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/releases/tag/8.0.0)
