### PR TITLE
Add RDS SQL Server infrastructure for prod data pipeline (Phase 1)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/iam.tf
@@ -1,0 +1,47 @@
+resource "aws_iam_role" "sqlserver_backup_s3_iam_role" {
+  name = "hmpps-acp-${var.environment}-sqlserver-backup-s3-iam-role"
+  path = "/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "rds.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "sqlserver_backup_s3_iam_role_policy" {
+  name = "hmpps-acp-${var.environment}-sqlserver-backup-s3-iam-role-policy"
+  role = aws_iam_role.sqlserver_backup_s3_iam_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ],
+        Resource = module.sqlserver_backup_s3_bucket.bucket_arn
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListMultipartUploadParts",
+          "s3:AbortMultipartUpload"
+        ],
+        Resource = "${module.sqlserver_backup_s3_bucket.bucket_arn}/*"
+      }
+    ]
+  })
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/irsa.tf
@@ -49,3 +49,27 @@ data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
   for_each = local.sqs_queues
   name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
 }
+
+module "irsa-sqlserver" {
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+  eks_cluster_name     = var.eks_cluster_name
+  service_account_name = "irsa-sqlserver"
+  namespace            = var.namespace
+
+  role_policy_arns = merge(
+    {
+      sqlserver = module.sqlserver.irsa_policy_arn
+    },
+    {
+      # db-restore job needs to list the backup bucket to discover the latest .bak file
+      sqlserver_backup_s3_bucket_policy = module.sqlserver_backup_s3_bucket.irsa_policy_arn
+    }
+  )
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/rds-sqlserver.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/rds-sqlserver.tf
@@ -1,0 +1,83 @@
+module "sqlserver" {
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+  application                = var.application
+  business_unit              = var.business_unit
+  db_allocated_storage       = var.db_allocated_storage
+  db_engine                  = var.db_engine
+  db_engine_version          = var.db_engine_version
+  db_instance_class          = var.db_instance_class
+  db_name                    = var.db_name
+  db_backup_retention_period = var.db_backup_retention_period
+  enable_rds_auto_start_stop = false
+  environment_name           = var.environment-name
+  infrastructure_support     = var.infrastructure_support
+  is_production              = var.is_production
+  license_model              = "license-included"
+  namespace                  = var.namespace
+  option_group_name          = aws_db_option_group.sqlserver_backup_rds_option_group.name
+  rds_family                 = var.db_rds_family
+  storage_type               = var.db_storage_type
+  team_name                  = var.team_name
+  vpc_name                   = var.vpc_name
+  character_set_name         = var.character_set_name
+
+
+  enable_irsa = true
+
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = var.force_ssl_value
+      apply_method = var.force_ssl_apply_method
+    }
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "sqlserver" {
+  metadata {
+    name      = "rds-sqlserver-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.sqlserver.rds_instance_endpoint
+    database_identifier   = module.sqlserver.db_identifier
+    database_name         = var.db_name
+    database_password     = module.sqlserver.database_password
+    database_username     = module.sqlserver.database_username
+    rds_instance_address  = module.sqlserver.rds_instance_address
+  }
+}
+
+resource "aws_db_option_group" "sqlserver_backup_rds_option_group" {
+  name                     = "hmpps-acp-${var.environment}-sqlserver-backup"
+  option_group_description = "Enable SQL Server Backup/Restore"
+  engine_name              = var.db_engine
+  major_engine_version     = join(".", slice(split(".", var.db_engine_version), 0, 2))
+
+  option {
+    option_name = "SQLSERVER_BACKUP_RESTORE"
+
+    option_settings {
+      name  = "IAM_ROLE_ARN"
+      value = aws_iam_role.sqlserver_backup_s3_iam_role.arn
+    }
+  }
+}
+
+resource "kubernetes_config_map" "sqlserver_restore_config_map" {
+  metadata {
+    name      = "rds-sqlserver-restore-config-map"
+    namespace = var.namespace
+  }
+
+  data = {
+    create_snapshot = var.sqlserver_restore_create_snapshot
+    db_port         = module.sqlserver.rds_instance_port
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/s3.tf
@@ -1,3 +1,4 @@
+# Existing S3 bucket — kept as-is, do not modify.
 module "s3_bucket" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
 
@@ -33,5 +34,50 @@ resource "kubernetes_secret" "s3_bucket" {
   data = {
     bucket_arn  = module.s3_bucket.bucket_arn
     bucket_name = module.s3_bucket.bucket_name
+  }
+}
+
+# New dedicated S3 bucket for SQL Server backup/restore pipeline.
+# Separate from the existing s3_bucket to avoid any disruption.
+module "sqlserver_backup_s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  # Expire old .bak files after 14 days — the DB restore only ever uses the latest file.
+  # Files accumulate at ~32GB/day so this keeps storage costs bounded.
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "expire-old-backups"
+
+      expiration = [
+        {
+          days = 14
+        },
+      ]
+    },
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "sqlserver_backup_s3_bucket" {
+  metadata {
+    name      = "sqlserver-backup-s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.sqlserver_backup_s3_bucket.bucket_arn
+    bucket_name = module.sqlserver_backup_s3_bucket.bucket_name
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
@@ -80,3 +80,75 @@ variable "eks_cluster_name" {
 variable "number_cache_clusters" {
   default = "2"
 }
+
+variable "db_allocated_storage" {
+  description = "The allocated storage for the RDS instance"
+  type        = number
+  default     = 600
+}
+
+variable "db_engine" {
+  description = "The DB engine to use for the RDS instance"
+  type        = string
+  default     = "sqlserver-web"
+}
+
+variable "db_engine_version" {
+  description = "The DB engine version for the RDS instance"
+  type        = string
+  default     = "15.00.4345.5.v1"
+}
+
+variable "db_instance_class" {
+  description = "The DB instance class for the RDS instance"
+  type        = string
+  default     = "db.m5.large"
+}
+
+variable "db_name" {
+  description = "The name of the DB"
+  type        = string
+  default     = "hmpps-manage-and-deliver-acp-prod-mssql"
+}
+
+variable "db_rds_family" {
+  description = "The RDS family for the RDS instance"
+  type        = string
+  default     = "sqlserver-web-15.0"
+}
+
+variable "db_storage_type" {
+  description = "The storage type for the RDS instance"
+  type        = string
+  default     = "gp2"
+}
+
+variable "character_set_name" {
+  description = "The character set name for the RDS instance"
+  type        = string
+  default     = null
+}
+
+variable "force_ssl_apply_method" {
+  description = "The apply method for force SSL"
+  type        = string
+  default     = "pending-reboot"
+}
+
+variable "force_ssl_value" {
+  description = "The value to set for forcing SSL"
+  type        = number
+  default     = 1
+}
+
+variable "sqlserver_restore_create_snapshot" {
+  description = "Boolean to declare whether or not a snapshot should be taken before the sqlserver restore"
+  type        = bool
+  default     = false
+}
+
+variable "db_backup_retention_period" {
+  description = "Number of days to retain automated backups"
+  type        = string
+  default     = "7"
+}


### PR DESCRIPTION
## Add RDS SQL Server infrastructure for prod data pipeline (Phase 1)

### What

Adds the foundational infrastructure required to restore IM .bak backups into a production RDS SQL Server instance. This mirrors the existing preprod setup with production-appropriate settings.

### Changes

**New files:**
- `rds-sqlserver.tf` — RDS SQL Server instance (`enable_rds_auto_start_stop=false`), option group with `SQLSERVER_BACKUP_RESTORE`, ConfigMap, and K8s secrets
- `iam.tf` — IAM role allowing RDS to read/write to the new backup S3 bucket

**Modified files:**
- `s3.tf` — Added new `sqlserver_backup_s3_bucket` module (dedicated bucket for .bak files, 14-day lifecycle). Existing `s3_bucket` module