### PR TITLE
Add laa-manage-your-civil-cases-production to CCA UAT's network policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-case-api-uat/04-networkpolicy.yaml
@@ -43,3 +43,6 @@ spec:
     - namespaceSelector:
         matchLabels:
           cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-uat
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-production


### PR DESCRIPTION
- Adds the `laa-manage-your-civil-cases-production` to CCA's UAT network policy allowed namespaces.