### PR TITLE
DPR2-2138 added ingress host to dns names

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-tools-dev/05-certificates.yaml
@@ -12,3 +12,4 @@ spec:
   dnsNames:
     - dpr-tools-api-dev.hmpps.service.justice.gov.uk
     - dpr-tools-ui-dev.hmpps.service.justice.gov.uk
+    - dpr-tools-authoring-api-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Added the ingress host of the authoring API service to the DNS names of the certificate.