### PR TITLE
LGA-3725: remove `cla-public` from `cla_backend` PROD

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/04-networkpolicy.yaml
@@ -42,9 +42,6 @@ spec:
           cloud-platform.justice.gov.uk/namespace: laa-cla-frontend-production
     - namespaceSelector:
         matchLabels:
-          cloud-platform.justice.gov.uk/namespace: laa-cla-public-production
-    - namespaceSelector:
-        matchLabels:
           cloud-platform.justice.gov.uk/namespace: laa-govuk-notify-orchestrator-production
     - namespaceSelector:
         matchLabels:


### PR DESCRIPTION
Due to `cla_public` deprecation process, we are removing references to it from `cla_backend` network