### PR TITLE
Add mandatory tagging to applyservice stag

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/main.tf
@@ -8,6 +8,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"
@@ -21,6 +27,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"
@@ -34,6 +46,12 @@ provider "aws" {
 
   default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-stag/resources/variables.tf
@@ -82,5 +82,11 @@ variable "service_monitor" {
   default     = true
 }
 
+variable "service_area" {
+  type        = string
+  description = "Service Area"
+  default     = "CICA Digital Apply Service"
+}
+
 variable "eks_cluster_name" {
 }


### PR DESCRIPTION
This pull request adds new tagging variables and default tag assignments to the Terraform configuration for the `claim-criminal-injuries-compensation-stag` namespace. The main goal is to improve AWS resource tagging by including additional metadata such as business unit, application, and service area.

Resource tagging improvements:

* Added new variables in `variables.tf` for `service_area`, with a default value of "CICA Digital Apply Service".
* Updated the `default_tags` block in `main.tf` to assign the following variables as AWS resource tags: `business-unit`, `application`, `is-production`, `owner`, `namespace`, and `service-area`. [[1]](diffhunk://#diff-c9ab011b4110f7fe8ada906ec7bb4fb4326bcd6ad01cce134d341ff66f6d8c0dR11-R16) [[2]](diffhunk://#diff-c9ab011b4110f7fe8ada906ec7bb4fb4326bcd6ad01cce134d341ff66f6d8c0dR30-R35) [[3]](diffhunk://#diff-c9ab011b4110f7fe8ada906ec7bb4fb4326bcd6ad01cce134d341ff66f6d8c0dR49-R54)