### PR TITLE
Bump elasticache module to latest to destroy unused irsa policies

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/ai-website-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/ai-website-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/applying-service-standards-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/applying-service-standards-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-dev/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/c100-application-dev/resources/redis.tf
@@ -3,7 +3,7 @@
 ########################################################
 
 module "redis-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/calculate-release-dates-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev-lgfs/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/elasticache.tf
@@ -4,7 +4,7 @@
 ################################################################################
 
 module "cccd_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chux-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chux-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/contact-moj-development/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "contact_moj_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/create-and-vary-a-licence-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-find-moj-data-dev/resources/elasticcache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-live-dev/resources/service_token_cache.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/formbuilder-platform-test-dev/resources/service_token_cache.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "service-token-cache-elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name = var.vpc_name
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/redis.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/grc-dev/resources/redis.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/help-with-prison-visits-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hwpv_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-activities-management-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-adjustments-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-alerts-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-appointment-reminders-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-appointment-reminders-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-for-early-release-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-for-early-release-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_assess_risks_and_needs_integrations_dev_elasticache_redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-poc-dev/resources/elasticache.tf
@@ -1,6 +1,6 @@
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-auth-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-breach-notice-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-payback-dev/resources/hmpps-community-payback-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-payback-dev/resources/hmpps-community-payback-ui.tf
@@ -18,7 +18,7 @@ module "hmpps_template_typescript" {
 
 # Note, redis is a requirement for hmpps-template-typescript application.
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-contacts-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-contacts-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-court-cases-release-dates-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-core-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_digital_prison_reporting_mi_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-services-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_dpr_dpr_tools_ui_ec_cluster" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-e-surveillance-dev/resources/hmpps-e-surveillance-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-e-surveillance-dev/resources/hmpps-e-surveillance-ui.tf
@@ -17,7 +17,7 @@ module "hmpps_e_surveillance_ui" {
 
 # Note, redis is a requirement for hmpps-template-typescript application.
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-and-work-plan-dev/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "education_work_plan_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-education-employment-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-dev/resources/hmpps-electronic-monitoring-crime-matching-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-dev/resources/hmpps-electronic-monitoring-crime-matching-ui.tf
@@ -18,7 +18,7 @@ module "hmpps_electronic_monitoring_crime_matching_ui" {
 
 # Note, redis is a requirement for hmpps-template-typescript application.
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/ui-elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/ui-elasticache.tf
@@ -1,7 +1,7 @@
 # Note, this resource is for use with the template app hmpps-template-typescript.
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-datastore-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_electronic_monitoring_datastore_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ems-cemo-ui-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_ems_cemo_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/template-typescript.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/template-typescript.tf
@@ -18,7 +18,7 @@ module "hmpps_template_typescript" {
 
 # Note, redis is a requirement for hmpps-template-typescript application.
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-movements-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-external-movements-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-historical-prisoner-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-jobs-board-reporting-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-launchpad-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-learner-records-dev/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-learner-records-dev/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "match_learner_record_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_manage_adjudications" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/hmpps-manage-adjudications.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-dev/resources/hmpps-manage-adjudications.tf
@@ -18,7 +18,7 @@ module "hmpps_template_typescript" {
 
 # Note, redis is a requirement for hmpps-template-typescript application.
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-custody-mailbox-register-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-custody-mailbox-register-dev/resources/elasticache.tf
@@ -1,7 +1,7 @@
 # Note, this resource is for use with the template app hmpps-template-typescript.
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-users-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-prisoner-apps-dev/resources/ui-elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-prisoner-apps-dev/resources/ui-elasticache.tf
@@ -1,7 +1,7 @@
 # Note, this resource is for use with the template app hmpps-template-typescript.
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-micro-frontend-components-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/person-record-manage-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/person-record-manage-ui.tf
@@ -17,7 +17,7 @@ module "hmpps_person_record_manage_ui" {
 
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-pin-phone-monitor-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "pcms_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-ppud-automation-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prison-roll-count-dev/resources/ui-elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prison-roll-count-dev/resources/ui-elasticache.tf
@@ -1,7 +1,7 @@
 # Note, this resource is for use with the template app hmpps-template-typescript.
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "csc_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-from-nomis-migration-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application_sync_dashboard
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-location-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-profile-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-record-a-recall-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-record-a-recall-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-registers-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "hmpps_registers_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   business_unit          = var.business_unit
   application            = var.hmpps-registers-application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-remand-and-sentencing-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/elasticache-backend.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/elasticache-backend.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "backend_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-resettlement-passport-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-restricted-patients-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_restricted_patients" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sentence-plan-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-strengths-based-needs-assessments-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "hmpps_strengths_based_needs_assessments_dev_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   namespace              = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-subject-access-request-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-suicide-risk-form-dev/resources/ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-suicide-risk-form-dev/resources/ui.tf
@@ -18,7 +18,7 @@ module "hmpps_template_typescript" {
 
 # Note, redis is a requirement for hmpps-template-typescript application.
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/template-typescript.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/template-typescript.tf
@@ -18,7 +18,7 @@ module "hmpps_template_typescript" {
 
 # Note, redis is a requirement for hmpps-template-typescript application.
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-tier-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-workload-dev/resources/elasticache.tf
@@ -1,6 +1,6 @@
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/intranet-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/james-dev/resources/james-typescript-test.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/james-dev/resources/james-typescript-test.tf
@@ -18,7 +18,7 @@ module "james_typescript_test" {
 
 # Note, redis is a requirement for james-typescript-test application.
 module "james_typescript_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-court-data-ui-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "lcdui_elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-dev/resources/elasticcache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-equinity-historical-data-frontend-dev/resources/elasticcache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-provider-details-api-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0" # use the latest release
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-status-dashboard-development/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/licences-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "licences_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-intelligence-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_intelligence_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/manage-soc-cases-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "manage_soc_cases_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/migration-link-exchange-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/migration-link-exchange-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   vpc_name               = var.vpc_name
   application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-categorisation-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "oc_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-events-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "offender_events_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/parliamentary-questions-development/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "parliamentary_questions_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pathfinder-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "pathfinder_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prison-visits-booking-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/prisoner-content-hub-development/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "drupal_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name
@@ -37,7 +37,7 @@ resource "kubernetes_secret" "drupal_redis" {
 }
 
 module "frontend_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/rd-ai-nexus-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "redis" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/san-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/san-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-api.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_api_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-staff-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-staff-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_staff_ui_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/elasticache-ui.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "slmtp_ui_elasticache_redis" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/token-verification-api-dev/resources/elasticache.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "tva_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment-name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/track-a-query-development/resources/elasticache.tf
@@ -4,7 +4,7 @@
 #################################################################################
 
 module "track_a_query_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-admin.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-admin.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_admin" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-public.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-public.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_public" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-staff.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-frontend-svc-dev/resources/elasticache-staff.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 module "elasticache_redis_staff" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name                = var.vpc_name
   application             = var.application
   environment_name        = var.environment

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/workforce-management-dev/resources/elasticache.tf
@@ -1,5 +1,5 @@
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=7.2.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
   vpc_name               = var.vpc_name
   application            = var.application
   environment_name       = var.environment


### PR DESCRIPTION
Bumping elasticache module to 8.0.0 to destroy unused irsa policies for dev namespaces.
Done as a part of [#7510](https://github.com/ministryofjustice/cloud-platform/issues/7510)

[Release notes for change](https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/releases/tag/8.0.0)
