### PR TITLE
LSM-291/Adj-api-prod-upgrade-db-to-v17-STEP-ONE

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-prod/resources/rds.tf
@@ -10,11 +10,11 @@ module "ma_rds" {
   infrastructure_support      = var.infrastructure_support
 
   db_instance_class           = "db.t4g.large"
-  rds_family                  = "postgres15"
-  db_engine_version           = "15.12"
+  rds_family                  = "postgres17"
+  db_engine_version           = "17.6"
   deletion_protection         = true
   db_password_rotated_date    = "15-02-2023"
-  allow_major_version_upgrade = "false"
+  allow_major_version_upgrade = true
   allow_minor_version_upgrade = "true"
   enable_irsa                 = true
 
@@ -22,7 +22,7 @@ module "ma_rds" {
   db_allocated_storage        = "1500"
 
   db_engine                   = "postgres"
-  prepare_for_major_upgrade   = false
+  prepare_for_major_upgrade   = true
 
   backup_window               = var.backup_window
   maintenance_window          = var.maintenance_window
@@ -88,9 +88,12 @@ module "dps_rds_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "15.12"
-  rds_family        = "postgres15"
+  db_engine_version = "17.6"
+  rds_family        = "postgres17"
   db_instance_class = "db.t4g.large"
+
+  allow_major_version_upgrade = true
+  prepare_for_major_upgrade   = true
 
   # It is mandatory to set the below values to create read replica instance
 


### PR DESCRIPTION
- updated db version to 17.6 for ma_rds and dps_rds_replica
- updated prepare_for_major_upgrade to true