### PR TITLE
DSTEW-1526: Remove eks_cluster_name default for laa-data-claims-notify-service-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-dev/resources/variables.tf
@@ -75,7 +75,5 @@ variable "github_token" {
 }
 
 variable "eks_cluster_name" {
-  description = "The name of the cluster (eg.: cloud-platform-live-0)"
-  type        = string
-  default     = "example_name"
+  description = "The name of the eks cluster to retrieve the OIDC information"
 }


### PR DESCRIPTION
-  Removes default = `example_name` from eks_cluster_name in `laa-data-claims-notify-service-dev`
- Pipeline supplies the cluster name at apply time; removing the default makes any misconfig fail loudly instead of silently breaking.