### PR TITLE
Remove skip_final_snapshot from RDS module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql5.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/rds-postgresql5.tf
@@ -155,7 +155,6 @@ module "rds3" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
 
   rds_name            = "folarin-dev-db3-migration-test"
-  skip_final_snapshot = true
   snapshot_identifier = "cloud-platform-37062b9a30121c9a-finalsnapshot"
 
   # VPC configuration


### PR DESCRIPTION
Removed the skip_final_snapshot option from the RDS module.