### PR TITLE
Adds mandatory tags to apply service prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/main.tf
@@ -7,6 +7,12 @@ provider "aws" {
   region = "eu-west-2"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"
@@ -20,6 +26,12 @@ provider "aws" {
   region = "eu-west-2"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"
@@ -33,6 +45,12 @@ provider "aws" {
   region = "eu-west-1"
     default_tags {
     tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
       GithubTeam = "cica"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-prod/resources/variables.tf
@@ -73,4 +73,11 @@ variable "slack_channel" {
   type        = string
   default     = "cica-digital"
 }
+
+variable "service_area" {
+  type        = string
+  description = "Service Area"
+  default     = "CICA Digital Apply Service"
+}
+
 variable "kubernetes_cluster" {}


### PR DESCRIPTION
This pull request enhances the tagging and configuration of AWS resources for the `claim-criminal-injuries-compensation-prod` environment. The main improvements are the addition of new default tags for better resource identification and the introduction of a new Terraform variable.

**Tagging improvements:**

* Added new default tags to the `aws` provider configuration, including `business-unit`, `application`, `is-production`, `owner`, `namespace`, and `service-area`, to improve resource identification and management. [[1]](diffhunk://#diff-95ad77160cf74dbf7e820edd65b1905f39f63a64a003d1cc00bcbd6183d1d9daR10-R15) [[2]](diffhunk://#diff-95ad77160cf74dbf7e820edd65b1905f39f63a64a003d1cc00bcbd6183d1d9daR29-R34) [[3]](diffhunk://#diff-95ad77160cf74dbf7e820edd65b1905f39f63a64a003d1cc00bcbd6183d1d9daR48-R53)

**Variable additions:**

* Introduced a new Terraform variable `service_area` with a default value of `"CICA Digital Apply Service"`, allowing this value to be referenced in resource definitions and tags.