### PR TITLE
Fix: rds version mismatch in laa-crown-court-remuneration-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-production/resources/rds.tf
@@ -14,7 +14,7 @@ module "migrated-rds-instance" {
 
   # Database configuration
   db_engine                = "oracle-se2"
-  db_engine_version        = "19.0.0.0.ru-2025-04.rur-2025-04.r1"
+  db_engine_version        = "19.0.0.0.ru-2025-07.rur-2025-07.r1"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.medium"
   storage_type             = "gp2"


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `laa-crown-court-remuneration-production`

```
module.migrated-rds-instance: downgrade from 19.0.0.0.ru-2025-07.rur-2025-07.r1 to 19.0.0.0.ru-2025-04.rur-2025-04.r1
```