### PR TITLE
AP-6241: Remove pingdom alert integration id [Assure production]

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-assure-hmrc-data-production/resources/pingdom.tf
@@ -14,5 +14,5 @@ resource "pingdom_check" "laa-assure-hmrc-data-production-healthcheck" {
   port                     = 443
   tags                     = "businessunit_${var.business_unit},application_${var.repo_name},component_ping,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.team_name},laa,apply-for-legal-aid,laa_production_environment_dashboard"
   probefilters             = "region:EU"
-  integrationids           = [96996, 129269]
+  integrationids           = [96996]
 }


### PR DESCRIPTION
AP-6241: Remove pingdom alert integration id [Assure production]

Remove public #laa-civil-apply slack channel integration id
to prevent "Out of hours" 503 statuses from overwhelming
the channel. We still alert to #apply-alerts-prod.
