### PR TITLE
Chore removed manual approval gate from user preferences pre-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/hmpps-user-preferences.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-user-preferences-preprod/resources/hmpps-user-preferences.tf
@@ -14,5 +14,5 @@ module "hmpps-user-preferences" {
   namespace                     = var.namespace
   kubernetes_cluster            = var.kubernetes_cluster
   github_owner                  = var.github_owner
-  reviewer_teams                = ["hmpps-probation-in-court", "probation-in-court-devs"]
+  # reviewer_teams                = ["hmpps-probation-in-court", "probation-in-court-devs"] # Optional, adds manual approval gate
 }


### PR DESCRIPTION
Key change:
* Removed reviewers to disable the manual approval gate on `hmpps-user-preferences` preprod