### PR TITLE
LSM-414/TAKE2-Adj-API-prod-db-update-STEP-ONE

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
@@ -14,7 +14,7 @@ module "ma_rds" {
   db_engine_version           = "15.12"
   deletion_protection         = true
   db_password_rotated_date    = "15-02-2023"
-  allow_major_version_upgrade = "false"
+  allow_major_version_upgrade = true
   allow_minor_version_upgrade = "true"
   enable_irsa                 = true
 
@@ -22,7 +22,7 @@ module "ma_rds" {
   db_allocated_storage        = "1500"
 
   db_engine                   = "postgres"
-  prepare_for_major_upgrade   = false
+  prepare_for_major_upgrade   = true
 
   backup_window               = var.backup_window
   maintenance_window          = var.maintenance_window
@@ -91,6 +91,9 @@ module "dps_rds_replica" {
   db_engine_version = "15.12"
   rds_family        = "postgres15"
   db_instance_class = "db.t4g.large"
+
+   allow_major_version_upgrade = true
+   prepare_for_major_upgrade   = true
 
   # It is mandatory to set the below values to create read replica instance
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
@@ -10,8 +10,8 @@ module "ma_rds" {
   infrastructure_support      = var.infrastructure_support
 
   db_instance_class           = "db.t4g.large"
-  rds_family                  = "postgres15"
-  db_engine_version           = "15.12"
+  rds_family                  = "postgres17"
+  db_engine_version           = "17.6"
   deletion_protection         = true
   db_password_rotated_date    = "15-02-2023"
   allow_major_version_upgrade = true
@@ -88,8 +88,8 @@ module "dps_rds_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "15.12"
-  rds_family        = "postgres15"
+  db_engine_version = "17.6"
+  rds_family        = "postgres17"
   db_instance_class = "db.t4g.large"
 
    allow_major_version_upgrade = true


### PR DESCRIPTION
- prepared ma_rds and dps_rds_replica for major upgrade
- upgraded ma_rds and dps_rds_replica to version 17.6