### PR TITLE
DSTEW-1526: Create staging namespace for laa-data-claims-notify-service

### DIFF
--- a/.checksum
+++ b/.checksum
@@ -1,3 +1,3 @@
 #This file is used by the auto pr github action. Please commit
-laa-data-claims-notify-service-dev
-h1:6DPvKmpt66wmxNNI+j0yfK7B1pH1C96yMAYBjwRgZX0=
+laa-data-claims-notify-service-staging
+h1:fq+lOVIbYPa11dX/RADsfKegp0i/zkWxRyy3fT5ZIvE=

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "laa-data-claims-notify-service-staging"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/slack-channel: "laa-data-stewardship-payments"
+    cloud-platform.justice.gov.uk/application: "LAA Data Claims Notify Service"
+    cloud-platform.justice.gov.uk/owner: "Controlled Work Claims: controlledworkclaims@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/laa-data-claims-notify-service"
+    cloud-platform.justice.gov.uk/team-name: "laa-amend-a-claim"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: laa-data-claims-notify-service-staging-admin
+  namespace: laa-data-claims-notify-service-staging
+subjects:
+  - kind: Group
+    name: "github:laa-amend-a-claim"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: laa-data-claims-notify-service-staging
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: laa-data-claims-notify-service-staging
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: laa-data-claims-notify-service-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: laa-data-claims-notify-service-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/resources/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/resources/variables.tf
@@ -1,0 +1,75 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "LAA Data Claims Notify Service"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "laa-data-claims-notify-service-staging"
+}
+
+variable "service_area" {
+  description = "Service area responsible for this service"
+  type        = string
+  default     = "Data Stewardship"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "LAA"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "laa-amend-a-claim"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "staging"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "controlledworkclaims@justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "laa-data-stewardship-payments"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-staging/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
- Creates the `laa-data-claims-notify-service-staging` namespace on the live cluster, mirroring the existing uat namespace for the LAA Data Claims Notify Service. 