### PR TITLE
cica: revert opensearch to version 3.3

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/opensearch.tf
@@ -20,7 +20,7 @@ module "opensearch" {
   eks_cluster_name = var.eks_cluster_name
 
   # Cluster configuration
-  engine_version      = "OpenSearch_3.5"
+  engine_version      = "OpenSearch_3.3"
   snapshot_bucket_arn = module.s3_snapshot_bucket.bucket_arn
   proxy_count         = 2
 


### PR DESCRIPTION
- revert back to 3.3 due to upgrade failures
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/21264