### PR TITLE
APG-2047 Increase database storage allocation in preprod namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
@@ -84,7 +84,7 @@ variable "number_cache_clusters" {
 variable "db_allocated_storage" {
   description = "The allocated storage for the RDS instance"
   type        = number
-  default     = 200
+  default     = 600
 }
 
 variable "db_engine" {


### PR DESCRIPTION
Updated the `db_allocated_storage` value to 600GB in the `manage-and-deliver-accredited-programmes` preprod namespace configuration for the SQL Server DB. This change hopefully resolves some storage issues we are seeing when restoring DB backups.