### PR TITLE
Fix: rds version mismatch in hmpps-complexity-of-need-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-complexity-of-need-preprod/resources/rds.tf
@@ -18,7 +18,7 @@ module "rds" {
   environment_name         = var.environment
   infrastructure_support   = var.infrastructure_support
 
-  db_engine_version           = "15.7"
+  db_engine_version           = "15.12"
   rds_family                  = "postgres15"
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false


### PR DESCRIPTION
- Fix Terraform RDS version drift for namespace: `hmpps-complexity-of-need-preprod`

```
module.rds: downgrade from 15.12 to 15.7
```