### PR TITLE
PDHD-152: Add test, preprod and prod mi and ui apps

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/00-namespace.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-probation-mi-ui-test
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "test"
+    cloud-platform.justice.gov.uk/namespace: "hmpps-probation-mi-ui-test"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "ask_dpr"
+    cloud-platform.justice.gov.uk/application: "Probation Management Information UI"
+    cloud-platform.justice.gov.uk/owner: "Digital Prison Reporting: digitalprisonreporting@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-digital-prison-reporting-mi-ui"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-digital-prison-reporting"
+    cloud-platform.justice.gov.uk/review-after: ""
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/01-rbac.yaml
@@ -1,0 +1,17 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-probation-mi-ui-test-admin
+  namespace: hmpps-probation-mi-ui-test
+subjects:
+  - kind: Group
+    name: "github:hmpps-digital-prison-reporting"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/02-limitrange.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-probation-mi-ui-test
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 512Mi
+    type: Container
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-probation-mi-ui-test
+spec:
+  hard:
+    pods: "50"
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-probation-mi-ui-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-probation-mi-ui-test
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/05-certificates.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-ui-certificate
+  namespace: hmpps-probation-mi-ui-test
+spec:
+  secretName: hmpps-probation-mi-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - hmpps-probation-mi-ui-test.hmpps.service.justice.gov.uk
+    - hmpps-probation-mi-api-test.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/07-rbac-haar-client-admin-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/07-rbac-haar-client-admin-team.yaml
@@ -1,0 +1,39 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-probation-mi-ui-test
+rules:
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "issuers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [ "", "extensions" ]
+    resources: [ "services", "ingresses", "configmaps", "pods/log" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: [ "get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-probation-mi-ui-test
+subjects:
+  - kind: Group
+    name: "github:hmpps-haar-client-admin"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: hmpps-haar-client-admin-team
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/cross-iam-role-irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/cross-iam-role-irsa.tf
@@ -1,0 +1,125 @@
+locals {
+  dpr_data_api_role = "dpr-data-api-cross-account-role"
+
+  accounts_map = {
+    development = "771283872747",
+    test        = "203591025782",
+    preprod     = "972272129531",
+    prod        = "004723187462"
+  }
+
+  environments_map = {
+    development = "development",
+    test        = "test",
+    preprod     = "preproduction",
+    prod        = "production"
+  }
+}
+
+data "aws_eks_cluster" "eks_cluster" {
+  name = var.eks_cluster_name
+}
+
+module "dpr_mi_assume_role" {
+  source                         = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                        = "5.13.0"
+  create_role                    = true
+  role_name                      = "dpr-reporting-mi-${var.environment}-cross-iam-${var.eks_cluster_name}"
+  provider_url                   = data.aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
+  role_policy_arns               = [aws_iam_policy.cross_iam_dpr_oidc.arn]
+  oidc_fully_qualified_subjects  = ["system:serviceaccount:${var.namespace}:dpr-reporting-mi-${lookup(local.environments_map, lower(var.environment))}-cross-iam"]
+  oidc_fully_qualified_audiences = ["sts.amazonaws.com"]
+}
+
+data "aws_iam_policy_document" "cross_iam_dpr_oidc" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = ["arn:aws:iam::${lookup(local.accounts_map, lower(var.environment))}:role/${local.dpr_data_api_role}"]
+  }
+}
+
+resource "aws_iam_policy" "cross_iam_dpr_oidc" {
+  name   = "${var.namespace}-cross-iam-dpr-oidc"
+  policy = data.aws_iam_policy_document.cross_iam_dpr_oidc.json
+
+  tags = {
+    business_unit          = var.business_unit
+    application            = var.application
+    is_production          = var.is_production
+    team_name              = var.team_name
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+  }
+}
+
+module "irsa" {
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+  eks_cluster_name     = var.eks_cluster_name
+  service_account_name = "dpr-reporting-mi-${var.environment}-cross-iam"
+  namespace            = var.namespace
+  role_policy_arns = {
+    secrets = aws_iam_policy.cross_iam_policy_mp.arn
+  }
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+data "aws_iam_policy_document" "cross_iam_policy_mp" {
+  statement {
+    actions = [
+      "secretsmanager:Get*",
+      "secretsmanager:List*",
+    ]
+    resources = ["arn:aws:secretsmanager:eu-west-2:${lookup(local.accounts_map, lower(var.environment))}:secret:dpr-redshift-secret-*-*"]
+  }
+
+  statement {
+    actions = [
+      "kms:Describe*",
+      "kms:Decrypt",
+      "kms:Get*",
+      "kms:List*",
+    ]
+    resources = ["arn:aws:kms:eu-west-2:${lookup(local.accounts_map, lower(var.environment))}:key/*"]
+  }
+
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = ["arn:aws:iam::${lookup(local.accounts_map, lower(var.environment))}:role/${local.dpr_data_api_role}"]
+  }
+}
+
+resource "aws_iam_policy" "cross_iam_policy_mp" {
+  name   = "${var.namespace}-cross-iam-role-mp"
+  policy = data.aws_iam_policy_document.cross_iam_policy_mp.json
+
+  tags = {
+    business_unit          = var.business_unit
+    application            = var.application
+    is_production          = var.is_production
+    team_name              = var.team_name
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "irsa-output"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/elasticache.tf
@@ -1,0 +1,33 @@
+module "hmpps_probation_mi_ui_ec_cluster" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
+
+  vpc_name = var.vpc_name
+
+  engine_version       = "7.0"
+  parameter_group_name = "default.redis7"
+  node_type            = "cache.t4g.micro"
+
+  team_name              = var.team_name
+  namespace              = var.namespace
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  enable_irsa            = true
+}
+
+resource "kubernetes_secret" "hmpps_probation_mi_ui_ec_cluster" {
+  metadata {
+    name      = "hmpps-probation-mi-ui-ec-cluster-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.hmpps_probation_mi_ui_ec_cluster.primary_endpoint_address
+    member_clusters          = jsonencode(module.hmpps_probation_mi_ui_ec_cluster.member_clusters)
+    auth_token               = module.hmpps_probation_mi_ui_ec_cluster.auth_token
+    replication_group_id     = module.hmpps_probation_mi_ui_ec_cluster.replication_group_id
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}
+
+provider "random" {}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/serviceaccount.tf
@@ -1,0 +1,10 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace           = var.namespace
+  kubernetes_cluster  = var.kubernetes_cluster
+  serviceaccount_name = "circleci"
+
+  serviceaccount_token_rotated_date = "20-03-2026"
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/ui-session-secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/ui-session-secret.tf
@@ -1,0 +1,16 @@
+resource "random_password" "session_secret" {
+  length  = 16
+  special = false
+}
+
+resource "kubernetes_secret" "session_secret" {
+  metadata {
+    name      = "ui-session-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    session_secret = random_password.session_secret.result
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/variables.tf
@@ -1,0 +1,73 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "eks_cluster_name" {
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Probation Management Information UI"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "hmpps-probation-mi-ui-test"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "hmpps-digital-prison-reporting"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "test"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "digitalprisonreporting@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "ask_dpr"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider."
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-test/resources/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5.1"
+    }
+  }
+}
+


### PR DESCRIPTION
As part of https://dsdmoj.atlassian.net/browse/PDHD-152 we need to spin up test, preprod and prod to match the current dev setup as per https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-mi-ui-dev