### PR TITLE
CRM457-3038: enable performance insights in app-stores

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-production/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crime-application-store-production/resources/rds-postgresql.tf
@@ -14,7 +14,7 @@ module "rds" {
   allow_minor_version_upgrade  = false
   allow_major_version_upgrade  = false
   prepare_for_major_upgrade    = false
-  performance_insights_enabled = false
+  performance_insights_enabled = true
   db_max_allocated_storage     = "10000"
   db_allocated_storage         = "20"
   deletion_protection          = true


### PR DESCRIPTION
Enable performance insights on the App-Store production database to help identify performance issues. 