### PR TITLE
DSTEW-463: Use name (rather than prefix) in security-group.tf 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-reporting-service-uat/resources/security-group.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-reporting-service-uat/resources/security-group.tf
@@ -7,8 +7,8 @@ data "aws_vpc" "selected" {
 }
 
 resource "aws_security_group" "rds" {
-  name_prefix = "${var.namespace}-rds-sg"
-  description = "RDS VPC Security Group for Reporting Service Ingress Traffic"
+  name = "${var.namespace}-rds-sg"
+  description = "RDS VPC Security Group for Reporting Service"
   vpc_id      = data.aws_vpc.selected.id
 
   lifecycle {


### PR DESCRIPTION
This is so that the name is fixed rather than appended by a random number.