### PR TITLE
Remove deletion protection for opg-lpa-fd-prototype's ecr

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/opg-lpa-fd-prototype/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/opg-lpa-fd-prototype/resources/ecr.tf
@@ -14,4 +14,6 @@ module "ecr-repo" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+
+  deletion_protection = false
 }


### PR DESCRIPTION
We will be deleting this namespace as it is no longer required.