### PR TITLE
Fix: rds version mismatch in wajid-irsa-test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/wajid-irsa-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/wajid-irsa-test/resources/rds.tf
@@ -62,7 +62,7 @@ module "rds_postgres" {
 
   # postgres specifics
   db_engine         = "postgres"
-  db_engine_version = "16.8"
+  db_engine_version = "16.9"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.large"
   db_parameter      = []


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `wajid-irsa-test`

```
module.rds_postgres: downgrade from 16.9 to 16.8
```