### PR TITLE
add Route53 hosted zone for dev.reuselibrary.service.justice.gov.uk

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/main.tf
@@ -1,15 +1,5 @@
 terraform {
-  backend "s3" {}
-  required_version = ">= 1.2.5"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.64.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.23.0"
-    }
+  backend "s3" {
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/main.tf
@@ -1,5 +1,15 @@
 terraform {
-  backend "s3" {
+  backend "s3" {}
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.64.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
   }
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/route53.tf
@@ -15,12 +15,13 @@ resource "aws_route53_zone" "dev_reuselibrary_team_route53_zone" {
 
 resource "kubernetes_secret" "dev_reuselibrary_route53_zone_sec" {
   metadata {
-    name      = "dev_reuselibrary-route53-zone-output"
+    name      = "${var.namespace}-route53-zone-output"
     namespace = var.namespace
   }
 
-  data = {
-    zone_id = aws_route53_zone.dev_reuselibrary_team_route53_zone.zone_id
+  # Use string_data so we can provide plain strings (provider encodes as needed)
+  string_data = {
+    zone_id     = aws_route53_zone.dev_reuselibrary_team_route53_zone.zone_id
     nameservers = join("\n", aws_route53_zone.dev_reuselibrary_team_route53_zone.name_servers)
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/route53.tf
@@ -19,8 +19,7 @@ resource "kubernetes_secret" "dev_reuselibrary_route53_zone_sec" {
     namespace = var.namespace
   }
 
-  # Use string_data so we can provide plain strings (provider encodes as needed)
-  string_data = {
+  data = {
     zone_id     = aws_route53_zone.dev_reuselibrary_team_route53_zone.zone_id
     nameservers = join("\n", aws_route53_zone.dev_reuselibrary_team_route53_zone.name_servers)
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "dev_reuselibrary_team_route53_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.github_owner
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "dev_reuselibrary_route53_zone_sec" {
+  metadata {
+    name      = "dev_reuselibrary-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.dev_reuselibrary_team_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.dev_reuselibrary_team_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuselibrary-dev/resources/variables.tf
@@ -35,7 +35,7 @@ variable "team_name" {
 variable "environment" {
   description = "Name of the environment type for this service"
   type        = string
-  default     = "development"
+  default     = "dev"
 }
 
 variable "infrastructure_support" {
@@ -66,4 +66,10 @@ variable "github_token" {
   type        = string
   description = "Required by the GitHub Terraform provider"
   default     = ""
+}
+
+variable "domain" {
+  type        = string
+  description = "Domain name for the service"
+  default     = "dev.reuselibrary.service.justice.gov.uk"
 }


### PR DESCRIPTION
output zone details via Kubernetes Secret

This PR adds Terraform to create a private/public Route 53 hosted zone for our service domain and a Kubernetes Secret that surfaces the zone ID and nameservers, following the Cloud Platform user guide