### PR TITLE
Remove email related DNS for brookhouseinquiry.org.uk

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/brookhouse-route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/brookhouse-route53.tf
@@ -26,40 +26,8 @@ resource "aws_route53_record" "brookhouse_route53_mx_record_mail" {
   zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
   name    = "brookhouseinquiry.org.uk"
   type    = "MX"
-  ttl     = "3600"
-  records = ["10 mail1.brookhouseinquiry.org.uk", "10 mail2.brookhouseinquiry.org.uk", "10 mail3.brookhouseinquiry.org.uk", "10 mail4.brookhouseinquiry.org.uk"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_a_record_mail1" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "mail1.brookhouseinquiry.org.uk"
-  type    = "A"
-  ttl     = "300"
-  records = ["18.168.37.156"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_a_record_mail2" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "mail2.brookhouseinquiry.org.uk"
-  type    = "A"
-  ttl     = "300"
-  records = ["18.168.37.157"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_a_record_mail3" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "mail3.brookhouseinquiry.org.uk"
-  type    = "A"
-  ttl     = "300"
-  records = ["18.168.37.158"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_a_record_mail4" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "mail4.brookhouseinquiry.org.uk"
-  type    = "A"
-  ttl     = "300"
-  records = ["18.168.37.159"]
+  ttl     = "0"
+  records = ["."]
 }
 
 resource "aws_route53_record" "brookhouse_route53_txt" {
@@ -67,7 +35,7 @@ resource "aws_route53_record" "brookhouse_route53_txt" {
   name    = "brookhouseinquiry.org.uk"
   type    = "TXT"
   ttl     = "3600"
-  records = ["E0G0S16406", "MS=ms51271079", "google-site-verification=yzqA25_KO_rZYL4b-UxXDXI7x-ZWUKYHjtyxyVILvqU", "adobe-idp-site-verification=12745d082f0122d00a6ac369ec9edff9a2b54fd6e569dee485e26119cd5523ee", "dn0QxuQ4AjkLbhQTyFA+nWix2yM5DE7xy0qbZgb1afVWAT/TcyzyZQOq7xkIsvcroCHw8YuEw/pw2JQGJMaZQQ==", "QuoVadis=22879b0e-362c-40bc-a726-da94acee34ed", "v=spf1 include:u2320754.wl005.sendgrid.net ip4:18.168.37.156/30 -all"]
+  records = ["E0G0S16406", "google-site-verification=yzqA25_KO_rZYL4b-UxXDXI7x-ZWUKYHjtyxyVILvqU", "adobe-idp-site-verification=12745d082f0122d00a6ac369ec9edff9a2b54fd6e569dee485e26119cd5523ee", "dn0QxuQ4AjkLbhQTyFA+nWix2yM5DE7xy0qbZgb1afVWAT/TcyzyZQOq7xkIsvcroCHw8YuEw/pw2JQGJMaZQQ==", "QuoVadis=22879b0e-362c-40bc-a726-da94acee34ed", "v=spf1 -all"]
 }
 
 resource "aws_route53_record" "brookhouse_route53_txt_asvdns" {
@@ -83,47 +51,15 @@ resource "aws_route53_record" "brookhouse_route53_txt_dmarc" {
   name    = "_dmarc.brookhouseinquiry.org.uk"
   type    = "TXT"
   ttl     = "300"
-  records = ["v=DMARC1; p=reject; sp=reject; fo=1; ri=3600; rua=mailto:ukho@rua.agari-eu.com; ruf=mailto:ukho@ruf.agari-eu.com"]
+  records = ["v=DMARC1;p=reject;rua=mailto:ukho@rua.agari-eu.com; ruf=mailto:ukho@ruf.agari-eu.com"]
 }
 
 resource "aws_route53_record" "brookhouse_route53_txt_dkim" {
   zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "08032021._domainkey.brookhouseinquiry.org.uk"
+  name    = "*._domainkey.brookhouseinquiry.org.uk"
   type    = "TXT"
   ttl     = "300"
-  records = ["v=DKIM1; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDQq1FyQaOs1If2qMDgFcPzoSPxgrW74N5sDgnGe0n4lHdZeuQK9TbSvGXsadobFHsdYi9TaRs7ZcTSXF2YutzPlKYXl1owqP81UpPHB9mdsGoIZpgVqdWvVm+lRwk8KtKXqUh84norLAZveWkWNlfEPwr8Rl7O+QcVYUEln3DCSwIDAQAB;"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_txt_dkim_everyone" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "everyone._domainkey.brookhouseinquiry.org.uk"
-  type    = "TXT"
-  ttl     = "300"
-  records = ["v=DKIM1; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDXkYQfwfJJZ+f8aUiS06jOhupWFHRwkL890axNTiJUPRhGZ+y6KHABwyXf06lR8CXzY20pwwy4j5vvQePMgvQbS7AkjhpiKK9O3kSX/KJ6GJ6zpgFO4Bhnq8eRYyBWuy1BZT+HNB5eoytxsUuXi0dmCWmq/rTBEYQMO/kCaWqJWQIDAQAB;"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_txt_dkim_07092023" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "07092023._domainkey.brookhouseinquiry.org.uk."
-  type    = "TXT"
-  ttl     = "300"
-  records = ["v=DKIM1; t=s; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApFBvkc4d43rDfJNqF4PxbaTKY3j6hfLVcPrF5TC4IdvHvhMLRE0QSbLi/nJLXskM0MM0ClSUlnPV16HahDgkQdSwRc3nZleV2KqO2fKLdRque2ddG7K\"\"+huY9IvAtyqPD9CeCxuxXeakVYFqUYUyM5uhPoDrtQsHT2lhZ/faAN/e6FpdtBbOIpxiITbuZxanaWaTcn3GoN/A0RWHt0LeLpitU23tepDbysfuZFk7ZCc+qhNKUL+rNd5yWeaHHbs4Ge1KH6rMN7pXgHUMpvNl8YMIR2I1OvTz/R3IKn6M73MdUV8vlgjsdrZ4s+jOYUCBxQL3ukc+ogfWy9babqxgtaQIDAQAB;"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_txt_dkim_20250812" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "20250812._domainkey.brookhouseinquiry.org.uk"
-  type    = "TXT"
-  ttl     = "3600"
-  records = ["v=DKIM1; t=s; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDQq1FyQaOs1If2qMDgFcPzoSPxgrW74N5sDgnGe0n4lHdZeuQK9TbSvGXsadobFHsdYi9TaRs7ZcTSXF2YutzPlKYXl1owqP81UpPHB9mdsGoIZpgVqdWvVm+lRwk8KtKXqUh84norLAZveWkWNlfEPwr8Rl7O+QcVYUEln3DCSwIDAQAB;"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_txt_mta" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "_mta-sts.brookhouseinquiry.org.uk"
-  type    = "TXT"
-  ttl     = "3600"
-  records = ["v=STSv1; id=20230517"]
+  records = ["v=DKIM1; p="]
 }
 
 resource "aws_route53_record" "brookhouse_route53_txt_pki" {
@@ -132,68 +68,4 @@ resource "aws_route53_record" "brookhouse_route53_txt_pki" {
   type    = "TXT"
   ttl     = "300"
   records = ["A736-F07F-B9BC-9593-19E1-3ED8-17BB-9F45"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_txt_smtp" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "_smtp._tls.brookhouseinquiry.org.uk"
-  type    = "TXT"
-  ttl     = "300"
-  records = ["v=TLSRPTv1;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_cname_record_sendgrid" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "2320754.brookhouseinquiry.org.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["sendgrid.net"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_cname_record_sendgrid_s1" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "s1._domainkey.brookhouseinquiry.org.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["s1.domainkey.u2320754.wl005.sendgrid.net"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_cname_record_sendgrid_s2" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "s2._domainkey.brookhouseinquiry.org.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["s2.domainkey.u2320754.wl005.sendgrid.net"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_cname_record_sendgrid_em" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "em6348.brookhouseinquiry.org.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["u2320754.wl005.sendgrid.net"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_cname_record_mta" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "mta-sts.brookhouseinquiry.org.uk"
-  type    = "CNAME"
-  ttl     = "3600"
-  records = ["orange-moss-0229de303.3.azurestaticapps.net"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_cname_record_sendgrid_url" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "url6609.brookhouseinquiry.org.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["sendgrid.net"]
-}
-
-resource "aws_route53_record" "brookhouse_route53_srv_record_autodiscover" {
-  zone_id = aws_route53_zone.brookhouse_route53_zone.zone_id
-  name    = "_autodiscover._tcp.brookhouseinquiry.org.uk"
-  type    = "SRV"
-  ttl     = "3600"
-  records = ["10 10 443 autodiscover.homeoffice.gov.uk"]
 }


### PR DESCRIPTION
## 👀 Purpose

- This PR removes email related DNS from the brookhouseinquiry.org.uk hostedzone.

## ♻️ What's changed

- Update MX `brookhouseinquiry.org.uk`
- Update TXT `brookhouseinquiry.org.uk`
- Update TXT `_dmarc.brookhouseinquiry.org.uk`
- Delete ARECORD `mail1.brookhouseinquiry.org.uk`
- Delete ARECORD `mail2.brookhouseinquiry.org.uk`
- Delete ARECORD `mail3.brookhouseinquiry.org.uk`
- Delete ARECORD `mail4.brookhouseinquiry.org.uk`
- Delete TXT `08032021._domainkey.brookhouseinquiry.org.uk`
- Delete TXT `everyone._domainkey.brookhouseinquiry.org.uk`
- Delete TXT `07092023._domainkey.brookhouseinquiry.org.uk`
- Delete TXT `20250812._domainkey.brookhouseinquiry.org.uk`
- Delete TXT `_mta-sts.brookhouseinquiry.org.uk`
- Delete TXT `_smtp._tls.brookhouseinquiry.org.uk`
- Delete CNAME `2320754.brookhouseinquiry.org.uk`
- Delete CNAME `s1._domainkey.brookhouseinquiry.org.uk`
- Delete CNAME `s2._domainkey.brookhouseinquiry.org.uk`
- Delete CNAME `em6348.brookhouseinquiry.org.uk`
- Delete CNAME `mta-sts.brookhouseinquiry.org.uk`
- Delete CNAME `url6609.brookhouseinquiry.org.uk`
- Delete SRV `_autodiscover._tcp.brookhouseinquiry.org.uk`
- Add TXT `*._domainkey.brookhouseinquiry.org.uk`