### PR TITLE
[CRIMAPP-1958] Enable RDS Logging to XSIAM Cortex on Crime Apply

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-criminal-legal-aid-production/resources/rds.tf
@@ -33,6 +33,9 @@ module "rds" {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london
   }
+
+  # Enables Cloudwatch logging for this RDS instance and sends them to Cortex XSIAM
+  opt_in_xsiam_logging = true
 }
 
 resource "kubernetes_secret" "rds" {


### PR DESCRIPTION
Enables Cloudwatch logging for crime apply rds instance for security auditing purposes as outlined in [docs](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/blob/main/README.md#enabling-logging-to-xsiam-cortex)
[Ticket](https://dsdmoj.atlassian.net/browse/CRIMAPP-1958)