### PR TITLE
Enhance mandatory tags SCP terraform error

### DIFF
--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -95,7 +95,7 @@ class CpEnv
       "terraform #{operation} #{last}"
     end
 
-    def add_tagging_scp_terraform_output_mask()
+    def add_tagging_scp_terraform_output_mask
       tagging_scp_id = "p-w8ht8v1x"
 
       "sed -E 's|#{tagging_scp_id}|#{tagging_scp_id} (Enforce mandatory tags), please see our tagging policy https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/finops-and-greenops-at-moj/standards/tagging.html|g'"

--- a/lib/cp_env/terraform.rb
+++ b/lib/cp_env/terraform.rb
@@ -68,7 +68,7 @@ class CpEnv
         last: %(-auto-approve)
       )
 
-      execute("cd #{tf_dir}; export TF_VAR_kubernetes_cluster=#{kubernetes_cluster}; #{cmd}")
+      execute("cd #{tf_dir}; export TF_VAR_kubernetes_cluster=#{kubernetes_cluster}; #{cmd} 2>&1 | #{add_tagging_scp_terraform_output_mask}")
     end
 
     def tf_plan
@@ -93,6 +93,12 @@ class CpEnv
       last = opts.fetch(:last)
 
       "terraform #{operation} #{last}"
+    end
+
+    def add_tagging_scp_terraform_output_mask()
+      tagging_scp_id = "p-w8ht8v1x"
+
+      "sed -E 's|#{tagging_scp_id}|#{tagging_scp_id} (Enforce mandatory tags), please see our tagging policy https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/finops-and-greenops-at-moj/standards/tagging.html|g'"
     end
   end
 end

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -65,7 +65,7 @@ describe CpEnv::Terraform do
 
       tf_init = "cd #{tf_dir}; export TF_VAR_kubernetes_cluster=#{kubernetes_cluster}; terraform init -backend-config=\"bucket=bucket\" -backend-config=\"key=key-prefix/live-1.cloud-platform.service.justice.gov.uk/mynamespace/terraform.tfstate\" -backend-config=\"dynamodb_table=lock-table\" -backend-config=\"region=region\""
 
-      tf_apply = "cd #{tf_dir}; export TF_VAR_kubernetes_cluster=#{kubernetes_cluster}; terraform apply -auto-approve"
+      tf_apply = "cd #{tf_dir}; export TF_VAR_kubernetes_cluster=#{kubernetes_cluster}; terraform apply -auto-approve 2>&1 | sed -E 's|p-w8ht8v1x|p-w8ht8v1x (Enforce mandatory tags), please see our tagging policy https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/finops-and-greenops-at-moj/standards/tagging.html|g'"
 
       expect_execute(tf_init, "", success)
       expect_execute(tf_apply, "", success)


### PR DESCRIPTION
Analogous solution merged into MP: https://github.com/ministryofjustice/modernisation-platform-environments/pull/16112

**Description**

COAT are rolling out the mandatory tagging SCP across the organisation.

The default error produced by the SCP is minimal in detail: https://github.com/ministryofjustice/modernisation-platform/actions/runs/23746934821/job/69190838889#step:9:725

This PR aims to use the unique SCP ID to enhance the error message of the mandatory tags SCP, adding more detail if a deployment is blocked by the SCP - https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/24139219371/job/70435869976#step:11:3097

This should facilitate a smoother SCP rollout.

**Additional Links**

SCP terraform configuration in root account: https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/organizations-policy-service-control.tf#L470

SCP in AWS console (must be logged into MOJ Master account) - https://us-east-1.console.aws.amazon.com/organizations/v2/home/policies/service-control-policy/p-w8ht8v1x