### PR TITLE
fix: delete only the transferred file from upload bucket rather than …

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
@@ -82,11 +82,10 @@ spec:
                     "s3://$SQLSERVER_BACKUP_S3_BUCKET_NAME/$LATEST_BAK" \
                     --only-show-errors
 
-                  echo "Copy complete. Deleting all objects from upload bucket..."
+                  echo "Copy complete. Removing $LATEST_BAK from upload bucket..."
 
                   aws s3 rm \
-                    "s3://$UPLOAD_S3_BUCKET_NAME" \
-                    --recursive \
+                    "s3://$UPLOAD_S3_BUCKET_NAME/$LATEST_BAK" \
                     --only-show-errors
 
                   echo "Transfer completed successfully at $(date)"


### PR DESCRIPTION
…recursive rm

Previously used aws s3 rm --recursive which deleted all objects regardless. Now deletes only the specific .bak file that was just copied, so:
- If the copy step fails, set -euo pipefail halts before deletion
- Any other files NEC may have uploaded are preserved until the next run
- The 14-day lifecycle policy on the backup bucket handles long-term cleanup