### PR TITLE
SDS-128 - Increase dynamodb autoscaler limits in LAA-SDS-DEV

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/dynamodb.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-dev/resources/dynamodb.tf
@@ -19,6 +19,10 @@ module "audit_dynamodb" {
 
   enable_encryption = "true"
   enable_autoscaler = "true"
+  autoscale_max_read_capacity = 40
+  autoscale_max_write_capacity = 40
+  autoscale_min_read_capacity = 1
+  autoscale_min_write_capacity = 1
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
We sometimes encounter `ProvisionedThroughputExceededException` exceptions when carrying out operations that include updates to our dynamodb audit table (e.g. file saves, updates, reads). 

This table does have autoscaling enabled but within default limits of 1 to 10 units. 

This change increases the maximum read and write capacities to 40 units in our dev environment, with goal of seeing if this prevents the `ProvisionedThroughputExceededException` exceptions.

Note information about dynamodb config can be found here: https://github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster