### PR TITLE
LGA-3946: turn off delete_protection for cla_public ECR

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-public-staging/resources/ecr.tf
@@ -18,6 +18,9 @@ module "ecr-repo" {
   # of credentials you need in CircleCI
   namespace = var.namespace
 
+  # set protecction off to deprecate all cla_public namespaces
+  deletion_protection = false
+  
   # Tags
   business_unit          = var.business_unit
   application            = var.application


### PR DESCRIPTION
As part of deprecating `cla_public`, we are removing its namespaces following the user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/cleaning-up.html#removing-an-unneeded-namespace