### PR TITLE
Add mandatory tags to apply service dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/main.tf
@@ -7,6 +7,12 @@ provider "aws" {
   region = "eu-west-2"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"
@@ -19,6 +25,12 @@ provider "aws" {
   region = "eu-west-2"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"
@@ -31,6 +43,12 @@ provider "aws" {
   region = "eu-west-1"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/variables.tf
@@ -79,4 +79,11 @@ variable "repo_name" {
   default     = [ "cica-apply-application-service", "cica-apply-maintenance-page", "cica-apply-data-capture-service", "cica-apply-web",
   "cica-apply-notify-gateway", "cica-apply-letter-service"]
 }
+
+variable "service_area" {
+  type        = string
+  description = "Service Area"
+  default     = "CICA Digital Apply Service"
+}
+
 variable "kubernetes_cluster" {}


### PR DESCRIPTION
This pull request enhances the tagging and configuration of AWS resources for the `claim-criminal-injuries-compensation-dev` namespace by introducing a new `service_area` variable and ensuring it, along with several other variables, is included in the default tags for all AWS providers. This improves resource identification, management, and traceability.

**Tagging improvements for AWS resources:**

* Added multiple variables (`business_unit`, `application`, `is_production`, `owner`, `namespace`, and the new `service_area`) to the `default_tags` block for all AWS providers in `main.tf`, ensuring consistent tagging across environments. [[1]](diffhunk://#diff-4c3f646ed1e5d797642f6b636665b6d98decf0bccb605637a1f62b29892ac980R10-R15) [[2]](diffhunk://#diff-4c3f646ed1e5d797642f6b636665b6d98decf0bccb605637a1f62b29892ac980R28-R33) [[3]](diffhunk://#diff-4c3f646ed1e5d797642f6b636665b6d98decf0bccb605637a1f62b29892ac980R46-R51)

**Configuration enhancements:**

* Introduced a new `service_area` variable in `variables.tf` with a default value of "CICA Digital Apply Service" to support the new tagging structure.