### PR TITLE
Add alternate DNS alias for InfoX production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-information-exchange-production/resources/route53.tf
@@ -12,6 +12,11 @@ resource "aws_route53_zone" "infox_route53_zone" {
   }
 }
 
+data "aws_route53_zone" "cloud_platform_shared_zone" {
+  name         = "live.cloud-platform.service.justice.gov.uk"
+  private_zone = false
+}
+
 resource "kubernetes_secret" "infox_route53_zone_secret" {
   metadata {
     name      = "infox-route53-zone-output"
@@ -22,4 +27,12 @@ resource "kubernetes_secret" "infox_route53_zone_secret" {
     zone_id = aws_route53_zone.infox_route53_zone.zone_id
     nameservers = join("\n", aws_route53_zone.infox_route53_zone.name_servers)
   }
+}
+
+resource "aws_route53_record" "alt_prod" {
+  ttl     = 300
+  type    = "CNAME"
+  name    = "infox.apps.live.cloud-platform.service.justice.gov.uk"
+  zone_id = data.aws_route53_zone.cloud_platform_shared_zone.zone_id
+  records = ["infox.service.justice.gov.uk"]
 }


### PR DESCRIPTION
Created a new Route53 CNAME record pointing `infox.apps.live.cloud-platform.service.justice.gov.uk` to `infox.service.justice.gov.uk` to support legacy HMCTS WebLogic clients that cannot validate our custom certificate CN due to SNI/SAN handling issues.

This provides an alternative hostname aligned with the Cloud Platform’s wildcard certificate, while retaining the existing `infox.service.justice.gov.uk` domain for all other consumers.

No application changes required — only DNS and ingress updates.