### PR TITLE
Add cross-namespace read access to preprod backup S3 bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/iam.tf
@@ -29,7 +29,11 @@ resource "aws_iam_role_policy" "sqlserver_backup_s3_iam_role_policy" {
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ],
-        Resource = module.sqlserver_backup_s3_bucket.bucket_arn
+        Resource = [
+          module.sqlserver_backup_s3_bucket.bucket_arn,
+          # Preprod backup bucket — allows RDS to restore directly from preprod .bak files
+          var.preprod_backup_bucket_arn
+        ]
       },
       {
         Effect = "Allow",
@@ -40,6 +44,41 @@ resource "aws_iam_role_policy" "sqlserver_backup_s3_iam_role_policy" {
           "s3:AbortMultipartUpload"
         ],
         Resource = "${module.sqlserver_backup_s3_bucket.bucket_arn}/*"
+      },
+      {
+        # Read-only access to preprod bucket (no write needed)
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject"
+        ],
+        Resource = "${var.preprod_backup_bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+# IAM policy for the irsa-sqlserver service account to read preprod's backup bucket.
+# This allows the find-backup-file init container to list/discover .bak files in preprod.
+resource "aws_iam_policy" "preprod_backup_s3_read" {
+  name = "hmpps-acp-${var.environment}-preprod-backup-s3-read"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ],
+        Resource = var.preprod_backup_bucket_arn
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject"
+        ],
+        Resource = "${var.preprod_backup_bucket_arn}/*"
       }
     ]
   })

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/irsa.tf
@@ -63,6 +63,10 @@ module "irsa-sqlserver" {
     {
       # db-restore job needs to list the backup bucket to discover the latest .bak file
       sqlserver_backup_s3_bucket_policy = module.sqlserver_backup_s3_bucket.irsa_policy_arn
+    },
+    {
+      # Cross-namespace: read preprod backup bucket for initial data load and Phase 2 copy
+      preprod_backup_s3_read = aws_iam_policy.preprod_backup_s3_read.arn
     }
   )
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
@@ -152,3 +152,9 @@ variable "db_backup_retention_period" {
   type        = string
   default     = "7"
 }
+
+variable "preprod_backup_bucket_arn" {
+  description = "ARN of the preprod SQL Server backup S3 bucket (cross-namespace read access for Phase 2 copy)"
+  type        = string
+  default     = "arn:aws:s3:::cloud-platform-421f9ae70e6559d242c61fe413ef46a4"
+}


### PR DESCRIPTION
Grants the prod RDS IAM role and irsa-sqlserver service account read-only access to the preprod SQL Server backup bucket. This enables:
- RDS to restore .bak files directly from preprod bucket (rds_restore_database)
- The find-backup-file init container to list/discover .bak files in preprod

Changes:
- iam.tf: Added preprod bucket to RDS role (read-only for preprod, full read/write for prod). Created aws_iam_policy.preprod_backup_s3_read.
- irsa.tf: Attached preprod_backup_s3_read policy to irsa-sqlserver module.
- variables.tf: Added preprod_backup_bucket_arn variable.

Jira: APG-2245