### PR TITLE
Rcd add tags uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/main.tf
@@ -8,6 +8,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"
@@ -21,6 +27,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"
@@ -34,6 +46,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/variables.tf
@@ -68,7 +68,7 @@ variable "github_token" {
   default     = ""
 }
 
-variable "service area" {
+variable "service_area" {
   type        = string
   description = "Service Area"
   default     = "CICA Digital Find app"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/variables.tf
@@ -68,6 +68,11 @@ variable "github_token" {
   default     = ""
 }
 
+variable "service area" {
+  type        = string
+  description = "Service Area"
+  default     = "CICA Digital Find app"
+}
 
 variable "eks_cluster_name" {
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/main.tf
@@ -8,6 +8,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"
@@ -21,6 +27,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"
@@ -34,6 +46,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/variables.tf
@@ -68,6 +68,11 @@ variable "github_token" {
   default     = ""
 }
 
+variable "service_area" {
+  type        = string
+  description = "Service Area"
+  default     = "CICA Digital Find app"
+}
 
 variable "eks_cluster_name" {
 }


### PR DESCRIPTION
This pull request enhances resource tagging for both the development and UAT environments by adding new default AWS tags and introducing a new `service_area` variable. These changes improve resource identification, ownership tracking, and alignment with organizational tagging standards.

**Tagging and Variable Improvements**

* Added new default AWS tags (`business-unit`, `application`, `is-production`, `owner`, `namespace`, `service-area`) to the `tags` block in `main.tf` for both `dev` and `uat` environments, ensuring consistent and comprehensive resource metadata. [[1]](diffhunk://#diff-71de475904e5cdd6c0edf8c5affb590a5711266d539a41f3a0d6c56a9c757af1R11-R16) [[2]](diffhunk://#diff-71de475904e5cdd6c0edf8c5affb590a5711266d539a41f3a0d6c56a9c757af1R30-R35) [[3]](diffhunk://#diff-71de475904e5cdd6c0edf8c5affb590a5711266d539a41f3a0d6c56a9c757af1R49-R54)
* Introduced a new `service_area` variable in `variables.tf` for both environments, with a default value of `"CICA Digital Find app"`, and referenced this variable in the new AWS tags. [[1]](diffhunk://#diff-b4d7785e9454ba84dc9ef29b901b3bf22134dc4bc19ae2b09976aa4e69389bceR71-R75) [[2]](diffhunk://#diff-0b65a1871fe4831b686e4feea046a29ec85aeaa1596e245fed4bed7dcd4218c3R71-R75)