### PR TITLE
hmpps-esupervision-prod: fix incorrect topic name

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/domain-events-topic.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/domain-events-topic.tf
@@ -10,7 +10,7 @@ resource "kubernetes_secret" "hmpps_domain_events_topic" {
 }
 
 data "aws_ssm_parameter" "hmpps-domain-events-topic-arn" {
-  name = "/hmpps-domain-events-preprod/topic-arn"
+  name = "/hmpps-domain-events-prod/topic-arn"
 }
 
 data "aws_sns_topic" "hmpps-domain-events" {


### PR DESCRIPTION
A preprod topic name was used, this PR sets the correct name.