### PR TITLE
LGA-3911: add github OIDC to ecr config

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-frontend-staging/resources/ecr.tf
@@ -8,7 +8,7 @@ module "cla_frontend_app_credentials" {
     aws = aws.london
   }
   # enable the oidc implementation for CircleCI
-  oidc_providers = ["circleci"]
+  oidc_providers = ["circleci", "github"]
 
   # specify which GitHub repository your CircleCI job runs from
   github_repositories = [var.repo_name, "cla-end-to-end-tests", "cla_backend", "cla_public", "fala"]
@@ -46,8 +46,9 @@ module "cla_frontend_socket_server_credentials" {
     aws = aws.london
   }
 
-  # enable the oidc implementation for CircleCI
-  oidc_providers = ["circleci"]
+  # enable the oidc implementation for CircleCI and Github (circleci config to be deleted once migrated)
+  oidc_providers = ["circleci", "github"]
+  github_actions_prefix = "SOCKET_SERVER"
 
   # specify which GitHub repository your CircleCI job runs from
   github_repositories = [var.repo_name, "cla-end-to-end-tests", "cla_backend", "cla_public", "fala"]


### PR DESCRIPTION
As part of our migration from **CircleCI** to **GitHub Actions**, I'm updating the ECR to include github as OIDC provider