### PR TITLE
Set up developer-portal dev/prod infra resources and certs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: dev.developerportal.service.justice.gov.uk
+  namespace: developer-portal-dev
+spec:
+  secretName: developerportal-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - dev.developerportal.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
@@ -1,0 +1,30 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+
+  # Repository configuration
+  repo_name = var.namespace
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = ["ministry-of-justice-developer-portal"]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for read only queries,
+  # uncomment below:
+
+  # enable_irsa = true
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf
@@ -1,0 +1,12 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["ministry-of-justice-developer-portal"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/variables.tf
@@ -47,7 +47,7 @@ variable "environment" {
 variable "infrastructure_support" {
   description = "Email address of the team responsible this service"
   type        = string
-  default     = "sandhya.buddharaju@justice.gov.uk"
+  default     = "DeveloperExperienceTeam@justice.gov.uk"
 }
 
 variable "is_production" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/07-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/07-certificates.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: developerportal.service.justice.gov.uk
+  namespace: developer-portal-prod
+spec:
+  secretName: developerportal-prod-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - developerportal.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/ecr.tf
@@ -1,0 +1,30 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+
+  # Repository configuration
+  repo_name = var.namespace
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = ["ministry-of-justice-developer-portal"]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for read only queries,
+  # uncomment below:
+
+  # enable_irsa = true
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/serviceaccount.tf
@@ -1,0 +1,12 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["ministry-of-justice-developer-portal"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-prod/resources/variables.tf
@@ -17,7 +17,7 @@ variable "application" {
 variable "namespace" {
   description = "Name of the namespace these resources are part of"
   type        = string
-  default     = "developer-portal-dev"
+  default     = "developer-portal-prod"
 }
 
 variable "service_area" {
@@ -41,19 +41,19 @@ variable "team_name" {
 variable "environment" {
   description = "Name of the environment type for this service"
   type        = string
-  default     = "development"
+  default     = "production"
 }
 
 variable "infrastructure_support" {
   description = "Email address of the team responsible this service"
   type        = string
-  default     = "sandhya.buddharaju@justice.gov.uk"
+  default     = "DeveloperExperienceTeam@justice.gov.uk"
 }
 
 variable "is_production" {
   description = "Whether this environment type is production or not"
   type        = string
-  default     = "false"
+  default     = "true"
 }
 
 variable "slack_channel" {


### PR DESCRIPTION
## Summary
This PR adds the core Cloud Platform infrastructure resources for Developer Portal in both development and production namespaces.

## Changes

- Added cert-manager certificate manifests
- Added ECR module configuration
- Added service account module configuration for GitHub Actions integration
- Updated namespace variables
- Key values configured
- Certificate hosts:
	- dev.developerportal.service.justice.gov.uk
	- developerportal.service.justice.gov.uk

- ECR:
- Module ref updated to 8.0.0
- github_repositories set to ministry-of-justice-developer-portal

- Service account:
- github_repositories set to ministry-of-justice-developer-portal
- Module ref updated to 1.2.0

- Infrastructure support email set to:
- DeveloperExperienceTeam@justice.gov.uk

- Production variables aligned for production environment.

## Validation
Terraform formatting run for both dev and prod resources.
TFLint run with repository rule set for both dev and prod resource folders.
Certificate YAML files parse successfully.