### PR TITLE
Add PrometheusRules and AlertmanagerConfig for hmpps-manage-and-deliver-accredited-programmes-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/05-prometheusrules.yaml
@@ -1,0 +1,59 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: hmpps-manage-and-deliver-accredited-programmes-preprod
+  labels:
+    role: alert-rules
+    namespace: hmpps-manage-and-deliver-accredited-programmes-preprod
+  name: hmpps-manage-and-deliver-accredited-programmes-preprod
+spec:
+
+  groups:
+  - name: hmpps-manage-and-deliver-accredited-programmes-preprod
+    rules:
+
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} > 0) > 90
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+
+    - alert: KubePod-NotReady
+      expr: |-
+        sum by (namespace, pod) (kube_pod_status_phase{namespace="hmpps-manage-and-deliver-accredited-programmes-preprod", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} has been in a non-ready state for longer than 15 minutes
+
+    - alert: KubePod-CrashLooping
+      expr: |-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"}[10m]) * 60 * 10 > 3
+      for: 10m
+      labels:
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Pod {{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times every 10 minutes
+
+    - alert: KubeDeployment-ReplicasMismatch
+      expr: |-
+        kube_deployment_spec_replicas{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"}
+          != kube_deployment_status_replicas_available{job="kube-state-metrics", namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"}
+      for: 15m
+      labels:
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - Deployment {{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes
+
+    - alert: CronJobStatusFailed
+      expr: |-
+        kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-preprod"} > 0
+      for: 1m
+      labels:
+        severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod
+      annotations:
+        message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed
+


### PR DESCRIPTION
- PrometheusRules with standard alerts
- AlertmanagerConfig with conditional count (no-op if webhook not set)
- slack_webhook_url_nonprod variable with default="" Severity: hmpps-accredited-programmes-manage-and-deliver-alerts-nonprod APG-1860