### PR TITLE
DSTEW-364: Remove shared github repo

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-access-api-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-access-api-uat/resources/ecr.tf
@@ -12,7 +12,7 @@ module "ecr" {
 
   # OpenID Connect configuration
   oidc_providers      = ["github"]
-  github_repositories = ["laa-data-access-api", "laa-data-stewardship-helm-charts"]
+  github_repositories = ["laa-data-access-api"]
 
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-access-api-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-access-api-uat/resources/serviceaccount.tf
@@ -7,7 +7,7 @@ module "serviceaccount" {
 
   serviceaccount_token_rotated_date = "01-01-2000"
 
-  github_repositories = ["laa-data-access-api", "laa-data-stewardship-helm-charts"]
+  github_repositories = ["laa-data-access-api"]
   github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
   github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
   github_actions_secret_kube_token     = var.github_actions_secret_kube_token


### PR DESCRIPTION

Concourse unable to deploy to exsiting helm charts variables, therefore, removing `laa-data-stewardship-helm-charts` from ecr and serviceaccount