### PR TITLE
Update 07-service-monitor.yaml

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-finance-sync-dev/07-service-monitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-finance-sync-dev/07-service-monitor.yaml
@@ -10,4 +10,3 @@ spec:
   endpoints:
     - port: http
       interval: 15s
-      path: /actuator/prometheus


### PR DESCRIPTION
Removed the endpoint path for prometheus, so we have a default metrics path