### PR TITLE
Configure MPC preprod RDS maintenance window

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/offender-management-preprod/resources/rds.tf
@@ -25,15 +25,14 @@ module "allocation-rds" {
   allow_major_version_upgrade = false
   prepare_for_major_upgrade   = false
   db_name                     = "allocations"
-  enable_rds_auto_start_stop  = true
-
+  enable_rds_auto_start_stop  = true # 22:00–06:00 UTC
+  maintenance_window          = "sun:19:00-sun:21:00"
 
   db_password_rotated_date = "2023-04-05T11:31:27Z"
 
   providers = {
     aws = aws.london
   }
-
 }
 
 resource "kubernetes_secret" "allocation-rds" {


### PR DESCRIPTION
Avoid overlap with the `enable_rds_auto_start_stop` window.