### PR TITLE
LAA holding page: preparation for deletion

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-holding-page-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-holding-page-production/resources/ecr.tf
@@ -22,4 +22,5 @@ module "ecr" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+  deletion_protection    = false
 }


### PR DESCRIPTION
Following guidance [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/cleaning-up.html#prepare-ecr), setting deletion_protection to  false prior to deleting the namespace