### PR TITLE
Fix disable prepare_for_major_upgrade on PSR preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-preprod/resources/rds-pre-sentence-service.tf
@@ -13,7 +13,7 @@ module "pre_sentence_service_rds" {
   db_engine_version           = var.db_engine_version
   db_instance_class           = var.db_instance_class
   rds_family                  = var.rds_family
-  prepare_for_major_upgrade   = true
+  prepare_for_major_upgrade   = false
   enable_rds_auto_start_stop  = true
 
   providers = {


### PR DESCRIPTION
Key change:
* Disabled `prepare_for_major_upgrade` on PRS preprod environment

Goal of this change is to resolve the failing build in this environment as see in build [21124](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/21124)