### PR TITLE
RR-1859 Turn off prepare for major upgrade flag

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-support-additional-needs-prod/resources/rds-postgresql.tf
@@ -16,7 +16,7 @@ module "rds" {
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
-  prepare_for_major_upgrade = true
+  prepare_for_major_upgrade = false
 
   # PostgreSQL specifics
   db_engine         = "postgres"


### PR DESCRIPTION
* Turns off `prepare-for-major-upgrade` flag that was turned on for postgres 16->17 upgrade in https://github.com/ministryofjustice/cloud-platform-environments/pull/36262