### PR TITLE
ESWE-969: Add audit secrets to MJMA and Jobs Board (preprod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/audit-namespaces-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-preprod/resources/audit-namespaces-secrets.tf
@@ -25,7 +25,9 @@ locals {
     "hmpps-workload-preprod",
     "make-recall-decision-preprod",
     "visit-someone-in-prison-frontend-svc-preprod",
-    "hmpps-managing-prisoner-apps-preprod"
+    "hmpps-managing-prisoner-apps-preprod",
+    "hmpps-jobs-board-preprod",
+    "hmpps-education-employment-preprod"
   ])
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/audit-namespaces-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/audit-namespaces-secrets.tf
@@ -25,7 +25,9 @@ locals {
     "hmpps-workload-prod",
     "make-recall-decision-prod",
     "visit-someone-in-prison-frontend-svc-prod",
-    "hmpps-managing-prisoner-apps-prod"
+    "hmpps-managing-prisoner-apps-prod",
+    "hmpps-jobs-board-prod",
+    "hmpps-education-employment-prod"
   ])
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/audit-namespaces-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-audit-prod/resources/audit-namespaces-secrets.tf
@@ -25,9 +25,7 @@ locals {
     "hmpps-workload-prod",
     "make-recall-decision-prod",
     "visit-someone-in-prison-frontend-svc-prod",
-    "hmpps-managing-prisoner-apps-prod",
-    "hmpps-jobs-board-prod",
-    "hmpps-education-employment-prod"
+    "hmpps-managing-prisoner-apps-prod"
   ])
 }
 


### PR DESCRIPTION
Setting up the preprod namespaces ahead of the audit code being rolled out.

Allows us to control deployment via the feature flag while keeping the helm config consistent across all environments:

```
namespace_secrets:
    sqs-hmpps-audit-secret:
      AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
      AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
```

Related:
* [preprod](https://github.com/ministryofjustice/cloud-platform-environments/pull/36748)
* [prod](https://github.com/ministryofjustice/cloud-platform-environments/pull/36749)