### PR TITLE
IR-1201 Add `hot_standby_feedback` parameter to RDS config in HMPPS IR prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
@@ -131,6 +131,11 @@ module "dps_rds_replica" {
       name         = "max_slot_wal_keep_size"
       value        = "40000"
       apply_method = "immediate"
+    },
+    {
+      name         = "hot_standby_feedback"
+      value        = "1"
+      apply_method = "immediate"
     }
   ]
 }


### PR DESCRIPTION
This pull request adds the `hot_standby_feedback` parameter to the RDS configuration in the HMPPS Incident Reporting (IR) production environment. This configuration change is aimed at improving compatibility and syncing mechanisms within the database system. 

- **Purpose**: Enhance RDS configuration based on environment needs.
- **Environment**: Production (HMPPS Incident Reporting).

### Checklist
- [ ] Verify the parameter meets production requirements.
- [ ] Test for compatibility with other RDS settings, if applicable.
- [ ] Update documentation, if required.