### PR TITLE
AD-1181 Added allow autogrant secret - staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-api-staging/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-api-staging/resources/secret.tf
@@ -25,5 +25,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "base-url-map-staging"
     },
+    "allow-auto-grant" = {
+      description             = "Flag for allowing autogrant within the API for Staging",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "allow-auto-grant-staging"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a secret in Staging. This secret is used as a flag for allowing or disabling autogrant functionality depending on environments.