### PR TITLE
Example: COAT tag validation action integration

### DIFF
--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -87,7 +87,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
         with:
-          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          role-to-assume: "arn:aws:iam::111111111111:role/my-read-only-role"
+          role-session-name: "myrolesessionname"
           aws-region: "eu-west-2"
 
       - name: Set mock default terraform vars

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -84,13 +84,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # # Required if data blocks used in terraform configuration, for AWS read operations
-      # - name: Configure AWS Credentials
-      #   uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
-      #   with:
-      #     role-to-assume: "arn:aws:iam::111111111111:role/my-read-only-role"
-      #     role-session-name: "myrolesessionname"
-      #     aws-region: "eu-west-2"
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
 
       - name: Set mock terraform vars
         run: |
@@ -100,10 +98,6 @@ jobs:
           
       - name: Validate Tags
         if: ${{ steps.changed-files.outputs.skip_tflint != 'true' }}
-        env:
-          AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
-          AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-          AWS_DEFAULT_REGION: "eu-west-2"
         id: validate
         uses: ministryofjustice/coat-tag-validator@37cca54b0e16536130d99bdf184cafd8bf2b71ae #v2.1.3
         with:

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -84,8 +84,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ECR_REGION }}

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -91,6 +91,12 @@ jobs:
       #     role-to-assume: "arn:aws:iam::111111111111:role/my-read-only-role"
       #     role-session-name: "myrolesessionname"
       #     aws-region: "eu-west-2"
+
+      - name: Set mock terraform vars
+        run: |
+          echo "TF_VAR_vpc_name=XIHIUHIU-1" >> "$GITHUB_ENV"
+          echo "TF_VAR_eks_cluster_name=XIHIUHIU" >> "$GITHUB_ENV"
+          echo "TF_VAR_kubernetes_cluster="XIHIUHIU.eks.amazonaws.com"" >> "$GITHUB_ENV"
           
       - name: Validate Tags
         if: ${{ steps.changed-files.outputs.skip_tflint != 'true' }}

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -1,0 +1,101 @@
+name: Validate Tags
+
+on:
+  pull_request:
+    paths:
+      - 'namespaces/*/*/resources/*.tf'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  get-changed-files:
+    name: Get changed files
+    runs-on: ubuntu-latest
+    outputs:
+      skip_validate_tags: ${{ steps.changed-files.outputs.skip_validate_tags }}
+      namespaces: ${{ steps.changed-files.outputs.namespaces }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch origin "${{ github.base_ref }}"
+            CHANGED_FILES=$(git diff --name-only "origin/${{ github.base_ref }}...${{ github.sha }}")
+          else
+            CHANGED_FILES=""
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          TF_FILES=$(echo "$CHANGED_FILES" | grep -E '^namespaces/[^/]+/[^/]+/resources/[^/]+\.tf$' || true)
+
+          if [[ -z "$TF_FILES" ]]; then
+            echo "No matching Terraform files changed. Skipping tag validation."
+            echo "skip_validate_tags=true" >> "$GITHUB_OUTPUT"
+            echo 'namespaces=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          AFFECTED_NAMESPACES=$(echo "$TF_FILES" \
+            | sed -E 's#^(namespaces/[^/]+/[^/]+/resources)/[^/]+\.tf$#\1#' \
+            | sort -u)
+
+          EXISTING_NAMESPACES=""
+          while IFS= read -r ns; do
+            if [[ -d "$ns" ]]; then
+              EXISTING_NAMESPACES="${EXISTING_NAMESPACES}${ns}"$'\n'
+            fi
+          done <<< "$AFFECTED_NAMESPACES"
+
+          EXISTING_NAMESPACES=$(echo "$EXISTING_NAMESPACES" | sed '/^$/d' | sort -u)
+
+          if [[ -z "$EXISTING_NAMESPACES" ]]; then
+            echo "No relevant namespaces changed. Skipping tag validation."
+            echo "skip_validate_tags=true" >> "$GITHUB_OUTPUT"
+            echo 'namespaces=[]' >> "$GITHUB_OUTPUT"
+          else
+            NAMESPACES_JSON=$(echo "$EXISTING_NAMESPACES" | jq -R . | jq -s -c .)
+
+            echo "Namespaces to validate:"
+            echo "$EXISTING_NAMESPACES"
+
+            echo "skip_validate_tags=false" >> "$GITHUB_OUTPUT"
+            echo "namespaces=$NAMESPACES_JSON" >> "$GITHUB_OUTPUT"
+          fi
+  
+  validate-tags:
+    name: Tag Validation
+    needs: get-changed-files
+    if: ${{ needs.get-changed-files.outputs.skip_validate_tags != 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path: ${{ fromJson(needs.get-changed-files.outputs.namespaces) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # # Required if data blocks used in terraform configuration, for AWS read operations
+      # - name: Configure AWS Credentials
+      #   uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
+      #   with:
+      #     role-to-assume: "arn:aws:iam::111111111111:role/my-read-only-role"
+      #     role-session-name: "myrolesessionname"
+      #     aws-region: "eu-west-2"
+          
+      - name: Validate Tags
+        if: ${{ steps.changed-files.outputs.skip_tflint != 'true' }}
+        id: validate
+        uses: ministryofjustice/coat-tag-validator@37cca54b0e16536130d99bdf184cafd8bf2b71ae #v2.1.3
+        with:
+          terraform_directory:  ${{ matrix.path }}
+          soft_fail: false

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   get-changed-files:

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -90,7 +90,7 @@ jobs:
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           aws-region: "eu-west-2"
 
-      - name: Set mock terraform vars
+      - name: Set mock default terraform vars
         run: |
           echo "TF_VAR_vpc_name=XIHIUHIU-1" >> "$GITHUB_ENV"
           echo "TF_VAR_eks_cluster_name=XIHIUHIU" >> "$GITHUB_ENV"

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -84,10 +84,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
         with:
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-          aws-region: ${{ vars.ECR_REGION }}
+          aws-region: "eu-west-2"
 
       - name: Set mock terraform vars
         run: |

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -100,6 +100,10 @@ jobs:
           
       - name: Validate Tags
         if: ${{ steps.changed-files.outputs.skip_tflint != 'true' }}
+        env:
+          AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
+          AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+          AWS_DEFAULT_REGION: "eu-west-2"
         id: validate
         uses: ministryofjustice/coat-tag-validator@37cca54b0e16536130d99bdf184cafd8bf2b71ae #v2.1.3
         with:

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/github-community-dev/resources/variables.tf
@@ -11,7 +11,7 @@ variable "kubernetes_cluster" {
 variable "application" {
   description = "Name of the application you are deploying"
   type        = string
-  default     = "github-community"
+  default     = "github-community-dev"
 }
 
 variable "namespace" {


### PR DESCRIPTION
- An example of how to integrate the coat tag validator tool (https://github.com/ministryofjustice/coat-tag-validator) into the cloud-platform-environments repository, to enable validation of terraform tags for namespaces pre-deployment.
- A terraform plan AWS role is required to successfully run the plan: https://github.com/ministryofjustice/cloud-platform-environments/actions/runs/25671525262/job/75357828198#step:4:350