### PR TITLE
BAVL-1057 move the BVLS API preprod deployment over to github actions.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-preprod/resources/hmpps-book-a-video-link-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-a-video-link-preprod/resources/hmpps-book-a-video-link-github.tf
@@ -1,0 +1,16 @@
+module "hmpps-activities-management-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.1.0"
+  github_repo                   = "hmpps-book-a-video-link-api"
+  application                   = "hmpps-book-a-video-link-api"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  is_production                 = var.is_production
+  selected_branch_patterns      = ["main"]
+  application_insights_instance = var.environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.team_name]
+}


### PR DESCRIPTION
PR to move the preprod book a video link API deployment to use github actions (replacing Circle CI)