### PR TITLE
DSTEW-1524: Add SQS, IRSA and SNS subscription to laa-data-claims-notify-service-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/05-prometheus-custom-rules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/05-prometheus-custom-rules.yaml
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-data-claims-notify-service-uat
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-laa-data-claims-notify-service-uat
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: NamespaceDown
+      expr: absent(up{namespace="laa-data-claims-notify-service-uat"}) == 1
+      for: 1m
+      labels:
+        severity: laa-data-claims-notify-service-uat
+      annotations:
+        message: Namespace laa-data-claims-notify-service-uat is down.
+        runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/WHCZA/pages/5829263558/Runbook+Data+Claims
+
+    - alert: KubeLowPodCount
+      expr: sum (kube_pod_status_phase{namespace="laa-data-claims-notify-service-uat", phase="Running"}) < 1
+      labels:
+        severity: laa-data-claims-notify-service-uat
+      annotations:
+        message: Namespace laa-data-claims-notify-service-uat has fewer than expected number of running pods.
+        runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/WHCZA/pages/5829263558/Runbook+Data+Claims
+
+    - alert: KubeQuotaExceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-data-claims-notify-service-uat"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-data-claims-notify-service-uat"} > 0) > 90
+      for: 1m
+      labels:
+        severity: laa-data-claims-notify-service-uat
+      annotations:
+        message: Namespace laa-data-claims-notify-service-uat is using more than 90% of its allocated resources.
+        runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/WHCZA/pages/5829263558/Runbook+Data+Claims

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/irsa.tf
@@ -1,0 +1,39 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name = var.eks_cluster_name
+
+  service_account_name = var.irsa_serviceaccount_name
+  namespace            = var.namespace
+
+  role_policy_arns = {
+    notify_queue = module.notify_queue.irsa_policy_arn
+    notify_dlq   = module.notify_dlq.irsa_policy_arn
+  }
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "${var.namespace}-irsa"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+    rolearn        = module.irsa.role_arn
+  }
+}
+
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.1"
+
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/sqs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/sqs.tf
@@ -1,0 +1,106 @@
+# Claims events SNS topic ARN, exported by laa-data-claims-api-uat.
+data "aws_ssm_parameter" "claims_sns_topic_arn" {
+  name = "/${var.producer_namespace}/topic-arn"
+}
+
+module "notify_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name                  = "claims-notify-queue"
+  encrypt_sqs_kms           = true
+  message_retention_seconds = 1209600
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.notify_dlq.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "notify_dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name        = "claims-notify-queue-dlq"
+  encrypt_sqs_kms = true
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+# Only the claims events SNS topic may send to the notify queue.
+data "aws_iam_policy_document" "notify_queue" {
+  statement {
+    effect    = "Allow"
+    actions   = ["sqs:SendMessage"]
+    resources = [module.notify_queue.sqs_arn]
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [data.aws_ssm_parameter.claims_sns_topic_arn.value]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "notify_queue" {
+  queue_url = module.notify_queue.sqs_id
+  policy    = data.aws_iam_policy_document.notify_queue.json
+}
+
+resource "aws_sns_topic_subscription" "notify" {
+  provider  = aws.london
+  topic_arn = data.aws_ssm_parameter.claims_sns_topic_arn.value
+  protocol  = "sqs"
+  endpoint  = module.notify_queue.sqs_arn
+
+  filter_policy = jsonencode({
+    SubmissionEventType = ["SUBMISSION_VALIDATION_SUCCEEDED"]
+  })
+}
+
+resource "kubernetes_secret" "notify_queue" {
+  metadata {
+    name      = "sqs-claims-notify-queue-secret"
+    namespace = var.namespace
+  }
+  data = {
+    sqs_queue_url  = module.notify_queue.sqs_id
+    sqs_queue_arn  = module.notify_queue.sqs_arn
+    sqs_queue_name = module.notify_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "notify_dlq" {
+  metadata {
+    name      = "sqs-claims-notify-queue-dlq-secret"
+    namespace = var.namespace
+  }
+  data = {
+    sqs_queue_url  = module.notify_dlq.sqs_id
+    sqs_queue_arn  = module.notify_dlq.sqs_arn
+    sqs_queue_name = module.notify_dlq.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/variables.tf
@@ -83,3 +83,15 @@ variable "serviceaccount_name" {
   description = "Name of the service account used by GitHub Actions to deploy the applications to cloud-platform"
   default     = "claims-notify-service-uat-service-account"
 }
+
+variable "irsa_serviceaccount_name" {
+  type        = string
+  description = "Name of the service account used by application pods (IRSA)"
+  default     = "claims-notify-service-uat-irsa-serviceaccount"
+}
+
+variable "producer_namespace" {
+  type        = string
+  description = "Namespace that owns the claims events SNS topic"
+  default     = "laa-data-claims-api-uat"
+}


### PR DESCRIPTION
 - Provisions the SQS infrastructure for `laa-data-claims-notify-service-uat`
 -  This is used to receive claims events from the `laa-data-claims-api-uat` SNS topic.
 - Adds IRSA so notify-service pods can read from the queue.