### PR TITLE
Remove snapshot_identifier from rds4 (deletion_protection enabled)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql5.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql5.tf
@@ -45,7 +45,6 @@ module "rds" {
 module "rds4" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
 
-  snapshot_identifier = "folarin-dev-db1-3rows-20260416"
   rds_name            = "folarin-dev-db4-deletion-protection-test"
 
   # VPC configuration


### PR DESCRIPTION
This is expected to fail in the apply pipeline as deletion_protection has been set to true in this database.