### PR TITLE
Align developer-portal-dev ECR, service account, and DNS/cert config

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/00-namespace.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "Platforms"
     cloud-platform.justice.gov.uk/slack-channel: "developer-experience-team"
-    cloud-platform.justice.gov.uk/application: "developer-portal"
+    cloud-platform.justice.gov.uk/application: "Developer Portal"
     cloud-platform.justice.gov.uk/owner: "OCTO Developer Experience Team: DeveloperExperienceTeam@justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/ministry-of-justice-developer-portal"
     cloud-platform.justice.gov.uk/team-name: "octo-developer-experience"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: dev.developer-portal.service.justice.gov.uk
+  name: dev.developerportal.service.justice.gov.uk
   namespace: developer-portal-dev
 spec:
   secretName: developer-portal-dev-cert

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
@@ -2,12 +2,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: dev.developerportal.service.justice.gov.uk
+  name: dev.developer-portal.service.justice.gov.uk
   namespace: developer-portal-dev
 spec:
-  secretName: developerportal-dev-cert
+  secretName: developer-portal-dev-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-  - dev.developerportal.service.justice.gov.uk
+  - dev.developer-portal.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
@@ -11,8 +11,10 @@ module "ecr" {
   repo_name = var.namespace
 
   # OpenID Connect configuration
-  oidc_providers      = ["github"]
-  github_repositories = ["ministry-of-justice-developer-portal"]
+  oidc_providers = ["github"]
+  # This repo is already wired from developer-portal-prod. Keeping it here causes
+  # repo-level Actions variable collisions (ECR_REGION/ECR_REPOSITORY).
+  # github_repositories = ["ministry-of-justice-developer-portal"]
 
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
@@ -12,9 +12,9 @@ module "ecr" {
 
   # OpenID Connect configuration
   oidc_providers = ["github"]
-  # This repo is already wired from developer-portal-prod. Keeping it here causes
-  # repo-level Actions variable collisions (ECR_REGION/ECR_REPOSITORY).
-  # github_repositories = ["ministry-of-justice-developer-portal"]
+
+  # specify which GitHub repository you're pushing from
+  github_repositories = ["ministry-of-justice-developer-portal"]
 
   # Tags
   business_unit          = var.business_unit
@@ -25,8 +25,4 @@ module "ecr" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 
-  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for read only queries,
-  # uncomment below:
-
-  # enable_irsa = true
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/prototype/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/prototype/ecr.tf
@@ -4,6 +4,9 @@ module "ecr-repo" {
   # Repository configuration
   repo_name = "${var.namespace}-ecr"
 
+  # Required before deleting this ECR module in a follow-up PR.
+  deletion_protection = false
+
   # OpenID Connect configuration
   oidc_providers      = ["github"]
   github_repositories = [var.namespace]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "route53_zone" {
+  name = "dev.developer-portal.service.justice.gov.uk"
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "route53_zone_output" {
+  metadata {
+    name      = "route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf
@@ -8,5 +8,7 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  github_repositories = ["ministry-of-justice-developer-portal"]
+  # This repo is already wired from developer-portal-prod to avoid shared
+  # repo-level secret/variable ownership conflicts.
+  # github_repositories = ["ministry-of-justice-developer-portal"]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf
@@ -8,7 +8,8 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  # This repo is already wired from developer-portal-prod to avoid shared
-  # repo-level secret/variable ownership conflicts.
-  # github_repositories = ["ministry-of-justice-developer-portal"]
+  github_repositories = ["ministry-of-justice-developer-portal"]
+  github_actions_secret_kube_namespace = "DEV_KUBE_NAMESPACE"
+  github_actions_secret_kube_cert      = "DEV_KUBE_CERT"
+  github_actions_secret_kube_token     = "DEV_KUBE_TOKEN"
 }


### PR DESCRIPTION
## Summary
This PR updates the `developer-portal-dev` namespace configuration to align CI/CD wiring and DNS/TLS setup with the intended dev domain configuration.

## Changes
- Updated ECR module wiring in [namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf](namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf)
  - Commented `github_repositories` to avoid shared GitHub Actions variable collisions with prod.
- Updated service account module wiring in [namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf](namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/serviceaccount.tf)
  - Commented `github_repositories` to avoid shared repo secret ownership conflicts with prod.
- Updated prototype ECR module in [namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/prototype/ecr.tf](namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/prototype/ecr.tf)
  - Added `deletion_protection = false` for staged cleanup workflow.
- Added Route53 zone config in [namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/route53.tf](namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/route53.tf)
  - Zone set to `dev.developer-portal.service.justice.gov.uk`.
- Updated certificate in [namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml](namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml)
  - Cert now targets `dev.developer-portal.service.justice.gov.uk`.

## Validation
- `terraform fmt -check -recursive` (dev resources): passed
- `terraform validate` (dev resources): passed
- `tflint`: not available locally in this shell