### PR TITLE
fix(workflow): update GITHUB_REPOSITORY env variable to only return the name without the owner

### DIFF
--- a/.github/workflows/iam-role-policy-changes-check.yaml
+++ b/.github/workflows/iam-role-policy-changes-check.yaml
@@ -7,7 +7,7 @@ env:
   PR_OWNER: ${{ github.event.pull_request.user.login }}
   GITHUB_OAUTH_TOKEN: ${{ secrets.DOCUMENT_REVIEW_GITHUB }}
   PR_NUMBER: ${{ github.event.number }}
-  GITHUB_REPOSITORY: ${{ github.repository }}
+  GITHUB_REPOSITORY: ${{ github.event.repository.name }}
   GITHUB_APP_ID: ${{ secrets.CLOUD_PLATFORM_ACTIONS_APP_ID }}
   GITHUB_APP_INSTALLATION_ID: ${{ secrets.CLOUD_PLATFORM_ACTIONS_INSTALL_ID }}
   GITHUB_APP_PRIVATE_KEY: ${{ secrets.CLOUD_PLATFORM_ACTIONS_PRIVATE_KEY }}


### PR DESCRIPTION
fix error in check 
`2026/04/09 15:40:53 Error creating review: POST https://api.github.com/repos/ministryofjustice/ministryofjustice/cloud-platform-environments/pulls/41526/reviews: 404 Not Found []`

To get only the repository name without the owner, the most direct way is to use the ${{ github.event.repository.name }} context variable. 
 
While github.repository returns owner/repo-name, github.event.repository.name extracts just the latter part (e.g., cloud-platform-enviroments). 