### PR TITLE
APG-2047 Set backup retention to 0 and add DB drop step before restore

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
@@ -239,6 +239,15 @@ spec:
                     -b \
                     -Q "IF DB_ID('${DATABASE_NAME}') IS NOT NULL
                           ALTER DATABASE [${DATABASE_NAME}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;"
+                  
+                  echo "Dropping existing database if it exists..."
+                  "${SQLCMD}" \
+                    -S "localhost,${DB_PORT}" \
+                    -U "${DATABASE_USERNAME}" \
+                    -P "${DATABASE_PASSWORD}" \
+                    -b \
+                    -C -Q "IF DB_ID(N'${DATABASE_NAME}') IS NOT NULL
+                             DROP DATABASE [${DATABASE_NAME}];"
 
                   # Submit the native RDS restore task.
                   # RDS pulls the .bak directly from S3 using the option-group IAM role —

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/rds-sqlserver.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/rds-sqlserver.tf
@@ -19,6 +19,7 @@ module "sqlserver" {
   team_name                  = var.team_name
   vpc_name                   = var.vpc_name
   character_set_name         = var.character_set_name
+  backup_retention_period    = 0
 
   enable_irsa = true
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/rds-sqlserver.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/rds-sqlserver.tf
@@ -19,7 +19,7 @@ module "sqlserver" {
   team_name                  = var.team_name
   vpc_name                   = var.vpc_name
   character_set_name         = var.character_set_name
-  backup_retention_period    = 0
+  backup_retention_period    = var.db_backup_retention_period
 
   enable_irsa = true
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/rds-sqlserver.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/rds-sqlserver.tf
@@ -7,6 +7,7 @@ module "sqlserver" {
   db_engine_version          = var.db_engine_version
   db_instance_class          = var.db_instance_class
   db_name                    = var.db_name
+  db_backup_retention_period = var.db_backup_retention_period
   enable_rds_auto_start_stop = true
   environment_name           = var.environment-name
   infrastructure_support     = var.infrastructure_support
@@ -19,7 +20,7 @@ module "sqlserver" {
   team_name                  = var.team_name
   vpc_name                   = var.vpc_name
   character_set_name         = var.character_set_name
-  backup_retention_period    = var.db_backup_retention_period
+
 
   enable_irsa = true
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
@@ -154,3 +154,9 @@ variable "sqlserver_restore_create_snapshot" {
   type        = bool
   default     = true
 }
+
+variable "db_backup_retention_period" {
+  description = "Number of days to retain automated backups"
+  type        = number
+  default     = 0
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
@@ -157,6 +157,6 @@ variable "sqlserver_restore_create_snapshot" {
 
 variable "db_backup_retention_period" {
   description = "Number of days to retain automated backups"
-  type        = number
-  default     = 0
+  type        = string
+  default     = "0"
 }


### PR DESCRIPTION
```
This pull request makes changes to the database restoration process in the HMPPS manage-and-deliver-accredited-programmes preprod namespace by:

- Setting backup retention to 0.
- Adding a database drop step before initiating the restore.

These updates aim to ensure proper handling of database restoration in the specified preprod environment.
```