### PR TITLE
Remove snapshot_identifier from rds3

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql5.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql5.tf
@@ -164,7 +164,6 @@ resource "kubernetes_secret" "rds" {
 module "rds3" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
 
-  snapshot_identifier = "folarin-dev-db1-3rows-20260416"
   rds_name            = "folarin-dev-db3-migration-test"
 
   # VPC configuration


### PR DESCRIPTION
Removed snapshot_identifier for RDS module configuration.