### PR TITLE
fix: wait for RDS snapshot to be available before proceeding with res…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hmpps-manage-and-deliver-acp-s3-transfer
   namespace: hmpps-manage-and-deliver-accredited-programmes-preprod
 spec:
-  # Run every night at 05:00 UTC (06:00 BST)
+  #  Run every night at 05:00 UTC (06:00 BST)
   schedule: "0 5 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
@@ -48,7 +48,7 @@ spec:
                 - /bin/bash
                 - -c
                 - |
-                  set -e
+                  set -euo pipefail
 
                   if [ "${CREATE_SNAPSHOT}" != "true" ]; then
                     echo "create_snapshot=${CREATE_SNAPSHOT}; skipping RDS snapshot"
@@ -69,7 +69,12 @@ spec:
                     --db-instance-identifier "${DATABASE_IDENTIFIER}" \
                     --db-snapshot-identifier "${SNAPSHOT_ID}"
 
-                  echo "Successfully created snapshot: ${SNAPSHOT_ID}"
+                  echo "Waiting for snapshot to become available..."
+
+                  aws rds wait db-snapshot-available \
+                    --db-snapshot-identifier "${SNAPSHOT_ID}"
+
+                  echo "Snapshot ${SNAPSHOT_ID} is available."
 
             - name: find-backup-file
               image: public.ecr.aws/aws-cli/aws-cli:2.15.15


### PR DESCRIPTION
…tore

aws rds create-db-snapshot is asynchronous — it returns immediately while the snapshot continues creating in the background. Without waiting, the restore could begin (and potentially fail, corrupting the DB) before the snapshot is in a usable state.

Added aws rds wait db-snapshot-available to block until the snapshot is confirmed available, matching the existing behaviour in the dev environment. Also hardened set -e to set -euo pipefail for consistency.