### PR TITLE
Set up developer-portal-dev infra resources and certs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: dev.developerportal.service.justice.gov.uk
+  namespace: developer-portal-dev
+spec:
+  secretName: developerportal-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - dev.developerportal.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
@@ -1,0 +1,30 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+
+  # Repository configuration
+  repo_name = var.namespace
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = ["ministry-of-justice-developer-portal"]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for read only queries,
+  # uncomment below:
+
+  # enable_irsa = true
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf
@@ -1,0 +1,12 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["ministry-of-justice-developer-portal"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/variables.tf
@@ -47,7 +47,7 @@ variable "environment" {
 variable "infrastructure_support" {
   description = "Email address of the team responsible this service"
   type        = string
-  default     = "sandhya.buddharaju@justice.gov.uk"
+  default     = "DeveloperExperienceTeam@justice.gov.uk"
 }
 
 variable "is_production" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.39.0"
+      version = "~> 6.6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Summary
This PR adds Developer Portal infrastructure resources for the development namespace.

## Changes
Added certificate manifest for dev domain:
namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml

Added ECR module configuration:
namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf

Added service account module configuration for CI/CD auth:
namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf

Updated namespace resource variables:
variables.tf

## Key values
Domain certificate: dev.developerportal.service.justice.gov.uk
ECR module version: 8.0.0
ECR GitHub repository mapping: ministry-of-justice-developer-portal
Service account GitHub repository mapping: ministry-of-justice-developer-portal
Infrastructure support email: DeveloperExperienceTeam@justice.gov.uk
Environment defaults remain development/non-production for dev namespace

## Why
This enables development environment hosting prerequisites for Developer Portal (certificate, image registry access, and deploy identity).