### PR TITLE
Add new route53 records for ECP

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-emergency-containment-platform/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-emergency-containment-platform/resources/route53.tf
@@ -24,3 +24,29 @@ resource "aws_route53_record" "cwa-prod-db" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "cwa-prod-db1" {
+  depends_on = [aws_route53_zone.aws-prd-legalservices-gov-uk]
+  zone_id = aws_route53_zone.aws-prd-legalservices-gov-uk.zone_id
+  name    = "cwa-prod-db1"
+  type    = "A"
+
+  alias {
+    name                   = "cwa-production-database-nlb-12d44851fda0f196.elb.eu-west-2.amazonaws.com"
+    zone_id                = "ZD4D7Y8KGAS4G"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cwa-prod-db3" {
+  depends_on = [aws_route53_zone.aws-prd-legalservices-gov-uk]
+  zone_id = aws_route53_zone.aws-prd-legalservices-gov-uk.zone_id
+  name    = "cwa-prod-db3"
+  type    = "A"
+
+  alias {
+    name                   = "cwa-production-db-nlb-green-68322e6a90023a4a.elb.eu-west-2.amazonaws.com"
+    zone_id                = "ZD4D7Y8KGAS4G"
+    evaluate_target_health = false
+  }
+}


### PR DESCRIPTION
In order to support blue/green deployments to ECP this PR introduces two new records for direct access to blue and green databases.