### PR TITLE
Add env to secret paths

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-manage-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-manage-staging/resources/serviceaccount.tf
@@ -9,4 +9,6 @@ module "serviceaccount" {
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["laa-civil-manage"]
+  github_environments = [var.environment]
+
 }


### PR DESCRIPTION
Same changes as PR 41549, applied to frontend staging.
Fixes an issue where secrets were stored in the repository instead of in environment variables.