### PR TITLE
Add Prometheus alerting

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/05-prometheusrules.yaml
@@ -6,6 +6,12 @@ metadata:
     role: alert-rules
     namespace: hmpps-manage-and-deliver-accredited-programmes-dev
   name: hmpps-manage-and-deliver-accredited-programmes-dev
+  # NOTE: severity labels currently use the shared team receiver
+  # "hmpps-accredited-programmes-alerts-preprod" which routes to the existing
+  # team Slack channel. When the dedicated Data Importer Service receivers are
+  # created, update severity to:
+  #   "hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod"
+  # and register a matching receiver pointing to the new Slack channel.
 spec:
 
   groups:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/05-prometheusrules.yaml
@@ -1,0 +1,59 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: hmpps-manage-and-deliver-accredited-programmes-dev
+  labels:
+    role: alert-rules
+    namespace: hmpps-manage-and-deliver-accredited-programmes-dev
+  name: hmpps-manage-and-deliver-accredited-programmes-dev
+spec:
+
+  groups:
+  - name: hmpps-manage-and-deliver-accredited-programmes-dev
+    rules:
+
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="hmpps-manage-and-deliver-accredited-programmes-dev"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="hmpps-manage-and-deliver-accredited-programmes-dev"} > 0) > 90
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+
+    - alert: KubePod-NotReady
+      expr: |-
+        sum by (namespace, pod) (kube_pod_status_phase{namespace="hmpps-manage-and-deliver-accredited-programmes-dev", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} has been in a non-ready state for longer than 15 minutes
+
+    - alert: KubePod-CrashLooping
+      expr: |-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-dev"}[10m]) * 60 * 10 > 3
+      for: 10m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times every 10 minutes
+
+    - alert: KubeDeployment-ReplicasMismatch
+      expr: |-
+        kube_deployment_spec_replicas{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-dev"}
+          != kube_deployment_status_replicas_available{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-dev"}
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Deployment {{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes
+
+    - alert: CronJobStatusFailed
+      expr: |-
+        kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-dev"} > 0
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/05-prometheusrules.yaml
@@ -6,12 +6,6 @@ metadata:
     role: alert-rules
     namespace: hmpps-manage-and-deliver-accredited-programmes-dev
   name: hmpps-manage-and-deliver-accredited-programmes-dev
-  # NOTE: severity labels currently use the shared team receiver
-  # "hmpps-accredited-programmes-alerts-preprod" which routes to the existing
-  # team Slack channel. When the dedicated Data Importer Service receivers are
-  # created, update severity to:
-  #   "hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod"
-  # and register a matching receiver pointing to the new Slack channel.
 spec:
 
   groups:
@@ -22,7 +16,7 @@ spec:
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="hmpps-manage-and-deliver-accredited-programmes-dev"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="hmpps-manage-and-deliver-accredited-programmes-dev"} > 0) > 90
       for: 1m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
 
@@ -31,7 +25,7 @@ spec:
         sum by (namespace, pod) (kube_pod_status_phase{namespace="hmpps-manage-and-deliver-accredited-programmes-dev", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
       for: 15m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} has been in a non-ready state for longer than 15 minutes
 
@@ -40,7 +34,7 @@ spec:
         rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-dev"}[10m]) * 60 * 10 > 3
       for: 10m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times every 10 minutes
 
@@ -50,7 +44,7 @@ spec:
           != kube_deployment_status_replicas_available{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-dev"}
       for: 15m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} - Deployment {{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes
 
@@ -59,7 +53,7 @@ spec:
         kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-dev"} > 0
       for: 1m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/05-prometheusrules.yaml
@@ -1,0 +1,59 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: hmpps-manage-and-deliver-accredited-programmes-preprod
+  labels:
+    role: alert-rules
+    namespace: hmpps-manage-and-deliver-accredited-programmes-preprod
+  name: hmpps-manage-and-deliver-accredited-programmes-preprod
+spec:
+
+  groups:
+  - name: hmpps-manage-and-deliver-accredited-programmes-preprod
+    rules:
+
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} > 0) > 90
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+
+    - alert: KubePod-NotReady
+      expr: |-
+        sum by (namespace, pod) (kube_pod_status_phase{namespace="hmpps-manage-and-deliver-accredited-programmes-preprod", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} has been in a non-ready state for longer than 15 minutes
+
+    - alert: KubePod-CrashLooping
+      expr: |-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"}[10m]) * 60 * 10 > 3
+      for: 10m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times every 10 minutes
+
+    - alert: KubeDeployment-ReplicasMismatch
+      expr: |-
+        kube_deployment_spec_replicas{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"}
+          != kube_deployment_status_replicas_available{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"}
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Deployment {{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes
+
+    - alert: CronJobStatusFailed
+      expr: |-
+        kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} > 0
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-preprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/05-prometheusrules.yaml
@@ -16,7 +16,7 @@ spec:
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} > 0) > 90
       for: 1m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
 
@@ -25,7 +25,7 @@ spec:
         sum by (namespace, pod) (kube_pod_status_phase{namespace="hmpps-manage-and-deliver-accredited-programmes-preprod", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
       for: 15m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} has been in a non-ready state for longer than 15 minutes
 
@@ -34,7 +34,7 @@ spec:
         rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"}[10m]) * 60 * 10 > 3
       for: 10m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times every 10 minutes
 
@@ -44,7 +44,7 @@ spec:
           != kube_deployment_status_replicas_available{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"}
       for: 15m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} - Deployment {{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes
 
@@ -53,7 +53,7 @@ spec:
         kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} > 0
       for: 1m
       labels:
-        severity: hmpps-accredited-programmes-alerts-preprod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
       annotations:
         message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/alertmanager-config.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/alertmanager-config.tf
@@ -1,0 +1,50 @@
+resource "kubernetes_secret" "slack_webhook_nonprod" {
+  metadata {
+    name      = "slack-webhook-secret-nonprod"
+    namespace = var.namespace
+  }
+
+  data = {
+    webhook_url = var.slack_webhook_url_nonprod
+  }
+}
+
+resource "kubernetes_manifest" "alertmanager_config_nonprod" {
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1alpha1"
+    kind       = "AlertmanagerConfig"
+    metadata = {
+      name      = "hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod"
+      namespace = var.namespace
+    }
+    spec = {
+      route = {
+        receiver = "slack-nonprod"
+        matchers = [
+          {
+            name  = "severity"
+            value = "hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod"
+          }
+        ]
+      }
+      receivers = [
+        {
+          name = "slack-nonprod"
+          slackConfigs = [
+            {
+              apiURL = {
+                name = kubernetes_secret.slack_webhook_nonprod.metadata[0].name
+                key  = "webhook_url"
+              }
+              channel  = "#accredited-programmes-manage-and-deliver-alerts-nonprod"
+              sendResolved = true
+              title    = "{{ .GroupLabels.alertname }}"
+              text     = "{{ range .Alerts }}{{ .Annotations.message }}{{ end }}"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/alertmanager-config.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/alertmanager-config.tf
@@ -1,4 +1,6 @@
 resource "kubernetes_secret" "slack_webhook_nonprod" {
+  count = var.slack_webhook_url_nonprod != "" ? 1 : 0
+
   metadata {
     name      = "slack-webhook-secret-nonprod"
     namespace = var.namespace
@@ -10,6 +12,8 @@ resource "kubernetes_secret" "slack_webhook_nonprod" {
 }
 
 resource "kubernetes_manifest" "alertmanager_config_nonprod" {
+  count = var.slack_webhook_url_nonprod != "" ? 1 : 0
+
   manifest = {
     apiVersion = "monitoring.coreos.com/v1alpha1"
     kind       = "AlertmanagerConfig"
@@ -33,7 +37,7 @@ resource "kubernetes_manifest" "alertmanager_config_nonprod" {
           slackConfigs = [
             {
               apiURL = {
-                name = kubernetes_secret.slack_webhook_nonprod.metadata[0].name
+                name = kubernetes_secret.slack_webhook_nonprod[0].metadata[0].name
                 key  = "webhook_url"
               }
               channel  = "#accredited-programmes-manage-and-deliver-alerts-nonprod"
@@ -47,4 +51,3 @@ resource "kubernetes_manifest" "alertmanager_config_nonprod" {
     }
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
@@ -160,3 +160,9 @@ variable "db_backup_retention_period" {
   type        = string
   default     = "0"
 }
+
+variable "slack_webhook_url_nonprod" {
+  description = "Slack webhook URL for non-production alerts"
+  type        = string
+  sensitive   = true
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
@@ -164,5 +164,6 @@ variable "db_backup_retention_period" {
 variable "slack_webhook_url_nonprod" {
   description = "Slack webhook URL for non-production alerts"
   type        = string
+  default     = ""
   sensitive   = true
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/05-prometheusrules.yaml
@@ -16,7 +16,7 @@ spec:
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="hmpps-manage-and-deliver-accredited-programmes-prod"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="hmpps-manage-and-deliver-accredited-programmes-prod"} > 0) > 90
       for: 1m
       labels:
-        severity: hmpps-accredited-programmes-alerts-prod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-prod
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
 
@@ -25,7 +25,7 @@ spec:
         sum by (namespace, pod) (kube_pod_status_phase{namespace="hmpps-manage-and-deliver-accredited-programmes-prod", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
       for: 15m
       labels:
-        severity: hmpps-accredited-programmes-alerts-prod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-prod
       annotations:
         message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} has been in a non-ready state for longer than 15 minutes
 
@@ -34,7 +34,7 @@ spec:
         rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-prod"}[10m]) * 60 * 10 > 3
       for: 10m
       labels:
-        severity: hmpps-accredited-programmes-alerts-prod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-prod
       annotations:
         message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times every 10 minutes
 
@@ -44,7 +44,7 @@ spec:
           != kube_deployment_status_replicas_available{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-prod"}
       for: 15m
       labels:
-        severity: hmpps-accredited-programmes-alerts-prod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-prod
       annotations:
         message: Namespace {{ $labels.namespace }} - Deployment {{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes
 
@@ -53,7 +53,7 @@ spec:
         kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-prod"} > 0
       for: 1m
       labels:
-        severity: hmpps-accredited-programmes-alerts-prod
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-prod
       annotations:
         message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/05-prometheusrules.yaml
@@ -1,0 +1,59 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: hmpps-manage-and-deliver-accredited-programmes-prod
+  labels:
+    role: alert-rules
+    namespace: hmpps-manage-and-deliver-accredited-programmes-prod
+  name: hmpps-manage-and-deliver-accredited-programmes-prod
+spec:
+
+  groups:
+  - name: hmpps-manage-and-deliver-accredited-programmes-prod
+    rules:
+
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="hmpps-manage-and-deliver-accredited-programmes-prod"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="hmpps-manage-and-deliver-accredited-programmes-prod"} > 0) > 90
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-prod
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+
+    - alert: KubePod-NotReady
+      expr: |-
+        sum by (namespace, pod) (kube_pod_status_phase{namespace="hmpps-manage-and-deliver-accredited-programmes-prod", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-prod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} has been in a non-ready state for longer than 15 minutes
+
+    - alert: KubePod-CrashLooping
+      expr: |-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-prod"}[10m]) * 60 * 10 > 3
+      for: 10m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-prod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times every 10 minutes
+
+    - alert: KubeDeployment-ReplicasMismatch
+      expr: |-
+        kube_deployment_spec_replicas{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-prod"}
+          != kube_deployment_status_replicas_available{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-prod"}
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-prod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Deployment {{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes
+
+    - alert: CronJobStatusFailed
+      expr: |-
+        kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-prod"} > 0
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-alerts-prod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/alertmanager-config.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/alertmanager-config.tf
@@ -1,0 +1,50 @@
+resource "kubernetes_secret" "slack_webhook_prod" {
+  metadata {
+    name      = "slack-webhook-secret-prod"
+    namespace = var.namespace
+  }
+
+  data = {
+    webhook_url = var.slack_webhook_url_prod
+  }
+}
+
+resource "kubernetes_manifest" "alertmanager_config_prod" {
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1alpha1"
+    kind       = "AlertmanagerConfig"
+    metadata = {
+      name      = "hmpps-accredited-programmes-manage-and-deliver-alerts-prod"
+      namespace = var.namespace
+    }
+    spec = {
+      route = {
+        receiver = "slack-prod"
+        matchers = [
+          {
+            name  = "severity"
+            value = "hmpps-accredited-programmes-manage-and-deliver-alerts-prod"
+          }
+        ]
+      }
+      receivers = [
+        {
+          name = "slack-prod"
+          slackConfigs = [
+            {
+              apiURL = {
+                name = kubernetes_secret.slack_webhook_prod.metadata[0].name
+                key  = "webhook_url"
+              }
+              channel  = "#accredited-programmes-manage-and-deliver-alerts-prod"
+              sendResolved = true
+              title    = "{{ .GroupLabels.alertname }}"
+              text     = "{{ range .Alerts }}{{ .Annotations.message }}{{ end }}"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/alertmanager-config.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/alertmanager-config.tf
@@ -1,4 +1,6 @@
 resource "kubernetes_secret" "slack_webhook_prod" {
+  count = var.slack_webhook_url_prod != "" ? 1 : 0
+
   metadata {
     name      = "slack-webhook-secret-prod"
     namespace = var.namespace
@@ -10,6 +12,8 @@ resource "kubernetes_secret" "slack_webhook_prod" {
 }
 
 resource "kubernetes_manifest" "alertmanager_config_prod" {
+  count = var.slack_webhook_url_prod != "" ? 1 : 0
+
   manifest = {
     apiVersion = "monitoring.coreos.com/v1alpha1"
     kind       = "AlertmanagerConfig"
@@ -33,7 +37,7 @@ resource "kubernetes_manifest" "alertmanager_config_prod" {
           slackConfigs = [
             {
               apiURL = {
-                name = kubernetes_secret.slack_webhook_prod.metadata[0].name
+                name = kubernetes_secret.slack_webhook_prod[0].metadata[0].name
                 key  = "webhook_url"
               }
               channel  = "#accredited-programmes-manage-and-deliver-alerts-prod"
@@ -47,4 +51,3 @@ resource "kubernetes_manifest" "alertmanager_config_prod" {
     }
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
@@ -84,5 +84,6 @@ variable "number_cache_clusters" {
 variable "slack_webhook_url_prod" {
   description = "Slack webhook URL for production alerts"
   type        = string
+  default     = ""
   sensitive   = true
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
@@ -80,3 +80,9 @@ variable "eks_cluster_name" {
 variable "number_cache_clusters" {
   default = "2"
 }
+
+variable "slack_webhook_url_prod" {
+  description = "Slack webhook URL for production alerts"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Add Prometheus alerting and AlertmanagerConfig for hmpps-manage-and-deliver-accredited-programmes namespaces

### What

Adds Kubernetes alerting infrastructure for the `hmpps-manage-and-deliver-accredited-programmes` dev, preprod, and prod namespaces.

### Changes

- **PrometheusRules** (`05-prometheusrules.yaml`) for dev, preprod, and prod with standard alerts:
  - Quota-Exceeded
  - KubePod-NotReady
  - KubePod-CrashLooping
  - KubeDeployment-ReplicasMismatch
  - CronJobStatusFailed

- **AlertmanagerConfig** (`alertmanager-config.tf`) for preprod and prod — self-service receiver registration using the `AlertmanagerConfig` CRD, routing alerts to dedicated Slack channels:
  - `#accredited-programmes-manage-and-deliver-alerts-nonprod`
  - `#accredited-programmes-manage-and-deliver-alerts-prod`

- **Variables** — `slack_webhook_url_prod` and `slack_webhook_url_nonprod` with `default = ""` so the pipeline won't fail before secrets are set. AlertmanagerConfig resources are conditional (`count`) and only created when the webhook URL is provided.

### Severity labels

- dev: `hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod`
- preprod: `hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod`
- prod: `hmpps-accredited-programmes-manage-and-deliver-alerts-prod`

These align with the project bootstrap request (REQ_709) and the `AlertmanagerConfig` matchers.

### Post-merge action required

Pipeline secrets need to be set for the AlertmanagerConfig to take effect:
- `TF_VAR_slack_webhook_url_prod` for `hmpps-manage-and-deliver-accredited-programmes-prod`
- `TF_VAR_slack_webhook_url_nonprod` for `hmpps-manage-and-deliver-accredited-programmes-preprod`

Until these are set, the PrometheusRules will fire but alerts won't route to Slack (the AlertmanagerConfig resources won't be created due to the conditional count).

### JIRA

APG-1860