### PR TITLE
EL-3159: removes duplicate runbook url for low pod count rules

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-production/05-prometheus-custom-rules.yaml
@@ -21,7 +21,6 @@ spec:
             runbook_url: https://ministryofjustice.github.io/laa-manage-your-civil-cases/
             dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/djtEK4abc/ccq-ingress-check-if-your-client-qualifies-for-legal-aid?orgId=1&var-namespace=laa-manage-your-civil-cases-production&var-ingress=check-client-qualifies-laa-estimate-eligibility
         - alert: MCCProductionLowPodCount
-          runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubepodnotready
           expr: |-
             sum by (namespace, pod) (kube_pod_status_phase{namespace="laa-manage-your-civil-cases-production", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
           for: 1m


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-3159)

What changed and Why?
Removes duplicate runbook url causing failing pipeline

Guidance to review (optional)
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/20972
Error: ' strict decoding error: unknown field "spec.groups[0].rules[1].runbook_url" '

Checklist
Before you ask people to review this PR:

Tests and linting are passing.
Branch is up to date with main (no merge conflicts).
No unnecessary whitespace changes (avoid unnecessary diffs).
PR description clearly explains what changed and why, with a JIRA ticket/Trello link.
Diff has been checked for any unexpected changes.
Commit messages are clear and explain what will change, if individual commit, needs to be revisited retroactively.