### PR TITLE
DSTEW-1525 expose claims events SNS topic ARN via SSM (staging)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-staging/resources/sns.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-staging/resources/sns.tf
@@ -32,6 +32,24 @@ resource "kubernetes_secret" "claims_events_sns_topic" {
   }
 }
 
+# Writes the topic ARN to SSM so other namespaces (e.g. laa-data-claims-notify-service-*)
+# can subscribe via `data "aws_ssm_parameter"`. Matches the repo-wide /${namespace}/topic-arn convention.
+resource "aws_ssm_parameter" "claims_events_sns_topic_arn" {
+  type        = "String"
+  name        = "/${var.namespace}/topic-arn"
+  value       = module.claims_events_sns_topic.topic_arn
+  description = "Claims events SNS topic ARN"
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    owner                  = var.team_name
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
 ###
 ########### SNS subscriptions ###########
 ###


### PR DESCRIPTION
- Writes the `laa-data-claims-api-staging` claims events SNS topic ARN to SSM at `/laa-data-claims-api-staging/topic-arn`
- Enables cross-namespace consumption of the topic ARN via `data "aws_ssm_parameter"` 
- required by `laa-data-claims-notify-service-staging` so its SNS to SQS subscription and queue policy can reference the topic ARN. 