### PR TITLE
Add password secrets for dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/app-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/pmoproject-application-dev/resources/app-secrets.tf
@@ -3,6 +3,11 @@ resource "random_password" "django_secret_key" {
   special = true
 }
 
+resource "random_password" "admin_password" {
+  length  = 32
+  special = true
+}
+
 resource "kubernetes_secret" "app_secrets" {
   metadata {
     name      = "projectsdb-app-secrets"
@@ -10,6 +15,9 @@ resource "kubernetes_secret" "app_secrets" {
   }
 
   data = {
-    django_secret_key = random_password.django_secret_key.result
+    django_secret_key         = random_password.django_secret_key.result
+    django_superuser_username = "admin"
+    django_superuser_email    = "admin@justice.gov.uk"
+    django_superuser_password = random_password.admin_password.result
   }
 }


### PR DESCRIPTION
This pull request adds a new randomly generated admin password and updates the Kubernetes secret to include credentials for a Django superuser. These changes improve the security and automation of secret management for the application.

**Secret management improvements:**

* Added a new `random_password` resource (`admin_password`) to generate a secure, random password for the Django superuser.
* Updated the `kubernetes_secret` resource (`app_secrets`) to include the Django superuser's username, email, and the newly generated password in the secret data.