### PR TITLE
Remove laa-sds additional buckets from test

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-test/resources/variables.tf
@@ -142,7 +142,7 @@ variable "serviceaccount_rules" {
 
 variable "bucket_names" {
   type = list(string)
-  default = ["laa-sds-internal", "laa-data-access-api", "laa-inquests-api"]
+  default = ["laa-sds-internal"]
 }
 
 variable "service_area" {


### PR DESCRIPTION
Remove extra S3 buckets from test environment, as the build process fails.