### PR TITLE
Added container registry for pmo project

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/ecr.tf
@@ -1,0 +1,30 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=7.1.0"
+
+  # Repository configuration
+  repo_name = var.namespace
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = ["projectsdb"]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for read only queries,
+  # uncomment below:
+
+  # enable_irsa = true
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/serviceaccount.tf
@@ -1,0 +1,12 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["projectsdb"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster


### PR DESCRIPTION
This pull request introduces new Terraform modules to manage AWS ECR credentials and Kubernetes service accounts for the `pmoproject-application-dev` environment. These changes automate and standardize the provisioning of infrastructure resources, improving maintainability and integration with CI/CD pipelines.

**Infrastructure provisioning and integration:**

* Added a new `ecr.tf` file to provision an AWS ECR repository using the `cloud-platform-terraform-ecr-credentials` module, including OIDC configuration for GitHub integration and tagging for environment and team metadata.
* Added a new `serviceaccount.tf` file to manage a Kubernetes service account with the `cloud-platform-terraform-serviceaccount` module, including support for GitHub Actions integration and token rotation metadata.