### PR TITLE
IR-1201 Add `hot_standby_feedback` parameter to RDS configuration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-dev/resources/rds.tf
@@ -130,6 +130,11 @@ module "read_replica" {
       name         = "max_slot_wal_keep_size"
       value        = "40000"
       apply_method = "immediate"
+    },
+    {
+      name         = "hot_standby_feedback"
+      value        = "1"
+      apply_method = "immediate"
     }
   ]
 }


### PR DESCRIPTION
This pull request introduces the `hot_standby_feedback` parameter to the RDS configuration in the HMPPS Incident Reporting development environment. This change ensures improved compatibility and responsiveness during high availability failovers in the database setup.

No issues are linked to this pull request.