### PR TITLE
fix: prevent silent failure on rds_restore_database submission error

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
@@ -7,6 +7,7 @@ spec:
   # Run every night at 05:45 UTC (06:45 BST) — 0:45:00 after the s3-transfer job
   schedule: "45 5 * * *"
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600  # If the scheduler misses the window by >10min, skip this run
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
   jobTemplate:
@@ -165,7 +166,7 @@ spec:
               #   /opt/mssql-tools/bin/sqlcmd  (older builds)
               # The startup script probes for both. We override the container
               # entrypoint so SQL Server itself is never started.
-              image: mcr.microsoft.com/mssql/server:2019-latest
+              image: mcr.microsoft.com/mssql/server:2019-CU31-ubuntu-20.04
               imagePullPolicy: IfNotPresent
               securityContext:
                 runAsUser: 10001
@@ -218,6 +219,10 @@ spec:
                   fi
 
                   BACKUP_KEY=$(cat /backup-info/backup-key)
+                  if [ -z "${BACKUP_KEY}" ]; then
+                    echo "ERROR: /backup-info/backup-key is empty — find-backup-file init container may have failed"
+                    exit 1
+                  fi
                   BACKUP_S3_ARN="arn:aws:s3:::${SQLSERVER_BACKUP_S3_BUCKET_NAME}/${BACKUP_KEY}"
 
                   echo "Starting restore at $(date)"
@@ -270,16 +275,23 @@ spec:
                     -U "${DATABASE_USERNAME}" \
                     -P "${DATABASE_PASSWORD}" \
                     -W \
-                    -b \
                     -C -Q "EXEC msdb.dbo.rds_restore_database
                           @restore_db_name    = '${DATABASE_NAME}',
                           @s3_arn_to_restore_from = '${BACKUP_S3_ARN}',
                           @with_norecovery    = 0,
-                          @type               = 'FULL';" 2>&1)
+                          @type               = 'FULL';" 2>&1) || true
 
                   # Extract task_id: prefer the explicit "Task Id: <N>" line printed by
                   # rds_restore_database; fall back to the first numeric field in the
                   # result set (the task_id column is always first).
+                  # First, check if the output indicates a SQL error — don't attempt
+                  # extraction from error messages as numeric codes could false-match.
+                  if echo "${SUBMIT_OUTPUT}" | grep -qE '^Msg [0-9]+, Level [0-9]+'; then
+                    echo "rds_restore_database returned a SQL error:"
+                    echo "${SUBMIT_OUTPUT}"
+                    exit 1
+                  fi
+
                   TASK_ID=$(echo "${SUBMIT_OUTPUT}" | grep -oE 'Task Id:\s*[0-9]+' | grep -oE '[0-9]+' || true)
                   if [ -z "${TASK_ID}" ]; then
                     TASK_ID=$(echo "${SUBMIT_OUTPUT}" | grep -oE '^\s*[0-9]+' | head -1 | tr -d ' ' || true)
@@ -296,13 +308,14 @@ spec:
 
                   # Poll every 30 s; time out after 60 minutes (120 * 30s)
                   POLL_COUNT=0
+                  CONSECUTIVE_FAILURES=0
                   while true; do
                     STATUS_OUTPUT=$("${SQLCMD}" \
                       -S "localhost,${DB_PORT}" \
                       -U "${DATABASE_USERNAME}" \
                       -P "${DATABASE_PASSWORD}" \
                       -h -1 -W \
-                      -C -Q "EXEC msdb.dbo.rds_task_status @task_id = ${TASK_ID};" 2>&1)
+                      -C -Q "EXEC msdb.dbo.rds_task_status @task_id = ${TASK_ID};" 2>&1) || true
 
                     echo "$(date) | ${STATUS_OUTPUT}"
 
@@ -310,6 +323,16 @@ spec:
                     # rds_task_status returns: task_id, task_type, lifecycle, ...
                     # With @task_id filter, only one row is returned.
                     LIFECYCLE=$(echo "${STATUS_OUTPUT}" | grep -oE '\b(SUCCESS|ERROR|CANCELLED|CREATED|IN_PROGRESS)\b' | head -1 || true)
+
+                    if [ -z "${LIFECYCLE}" ]; then
+                      CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+                      if [ "${CONSECUTIVE_FAILURES}" -ge 5 ]; then
+                        echo "Port-forward appears dead — ${CONSECUTIVE_FAILURES} consecutive poll failures"
+                        exit 1
+                      fi
+                    else
+                      CONSECUTIVE_FAILURES=0
+                    fi
 
                     if [ "${LIFECYCLE}" = "SUCCESS" ]; then
                       echo "Restore completed successfully at $(date)"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
@@ -247,24 +247,77 @@ spec:
                   done
                   echo "SQL Server reachable."
 
+                  # Cancel any in-progress or created restore tasks for this DB.
+                  # Stuck tasks from previous failed runs block new restores and
+                  # prevent the database from being dropped.
+                  echo "Checking for stuck restore tasks to cancel..."
+                  STUCK_TASKS=$("${SQLCMD}" \
+                    -S "localhost,${DB_PORT}" \
+                    -U "${DATABASE_USERNAME}" \
+                    -P "${DATABASE_PASSWORD}" \
+                    -h -1 -W \
+                    -C -Q "SELECT task_id FROM msdb.dbo.rds_fn_task_status(NULL, NULL)
+                           WHERE db_name = '${DATABASE_NAME}'
+                             AND lifecycle IN ('CREATED','IN_PROGRESS');" 2>&1) || true
+                  for STUCK_ID in $(echo "${STUCK_TASKS}" | grep -v '^Msg ' | grep -oE '[0-9]+'); do
+                    echo "  Cancelling stuck task ${STUCK_ID}..."
+                    "${SQLCMD}" \
+                      -S "localhost,${DB_PORT}" \
+                      -U "${DATABASE_USERNAME}" \
+                      -P "${DATABASE_PASSWORD}" \
+                      -C -Q "EXEC msdb.dbo.rds_cancel_task @task_id = ${STUCK_ID};" 2>&1 || true
+                  done
+
+                  # Allow cancellations to take effect before attempting drop
+                  if echo "${STUCK_TASKS}" | grep -v '^Msg ' | grep -qE '[0-9]+'; then
+                    echo "  Waiting 15s for task cancellations to complete..."
+                    sleep 15
+                  fi
+
                   # Kill any existing connections so the overwrite restore can proceed.
                   # This may fail if the DB doesn't exist, is recovering after an RDS
                   # auto-start, or was already dropped by a previous attempt — all OK.
+                  echo "Killing active sessions on target database..."
+                  "${SQLCMD}" \
+                    -S "localhost,${DB_PORT}" \
+                    -U "${DATABASE_USERNAME}" \
+                    -P "${DATABASE_PASSWORD}" \
+                    -C -Q "
+                      DECLARE @sql NVARCHAR(MAX) = '';
+                      SELECT @sql += 'KILL ' + CAST(session_id AS NVARCHAR(10)) + '; '
+                      FROM sys.dm_exec_sessions
+                      WHERE database_id = DB_ID('${DATABASE_NAME}')
+                        AND session_id != @@SPID;
+                      IF LEN(@sql) > 0
+                      BEGIN
+                        PRINT 'Killing sessions: ' + @sql;
+                        EXEC sp_executesql @sql;
+                      END
+                      ELSE
+                        PRINT 'No other sessions to kill.';" 2>&1 || echo "  (Kill sessions failed, continuing...)"
+
                   echo "Setting database to SINGLE_USER to clear existing connections..."
                   "${SQLCMD}" \
                     -S "localhost,${DB_PORT}" \
                     -U "${DATABASE_USERNAME}" \
                     -P "${DATABASE_PASSWORD}" \
                     -C -Q "IF DB_ID('${DATABASE_NAME}') IS NOT NULL
-                          ALTER DATABASE [${DATABASE_NAME}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;" 2>&1 || echo "  (SINGLE_USER failed — DB may not exist or is recovering, continuing...)"
-                  
-                  echo "Dropping existing database if it exists..."
+                          ALTER DATABASE [${DATABASE_NAME}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                          IF DB_ID('${DATABASE_NAME}') IS NOT NULL
+                          ALTER DATABASE [${DATABASE_NAME}] SET MULTI_USER;" 2>&1 || echo "  (SINGLE_USER/MULTI_USER failed, continuing...)"
+
+                  # Use RDS-native rds_drop_database — this handles databases in
+                  # RESTORING/RECOVERING states that T-SQL DROP DATABASE cannot touch.
+                  # Falls back to standard DROP DATABASE if rds_drop_database fails.
+                  echo "Dropping existing database using rds_drop_database..."
                   "${SQLCMD}" \
                     -S "localhost,${DB_PORT}" \
                     -U "${DATABASE_USERNAME}" \
                     -P "${DATABASE_PASSWORD}" \
-                    -C -Q "IF DB_ID(N'${DATABASE_NAME}') IS NOT NULL
-                             DROP DATABASE [${DATABASE_NAME}];" 2>&1 || echo "  (DROP DATABASE failed — DB may not exist, continuing...)"
+                    -C -Q "EXEC msdb.dbo.rds_drop_database @db_name = '${DATABASE_NAME}';" 2>&1 || echo "  (rds_drop_database failed — DB may not exist, continuing...)"
+
+                  # Brief wait for the drop to propagate internally
+                  sleep 10
 
                   # Submit the native RDS restore task.
                   # RDS pulls the .bak directly from S3 using the option-group IAM role —


### PR DESCRIPTION
The submission sqlcmd call used -b which, combined with set -euo pipefail, caused the script to die silently at the variable assignment if the stored procedure returned any SQL error (e.g. concurrent RESTORE_DB task). No diagnostic output was ever printed.

Changes:
- Remove -b from submission call, add || true — errors are now captured in SUBMIT_OUTPUT and printed before exit
- Add SQL error detection (Msg N, Level N) before task_id extraction to prevent numeric error codes false-matching as task IDs
- Add || true to polling call — prevents silent death on network blips
- Add consecutive-failure counter (5 = fast-fail) in poll loop instead of silently burning 60 minutes when port-forward dies
- Validate BACKUP_KEY is non-empty after reading from shared volume
- Add startingDeadlineSeconds: 600 — missed runs are now recorded
- Pin mssql image to 2019-CU31-ubuntu-20.04 (was mutable :latest tag)