### PR TITLE
Create new RDS instance for visit scheduler DB on preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -38,8 +38,8 @@ module "visit_scheduler_pg_rds" {
   allow_major_version_upgrade = "false"
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "17"
-  rds_family                  = "postgres17"
+  db_engine_version           = "15.12"
+  rds_family                  = "postgres15"
   db_instance_class           = "db.t4g.small"
   db_allocated_storage        = "35"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -24,6 +24,32 @@ module "visit_scheduler_rds" {
   enable_irsa = true
 }
 
+module "visit_scheduler_pg_rds" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  allow_major_version_upgrade = "false"
+  prepare_for_major_upgrade   = false
+  db_engine                   = "postgres"
+  db_engine_version           = "17"
+  rds_family                  = "postgres17"
+  db_instance_class           = "db.t4g.small"
+  db_allocated_storage        = "35"
+
+  providers = {
+    aws = aws.london
+  }
+
+  enable_irsa = true
+}
+
 resource "kubernetes_secret" "visit_scheduler_rds" {
   metadata {
     name      = "visit-scheduler-rds"
@@ -31,11 +57,11 @@ resource "kubernetes_secret" "visit_scheduler_rds" {
   }
 
   data = {
-    rds_instance_endpoint = module.visit_scheduler_rds.rds_instance_endpoint
-    database_name         = module.visit_scheduler_rds.database_name
-    database_username     = module.visit_scheduler_rds.database_username
-    database_password     = module.visit_scheduler_rds.database_password
-    rds_instance_address  = module.visit_scheduler_rds.rds_instance_address
+    rds_instance_endpoint = module.visit_scheduler_pg_rds.rds_instance_endpoint
+    database_name         = module.visit_scheduler_pg_rds.database_name
+    database_username     = module.visit_scheduler_pg_rds.database_username
+    database_password     = module.visit_scheduler_pg_rds.database_password
+    rds_instance_address  = module.visit_scheduler_pg_rds.rds_instance_address
   }
 }
 
@@ -48,11 +74,11 @@ resource "kubernetes_secret" "visit_scheduler_rds_refresh_creds" {
   }
 
   data = {
-    rds_instance_endpoint = module.visit_scheduler_rds.rds_instance_endpoint
-    database_name         = module.visit_scheduler_rds.database_name
-    database_username     = module.visit_scheduler_rds.database_username
-    database_password     = module.visit_scheduler_rds.database_password
-    rds_instance_address  = module.visit_scheduler_rds.rds_instance_address
+    rds_instance_endpoint = module.visit_scheduler_pg_rds.rds_instance_endpoint
+    database_name         = module.visit_scheduler_pg_rds.database_name
+    database_username     = module.visit_scheduler_pg_rds.database_username
+    database_password     = module.visit_scheduler_pg_rds.database_password
+    rds_instance_address  = module.visit_scheduler_pg_rds.rds_instance_address
   }
 }
 


### PR DESCRIPTION
## What does this PR do?
After an upgrade to the existing visit scheduler DB, something went wrong and it is currently stuck in an unusable state. We have to leave the DB while aws investigate. For now, to unblock the team, we will create a new rds instance and point the APIs to that, also point the preprod restore job to it as well, to populate with prod data.