### PR TITLE
Reset flags post upgrade to 16.8 - visit-someone-in-prison-backend-svc-dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-dev/resources/rds.tf
@@ -9,8 +9,8 @@ module "visit_scheduler_rds" {
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
 
-  allow_major_version_upgrade = "true"
-  prepare_for_major_upgrade   = true
+  allow_major_version_upgrade = "false"
+  prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
   db_engine_version           = "16.8"
   rds_family                  = "postgres16"


### PR DESCRIPTION
Reset allow_major_version_upgrade and prepare_for_major_upgrade flags to false after upgrading to 16.8 on visit-someone-in-prison-backend-svc-dev namespace.