### PR TITLE
fix: reduce db-restore backoffLimit from 3 to 1

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
@@ -11,7 +11,7 @@ spec:
   failedJobsHistoryLimit: 5
   jobTemplate:
     spec:
-      backoffLimit: 3
+      backoffLimit: 1  # Reduced from 3 — retries re-submit RDS restores which conflict
       activeDeadlineSeconds: 5400  # Hard timeout: 90 minutes (covers 60-min poll + overhead)
       template:
         spec:


### PR DESCRIPTION
Each retry restarts the pod from scratch, which re-submits a new rds_restore_database task. RDS rejects concurrent restores on the same DB, so retries just waste time waiting for the conflict error.

A single attempt is sufficient — if it fails, the activeDeadlineSeconds backstop (90 min) kills the job cleanly, and the next scheduled run at 05:45 UTC tomorrow will retry with a fresh state.