### PR TITLE
chore: Trigger secrets recreation for reuse-library-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/resources/serviceaccount.tf
@@ -10,5 +10,5 @@ module "serviceaccount" {
   github_actions_secret_kube_cert      = "DEV_KUBE_CERT"
   github_actions_secret_kube_token     = "DEV_KUBE_TOKEN"
 
-  serviceaccount_token_rotated_date = "30-04-2026"
+  serviceaccount_token_rotated_date = "12-05-2026"
 }


### PR DESCRIPTION
## Description

Rotate GitHub Actions secrets for reuse-library-dev namespace by updating the service account token rotation date.

## Changes

- Updated `serviceaccount_token_rotated_date` in [reuse-library-dev/resources/serviceaccount.tf](reuse-library-dev/resources/serviceaccount.tf) from `30-04-2026` to `12-05-2026`

## Why

This triggers Terraform to regenerate the Kubernetes service account token and republish the GitHub Actions secrets (`DEV_KUBE_NAMESPACE`, `DEV_KUBE_CERT`, `DEV_KUBE_TOKEN`) to the `gov-reuse` GitHub repository.

## Testing

The Terraform plan and apply should show the service account resource being updated, which will regenerate and sync the credentials to GitHub Actions secrets.

## Related

- Repository: `ministryofjustice/gov-reuse`
- Namespace: `reuse-library-dev`