### PR TITLE
Cicads 652 create opensearch bedrock connector

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/data.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/opensearch-connector-bedrock.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/opensearch-connector-bedrock.tf
@@ -1,0 +1,50 @@
+resource "aws_iam_role" "bedrock_role" {
+  name = "${var.namespace}-opensearch-bedrock-connector"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "opensearchservice.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+            "aws:SourceArn"     = module.opensearch.domain_arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "bedrock_policy" {
+  role = aws_iam_role.bedrock_role.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:Get*",
+          "bedrock:List*",
+        ],
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "kubernetes_secret" "bedrock_connector" {
+  metadata {
+    name      = "${var.team_name}-bedrock-connector"
+    namespace = var.namespace
+  }
+
+  data = {
+    role_arn = aws_iam_role.bedrock_role.arn
+  }
+}


### PR DESCRIPTION
## What

Adds the Terraform prerequisites for OpenSearch to use Bedrock embeddings in the `cica-review-case-documents-dev` namespace.

This change:
- adds a root-level `aws_caller_identity` data source
- creates an IAM role for the OpenSearch Bedrock connector
- restricts role assumption to the current AWS account and this specific OpenSearch domain
- grants the role permission to invoke Bedrock models
- stores the connector role ARN in a Kubernetes secret for use by workloads in the namespace
- removed redundant temporary auth credentials

## Why

The application will eventually issue neural queries to OpenSearch from within the same namespace. For that to work, OpenSearch needs an IAM role it can assume when calling Bedrock for embeddings.

This PR sets up that IAM wiring and makes the role ARN available in-cluster so connector creation can later be automated by a service or job running in the namespace.

## Notes

This PR does not create the OpenSearch connector or register/deploy the model in ML Commons.

Those steps will still be performed after infrastructure has been created.