### PR TITLE
DSTEW-556: Post-DB-upgrade changes

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/rds-postgresql.tf
@@ -38,7 +38,6 @@ module "rds" {
   ]
 
   # PostgreSQL specifics
-  prepare_for_major_upgrade = true
   db_engine                 = "postgres"
   db_engine_version         = "18.1"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family                = "postgres18"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/service-pod.tf
@@ -1,0 +1,7 @@
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.1" # use the latest release
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name # this uses the service account name from the irsa module
+}


### PR DESCRIPTION
Remove "prepare_for_major_upgrade=true" (the upgrade has happened).

Add a service pod to enable the use of CLI commands.