### PR TITLE
HIA-1379: Onboard new Justice AI client in dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-dev/resources/locals.tf
@@ -45,6 +45,7 @@ locals {
     "community-campus",
     "enhanced-reception-checks",
     "synalogik",
+    "jaiu-onboarding-optimisation",
   ]
 
   client_queues = {


### PR DESCRIPTION
HIA-1368: Extending domain event subscriptions in dev

Adding the `jaiu-onboarding-optimisation` agreed upon the client page [here](https://dsdmoj.atlassian.net/wiki/spaces/HIA/pages/6137185321/External+Client+-+JAIU+Onboarding+Optimisation)