### PR TITLE
DSTEW-1526: Add secrets manager to laa-data-claims-notify-service-uat.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/secrets.tf
@@ -1,0 +1,19 @@
+module "secrets_manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "laa-data-claims-notify-service-secrets" = {
+      description             = "laa-data-claims-notify-service ${var.environment} secrets",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "laa-data-claims-notify-service-secrets"
+    },
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/variables.tf
@@ -73,3 +73,9 @@ variable "github_token" {
   description = "Required by the GitHub Terraform provider"
   default     = ""
 }
+
+variable "eks_cluster_name" {
+  description = "The name of the cluster (eg.: cloud-platform-live-0)"
+  type        = string
+  default     = "example_name"
+}


### PR DESCRIPTION
- Adds the `cloud-platform-terraform-secrets-manager` module (ref `3.0.7`) to the `laa-data-claims-notify-service-uat` namespace.