### PR TITLE
DSTEW-463: Enable pglogical extension on this database 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-reporting-service-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-reporting-service-uat/resources/rds-postgresql.tf
@@ -18,8 +18,16 @@ module "rds" {
   enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
+  #Enable logical replication from claims-api database
+  db_parameter = [
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    }
+  ]
+
   # PostgreSQL specifics
-  prepare_for_major_upgrade = true
   db_engine         = "postgres"
   db_engine_version = "17.4"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres17"


### PR DESCRIPTION
This is to allow logical replication from the claims-data database.