### PR TITLE
ACE-689: Set up HMPPS namespaces for preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-arns-assessment-platform-preprod
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "preprod"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "arns-core-exp-team"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "aap-alerts"
+    cloud-platform.justice.gov.uk/application: "HMPPS ARNS Assessment Platform"
+    cloud-platform.justice.gov.uk/owner: "HMPPS Assess Risks Strengths and Needs: arns@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-arns-assessment-platform-api.git,https://github.com/ministryofjustice/hmpps-arns-assessment-platform-ui.git"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-assessments-live"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/01-rbac.yaml
@@ -1,0 +1,17 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-arns-assessment-platform-preprod-admin
+  namespace: hmpps-arns-assessment-platform-preprod
+subjects:
+  - kind: Group
+    name: "github:hmpps-assessments-live"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/02-limitrange.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-arns-assessment-platform-preprod
+spec:
+  limits:
+    - default:
+        cpu: 2000m
+        memory: 1024Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 512Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-arns-assessment-platform-preprod
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-arns-assessment-platform-preprod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-arns-assessment-platform-preprod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/06-certificate.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-arns-assessment-platform-ui-preprod
+  namespace: hmpps-arns-assessment-platform-preprod
+spec:
+  secretName: hmpps-arns-assessment-platform-ui-cert-preprod
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - arns-assessment-platform-preprod.hmpps.service.justice.gov.uk
+    - '*.arns-assessment-platform-preprod.hmpps.service.justice.gov.uk'
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-arns-assessment-platform-api-preprod
+  namespace: hmpps-arns-assessment-platform-preprod
+spec:
+  secretName: hmpps-arns-assessment-platform-api-cert-preprod
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - arns-assessment-platform-api-preprod.hmpps.service.justice.gov.uk
+    - '*.arns-assessment-platform-api-preprod.hmpps.service.justice.gov.uk'

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/07-rbac-haar-client-admin-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/07-rbac-haar-client-admin-team.yaml
@@ -1,0 +1,39 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-arns-assessment-platform-preprod
+rules:
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "issuers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [ "", "extensions" ]
+    resources: [ "services", "ingresses", "configmaps", "pods/log" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: [ "get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-arns-assessment-platform-preprod
+subjects:
+  - kind: Group
+    name: "github:hmpps-haar-client-admin"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: hmpps-haar-client-admin-team
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/aap-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/aap-api.tf
@@ -1,0 +1,13 @@
+module "hmpps_arns_assessment_platform_api" {
+source                          = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.1.0"
+  github_repo                   = "hmpps-arns-assessment-platform-api"
+  application                   = "hmpps-arns-assessment-platform-api"
+  github_team                   = "hmpps-assessments-live"
+  environment                   = var.environment
+  is_production                 = var.is_production
+  application_insights_instance = "preprod"
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/aap-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/aap-ui.tf
@@ -1,0 +1,50 @@
+module "hmpps_arns_assessment_platform_ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.1.0"
+  github_repo                   = "hmpps-arns-assessment-platform-ui"
+  application                   = "hmpps-arns-assessment-platform-ui"
+  github_team                   = "hmpps-assessments-live"
+  environment                   = var.environment
+  is_production                 = var.is_production
+  application_insights_instance = "preprod"
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}
+
+# Note, redis is a requirement for hmpps-template-typescript application.
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = module.hmpps_arns_assessment_platform_ui.application
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  number_cache_clusters = var.number_cache_clusters
+  # sized for micro in preprod, preprod, suggest small for production
+  node_type            = "cache.t4g.micro"
+  engine_version       = "7.0"
+  parameter_group_name = "default.redis7"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "${module.hmpps_arns_assessment_platform_ui.application}-elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    replication_group_id     = module.elasticache_redis.replication_group_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      GithubTeam = var.team_name
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      GithubTeam = var.team_name
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      GithubTeam = var.team_name
+    }
+  }
+}
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/rds-postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/rds-postgres.tf
@@ -1,0 +1,108 @@
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.1"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = false
+  db_max_allocated_storage     = "500"
+  enable_rds_auto_start_stop   = true
+  db_password_rotated_date     = "2025-09-24"
+
+  # PostgreSQL specifics
+  db_engine         = "postgres"
+  db_engine_version = "16"
+  rds_family        = "postgres16"
+  db_instance_class = "db.t4g.micro"
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+# To create a read replica, use the below code and update the values to specify the RDS instance
+# from which you are replicating. In this example, we're assuming that rds is the
+# source RDS instance and read-replica is the replica we are creating.
+
+module "read_replica" {
+  # default off
+  count  = 0
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.0.1"
+
+  vpc_name               = var.vpc_name
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  # If any other inputs of the RDS is passed in the source db which are different from defaults,
+  # add them to the replica
+
+  # PostgreSQL specifics
+  db_engine         = "postgres"
+  db_engine_version = "16"
+  rds_family        = "postgres16"
+  db_instance_class = "db.t4g.micro"
+  # It is mandatory to set the below values to create read replica instance
+
+  # Set the db_identifier of the source db
+  replicate_source_db = module.rds.db_identifier
+
+  # Set to true. No backups or snapshots are created for read replica
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+}
+
+
+resource "kubernetes_secret" "read_replica" {
+  # default off
+  count = 0
+
+  metadata {
+    name      = "rds-postgresql-read-replica-output"
+    namespace = var.namespace
+  }
+}
+
+
+# Configmap to store non-sensitive data related to the RDS instance
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/variables.tf
@@ -1,0 +1,58 @@
+variable "vpc_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "ARNS Assessment Platform"
+}
+
+variable "namespace" {
+  default = "hmpps-arns-assessment-platform-preprod"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-assessments-live"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "preprod"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "arns@justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "aap-notifications"
+}
+
+variable "number_cache_clusters" {
+  default = "2"
+}
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-arns-assessment-platform-preprod/resources/versions.tf
@@ -1,0 +1,18 @@
+
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
1. Copied existing dev namespace config
2. renamed "dev" references to "preprod"
3. Updated GItHub teams references to "hmpps-assessments-live"