### PR TITLE
Add developer-portal-prod namespace and resources

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "developer-portal-dev"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/slack-channel: "developer-experience-team"
+    cloud-platform.justice.gov.uk/application: "developer-portal"
+    cloud-platform.justice.gov.uk/owner: "OCTO Developer Experience Team: sandhya.buddharaju@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/ministry-of-justice-developer-portal"
+    cloud-platform.justice.gov.uk/team-name: "octo-developer-experience"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/00-namespace.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "developer-portal-dev"
+  name: "developer-portal-prod"
   labels:
-    cloud-platform.justice.gov.uk/is-production: "false"
-    cloud-platform.justice.gov.uk/environment-name: "development"
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "Platforms"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/00-namespace.yaml
@@ -10,7 +10,7 @@ metadata:
     cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/slack-channel: "developer-experience-team"
     cloud-platform.justice.gov.uk/application: "developer-portal"
-    cloud-platform.justice.gov.uk/owner: "OCTO Developer Experience Team: sandhya.buddharaju@justice.gov.uk"
+    cloud-platform.justice.gov.uk/owner: "OCTO Developer Experience Team: DeveloperExperienceTeam@justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/ministry-of-justice-developer-portal"
     cloud-platform.justice.gov.uk/team-name: "octo-developer-experience"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/01-rbac.yaml
@@ -1,8 +1,8 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: developer-portal-dev-admin
-  namespace: developer-portal-dev
+  name: developer-portal-prod-admin
+  namespace: developer-portal-prod
 subjects:
   - kind: Group
     name: "github:octo-developer-experience"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: developer-portal-dev-admin
+  namespace: developer-portal-dev
+subjects:
+  - kind: Group
+    name: "github:octo-developer-experience"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: developer-portal-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/02-limitrange.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: limitrange
-  namespace: developer-portal-dev
+  namespace: developer-portal-prod
 spec:
   limits:
   - default:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/03-resourcequota.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: namespace-quota
-  namespace: developer-portal-dev
+  namespace: developer-portal-prod
 spec:
   hard:
     pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: developer-portal-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: developer-portal-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: developer-portal-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/04-networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default
-  namespace: developer-portal-dev
+  namespace: developer-portal-prod
 spec:
   podSelector: {}
   policyTypes:
@@ -15,7 +15,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
-  namespace: developer-portal-dev
+  namespace: developer-portal-prod
 spec:
   podSelector: {}
   policyTypes:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/basic-auth.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/basic-auth.tf
@@ -1,0 +1,13 @@
+# Username and password for the prototype kit website's http basic
+# authentication
+resource "kubernetes_secret" "basic_auth" {
+  metadata {
+    name      = "basic-auth"
+    namespace = var.namespace
+  }
+
+  data = {
+    username = "prototype"
+    password = "notarealwebsite"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/build/.dockerignore
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/build/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules/*
+public

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/build/Dockerfile
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/build/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:18.16-bullseye-slim
+
+ENV NODE_ENV=production
+
+RUN addgroup --gid 1017 --system appgroup \
+  && adduser --uid 1017 --system appuser --gid 1017
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y make python3
+
+COPY . .
+
+RUN npm install
+
+RUN chown -R appuser:appgroup /app
+
+USER 1017
+
+RUN chmod +x start.sh
+
+CMD ["./start.sh"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/build/start.sh
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/build/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu pipefail
+
+npm run serve

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/ecr.tf
@@ -1,0 +1,19 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+
+  # Repository configuration
+  repo_name = "${var.namespace}-ecr"
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = [var.namespace]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/serviceaccount.tf
@@ -1,0 +1,8 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = [var.namespace]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/templates/cd.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/templates/cd.yaml
@@ -1,0 +1,56 @@
+name: Continuous Deployment
+
+# For a description of how this works, see this Cloud Platform User Guide page:
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/github-actions-continuous-deployment.html
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "branch-name"
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr
+      - run: |
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+      - name: Update image tag and branch name
+        run: export BRANCH=${GITHUB_REF##*/} && cat kubernetes-deploy-${GITHUB_REF##*/}.tpl | envsubst > kubernetes-deploy.yaml
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+      - name: Authenticate to the cluster
+        run: |
+          echo "${KUBE_CERT}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+        env:
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+          KUBE_CERT: ${{ secrets.KUBE_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+      - name: Apply the updated manifest
+        run: |
+          kubectl -n ${KUBE_NAMESPACE} apply -f kubernetes-deploy.yaml
+        env:
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/templates/kubernetes-deploy.tpl
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/templates/kubernetes-deploy.tpl
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moj-prototype-${BRANCH}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prototype-${BRANCH}
+  template:
+    metadata:
+      labels:
+        app: prototype-${BRANCH}
+    spec:
+      containers:
+      - name: prototype
+        image: ${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}
+        env:
+          - name: USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: basic-auth
+                key: username
+          - name: PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basic-auth
+                key: password
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prototype-service-${BRANCH}
+  labels:
+    app: prototype-service-${BRANCH}
+spec:
+  ports:
+  - port: 3000
+    name: http
+    targetPort: 3000
+  selector:
+    app: prototype-${BRANCH}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prototype-ingress-${BRANCH}
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: prototype-ingress-${BRANCH}-${KUBE_NAMESPACE}-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+spec:
+  ingressClassName: default
+  tls:
+  - hosts:
+    - ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: prototype-service-${BRANCH}
+            port:
+              number: 3000

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/prototype/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2.5"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/variables.tf
@@ -1,0 +1,75 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "developer-portal"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "developer-portal-dev"
+}
+
+variable "service_area" {
+  description = "Service area responsible for this service"
+  type        = string
+  default     = "office-of-the-cto"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "Platforms"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "octo-developer-experience"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "sandhya.buddharaju@justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "developer-experience-team"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.39.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a new production namespace directory for Developer Portal by copying the existing namespace scaffolding 

## Changes made

- Added namespace manifests:
- 00-namespace.yaml
- 01-rbac.yaml]
- 02-limitrange.yaml]
- 03-resourcequota.yaml
- 04-networkpolicy.yaml

## Added Terraform resources:

- provider/main Terraform files
- prototype resources (ECR, service account, basic auth, templates, build files)
- prototype Terraform version constraints file
