### PR TITLE
S3 in address matcher

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
@@ -1,0 +1,19 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  service_account_name = "address-matcher-api-s3"
+  namespace            = var.namespace
+
+  role_policy_arns = {
+    models      = module.address_matcher_models_s3.irsa_policy_arn
+    lookup_data = module.address_matcher_lookup_data_s3.irsa_policy_arn
+  }
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/s3.tf
@@ -1,0 +1,43 @@
+module "address_matcher_models_s3" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+
+  versioning             = true
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  providers = { aws = aws.london }
+}
+
+module "address_matcher_lookup_data_s3" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+
+  versioning             = true
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  providers = { aws = aws.london }
+}
+
+resource "kubernetes_secret" "s3_buckets" {
+  metadata {
+    name      = "s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    models_bucket_arn       = module.address_matcher_models_s3.bucket_arn
+    models_bucket_name      = module.address_matcher_models_s3.bucket_name
+    lookup_data_bucket_arn  = module.address_matcher_lookup_data_s3.bucket_arn
+    lookup_data_bucket_name = module.address_matcher_lookup_data_s3.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/variables.tf
@@ -3,6 +3,8 @@ variable "vpc_name" {
   type        = string
 }
 
+variable "eks_cluster_name" {}
+
 variable "kubernetes_cluster" {
   description = "Kubernetes cluster name for references to secrets for service accounts"
   type        = string

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6.0"
+    }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/versions.tf
@@ -13,9 +13,5 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.6.0"
-    }
   }
 }


### PR DESCRIPTION
# Add S3 buckets and IRSA for address-matcher-api

Adds two S3 buckets (model artifacts, lookup data) and an IRSA service account to the address-matcher-api namespace.

The buckets will store data and models subject to licensing and data sharing agreements not always suitable for git. 

This is our first S3 implementation on the platform, so any guidance on how to improve this is welcome. 

There is no wiring on the API side yet for testing; this PR provisions the infrastructure only.

## Changes:

    - s3.tf: two versioned S3 buckets via cloud-platform-terraform-s3-bucket v5.3.0
    - irsa.tf: IRSA via cloud-platform-terraform-irsa v2.1.0
    - variables.tf: add eks_cluster_name
    - versions.tf: add random provider (required by S3/IRSA modules)