### PR TITLE
Add rds4 cross-DB restore, remove rds2

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql5.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql5.tf
@@ -42,10 +42,11 @@ module "rds" {
   # opt_in_xsiam_logging = true
 }
 
-module "rds2" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=add-snapshot-identifier-lifecycle-ignore"
+module "rds4" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
 
-  rds_name            = "folarin-dev-db2-restored"
+  snapshot_identifier = "folarin-dev-db1-3rows-20260416"
+  rds_name            = "folarin-dev-db4-deletion-protection-test"
 
   # VPC configuration
   vpc_name = var.vpc_name
@@ -55,15 +56,12 @@ module "rds2" {
   allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
-  # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
-  # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  db_engine_version = "16"
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
-  snapshot_identifier = "folarin-dev-db1-3rows-20260416"
 
   # Tags
   application            = var.application
@@ -73,14 +71,6 @@ module "rds2" {
   is_production          = var.is_production
   namespace              = var.namespace
   team_name              = var.team_name
-
-  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for CLI queries,
-  # uncomment below:
-
-  # enable_irsa = true
-
-  # If you want to enable Cloudwatch logging for this postgres RDS instance, uncomment the code below:
-  # opt_in_xsiam_logging = true
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -219,25 +209,19 @@ resource "kubernetes_config_map" "rds3" {
   }
 }
 
-resource "kubernetes_secret" "rds2" {
+resource "kubernetes_secret" "rds4" {
   metadata {
-    name      = "rds-postgresql-instance-output-2"
+    name      = "rds-postgresql-instance-output-4"
     namespace = var.namespace
   }
 
   data = {
-    rds_instance_endpoint = module.rds2.rds_instance_endpoint
-    database_name         = module.rds2.database_name
-    database_username     = module.rds2.database_username
-    database_password     = module.rds2.database_password
-    rds_instance_address  = module.rds2.rds_instance_address
+    rds_instance_endpoint = module.rds4.rds_instance_endpoint
+    database_name         = module.rds4.database_name
+    database_username     = module.rds4.database_username
+    database_password     = module.rds4.database_password
+    rds_instance_address  = module.rds4.rds_instance_address
   }
-  /* You can replace all of the above with the following, if you prefer to
-     * use a single database URL value in your application code:
-     *
-     * url = "postgres://${module.rds2.database_username}:${module.rds2.database_password}@${module.rds2.rds_instance_endpoint}/${module.rds2.database_name}"
-     *
-     */
 }
 
 
@@ -278,14 +262,14 @@ resource "kubernetes_config_map" "rds" {
   }
 }
 
-resource "kubernetes_config_map" "rds2" {
+resource "kubernetes_config_map" "rds4" {
   metadata {
-    name      = "rds-postgresql-instance-output-2"
+    name      = "rds-postgresql-instance-output-4"
     namespace = var.namespace
   }
 
   data = {
-    database_name = module.rds2.database_name
-    db_identifier = module.rds2.db_identifier
+    database_name = module.rds4.database_name
+    db_identifier = module.rds4.db_identifier
   }
 }


### PR DESCRIPTION
Once restored, will set the deletion_protection variable to true (false by default) on the next pr while attempting to remove the snapshot identifier. This should trigger an error (similar to deletion protection on ecr).