### PR TITLE
fix: fix task_id extraction and make SINGLE_USER/DROP non-fatal

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
@@ -242,24 +242,24 @@ spec:
                   done
                   echo "SQL Server reachable."
 
-                  # Kill any existing connections so the overwrite restore can proceed
+                  # Kill any existing connections so the overwrite restore can proceed.
+                  # This may fail if the DB doesn't exist, is recovering after an RDS
+                  # auto-start, or was already dropped by a previous attempt — all OK.
                   echo "Setting database to SINGLE_USER to clear existing connections..."
                   "${SQLCMD}" \
                     -S "localhost,${DB_PORT}" \
                     -U "${DATABASE_USERNAME}" \
                     -P "${DATABASE_PASSWORD}" \
-                    -b \
                     -C -Q "IF DB_ID('${DATABASE_NAME}') IS NOT NULL
-                          ALTER DATABASE [${DATABASE_NAME}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;"
+                          ALTER DATABASE [${DATABASE_NAME}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;" 2>&1 || echo "  (SINGLE_USER failed — DB may not exist or is recovering, continuing...)"
                   
                   echo "Dropping existing database if it exists..."
                   "${SQLCMD}" \
                     -S "localhost,${DB_PORT}" \
                     -U "${DATABASE_USERNAME}" \
                     -P "${DATABASE_PASSWORD}" \
-                    -b \
                     -C -Q "IF DB_ID(N'${DATABASE_NAME}') IS NOT NULL
-                             DROP DATABASE [${DATABASE_NAME}];"
+                             DROP DATABASE [${DATABASE_NAME}];" 2>&1 || echo "  (DROP DATABASE failed — DB may not exist, continuing...)"
 
                   # Submit the native RDS restore task.
                   # RDS pulls the .bak directly from S3 using the option-group IAM role —
@@ -269,7 +269,7 @@ spec:
                     -S "localhost,${DB_PORT}" \
                     -U "${DATABASE_USERNAME}" \
                     -P "${DATABASE_PASSWORD}" \
-                    -h -1 -W \
+                    -W \
                     -b \
                     -C -Q "EXEC msdb.dbo.rds_restore_database
                           @restore_db_name    = '${DATABASE_NAME}',
@@ -277,9 +277,13 @@ spec:
                           @with_norecovery    = 0,
                           @type               = 'FULL';" 2>&1)
 
-                  # Extract the task_id from the "Task Id: <N>" line in the submission output.
-                  # This is more reliable than parsing the tabular row, which varies by column width.
+                  # Extract task_id: prefer the explicit "Task Id: <N>" line printed by
+                  # rds_restore_database; fall back to the first numeric field in the
+                  # result set (the task_id column is always first).
                   TASK_ID=$(echo "${SUBMIT_OUTPUT}" | grep -oE 'Task Id:\s*[0-9]+' | grep -oE '[0-9]+' || true)
+                  if [ -z "${TASK_ID}" ]; then
+                    TASK_ID=$(echo "${SUBMIT_OUTPUT}" | grep -oE '^\s*[0-9]+' | head -1 | tr -d ' ' || true)
+                  fi
 
                   if [ -z "${TASK_ID}" ]; then
                     echo "Failed to extract task_id from submission output:"


### PR DESCRIPTION
Fixes two issues discovered from the May 1 overnight failure (db-restore-cronjob-29626905):

1. Task ID extraction broken by -h -1 flag
PR #42114 added -h -1 -W to the rds_restore_database submission call, which suppresses sqlcmd column headers. However, the task_id extraction relied on grepping for Task Id: <N> — a line that only appears when headers are enabled. Result: every run since #42114 merged fails with "Failed to extract task_id from submission output".

Fix: Removed -h -1 from the submission call (kept -W for whitespace trimming). Headers are now present, including the Task Id: <N> trailer line. Added a fallback parser that extracts the first numeric column value in case header format varies across sqlcmd versions.

2. SINGLE_USER / DROP DATABASE fatal when DB is recovering
The RDS instance has the cloud-platform-rds-auto-shutdown tag, which stops it outside business hours. When the cronjob runs at 05:45 UTC, the instance may still be starting up — the user database can be in RECOVERING state. The previous code used -b (exit on SQL error) for SINGLE_USER and DROP DATABASE, causing the script to die before reaching the restore submission.

Fix: Removed -b from these two calls and added || echo "..." fallback. These are best-effort cleanup steps — if they fail (DB doesn't exist, is recovering, or was already dropped), the script continues to rds_restore_database which handles the state independently.

Testing
Confirmed via db-restore-debug pod logs that the SINGLE_USER error was the root cause of today's failure
Task ID extraction format verified against historical logs (tasks 5–17)
No changes to init containers, polling loop, or activeDeadlineSeconds