### PR TITLE
🏅 Add Data Platform LLM Gateway Development Certificate

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-llm-gateway-development/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-llm-gateway-development/05-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: llms-gateway-tls
+  namespace: data-platform-llm-gateway-development
+spec:
+  secretName: llms-gateway-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - llm-gateway.development.data-platform.service.justice.gov.uk


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/data-platform/issues/24

## Proposed Changes

- Creates `llm-gateway.development.data-platform.service.justice.gov.uk` 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>