### PR TITLE
Add S3 Inventory to Alfresco Preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/athena.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/athena.tf
@@ -1,0 +1,178 @@
+locals {
+  inventory_base          = "s3://${module.s3_inventory_reports.bucket_name}/${var.inventory_prefix}"
+  athena_results_location = "s3://${module.s3_inventory_reports.bucket_name}/query_results/"
+  expected_keys_location  = coalesce(var.expected_keys_location, "s3://${module.s3_inventory_reports.bucket_name}/expected-keys/")
+}
+
+# Glue database (follows audit naming convention)
+resource "aws_glue_catalog_database" "alfresco_glue" {
+  name         = "hmpps_alfresco_${var.environment_name}_glue_catalog_db"
+  location_uri = "s3://${module.s3_inventory_reports.bucket_name}/"
+}
+
+# Athena workgroup (follows audit pattern)
+resource "aws_athena_workgroup" "alfresco_queries" {
+  name = "hmpps_alfresco_${var.environment_name}"
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+    result_configuration { output_location = local.athena_results_location }
+  }
+}
+
+# Glue table over S3 Inventory (Parquet) with partition projection on dt
+resource "aws_glue_catalog_table" "s3_inventory" {
+  database_name = aws_glue_catalog_database.alfresco_glue.name
+  name          = "s3_inventory"
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    classification               = "parquet"
+    EXTERNAL                     = "TRUE"
+    "projection.enabled"         = "true"
+    "projection.dt.type"         = "date"
+    "projection.dt.range"        = "2016-01-01,NOW"
+    "projection.dt.format"       = "yyyy-MM-dd"
+    "storage.location.template"  = "${local.inventory_base}/dt=$${dt}/"
+  }
+
+  partition_keys {
+    name = "dt"
+    type = "string"
+  }
+
+  storage_descriptor {
+    location      = local.inventory_base
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+    compressed    = true
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+      parameters = { "serialization.format" = "1" }
+    }
+    columns {
+      name = "bucket"
+      type = "string"
+    }
+    columns {
+      name = "key"
+      type = "string"
+    }
+    columns {
+      name = "size"
+      type = "bigint"
+    }
+    columns {
+      name = "etag"
+      type = "string"
+    }
+    columns {
+      name = "storageclass"
+      type = "string"
+    }
+    columns {
+      name = "islatest"
+      type = "boolean"
+    }
+    columns {
+      name = "isdeletemarker"
+      type = "boolean"
+    }
+    columns {
+      name = "lastmodifieddate"
+      type = "timestamp"
+    }
+    columns {
+      name = "encryptionstatus"
+      type = "string"
+    }
+  }
+}
+
+# Glue table for the expected keys CSV exported from RDS
+resource "aws_glue_catalog_table" "expected_keys" {
+  database_name = aws_glue_catalog_database.alfresco_glue.name
+  name          = "expected_keys"
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL                  = "TRUE"
+    "skip.header.line.count"  = "0"
+    classification            = "csv"
+  }
+
+  storage_descriptor {
+    location      = local.expected_keys_location
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.OpenCSVSerde"
+      parameters = { 
+          separatorChar = ",", 
+          quoteChar = "\"", 
+          escapeChar = "\\" 
+      }
+    }
+    columns {
+      name = "key"
+      type = "string"
+    }
+    columns {
+      name = "content_size"
+      type = "bigint"
+    }
+  }
+}
+
+# K8s secrets (same shapes/names as audit)
+resource "kubernetes_secret" "glue_database_name" {
+  metadata { 
+    name = "glue-database-name"
+    namespace = var.namespace
+  }
+  data = {
+    database_arn  = aws_glue_catalog_database.alfresco_glue.arn
+    database_name = aws_glue_catalog_database.alfresco_glue.name
+  }
+}
+
+resource "kubernetes_secret" "glue_catalog_table_name" {
+  metadata { 
+    name = "glue-catalog-table-name"
+    namespace = var.namespace
+  }
+  data = {
+    table_arn  = aws_glue_catalog_table.s3_inventory.arn
+    table_name = aws_glue_catalog_table.s3_inventory.name
+  }
+}
+
+resource "kubernetes_secret" "expected_keys_glue_catalog_table_name" {
+  metadata { 
+    name = "expected-keys-glue-catalog-table-name"
+    namespace = var.namespace
+  }
+  data = {
+    table_arn  = aws_glue_catalog_table.expected_keys.arn
+    table_name = aws_glue_catalog_table.expected_keys.name
+  }
+}
+
+resource "kubernetes_secret" "athena_workgroup" {
+  metadata { 
+    name = "athena-workgroup-secret"
+    namespace = var.namespace
+  }
+  data = {
+    workgroup_arn  = aws_athena_workgroup.alfresco_queries.arn
+    workgroup_name = aws_athena_workgroup.alfresco_queries.name
+  }
+}
+
+resource "kubernetes_secret" "athena_output_location" {
+  metadata { 
+    name = "athena-output-location-secret"
+    namespace = var.namespace
+  }
+  data = { output_location = local.athena_results_location }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/irsa.tf
@@ -9,6 +9,7 @@ module "irsa" {
   role_policy_arns = {
     s3        = module.s3_bucket.irsa_policy_arn
     migration = aws_iam_policy.migration_policy.arn
+    athena    = aws_iam_policy.athena_allow_irsa.arn
   }
 
   # Tags
@@ -20,3 +21,46 @@ module "irsa" {
   environment_name       = var.environment_name
   infrastructure_support = var.infrastructure_support
 }
+
+# IRSA policy for service pod to run Athena + read/write inventory/results (mirrors audit)
+data "aws_iam_policy_document" "athena_irsa" {
+  statement {
+    actions = [
+      "athena:StartQueryExecution",
+      "athena:GetQueryExecution",
+      "athena:GetQueryResults",
+
+      "s3:PutObject",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+
+      "glue:GetDatabase",
+      "glue:GetTable",
+      "glue:GetPartition",
+    ]
+    resources = [
+      aws_athena_workgroup.alfresco_queries.arn,
+      "arn:aws:athena:eu-west-2:*:queryexecution/*",
+
+      "arn:aws:glue:eu-west-2:*:catalog",
+      aws_glue_catalog_database.alfresco_glue.arn,
+      aws_glue_catalog_table.s3_inventory.arn,
+      aws_glue_catalog_table.expected_keys.arn,
+
+      module.s3_inventory_reports.bucket_arn,
+      "${module.s3_inventory_reports.bucket_arn}/*",
+
+      module.s3_bucket.bucket_arn,                    # (optional) allow reading content-bucket metrics if needed
+      "${module.s3_bucket.bucket_arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "athena_allow_irsa" {
+  name        = "${var.namespace}-athena-read-write"
+  path        = "/cloud-platform/"
+  description = "IRSA policy to run Athena queries for S3 Inventory checker"
+  policy      = data.aws_iam_policy_document.athena_irsa.json
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/s3-inventory.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/s3-inventory.tf
@@ -1,0 +1,66 @@
+# Destination bucket for S3 Inventory reports
+module "s3_inventory_reports" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment_name
+  infrastructure_support = var.infrastructure_support
+  logging_enabled        = false
+}
+
+# (Recommended) ownership controls so S3's ACLs land as bucket-owner
+resource "aws_s3_bucket_ownership_controls" "s3_inventory_reports" {
+  bucket = module.s3_inventory_reports.bucket_name
+  rule { object_ownership = "BucketOwnerPreferred" }
+}
+
+# Allow the SOURCE bucket's account to put inventory objects with the expected ACL
+resource "aws_s3_bucket_policy" "s3_inventory_reports" {
+  bucket = module.s3_inventory_reports.bucket_name
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid: "AllowInventoryWrite",
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" },
+        Action: [ "s3:PutObject" ],
+        Resource: "${module.s3_inventory_reports.bucket_arn}/${var.inventory_prefix}/*",
+        Condition: { StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" } }
+      },
+      {
+        Sid: "AllowGetBucketAcl",
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" },
+        Action: [ "s3:GetBucketAcl" ],
+        Resource: module.s3_inventory_reports.bucket_arn
+      }
+    ]
+  })
+}
+
+# S3 Inventory from your Alfresco content bucket -> destination bucket
+resource "aws_s3_bucket_inventory" "alfresco_s3_inventory_daily" {
+  bucket                   = module.s3_bucket.bucket_name  # source (your content bucket)
+  name                     = "alfresco-${var.environment_name}-daily-inventory"
+  included_object_versions = "Current"     # use "All" if you want version-level rows
+  schedule {
+    frequency = "Daily"
+  }
+  enabled                  = true
+
+  destination {
+    bucket {
+      bucket_arn = module.s3_inventory_reports.bucket_arn
+      format     = "Parquet"
+      prefix     = var.inventory_prefix
+    }
+  }
+
+  optional_fields = [
+    "Size", "ETag", "StorageClass", "LastModifiedDate", "EncryptionStatus"
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-preprod/resources/variables.tf
@@ -183,3 +183,15 @@ variable "serviceaccount_rules" {
     },
   ]
 }
+
+variable "inventory_prefix" {
+  description = "Prefix inside the inventory destination bucket where S3 Inventory files are written"
+  type        = string
+  default     = "s3-inventory"
+}
+
+variable "expected_keys_location" {
+  description = "S3 URI prefix holding expected_keys.csv exported from RDS (override to use a different bucket/prefix)"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Config required to generate daily S3 Inventory reports and be able to query them through Athena