### PR TITLE
This needs bumping to match the RDS instance reported allocated storage

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/visit-someone-in-prison-backend-svc-preprod/resources/rds.tf
@@ -15,7 +15,7 @@ module "visit_scheduler_rds" {
   db_engine_version           = "16.8"
   rds_family                  = "postgres16"
   db_instance_class           = "db.t4g.small"
-  db_allocated_storage        = "35"
+  db_allocated_storage        = "119"
 
   snapshot_identifier = "cloud-platform-84e747a7557ea77f-2025-09-23-13-35"
 


### PR DESCRIPTION
Without doing this the pipeline fails.

Failure: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/15926

Actual size: "AllocatedStorage": 119,