### PR TITLE
[ESWE-1468] "Prisoner Received" domain event is missing on `hmpps-integration-api-prod`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/hmpps-domain-event-subscription.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-prod/resources/hmpps-domain-event-subscription.tf
@@ -114,6 +114,7 @@ resource "aws_sns_topic_subscription" "integration_api_domain_events_subscriptio
       "prison-offender-events.prisoner.person-restriction.upserted",
       "prison-offender-events.prisoner.person-restriction.deleted",
       "prison-offender-events.prisoner.non-association-detail.changed",
+      "prison-offender-events.prisoner.received",
       "calculate-release-dates.prisoner.changed",
       "risk-assessment.scores.ogrs.determined",
       "risk-assessment.scores.rsr.determined",


### PR DESCRIPTION
`prison-offender-events.prisoner.received` is missing on `hmpps-integration-api-prod`