### PR TITLE
Add applyservice uat mandatory tagging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/main.tf
@@ -7,6 +7,12 @@ provider "aws" {
   region = "eu-west-2"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"
@@ -20,6 +26,12 @@ provider "aws" {
   region = "eu-west-2"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"
@@ -33,6 +45,12 @@ provider "aws" {
   region = "eu-west-1"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-uat/resources/variables.tf
@@ -79,6 +79,12 @@ variable "repo_name" {
 
 variable "kubernetes_cluster" {}
 
+variable "service_area" {
+  type        = string
+  description = "Service Area"
+  default     = "CICA Digital Apply Service"
+}
+
 variable "dcs_project_id" {
   type        = string
   description = "The circle project ID for data-capture-service"


### PR DESCRIPTION
This pull request enhances the AWS provider configuration for the `claim-criminal-injuries-compensation-uat` namespace by adding additional tagging for resources and introducing a new Terraform variable. These changes improve resource management and metadata consistency across environments.

**Tagging improvements:**

* Added new tags to the AWS provider's `default_tags` block in `main.tf` for both `eu-west-2` and `eu-west-1` regions, including `business-unit`, `application`, `is-production`, `owner`, `namespace`, and `service-area`, to ensure better identification and tracking of resources. [[1]](diffhunk://#diff-6dda08377fb1c4772e1fb6711795e9efc0b44825270809eed29c0e1c1d2a17dbR10-R15) [[2]](diffhunk://#diff-6dda08377fb1c4772e1fb6711795e9efc0b44825270809eed29c0e1c1d2a17dbR29-R34) [[3]](diffhunk://#diff-6dda08377fb1c4772e1fb6711795e9efc0b44825270809eed29c0e1c1d2a17dbR48-R53)

**Variable additions:**

* Introduced a new Terraform variable `service_area` in `variables.tf` with a default value of "CICA Digital Apply Service" to support the new tag and improve configurability.