### PR TITLE
CRM457-3019: updated to include mandatory resource tags

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/resources/variables.tf
@@ -41,7 +41,7 @@ variable "environment" {
 variable "infrastructure_support" {
   description = "Email address of the team responsible this service"
   type        = string
-  default     = "nscc@justice.gov.uk"
+  default     = "NSCC: nscc@justice.gov.uk"
 }
 
 variable "is_production" {
@@ -162,4 +162,9 @@ variable "serviceaccount_rules" {
       ]
     }
   ]
+}
+
+variable "service_area" {
+  description = "Service area responsible for this service"
+  default = "Payments and Billing"
 }


### PR DESCRIPTION
Updating laa-crime-forms-submit-dev namespace to conform with mandatory tagging enforcement.