### PR TITLE
AD-1181 Added allow autogrant secret - Prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-api-production/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-api-production/resources/secret.tf
@@ -39,5 +39,10 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "gov-notify-api-key-prod"
     },
+    "allow-auto-grant" = {
+      description             = "Flag for allowing autogrant within the API for Production",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "allow-auto-grant-prod"
+    },
   }
 }


### PR DESCRIPTION
This PR adds a secret in Production. This secret is used as a flag for allowing or disabling autogrant functionality depending on environments.