### PR TITLE
Calico Tiers Permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/serviceaccount.tf
@@ -55,7 +55,12 @@ module "serviceaccount" {
       api_groups = ["crd.projectcalico.org"]
       resources  = ["networkpolicies"]
       verbs      = ["get", "list", "describe", "create", "delete", "watch", "update"]
-    }
+    },
+    {
+      api_groups = ["crd.projectcalico.org"]
+      resources  = ["tiers"]
+      verbs      = ["get"]
+    },
   ]
 
 }


### PR DESCRIPTION
Adding Calico tiers permissions to service account due to following error:
```
cannot get networkpolicies.projectcalico.org in tier "default" and namespace "***" (user cannot get tier)
```