### PR TITLE
DPR2-2138 added hmpps-dpr-tools-authoring-api.tf based on hmpps_template-kotlin

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/resources/hmpps-dpr-tools-authoring-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/resources/hmpps-dpr-tools-authoring-api.tf
@@ -1,0 +1,16 @@
+module "hmpps_template_kotlin" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.1.0"
+  github_repo = "hmpps-dpr-tools-authoring-api"
+  application = "hmpps-dpr-tools-authoring-api"
+  github_team = "hmpps-data-hub"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  #reviewer_teams                = ["hmpps-dev-team-1", "hmpps-dev-team-2"] # Optional team that should review deployments to this environment.
+  #selected_branch_patterns      = ["main", "release/*", "feature/*"] # Optional
+  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}


### PR DESCRIPTION
These changes add the hmpps-dpr-tools-authoring-api.tf file which is based on [hmpps_template-kotlin](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/template-kotlin.tf).
The aim is to be able to deploy our [new service](https://github.com/ministryofjustice/hmpps-dpr-tools-authoring-api) to the `hmpps-dpr-tools-dev` existing namespace. 
