### PR TITLE
Add daily db-restore CronJob for prod (reads from preprod backup bucket)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/db_restore.yaml
@@ -1,0 +1,374 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-restore-cronjob
+  namespace: hmpps-manage-and-deliver-accredited-programmes-prod
+spec:
+  # Run daily at 06:30 UTC — after preprod's restore completes (05:45 + ~8min).
+  # Uses the same .bak file from preprod's backup bucket.
+  schedule: "30 6 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 5400  # 90 minutes
+      template:
+        spec:
+          serviceAccountName: irsa-sqlserver
+          restartPolicy: OnFailure
+          volumes:
+            - name: backup-info
+              emptyDir: {}
+          initContainers:
+            - name: create-rds-snapshot
+              image: public.ecr.aws/aws-cli/aws-cli:2.15.15
+              securityContext:
+                runAsUser: 1000
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: DATABASE_IDENTIFIER
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-sqlserver-instance-output
+                      key: database_identifier
+                - name: CREATE_SNAPSHOT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: rds-sqlserver-restore-config-map
+                      key: create_snapshot
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+
+                  if [ "${CREATE_SNAPSHOT}" != "true" ]; then
+                    echo "create_snapshot=${CREATE_SNAPSHOT}; skipping RDS snapshot"
+                    exit 0
+                  fi
+
+                  if [ -z "${DATABASE_IDENTIFIER}" ]; then
+                    echo "DATABASE_IDENTIFIER is empty"
+                    exit 1
+                  fi
+
+                  TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+                  SNAPSHOT_ID="${DATABASE_IDENTIFIER}-${TIMESTAMP}"
+
+                  echo "Creating snapshot: ${SNAPSHOT_ID}"
+
+                  aws rds create-db-snapshot \
+                    --db-instance-identifier "${DATABASE_IDENTIFIER}" \
+                    --db-snapshot-identifier "${SNAPSHOT_ID}"
+
+                  echo "Waiting for snapshot to become available..."
+
+                  aws rds wait db-snapshot-available \
+                    --db-snapshot-identifier "${SNAPSHOT_ID}"
+
+                  echo "Snapshot ${SNAPSHOT_ID} is available."
+
+            - name: find-backup-file
+              image: public.ecr.aws/aws-cli/aws-cli:2.15.15
+              securityContext:
+                runAsUser: 1000
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: backup-info
+                  mountPath: /backup-info
+              env:
+                - name: HOME
+                  value: /tmp
+                # Reads from preprod backup bucket — prod has cross-namespace read access
+                - name: SQLSERVER_BACKUP_S3_BUCKET_NAME
+                  value: "cloud-platform-421f9ae70e6559d242c61fe413ef46a4"
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+
+                  echo "Searching for latest backup in s3://${SQLSERVER_BACKUP_S3_BUCKET_NAME}/"
+
+                  BACKUP_KEY=$(aws s3 ls "s3://${SQLSERVER_BACKUP_S3_BUCKET_NAME}/" \
+                    --recursive \
+                    | awk '{print $4}' \
+                    | grep '\.bak$' \
+                    | sort \
+                    | tail -1)
+
+                  if [ -z "${BACKUP_KEY}" ]; then
+                    echo "No backup file found in s3://${SQLSERVER_BACKUP_S3_BUCKET_NAME}/"
+                    exit 1
+                  fi
+
+                  echo "Found backup file: ${BACKUP_KEY}"
+                  echo "${BACKUP_KEY}" > /backup-info/backup-key
+
+            - name: port-forward
+              image: ministryofjustice/port-forward
+              restartPolicy: Always
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+              ports:
+                - containerPort: 1433
+              env:
+                - name: REMOTE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-sqlserver-instance-output
+                      key: rds_instance_address
+                - name: LOCAL_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: rds-sqlserver-restore-config-map
+                      key: db_port
+                - name: REMOTE_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: rds-sqlserver-restore-config-map
+                      key: db_port
+          containers:
+            - name: db-restore
+              image: mcr.microsoft.com/mssql/server:2019-CU31-ubuntu-20.04
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                runAsUser: 10001
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: backup-info
+                  mountPath: /backup-info
+              env:
+                - name: DB_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: rds-sqlserver-restore-config-map
+                      key: db_port
+                - name: DATABASE_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-sqlserver-instance-output
+                      key: database_name
+                - name: DATABASE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-sqlserver-instance-output
+                      key: database_username
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rds-sqlserver-instance-output
+                      key: database_password
+                # Reads from preprod backup bucket — prod has cross-namespace read access
+                - name: SQLSERVER_BACKUP_S3_BUCKET_NAME
+                  value: "cloud-platform-421f9ae70e6559d242c61fe413ef46a4"
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+
+                  # Locate sqlcmd binary
+                  SQLCMD=/opt/mssql-tools18/bin/sqlcmd
+                  if [ ! -f "${SQLCMD}" ]; then
+                    SQLCMD=/opt/mssql-tools/bin/sqlcmd
+                  fi
+
+                  BACKUP_KEY=$(cat /backup-info/backup-key)
+                  if [ -z "${BACKUP_KEY}" ]; then
+                    echo "ERROR: /backup-info/backup-key is empty — find-backup-file init container may have failed"
+                    exit 1
+                  fi
+                  BACKUP_S3_ARN="arn:aws:s3:::${SQLSERVER_BACKUP_S3_BUCKET_NAME}/${BACKUP_KEY}"
+
+                  echo "Starting restore at $(date)"
+                  echo "Source : ${BACKUP_S3_ARN}"
+                  echo "Target : ${DATABASE_NAME}"
+
+                  # Wait for the port-forward sidecar to be ready
+                  echo "Waiting for SQL Server to be reachable via port-forward..."
+                  RETRIES=0
+                  until "${SQLCMD}" \
+                      -S "localhost,${DB_PORT}" \
+                      -U "${DATABASE_USERNAME}" \
+                      -P "${DATABASE_PASSWORD}" \
+                      -C -Q "SELECT 1" > /dev/null 2>&1; do
+                    RETRIES=$((RETRIES + 1))
+                    if [ "${RETRIES}" -ge 30 ]; then
+                      echo "Timed out waiting for SQL Server after $((RETRIES * 10))s"
+                      exit 1
+                    fi
+                    echo "  attempt ${RETRIES}/30 — retrying in 10s..."
+                    sleep 10
+                  done
+                  echo "SQL Server reachable."
+
+                  # Cancel any in-progress or created restore tasks for this DB.
+                  echo "Checking for stuck restore tasks to cancel..."
+                  STUCK_TASKS=$("${SQLCMD}" \
+                    -S "localhost,${DB_PORT}" \
+                    -U "${DATABASE_USERNAME}" \
+                    -P "${DATABASE_PASSWORD}" \
+                    -h -1 -W \
+                    -C -Q "SELECT task_id FROM msdb.dbo.rds_fn_task_status(NULL, NULL)
+                           WHERE db_name = '${DATABASE_NAME}'
+                             AND lifecycle IN ('CREATED','IN_PROGRESS');" 2>&1) || true
+                  for STUCK_ID in $(echo "${STUCK_TASKS}" | grep -v '^Msg ' | grep -oE '[0-9]+'); do
+                    echo "  Cancelling stuck task ${STUCK_ID}..."
+                    "${SQLCMD}" \
+                      -S "localhost,${DB_PORT}" \
+                      -U "${DATABASE_USERNAME}" \
+                      -P "${DATABASE_PASSWORD}" \
+                      -C -Q "EXEC msdb.dbo.rds_cancel_task @task_id = ${STUCK_ID};" 2>&1 || true
+                  done
+
+                  if echo "${STUCK_TASKS}" | grep -v '^Msg ' | grep -qE '[0-9]+'; then
+                    echo "  Waiting 15s for task cancellations to complete..."
+                    sleep 15
+                  fi
+
+                  # Kill any existing connections
+                  echo "Killing active sessions on target database..."
+                  "${SQLCMD}" \
+                    -S "localhost,${DB_PORT}" \
+                    -U "${DATABASE_USERNAME}" \
+                    -P "${DATABASE_PASSWORD}" \
+                    -C -Q "
+                      DECLARE @sql NVARCHAR(MAX) = '';
+                      SELECT @sql += 'KILL ' + CAST(session_id AS NVARCHAR(10)) + '; '
+                      FROM sys.dm_exec_sessions
+                      WHERE database_id = DB_ID('${DATABASE_NAME}')
+                        AND session_id != @@SPID;
+                      IF LEN(@sql) > 0
+                      BEGIN
+                        PRINT 'Killing sessions: ' + @sql;
+                        EXEC sp_executesql @sql;
+                      END
+                      ELSE
+                        PRINT 'No other sessions to kill.';" 2>&1 || echo "  (Kill sessions failed, continuing...)"
+
+                  echo "Setting database to SINGLE_USER to clear existing connections..."
+                  "${SQLCMD}" \
+                    -S "localhost,${DB_PORT}" \
+                    -U "${DATABASE_USERNAME}" \
+                    -P "${DATABASE_PASSWORD}" \
+                    -C -Q "IF DB_ID('${DATABASE_NAME}') IS NOT NULL
+                          ALTER DATABASE [${DATABASE_NAME}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                          IF DB_ID('${DATABASE_NAME}') IS NOT NULL
+                          ALTER DATABASE [${DATABASE_NAME}] SET MULTI_USER;" 2>&1 || echo "  (SINGLE_USER/MULTI_USER failed, continuing...)"
+
+                  # Drop existing database
+                  echo "Dropping existing database using rds_drop_database..."
+                  "${SQLCMD}" \
+                    -S "localhost,${DB_PORT}" \
+                    -U "${DATABASE_USERNAME}" \
+                    -P "${DATABASE_PASSWORD}" \
+                    -C -Q "EXEC msdb.dbo.rds_drop_database @db_name = '${DATABASE_NAME}';" 2>&1 || echo "  (rds_drop_database failed — DB may not exist, continuing...)"
+
+                  sleep 10
+
+                  # Submit the RDS restore task
+                  echo "Submitting rds_restore_database task..."
+                  SUBMIT_OUTPUT=$("${SQLCMD}" \
+                    -S "localhost,${DB_PORT}" \
+                    -U "${DATABASE_USERNAME}" \
+                    -P "${DATABASE_PASSWORD}" \
+                    -W \
+                    -C -Q "EXEC msdb.dbo.rds_restore_database
+                          @restore_db_name    = '${DATABASE_NAME}',
+                          @s3_arn_to_restore_from = '${BACKUP_S3_ARN}',
+                          @with_norecovery    = 0,
+                          @type               = 'FULL';" 2>&1) || true
+
+                  if echo "${SUBMIT_OUTPUT}" | grep -qE '^Msg [0-9]+, Level [0-9]+'; then
+                    echo "rds_restore_database returned a SQL error:"
+                    echo "${SUBMIT_OUTPUT}"
+                    exit 1
+                  fi
+
+                  TASK_ID=$(echo "${SUBMIT_OUTPUT}" | grep -oE 'Task Id:\s*[0-9]+' | grep -oE '[0-9]+' || true)
+                  if [ -z "${TASK_ID}" ]; then
+                    TASK_ID=$(echo "${SUBMIT_OUTPUT}" | grep -oE '^\s*[0-9]+' | head -1 | tr -d ' ' || true)
+                  fi
+
+                  if [ -z "${TASK_ID}" ]; then
+                    echo "Failed to extract task_id from submission output:"
+                    echo "${SUBMIT_OUTPUT}"
+                    exit 1
+                  fi
+
+                  echo "Restore task submitted. Task ID: ${TASK_ID}"
+                  echo "Polling rds_task_status for task ${TASK_ID}..."
+
+                  POLL_COUNT=0
+                  CONSECUTIVE_FAILURES=0
+                  while true; do
+                    STATUS_OUTPUT=$("${SQLCMD}" \
+                      -S "localhost,${DB_PORT}" \
+                      -U "${DATABASE_USERNAME}" \
+                      -P "${DATABASE_PASSWORD}" \
+                      -h -1 -W \
+                      -C -Q "EXEC msdb.dbo.rds_task_status @task_id = ${TASK_ID};" 2>&1) || true
+
+                    echo "$(date) | ${STATUS_OUTPUT}"
+
+                    LIFECYCLE=$(echo "${STATUS_OUTPUT}" | grep -oE '\b(SUCCESS|ERROR|CANCELLED|CREATED|IN_PROGRESS)\b' | head -1 || true)
+
+                    if [ -z "${LIFECYCLE}" ]; then
+                      CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+                      if [ "${CONSECUTIVE_FAILURES}" -ge 5 ]; then
+                        echo "Port-forward appears dead — ${CONSECUTIVE_FAILURES} consecutive poll failures"
+                        exit 1
+                      fi
+                    else
+                      CONSECUTIVE_FAILURES=0
+                    fi
+
+                    if [ "${LIFECYCLE}" = "SUCCESS" ]; then
+                      echo "Restore completed successfully at $(date)"
+                      exit 0
+                    fi
+
+                    if [ "${LIFECYCLE}" = "ERROR" ] || [ "${LIFECYCLE}" = "CANCELLED" ]; then
+                      echo "Restore task failed (lifecycle=${LIFECYCLE}) at $(date)"
+                      exit 1
+                    fi
+
+                    POLL_COUNT=$((POLL_COUNT + 1))
+                    if [ "${POLL_COUNT}" -ge 120 ]; then
+                      echo "Restore timed out after 60 minutes"
+                      exit 1
+                    fi
+
+                    sleep 30
+                  done
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/db_restore_one_off.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/db_restore_one_off.yaml
@@ -1,0 +1,249 @@
+# One-off Job for initial data load or ad-hoc re-restores.
+# Usage: kubectl apply -f db_restore_one_off.yaml
+# Clean up after: kubectl delete job db-restore-from-preprod-001
+# Increment the name suffix (e.g. -002) for subsequent runs.
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-restore-from-preprod-001
+  namespace: hmpps-manage-and-deliver-accredited-programmes-prod
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 5400  # 90 minutes
+  template:
+    spec:
+      serviceAccountName: irsa-sqlserver
+      restartPolicy: OnFailure
+      volumes:
+        - name: backup-info
+          emptyDir: {}
+      initContainers:
+        - name: find-backup-file
+          image: public.ecr.aws/aws-cli/aws-cli:2.15.15
+          securityContext:
+            runAsUser: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: backup-info
+              mountPath: /backup-info
+          env:
+            - name: HOME
+              value: /tmp
+            # Hardcoded to preprod backup bucket for initial data load
+            - name: SQLSERVER_BACKUP_S3_BUCKET_NAME
+              value: "cloud-platform-421f9ae70e6559d242c61fe413ef46a4"
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              echo "Searching for latest backup in s3://${SQLSERVER_BACKUP_S3_BUCKET_NAME}/"
+
+              BACKUP_KEY=$(aws s3 ls "s3://${SQLSERVER_BACKUP_S3_BUCKET_NAME}/" \
+                --recursive \
+                | awk '{print $4}' \
+                | grep '\.bak$' \
+                | sort \
+                | tail -1)
+
+              if [ -z "${BACKUP_KEY}" ]; then
+                echo "No backup file found in s3://${SQLSERVER_BACKUP_S3_BUCKET_NAME}/"
+                exit 1
+              fi
+
+              echo "Found backup file: ${BACKUP_KEY}"
+              echo "${BACKUP_KEY}" > /backup-info/backup-key
+
+        - name: port-forward
+          image: ministryofjustice/port-forward
+          restartPolicy: Always
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 1433
+          env:
+            - name: REMOTE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: rds-sqlserver-instance-output
+                  key: rds_instance_address
+            - name: LOCAL_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: rds-sqlserver-restore-config-map
+                  key: db_port
+            - name: REMOTE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: rds-sqlserver-restore-config-map
+                  key: db_port
+      containers:
+        - name: db-restore
+          image: mcr.microsoft.com/mssql/server:2019-CU31-ubuntu-20.04
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 10001
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: backup-info
+              mountPath: /backup-info
+          env:
+            - name: DB_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: rds-sqlserver-restore-config-map
+                  key: db_port
+            - name: DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: rds-sqlserver-instance-output
+                  key: database_name
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rds-sqlserver-instance-output
+                  key: database_username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rds-sqlserver-instance-output
+                  key: database_password
+            # Hardcoded to preprod backup bucket for initial data load
+            - name: SQLSERVER_BACKUP_S3_BUCKET_NAME
+              value: "cloud-platform-421f9ae70e6559d242c61fe413ef46a4"
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              # Locate sqlcmd binary
+              SQLCMD=/opt/mssql-tools18/bin/sqlcmd
+              if [ ! -f "${SQLCMD}" ]; then
+                SQLCMD=/opt/mssql-tools/bin/sqlcmd
+              fi
+
+              BACKUP_KEY=$(cat /backup-info/backup-key)
+              if [ -z "${BACKUP_KEY}" ]; then
+                echo "ERROR: /backup-info/backup-key is empty"
+                exit 1
+              fi
+              BACKUP_S3_ARN="arn:aws:s3:::${SQLSERVER_BACKUP_S3_BUCKET_NAME}/${BACKUP_KEY}"
+
+              echo "Starting restore at $(date)"
+              echo "Source : ${BACKUP_S3_ARN}"
+              echo "Target : ${DATABASE_NAME}"
+
+              # Wait for port-forward sidecar
+              echo "Waiting for SQL Server to be reachable..."
+              RETRIES=0
+              until "${SQLCMD}" -S "localhost,${DB_PORT}" -U "${DATABASE_USERNAME}" -P "${DATABASE_PASSWORD}" -C -Q "SELECT 1" > /dev/null 2>&1; do
+                RETRIES=$((RETRIES + 1))
+                if [ "${RETRIES}" -ge 30 ]; then
+                  echo "Timed out after $((RETRIES * 10))s"
+                  exit 1
+                fi
+                echo "  attempt ${RETRIES}/30 — retrying in 10s..."
+                sleep 10
+              done
+              echo "SQL Server reachable."
+
+              # Submit the RDS restore task — first restore, no existing DB to drop
+              echo "Submitting rds_restore_database task..."
+              SUBMIT_OUTPUT=$("${SQLCMD}" \
+                -S "localhost,${DB_PORT}" \
+                -U "${DATABASE_USERNAME}" \
+                -P "${DATABASE_PASSWORD}" \
+                -W \
+                -C -Q "EXEC msdb.dbo.rds_restore_database
+                      @restore_db_name    = '${DATABASE_NAME}',
+                      @s3_arn_to_restore_from = '${BACKUP_S3_ARN}',
+                      @with_norecovery    = 0,
+                      @type               = 'FULL';" 2>&1) || true
+
+              # Check for SQL error
+              if echo "${SUBMIT_OUTPUT}" | grep -qE '^Msg [0-9]+, Level [0-9]+'; then
+                echo "rds_restore_database returned a SQL error:"
+                echo "${SUBMIT_OUTPUT}"
+                exit 1
+              fi
+
+              # Extract task_id
+              TASK_ID=$(echo "${SUBMIT_OUTPUT}" | grep -oE 'Task Id:\s*[0-9]+' | grep -oE '[0-9]+' || true)
+              if [ -z "${TASK_ID}" ]; then
+                TASK_ID=$(echo "${SUBMIT_OUTPUT}" | grep -oE '^\s*[0-9]+' | head -1 | tr -d ' ' || true)
+              fi
+
+              if [ -z "${TASK_ID}" ]; then
+                echo "Failed to extract task_id:"
+                echo "${SUBMIT_OUTPUT}"
+                exit 1
+              fi
+
+              echo "Restore task submitted. Task ID: ${TASK_ID}"
+              echo "Polling rds_task_status..."
+
+              # Poll every 30s; timeout 60 minutes
+              POLL_COUNT=0
+              CONSECUTIVE_FAILURES=0
+              while true; do
+                STATUS_OUTPUT=$("${SQLCMD}" \
+                  -S "localhost,${DB_PORT}" \
+                  -U "${DATABASE_USERNAME}" \
+                  -P "${DATABASE_PASSWORD}" \
+                  -h -1 -W \
+                  -C -Q "EXEC msdb.dbo.rds_task_status @task_id = ${TASK_ID};" 2>&1) || true
+
+                echo "$(date) | ${STATUS_OUTPUT}"
+
+                LIFECYCLE=$(echo "${STATUS_OUTPUT}" | grep -oE '\b(SUCCESS|ERROR|CANCELLED|CREATED|IN_PROGRESS)\b' | head -1 || true)
+
+                if [ -z "${LIFECYCLE}" ]; then
+                  CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+                  if [ "${CONSECUTIVE_FAILURES}" -ge 5 ]; then
+                    echo "Port-forward appears dead"
+                    exit 1
+                  fi
+                else
+                  CONSECUTIVE_FAILURES=0
+                fi
+
+                if [ "${LIFECYCLE}" = "SUCCESS" ]; then
+                  echo "Restore completed successfully at $(date)"
+                  exit 0
+                fi
+
+                if [ "${LIFECYCLE}" = "ERROR" ] || [ "${LIFECYCLE}" = "CANCELLED" ]; then
+                  echo "Restore failed (lifecycle=${LIFECYCLE}) at $(date)"
+                  exit 1
+                fi
+
+                POLL_COUNT=$((POLL_COUNT + 1))
+                if [ "${POLL_COUNT}" -ge 120 ]; then
+                  echo "Timed out after 60 minutes"
+                  exit 1
+                fi
+
+                sleep 30
+              done
+


### PR DESCRIPTION
Adds a CronJob that runs daily at 06:30 UTC to restore the latest IM .bak file from preprod's backup bucket into the prod RDS SQL Server instance. This is scheduled 45 minutes after preprod's restore to ensure the latest backup is available.

Key differences from preprod's db_restore.yaml:
- Namespace: hmpps-manage-and-deliver-accredited-programmes-prod
- Schedule: 06:30 UTC (vs 05:45 for preprod)
- Source bucket: hardcoded to preprod backup bucket (cross-namespace read access already configured via merged IAM/bucket policy PRs)
- No auto-start/stop considerations (prod RDS is always on)

Includes full session kill, SINGLE_USER, rds_drop_database, and rds_restore_database workflow proven in preprod since May 6.

Jira: APG-2245