### PR TITLE
Add resources for `chaps-dotnet-production` namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chaps-dotnet-production
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-chaps"
+    cloud-platform.justice.gov.uk/application: "CHAPS"
+    cloud-platform.justice.gov.uk/owner: "CDPT: chaps-support@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/chapsdotnet"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/00-namespace.yaml
@@ -11,6 +11,6 @@ metadata:
     cloud-platform.justice.gov.uk/slack-channel: "cdpt-chaps"
     cloud-platform.justice.gov.uk/application: "CHAPS"
     cloud-platform.justice.gov.uk/owner: "CDPT: chaps-support@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/chapsdotnet"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/chaps"
     cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/01-rbac.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: chaps-dotnet-production-admin
+  namespace: chaps-dotnet-production
+subjects:
+  - kind: Group
+    name: "github:dotnet"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: chaps-dotnet-production
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 500m
+      memory: 500Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: chaps-dotnet-production
+spec:
+  hard:
+    pods: "12"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: chaps-dotnet-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: chaps-dotnet-production
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/ecr.tf
@@ -1,0 +1,29 @@
+module "ecr" {
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+  repo_name = "${var.namespace}-ecr"
+
+  # OIDC configuration
+  oidc_providers      = ["github"]
+  github_repositories = ["chaps"]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "ecr_credentials" {
+  metadata {
+    name      = "ecr-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_arn = module.ecr.repo_arn
+    repo_url = module.ecr.repo_url
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/irsa.tf
@@ -1,0 +1,23 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "${var.namespace}-service-account"
+  namespace            = var.namespace # this is also used as a tag
+
+  # Attach the approprate policies using a key => value map
+  # If you're using Cloud Platform provided modules (e.g. SNS, S3), 
+  # these provide an output called `irsa_policy_arn` that can be used.
+  role_policy_arns = {}
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      GithubTeam = "central-digital-product-team"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/pingdom.tf
@@ -1,0 +1,21 @@
+/*provider "pingdom" {
+}*/
+
+# Integration IDs
+# 96624 = #dps_alerts
+
+/*resource "pingdom_check" "chaps-production-aliveness-check" {
+  type                     = "http"
+  name                     = "Central Digital - CHAPS .NET8 Production"
+  host                     = "service-standards-assurance.justice.gov.uk"
+  resolution               = 1
+  notifywhenbackup         = true
+  sendnotificationwhendown = 6
+  notifyagainevery         = 0
+  url                      = "/"
+  encryption               = true
+  port                     = 443
+  tags                     = "hq,central-digital,cloudplatform-managed,cdpt"
+  probefilters             = "region:EU"
+  #integrationids           = []
+}*/

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/rds.tf
@@ -1,0 +1,155 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+*/
+module "rds_mssql" {
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+  storage_type = "gp3"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  performance_insights_enabled = true
+  db_max_allocated_storage     = "1000"
+
+  # SQL Server specifics
+  db_engine            = "sqlserver-web"
+  db_engine_version    = "14.00.3381.3.v1"
+  rds_family           = "sqlserver-web-14.0"
+  db_instance_class    = "db.t3.2xlarge"
+  db_allocated_storage = 32 # minimum of 20GiB for SQL Server
+  option_group_name    = aws_db_option_group.sqlserver_backup_restore.name
+  enable_irsa          = true
+  deletion_protection  = true
+
+  # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
+  # You will need to specify "pending-reboot" here, as default is set to "immediate".
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+
+  ]
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+resource "kubernetes_secret" "rds_mssql" {
+  metadata {
+    name      = "rds-mssql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_username = module.rds_mssql.database_username
+    database_password = module.rds_mssql.database_password
+  }
+}
+
+resource "kubernetes_config_map" "rds_mssql" {
+  metadata {
+    name      = "rds-mssql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds_mssql.rds_instance_endpoint
+    rds_instance_address  = module.rds_mssql.rds_instance_address
+  }
+}
+
+resource "aws_db_option_group" "sqlserver_backup_restore" {
+  name                 = "${var.namespace}-sqlserver-14-backup-restore"
+  engine_name          = "sqlserver-web"
+  major_engine_version = "14.00"
+
+  option {
+    option_name = "SQLSERVER_BACKUP_RESTORE"
+    option_settings {
+      name = "IAM_ROLE_ARN"
+      value  = aws_iam_role.rds_s3_backup_restore.arn
+    }
+  }
+}
+
+variable "backup_bucket" { 
+  type = string 
+  default = "tp-dbbackups"
+  description = "S3 bucket that stores SQL Server .bak files" 
+}        
+
+variable "backup_prefix" { 
+  type = string 
+  default = "chaps-dev/"
+  description = "Key prefix within the backup bucket" 
+} 
+
+
+resource "aws_iam_role" "rds_s3_backup_restore" {
+  name = "${var.namespace}-rds-s3-backup-restore"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = { Service = "rds.amazonaws.com" },
+      Action   = "sts:AssumeRole"
+    }]
+  })
+}
+
+
+locals {
+  bucket_arn         = format("arn:aws:s3:::%s", var.backup_bucket)
+  objects_prefix_arn = format("arn:aws:s3:::%s/%s*", var.backup_bucket, var.backup_prefix)
+}
+
+
+# Least-privilege inline policy: list bucket + R/W objects in the prefix
+resource "aws_iam_role_policy" "rds_s3_backup_restore" {
+  name = "${var.namespace}-rds-s3-backup-restore"
+  role = aws_iam_role.rds_s3_backup_restore.id
+
+  policy = jsonencode({
+    Version   = "2012-10-17",
+    Statement = [
+      {
+        Sid      = "BucketLocation"
+        Effect   = "Allow"
+        Action   = ["s3:GetBucketLocation"]
+        Resource = local.bucket_arn
+      },
+      {
+        Sid             = "ListBucket"
+        Effect          = "Allow"
+        Action          = ["s3:ListBucket"]
+        Resource        = local.bucket_arn
+        Condition       = {
+          StringLike    = { 
+            "s3:prefix" = [
+              format("%s*", var.backup_prefix), 
+              var.backup_prefix
+            ]
+          }
+        }
+      },
+      {
+        Sid      = "RWPrefix",
+        Effect   = "Allow",
+        Action   = ["s3:GetObject","s3:PutObject","s3:DeleteObject"]
+        Resource = local.objects_prefix_arn
+      }
+    ]
+  })
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "chaps_route53_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.github_owner
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "chaps_route53_zone_sec" {
+  metadata {
+    name      = "chaps-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id = aws_route53_zone.chaps_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.chaps_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/serviceaccount.tf
@@ -1,0 +1,13 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace            = var.namespace
+  kubernetes_cluster   = var.kubernetes_cluster
+  serviceaccount_rules = var.service_account_rules
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["chaps"]
+  github_environments = [var.environment]
+  serviceaccount_token_rotated_date = "14-05-2026"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/variables.tf
@@ -1,0 +1,119 @@
+variable "vpc_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Correspondence Handling and Processing System"
+}
+
+variable "namespace" {
+  default = "chaps-dotnet-production"
+}
+
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HQ"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "central-digital-product-team"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "production"
+}
+
+variable "domain" {
+  description = "The domain name to use for the Route53 zone."
+  default = "correspondence-handling-and-processing.service.justice.gov.uk"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "chaps-support@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "true"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "cdpt-chaps"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}
+
+variable "service_account_rules" {
+  description = "The capabilities of this service account"
+
+  type = list(object({
+    api_groups = list(string),
+    resources  = list(string),
+    verbs      = list(string)
+  }))
+
+  # These values are usually sufficient for a CI/CD pipeline
+  default = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+        "certificates"
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "delete",
+        "list",
+        "watch",
+        "update",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "networking.k8s.io",
+        "cert-manager.io"
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "certificates"
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    /*pingdom = {
+      source  = "DrFaust92/pingdom"
+      version = "~> 1.3.1"
+    }*/
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces the initial setup for the `chaps-dotnet-production` namespace in the Cloud Platform, including all foundational Kubernetes and AWS infrastructure required for the CHAPS .NET production environment. The changes create the namespace, configure security and resource policies, set up AWS resources such as ECR, RDS, and Route53, and provide the necessary Terraform configuration and variables for managing this environment.

The most important changes are:

**Kubernetes Namespace and Policies**
* Created the `chaps-dotnet-production` namespace with production labels, annotations for ownership, and pod security enforcement.
* Added RBAC `RoleBinding` for `github:dotnet` and `github:central-digital-product-team` groups with `admin` privileges.
* Enforced resource limits with a `LimitRange` and restricted total pods with a `ResourceQuota`. [[1]](diffhunk://#diff-6e56272a6c2c40b7f2a06534086b48c4372e58f04272ae21977cd1efc6b61de2R1-R14) [[2]](diffhunk://#diff-3ec3586e8409b782b68f850fa9289c2740639fcf0d218827dcfea57ce7d98829R1-R8)
* Defined default and ingress-specific `NetworkPolicy` resources to control network access.

**AWS Infrastructure (Terraform)**
* Provisioned an ECR repository with OIDC authentication and stored credentials as a Kubernetes secret.
* Set up an RDS SQL Server instance with S3 backup/restore permissions, outputting credentials and endpoints as Kubernetes secrets/configmaps.
* Created a Route53 DNS zone for the service, exposing zone details as a Kubernetes secret.
* Added IRSA and service account modules for secure AWS access from Kubernetes workloads. [[1]](diffhunk://#diff-ffd1e9806071aa363643c3b28e2528205b91b8c16bfc595ed26a7bcc76453636R1-R23) [[2]](diffhunk://#diff-37f2db7effe93dd3826c166bfb228727899328f35c298c937ebb4bddd52f7c31R1-R13)

**Terraform Configuration**
* Introduced provider configuration for AWS (London/Ireland), GitHub, and (commented) Pingdom, including required versions for all providers. [[1]](diffhunk://#diff-8f873aabd9354a73ddf6d7ad44890b0414ef228a6b030bc12cd648b6f30defddR1-R26) [[2]](diffhunk://#diff-60f2bb00dc2285f3ea7cfd59f5bd3b918a30f6cbca2f7e99c05b43243fcd415fR1-R21) [[3]](diffhunk://#diff-3a116c4e31bf52a105a46a063c6696b14865ff7970c3e7991b64412e547a65f6R1-R21)

**Variables and Defaults**
* Defined all required variables for the environment, including VPC, cluster, application metadata, team info, GitHub integration, and service account RBAC rules.