### PR TITLE
fix: disable pre-restore RDS snapshot to bypass SCP denial

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
@@ -152,7 +152,7 @@ variable "log_path" {
 variable "sqlserver_restore_create_snapshot" {
   description = "Boolean to declare whether or not a snapshot should be taken before the sqlserver restore"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "db_backup_retention_period" {


### PR DESCRIPTION
The AWS Organization SCP (p-uysdg5pm) now explicitly denies rds:CreateDBSnapshot, causing the db-restore cronjob to fail since April 28.

The snapshot is unnecessary for this preprod environment:
- The database is fully rebuilt nightly from a production .bak file
- RDS automated backups are disabled (retention = 0)
- Source .bak files are retained for 14 days in the backup bucket

Sets sqlserver_restore_create_snapshot default to false to match the configmap patch already applied to unblock tonight's restore.