### PR TITLE
remove hmps-user-preferences from court-probation-dev ns

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/court-event-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/court-event-github.tf
@@ -106,24 +106,6 @@ module "hmpps-probation-in-court-automation-tests-service" {
   github_owner                  = var.github_owner
 }
 
-module "hmpps-user-preferences" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
-  force_rotate_token = true
-  custom_token_rotation_date = "2026-03-20"
-  github_repo                   = "hmpps-user-preferences"
-  application                   = "hmpps-user-preferences"
-  github_team                   = "hmpps-probation-in-court"
-  environment                   = "dev"
-  is_production                 = var.is_production
-  selected_branch_patterns      = ["main"]
-  application_insights_instance = "dev"
-  source_template_repo          = "hmpps-template-kotlin"
-  github_token                  = var.github_token
-  namespace                     = var.namespace
-  kubernetes_cluster            = var.kubernetes_cluster
-  github_owner                  = var.github_owner
-}
-
 module "prepare-a-case" {
   source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
   force_rotate_token = true


### PR DESCRIPTION
Key changes:
* removed `hmps-user-preferences` from `court-probation-dev` namespace