### PR TITLE
Fixed invalid link + add secrets for app

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/00-namespace.yaml
@@ -11,6 +11,6 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "dmet-corporate"
     cloud-platform.justice.gov.uk/application: "PMOProject Property Project Management"
     cloud-platform.justice.gov.uk/owner: "Property: dataengineering-gg@justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/moj-analytical-services/projectsdb"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/projectsdb"
     cloud-platform.justice.gov.uk/team-name: "data-engineering"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/app-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/app-secrets.tf
@@ -1,0 +1,15 @@
+resource "random_password" "django_secret_key" {
+  length  = 64
+  special = true
+}
+
+resource "kubernetes_secret" "app_secrets" {
+  metadata {
+    name      = "projectsdb-app-secrets"
+    namespace = var.namespace
+  }
+
+  data = {
+    django_secret_key = random_password.django_secret_key.result
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6.0"
+    }
   }
 }


### PR DESCRIPTION
This pull request introduces secure secret management for the `pmoproject-application-dev` namespace by generating and storing a Django secret key using Terraform and Kubernetes resources. Additionally, it updates the source code repository URL in the namespace metadata and adds a new Terraform provider dependency.

Secret management improvements:

* Added a new Terraform resource to generate a 64-character random password (`django_secret_key`) using the `random_password` resource, and created a corresponding Kubernetes secret (`projectsdb-app-secrets`) to securely store this key.
* Added the `hashicorp/random` provider (version `~> 3.6.0`) to `versions.tf` to enable random secret generation.

Metadata update:

* Updated the `cloud-platform.justice.gov.uk/source-code` metadata field in the namespace YAML to point to `https://github.com/ministryofjustice/projectsdb` instead of the previous GitHub URL.