### PR TITLE
IR-1201 Add `hot_standby_feedback` parameter to RDS configuration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-preprod/resources/rds.tf
@@ -127,6 +127,11 @@ module "dps_rds_replica" {
       name         = "max_slot_wal_keep_size"
       value        = "40000"
       apply_method = "immediate"
+    },
+    {
+      name         = "hot_standby_feedback"
+      value        = "1"
+      apply_method = "immediate"
     }
   ]
 


### PR DESCRIPTION
### Overview
This pull request introduces the `hot_standby_feedback` parameter to the RDS configuration in the HMPPS Incident Reporting preprod environment.

### Why
This change ensures improved database replication performance and reduces potential delays in standby node feedback within the preprod environment.

### Changes
- Updated the RDS configuration to include `hot_standby_feedback`.

### Checklist
- [ ] Documentation updated if applicable
- [ ] Code has been tested in the preprod environment
- [ ] Follow-up tasks identified if needed