### PR TITLE
[CRIMAPP-1958] Enable RDS Logging to XSIAM Cortex

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-production/resources/rds.tf
@@ -29,6 +29,9 @@ module "rds" {
   # use "prepare_for_major_upgrade" when upgrading the major version of an engine
   prepare_for_major_upgrade = false
 
+  # Enables Cloudwatch logging for this RDS instance and sends them to Cortex XSIAM
+  opt_in_xsiam_logging = true
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london


### PR DESCRIPTION
Enables Cloudwatch logging for security auditing purposes as outlined in [docs](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/blob/main/README.md#enabling-logging-to-xsiam-cortex)
[Ticket](https://dsdmoj.atlassian.net/browse/CRIMAPP-1958)