### PR TITLE
Add service pod for prod namespace (irsa-sqlserver debug access)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/service_pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/service_pod.tf
@@ -1,7 +1,7 @@
 # Service pod for debugging — provides shell access with irsa-sqlserver permissions.
 # Useful for manual S3 ls, aws rds commands, and ad-hoc troubleshooting.
 module "sqlserver_service_pod" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.1"
 
   # Configuration
   namespace            = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/service_pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/service_pod.tf
@@ -1,0 +1,10 @@
+# Service pod for debugging — provides shell access with irsa-sqlserver permissions.
+# Useful for manual S3 ls, aws rds commands, and ad-hoc troubleshooting.
+module "sqlserver_service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.0"
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa-sqlserver.service_account.name
+}
+


### PR DESCRIPTION
Adds a service pod using the irsa-sqlserver service account, providing shell access for manual debugging (aws s3 ls, rds commands, etc.). Uses the same cloud-platform-terraform-service-pod module as preprod. Jira: APG-2245