### PR TITLE
feat: add 30-day lifecycle policy to upload bucket as safety net

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/s3.tf
@@ -11,6 +11,21 @@ module "upload_s3_bucket" {
   log_path               = var.log_path
   namespace              = var.namespace
 
+  # Safety net: auto-delete files after 30 days if the cronjob fails to remove them.
+  # Normal operation removes files within hours; this prevents runaway accumulation
+  # (e.g. the 1.47TB incident of Apr 29 2026 caused by weeks of missed deletions).
+  lifecycle_rule = [
+    {
+      id      = "expire-stale-uploads"
+      enabled = true
+      expiration = [
+        {
+          days = 30
+        }
+      ]
+    }
+  ]
+
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
Prevents runaway file accumulation if the S3 transfer cronjob fails for an extended period. Under normal operation files are removed within hours of arrival; this acts as a backstop only.

Context: On Apr 29 2026, 46 undeleted .bak files (~1.47TB) accumulated over ~7 weeks and caused node eviction due to ephemeral storage exhaustion. A 30-day lifecycle would have capped this at ~30 files (~960GB) and prevented the incident from escalating as severely.