### PR TITLE
RR-1859 Upgrade SAN preprod RDS to use postgres 17

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-preprod/resources/rds-postgresql.tf
@@ -17,11 +17,12 @@ module "rds" {
   db_max_allocated_storage     = "500"
   enable_rds_auto_start_stop   = true # Pre-prod database is stopped overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
+  prepare_for_major_upgrade = true
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
-  rds_family        = "postgres16"
+  db_engine_version = "17"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family        = "postgres17"
   db_instance_class = "db.t4g.micro"
 
   # Tags
@@ -59,8 +60,8 @@ module "read_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
-  rds_family        = "postgres16"
+  db_engine_version = "17"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family        = "postgres17"
   db_instance_class = "db.t4g.micro"
   # It is mandatory to set the below values to create read replica instance
 


### PR DESCRIPTION
* Upgrade the version of postgres used in the Support for Additional Needs pre-prod environment.

Dev change was made here: https://github.com/ministryofjustice/cloud-platform-environments/pull/36251 and was found to have no issues.