### PR TITLE
LGA-4020: add access to CFE networkpolicy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/04-networkpolicy.yaml
@@ -67,3 +67,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               cloud-platform.justice.gov.uk/namespace: laa-cla-backend-production
+        - namespaceSelector:
+            matchLabels:
+              cloud-platform.justice.gov.uk/namespace: laa-access-civil-legal-aid-production


### PR DESCRIPTION
Due to the ongoing migration of endpoints from `cla_backend` to `access-civil-legal-aid`, we are updating the service to call CFE via its internal cluster DNS address, rather than external URLs. 
