### PR TITLE
LAALAA: add GHA to ECR providers

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/ecr.tf
@@ -8,7 +8,7 @@ module "ecr-repo-api" {
     aws = aws.london
   }
   # enable the oidc implementation for CircleCI
-  oidc_providers = ["circleci"]
+  oidc_providers = ["circleci", "github"]
 
   # specify which GitHub repository your CircleCI job runs from
   github_repositories = [var.repo_name]


### PR DESCRIPTION
As part of the migration from CircleCI to Github Actions, I am including it in the `ecr.tf` for LAALAA