### PR TITLE
LFSP-157: Add network policy for laa-fee-scheme-api-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-scheme-api-staging/04-networkpolicy.yaml
@@ -25,3 +25,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-claims-event-service
+  namespace: laa-fee-scheme-api-staging
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: laa-data-claims-event-service-staging


### PR DESCRIPTION
Added network policy to allow access from data claims event service.