### PR TITLE
Add reuse-library-prod namespace configuration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "reuselibrary-dev"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "reuse-portal"
+    cloud-platform.justice.gov.uk/application: "service"
+    cloud-platform.justice.gov.uk/owner: "Reuse Library Team: reuse-library@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/gov-reuse"
+    cloud-platform.justice.gov.uk/team-name: "reuse-library-gh-admins"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/00-namespace.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "reuselibrary-dev"
+  name: "reuse-library-prod"
   labels:
-    cloud-platform.justice.gov.uk/is-production: "false"
-    cloud-platform.justice.gov.uk/environment-name: "development"
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
     pod-security.kubernetes.io/enforce: restricted
   annotations:
     cloud-platform.justice.gov.uk/business-unit: "HQ"
-    cloud-platform.justice.gov.uk/slack-channel: "reuse-portal"
-    cloud-platform.justice.gov.uk/application: "service"
+    cloud-platform.justice.gov.uk/slack-channel: "reuse-library"
+    cloud-platform.justice.gov.uk/application: "Reuse Library"
     cloud-platform.justice.gov.uk/owner: "Reuse Library Team: reuse-library@justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/gov-reuse"
     cloud-platform.justice.gov.uk/team-name: "reuse-library-gh-admins"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: reuselibrary-dev-admin
+  namespace: reuselibrary-dev
+subjects:
+  - kind: Group
+    name: "github:reuse-library-gh-admins"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/01-rbac.yaml
@@ -1,8 +1,8 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: reuselibrary-dev-admin
-  namespace: reuselibrary-dev
+  name: reuse-library-prod-admin
+  namespace: reuse-library-prod
 subjects:
   - kind: Group
     name: "github:reuse-library-gh-admins"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: reuselibrary-dev
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/02-limitrange.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: limitrange
-  namespace: reuselibrary-dev
+  namespace: reuse-library-prod
 spec:
   limits:
   - default:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: reuselibrary-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/03-resourcequota.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: namespace-quota
-  namespace: reuselibrary-dev
+  namespace: reuse-library-prod
 spec:
   hard:
     pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: reuselibrary-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: reuselibrary-dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/04-networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default
-  namespace: reuselibrary-dev
+  namespace: reuse-library-prod
 spec:
   podSelector: {}
   policyTypes:
@@ -15,7 +15,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-ingress-controllers
-  namespace: reuselibrary-dev
+  namespace: reuse-library-prod
 spec:
   podSelector: {}
   policyTypes:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/ecr.tf
@@ -3,9 +3,14 @@ module "container_repository" {
 
   # Repo & OIDC
   repo_name           = var.namespace
+
+  # set this if you use one GitHub repository to push to multiple container repositories
+  # this ensures the variable key used in the workflow is unique
+  github_actions_prefix = "prod"
+
   oidc_providers      = ["github"]
   github_repositories = ["gov-reuse"]
-  github_environments = ["dev"]
+  
 
   # Tags/metadata
   business_unit          = var.business_unit
@@ -16,6 +21,4 @@ module "container_repository" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 
-  # Optional: allow querying ECR via IRSA from the namespace (read-only)
-  # enable_irsa = true
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/ecr.tf
@@ -1,0 +1,21 @@
+module "container_repository" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+
+  # Repo & OIDC
+  repo_name           = var.namespace
+  oidc_providers      = ["github"]
+  github_repositories = ["gov-reuse"]
+  github_environments = ["dev"]
+
+  # Tags/metadata
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  # Optional: allow querying ECR via IRSA from the namespace (read-only)
+  # enable_irsa = true
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "dev_reuselibrary_team_route53_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.github_owner
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "dev_reuselibrary_route53_zone_sec" {
+  metadata {
+    name      = "${var.namespace}-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.dev_reuselibrary_team_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.dev_reuselibrary_team_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
@@ -13,14 +13,14 @@ resource "aws_route53_zone" "dev_reuselibrary_team_route53_zone" {
   }
 }
 
-resource "kubernetes_secret" "dev_reuselibrary_route53_zone_sec" {
+resource "kubernetes_secret" "route53_zone_sec" {
   metadata {
-    name      = "${var.namespace}-route53-zone-output"
+    name      = "route53-zone-output"
     namespace = var.namespace
   }
 
   data = {
-    zone_id     = aws_route53_zone.dev_reuselibrary_team_route53_zone.zone_id
-    nameservers = join("\n", aws_route53_zone.dev_reuselibrary_team_route53_zone.name_servers)
+    zone_id     = aws_route53_zone.route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.route53_zone.name_servers)
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
@@ -1,5 +1,5 @@
-resource "aws_route53_zone" "dev_reuselibrary_team_route53_zone" {
-  name = var.domain
+resource "aws_route53_zone" "prod_reuselibrary_team_route53_zone" {
+  name = "reuselibrary.service.justice.gov.uk"
 
   tags = {
     team_name              = var.team_name
@@ -20,7 +20,7 @@ resource "kubernetes_secret" "route53_zone_sec" {
   }
 
   data = {
-    zone_id     = aws_route53_zone.route53_zone.zone_id
-    nameservers = join("\n", aws_route53_zone.route53_zone.name_servers)
+    zone_id     = aws_route53_zone.prod_reuselibrary_team_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.prod_reuselibrary_team_route53_zone.name_servers)
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
 
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
@@ -10,5 +10,5 @@ module "serviceaccount" {
   github_actions_secret_kube_cert      = "PROD_KUBE_CERT"
   github_actions_secret_kube_token     = "PROD_KUBE_TOKEN"
 
-  serviceaccount_token_rotated_date = "20-03-2026"
+  serviceaccount_token_rotated_date = "30-04-2026"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/serviceaccount.tf
@@ -4,8 +4,11 @@ module "serviceaccount" {
   namespace           = var.namespace
   kubernetes_cluster  = var.kubernetes_cluster
 
-  # Creates repo-level secrets (ca.crt / token / server)
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["gov-reuse"]
+  github_actions_secret_kube_namespace = "PROD_KUBE_NAMESPACE"
+  github_actions_secret_kube_cert      = "PROD_KUBE_CERT"
+  github_actions_secret_kube_token     = "PROD_KUBE_TOKEN"
 
   serviceaccount_token_rotated_date = "20-03-2026"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/serviceaccount.tf
@@ -1,0 +1,11 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace           = var.namespace
+  kubernetes_cluster  = var.kubernetes_cluster
+
+  # Creates repo-level secrets (ca.crt / token / server)
+  github_repositories = ["gov-reuse"]
+
+  serviceaccount_token_rotated_date = "20-03-2026"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/variables.tf
@@ -1,0 +1,75 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Reuse Library Portal"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "reuselibrary-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HQ"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "reuse-library-gh-admins"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "dev"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "reuse-library@justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "reuse-portal"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+
+variable "domain" {
+  type        = string
+  description = "Domain name for the service"
+  default     = "dev.reuselibrary.service.justice.gov.uk"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/variables.tf
@@ -68,8 +68,4 @@ variable "github_token" {
   default     = ""
 }
 
-variable "domain" {
-  type        = string
-  description = "Domain name for the service"
-  default     = "dev.reuselibrary.service.justice.gov.uk"
-}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/variables.tf
@@ -17,7 +17,7 @@ variable "application" {
 variable "namespace" {
   description = "Name of the namespace these resources are part of"
   type        = string
-  default     = "reuselibrary-dev"
+  default     = "reuse-library-prod"
 }
 
 variable "business_unit" {
@@ -35,7 +35,7 @@ variable "team_name" {
 variable "environment" {
   description = "Name of the environment type for this service"
   type        = string
-  default     = "dev"
+  default     = "production"
 }
 
 variable "infrastructure_support" {
@@ -53,7 +53,7 @@ variable "is_production" {
 variable "slack_channel" {
   description = "Slack channel name for your team, if we need to contact you about this service"
   type        = string
-  default     = "reuse-portal"
+  default     = "reuse-library"
 }
 
 variable "github_owner" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR creates a new production namespace for Reuse Library and adds the base platform and Terraform configuration required to run it.

-## Changes
- Adds a new namespace for reuse-library-prod with ownership, team, and service metadata.
- Adds namespace RBAC granting admin access to the GitHub team group.
- Adds default namespace guardrails:
- LimitRange for default CPU/memory requests and limits.
- ResourceQuota limiting total pod count.
- NetworkPolicy defaults plus ingress-controller access policy.
- Adds Terraform resources/modules for:
- ECR credentials and GitHub OIDC access for the gov-reuse repository.
- Service account and GitHub Actions kube secrets for CI/CD.
- Route53 hosted zone creation and Kubernetes secret output.