### PR TITLE
Adds mandatory tags to RCD uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/main.tf
@@ -8,6 +8,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"
@@ -21,6 +27,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"
@@ -34,6 +46,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica-review-case-documents"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/variables.tf
@@ -68,6 +68,11 @@ variable "github_token" {
   default     = ""
 }
 
+variable "service_area" {
+  type        = string
+  description = "Service Area"
+  default     = "CICA Digital Find app"
+}
 
 variable "eks_cluster_name" {
 }


### PR DESCRIPTION
This pull request adds new default tags to AWS resources and introduces a new variable to improve resource identification and management. The main changes are the addition of several metadata tags to the AWS provider configuration and the definition of a new `service_area` variable.

Resource tagging improvements:
* Added default tags to all AWS resources in `main.tf`, including `business-unit`, `application`, `is-production`, `owner`, `namespace`, and `service-area`, using corresponding variables for each value. This enhances traceability and resource management. [[1]](diffhunk://#diff-08270aa6073644d690df06dde5c029516c8bc66154f1e540f7d09e5023b8f714R11-R16) [[2]](diffhunk://#diff-08270aa6073644d690df06dde5c029516c8bc66154f1e540f7d09e5023b8f714R30-R35) [[3]](diffhunk://#diff-08270aa6073644d690df06dde5c029516c8bc66154f1e540f7d09e5023b8f714R49-R54)

Variable additions:
* Introduced a new variable `service_area` in `variables.tf` with a default value of "CICA Digital Find app" to support the new tag.