### PR TITLE
Add cert-manager service account permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/serviceaccount.tf
@@ -9,4 +9,48 @@ module "serviceaccount" {
 
   github_repositories = ["electronic-monitoring-data-dashboard"]
   github_environments = ["development"]
+
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+      ]
+      verbs = ["patch", "get", "create", "update", "delete", "list", "watch"]
+    },
+    {
+      api_groups = ["extensions", "apps", "batch", "networking.k8s.io", "policy"]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "poddisruptionbudgets",
+        "networkpolicies",
+      ]
+      verbs = ["get", "update", "delete", "create", "patch", "list", "watch"]
+    },
+    {
+      api_groups = ["monitoring.coreos.com"]
+      resources  = ["prometheusrules", "servicemonitors"]
+      verbs      = ["*"]
+    },
+    {
+      api_groups = ["autoscaling"]
+      resources  = ["hpa", "horizontalpodautoscalers"]
+      verbs      = ["get", "update", "delete", "create", "patch"]
+    },
+    {
+      api_groups = ["cert-manager.io"]
+      resources  = ["issuers", "certificates", "certificaterequests"]
+      verbs      = ["get", "create", "update", "patch", "delete", "list", "watch"]
+    },
+  ]
+
 }


### PR DESCRIPTION
Add cert-manager permissions to enable service account to create and manage internal certs for mTLS for within namespace pod traffic.