### PR TITLE
Add dev ECR GitHub Actions prefix to avoid variable collisions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: dev.developerportal.service.justice.gov.uk
+  name: dev.developer-portal.service.justice.gov.uk
   namespace: developer-portal-dev
 spec:
   secretName: developer-portal-dev-cert

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: dev.developer-portal.service.justice.gov.uk
+  name: dev.developerportal.service.justice.gov.uk
   namespace: developer-portal-dev
 spec:
   secretName: developer-portal-dev-cert

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf
@@ -10,6 +10,10 @@ module "ecr" {
   # Repository configuration
   repo_name = var.namespace
 
+  # Use env-specific GitHub Actions variable names to avoid repo-level collisions
+  # with developer-portal-prod (ECR_REGION/ECR_REPOSITORY).
+  github_actions_prefix = "dev"
+
   # OpenID Connect configuration
   oidc_providers = ["github"]
 


### PR DESCRIPTION
## Summary
This PR fixes the apply failure for `developer-portal-dev` caused by GitHub Actions variable name collisions, and keeps certificate metadata compliant with the YAML metadata check.

## Changes
- Updated [namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf](namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/resources/ecr.tf)
  - Added `github_actions_prefix = "dev"` to avoid collisions when creating GitHub Actions variables.
- Updated [namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml](namespaces/live.cloud-platform.service.justice.gov.uk/developer-portal-dev/05-certificates.yaml)
  - Kept `metadata.name` stable to satisfy the YAML metadata change check.

## Why
Apply failed with:
- `409 Already exists - Variable already exists` for `ECR_REGION` and `ECR_REPOSITORY`.

Adding the dev prefix avoids creating colliding unprefixed repository variables.

## Validation
- Change is scoped to `developer-portal-dev`.
- Branch pushed and ready for CI rerun.