### PR TITLE
Apg 2245/preprod allow prod read bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/s3.tf
@@ -179,3 +179,37 @@ resource "kubernetes_secret" "sqlserver_backup_s3_bucket" {
     bucket_name = module.sqlserver_backup_s3_bucket.bucket_name
   }
 }
+
+# Allow prod namespace roles to read .bak files from this bucket.
+# Prod's RDS IAM role uses rds_restore_database to pull directly from S3.
+# Prod's IRSA role (irsa-sqlserver) lists/discovers the latest .bak file.
+resource "aws_s3_bucket_policy" "sqlserver_backup_allow_prod_read" {
+  bucket = module.sqlserver_backup_s3_bucket.bucket_name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowProdRDSAndIRSARead",
+        Effect = "Allow",
+        Principal = {
+          AWS = [
+            # Prod RDS IAM role (used by rds_restore_database)
+            var.prod_rds_iam_role_arn,
+            # Prod IRSA role (used by irsa-sqlserver service account)
+            var.prod_irsa_sqlserver_role_arn
+          ]
+        },
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ],
+        Resource = [
+          module.sqlserver_backup_s3_bucket.bucket_arn,
+          "${module.sqlserver_backup_s3_bucket.bucket_arn}/*"
+        ]
+      }
+    ]
+  })
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/variables.tf
@@ -160,3 +160,15 @@ variable "db_backup_retention_period" {
   type        = string
   default     = "0"
 }
+
+variable "prod_rds_iam_role_arn" {
+  description = "ARN of the prod RDS IAM role that needs read access to this bucket for rds_restore_database"
+  type        = string
+  default     = "arn:aws:iam::754256621582:role/hmpps-acp-prod-sqlserver-backup-s3-iam-role"
+}
+
+variable "prod_irsa_sqlserver_role_arn" {
+  description = "ARN of the prod irsa-sqlserver IRSA role that needs read access to list/discover .bak files"
+  type        = string
+  default     = "arn:aws:iam::754256621582:role/cloud-platform-irsa-f5e19b28e8b34753-live"
+}


### PR DESCRIPTION
Add bucket policy allowing prod roles to read preprod backup S3 bucket

Adds an S3 bucket policy on the preprod sqlserver_backup_s3_bucket
granting read-only access to prod's RDS IAM role and IRSA role. This
enables the prod RDS instance to restore .bak files directly from the
preprod bucket using rds_restore_database, and the prod irsa-sqlserver
service account to list/discover available backup files.

Changes:
- s3.tf: Added aws_s3_bucket_policy.sqlserver_backup_allow_prod_read
  with GetObject, ListBucket, GetBucketLocation permissions.
- variables.tf: Added prod_rds_iam_role_arn and
  prod_irsa_sqlserver_role_arn variables.

Jira: APG-2245

