### PR TITLE
Remove service pod from esupervision dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/service_pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/service_pod.tf
@@ -1,6 +1,0 @@
-module "service_pod" {
-    source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.0"
-
-    namespace = var.namespace
-    service_account_name = module.irsa.service_account.name
-}


### PR DESCRIPTION
The service pod is no longer required in the dev namespace for HMPPS esupervision.