### PR TITLE
Dstew 556 claims reporting postgres upgrade staging step1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-staging/resources/rds-postgresql.tf
@@ -38,7 +38,6 @@ module "rds" {
   ]
 
   # PostgreSQL specifics
-  prepare_for_major_upgrade = true
   db_engine         = "postgres"
   db_engine_version = "17.4"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres17"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-staging/resources/rds-postgresql.tf
@@ -38,6 +38,7 @@ module "rds" {
   ]
 
   # PostgreSQL specifics
+  prepare_for_major_upgrade = true
   db_engine         = "postgres"
   db_engine_version = "17.4"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres17"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-reporting-service-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-reporting-service-staging/resources/rds-postgresql.tf
@@ -28,6 +28,7 @@ module "rds" {
   ]
 
   # PostgreSQL specifics
+  prepare_for_major_upgrade = true
   db_engine         = "postgres"
   db_engine_version = "18.1"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres18"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-reporting-service-staging/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-reporting-service-staging/resources/rds-postgresql.tf
@@ -14,7 +14,7 @@ module "rds" {
   allow_minor_version_upgrade  = true
   allow_major_version_upgrade  = false
   performance_insights_enabled = false
-  db_max_allocated_storage     = "500"
+  db_max_allocated_storage     = "10000"
   enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
@@ -29,9 +29,9 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "17.4"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
-  rds_family        = "postgres17"
-  db_instance_class = "db.t4g.micro"
+  db_engine_version = "18.1"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family        = "postgres18"
+  db_instance_class = "db.m6g.large"
 
   # Tags
   application            = var.application
@@ -73,8 +73,8 @@ module "read_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "17.4"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
-  rds_family        = "postgres17"
+  db_engine_version = "18.1"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family        = "postgres18"
   db_instance_class = "db.t4g.micro"
   # It is mandatory to set the below values to create read replica instance
 


### PR DESCRIPTION
DSTEW-556: upgrade Postgres to v18.1
Set prepare_for_major_upgrade = true
Upgrade storage and instance class to match that of the replication source DB (in laa-data-claims-api-staging namespace)