### PR TITLE
IMS - Step 1 prod DB upgrade tp Postgres 17

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/rds-aurora.tf
@@ -6,7 +6,7 @@ module "rds_aurora" {
 
   # Database configuration
   engine         = "aurora-postgresql"
-  engine_version = "15.5"
+  engine_version = "15.10"
   engine_mode    = "provisioned"
   instance_type  = "db.serverless"
   serverlessv2_scaling_configuration = {
@@ -15,7 +15,7 @@ module "rds_aurora" {
   }
   replica_count                = 1
   performance_insights_enabled = true
-  db_parameter_group_name      = resource.aws_db_parameter_group.default.name
+  db_parameter_group_name = "default.aurora-postgresql15"
   allow_major_version_upgrade  = true
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/rds-legacy.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/rds-legacy.tf
@@ -6,7 +6,7 @@ module "rds_aurora_legacy" {
 
   # Database configuration
   engine         = "aurora-postgresql"
-  engine_version = "15.4"
+  engine_version = "15.10"
   engine_mode    = "provisioned"
   instance_type  = "db.serverless"
   serverlessv2_scaling_configuration = {


### PR DESCRIPTION
First step of upgrading existing IMS prod postgres databases to match current deployed engine versions.