### PR TITLE
Add tagging to RCD dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/main.tf
@@ -8,6 +8,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"
@@ -21,6 +27,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"
@@ -34,6 +46,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/variables.tf
@@ -68,7 +68,7 @@ variable "github_token" {
   default     = ""
 }
 
-variable "service area" {
+variable "service_area" {
   type        = string
   description = "Service Area"
   default     = "CICA Digital Find app"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/variables.tf
@@ -68,6 +68,11 @@ variable "github_token" {
   default     = ""
 }
 
+variable "service area" {
+  type        = string
+  description = "Service Area"
+  default     = "CICA Digital Find app"
+}
 
 variable "eks_cluster_name" {
 }


### PR DESCRIPTION
This pull request updates the AWS provider configuration for the `cica-review-case-documents-dev` namespace by standardizing and expanding the default resource tags, and introducing a new variable for the service area. These changes improve resource identification and management within the environment.

Tagging improvements:

* Added new default tags to all AWS resources, including `business-unit`, `application`, `is-production`, `owner`, `namespace`, and `service-area`, using corresponding variables to ensure consistent metadata across resources. [[1]](diffhunk://#diff-71de475904e5cdd6c0edf8c5affb590a5711266d539a41f3a0d6c56a9c757af1R11-R16) [[2]](diffhunk://#diff-71de475904e5cdd6c0edf8c5affb590a5711266d539a41f3a0d6c56a9c757af1R30-R35) [[3]](diffhunk://#diff-71de475904e5cdd6c0edf8c5affb590a5711266d539a41f3a0d6c56a9c757af1R49-R54)

Variable additions:

* Introduced a new variable `service area` in `variables.tf` to define the service area as "CICA Digital Find app" by default, supporting the new tagging scheme.