### PR TITLE
feat(prod): add dedicated upload bucket, logging bucket, IRSA cronjob…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/cronjob-s3-transfer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/cronjob-s3-transfer.yaml
@@ -1,0 +1,112 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hmpps-manage-and-deliver-acp-s3-transfer
+  namespace: hmpps-manage-and-deliver-accredited-programmes-prod
+spec:
+  #  Run every night at 05:00 UTC (06:00 BST)
+  schedule: "0 5 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          serviceAccountName: irsa-s3-cronjob
+          restartPolicy: OnFailure
+          containers:
+            - name: s3-transfer
+              image: public.ecr.aws/aws-cli/aws-cli:2.15.15
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                runAsUser: 1000
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 100Mi
+                  ephemeral-storage: 1Gi
+                limits:
+                  cpu: 1000m
+                  memory: 1000Mi
+                  ephemeral-storage: 2Gi
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: UPLOAD_S3_BUCKET_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: upload-s3-bucket-output
+                      key: bucket_name
+                - name: SQLSERVER_BACKUP_S3_BUCKET_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: sqlserver-backup-s3-bucket-output
+                      key: bucket_name
+              command:
+                - /bin/bash
+                - -c
+              args:
+                - |
+                  set -euo pipefail
+
+                  echo "Starting S3 transfer at $(date)"
+
+                  # Find the latest .bak file in the upload bucket by filename sort
+                  # (filename encodes date as YYYYMMDDHHmmss — alphabetic sort = date sort).
+                  # We copy only the latest file rather than syncing everything, to avoid
+                  # accumulating a large backlog that can exhaust node ephemeral storage.
+                  LATEST_BAK=$(aws s3 ls "s3://$UPLOAD_S3_BUCKET_NAME/" \
+                    | awk '{print $4}' \
+                    | grep '\.bak$' \
+                    | sort \
+                    | tail -1)
+
+                  if [ -z "$LATEST_BAK" ]; then
+                    echo "No .bak files found in s3://$UPLOAD_S3_BUCKET_NAME — nothing to transfer."
+                    exit 0
+                  fi
+
+                  echo "Latest .bak file: $LATEST_BAK"
+
+                  aws s3 cp \
+                    "s3://$UPLOAD_S3_BUCKET_NAME/$LATEST_BAK" \
+                    "s3://$SQLSERVER_BACKUP_S3_BUCKET_NAME/$LATEST_BAK" \
+                    --only-show-errors
+
+                  echo "Copy complete. Removing $LATEST_BAK from upload bucket..."
+
+                  aws s3 rm \
+                    "s3://$UPLOAD_S3_BUCKET_NAME/$LATEST_BAK" \
+                    --only-show-errors
+
+                  # Tidy up any remaining .bak files older than 14 days from the upload bucket,
+                  # but only if there is more than one file remaining — never delete the last one.
+                  CUTOFF=$(date -d '14 days ago' +%Y-%m-%d 2>/dev/null || date -v-14d +%Y-%m-%d)
+                  ALL_BAKS=$(aws s3 ls "s3://$UPLOAD_S3_BUCKET_NAME/" | grep '\.bak$')
+                  BAK_COUNT=$(echo "$ALL_BAKS" | grep -c '\.bak' || true)
+
+                  if [ "${BAK_COUNT:-0}" -gt 1 ]; then
+                    echo "Found $BAK_COUNT .bak files remaining — checking for files older than $CUTOFF..."
+                    echo "$ALL_BAKS" | while read -r line; do
+                      FILE_DATE=$(echo "$line" | awk '{print $1}')
+                      FILE_NAME=$(echo "$line" | awk '{print $4}')
+                      if [ "$FILE_DATE" \< "$CUTOFF" ]; then
+                        echo "Deleting old file: $FILE_NAME (last modified $FILE_DATE)"
+                        aws s3 rm "s3://$UPLOAD_S3_BUCKET_NAME/$FILE_NAME" --only-show-errors
+                      fi
+                    done
+                  else
+                    echo "Only $BAK_COUNT .bak file(s) remaining — skipping age-based cleanup to preserve last file."
+                  fi
+
+                  echo "Transfer completed successfully at $(date)"
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/irsa.tf
@@ -77,3 +77,26 @@ module "irsa-sqlserver" {
   environment_name       = var.environment-name
   infrastructure_support = var.infrastructure_support
 }
+
+module "irsa-cronjob" {
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+  eks_cluster_name     = var.eks_cluster_name
+  service_account_name = "irsa-s3-cronjob"
+  namespace            = var.namespace
+
+  role_policy_arns = merge(
+    {
+      sqlserver_backup_s3_bucket_policy = module.sqlserver_backup_s3_bucket.irsa_policy_arn
+    },
+    {
+      upload_s3_bucket_policy = module.upload_s3_bucket.irsa_policy_arn
+    }
+  )
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment-name
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/s3.tf
@@ -81,3 +81,142 @@ resource "kubernetes_secret" "sqlserver_backup_s3_bucket" {
     bucket_name = module.sqlserver_backup_s3_bucket.bucket_name
   }
 }
+
+# Upload bucket — NEC DataSync will push .bak files here (once their prod role is created).
+# The s3-transfer CronJob copies from here to the backup bucket, then deletes.
+module "upload_s3_bucket" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  logging_enabled        = var.logging_enabled
+  log_target_bucket      = module.s3_upload_logging_bucket.bucket_name
+  log_path               = var.log_path
+  namespace              = var.namespace
+
+  # Safety net: auto-delete files after 30 days if the cronjob fails to remove them.
+  lifecycle_rule = [
+    {
+      id      = "expire-stale-uploads"
+      enabled = true
+      expiration = [
+        {
+          days = 30
+        }
+      ]
+    }
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "aws_s3_bucket_policy" "upload_s3_bucket_policy" {
+  bucket     = module.upload_s3_bucket.bucket_name
+  depends_on = [module.irsa-cronjob]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = [
+            module.irsa-cronjob.role_arn,
+            # NEC prod DataSync role — uncomment once NEC confirm the role has been created.
+            # "arn:aws:iam::778742069978:role/im-production-s3-datasync-prod"
+          ]
+        }
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:DeleteObject",
+          "s3:GetBucketLocation",
+          "s3:GetObjectAcl",
+          "s3:GetObjectVersion",
+          "s3:GetObjectTagging",
+          "s3:ListBucketMultipartUploads",
+          "s3:ListMultipartUploadParts",
+          "s3:AbortMultipartUpload",
+        ]
+        Resource = [
+          module.upload_s3_bucket.bucket_arn,
+          "${module.upload_s3_bucket.bucket_arn}/*"
+        ]
+      },
+    ]
+  })
+}
+
+resource "kubernetes_secret" "upload_s3_bucket" {
+  metadata {
+    name      = "upload-s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.upload_s3_bucket.bucket_arn
+    bucket_name = module.upload_s3_bucket.bucket_name
+  }
+}
+
+module "s3_upload_logging_bucket" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  bucket_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "S3ServerAccessLogsPolicy",
+        Effect = "Allow",
+        Principal = {
+          Service = "logging.s3.amazonaws.com"
+        },
+        Action = [
+          "s3:PutObject"
+        ],
+        Resource = "$${bucket_arn}/*"
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = [
+            module.irsa-cronjob.role_arn
+          ]
+        }
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "$${bucket_arn}",
+          "$${bucket_arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "kubernetes_secret" "s3_upload_logging_bucket" {
+  metadata {
+    name      = "s3-logging-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    BUCKET_ARN  = module.s3_upload_logging_bucket.bucket_arn
+    BUCKET_NAME = module.s3_upload_logging_bucket.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
@@ -158,3 +158,11 @@ variable "preprod_backup_bucket_arn" {
   type        = string
   default     = "arn:aws:s3:::cloud-platform-421f9ae70e6559d242c61fe413ef46a4"
 }
+
+variable "logging_enabled" {
+  default = true
+}
+
+variable "log_path" {
+  default = "logs/"
+}


### PR DESCRIPTION
… and S3 transfer CronJob

Phase 2 - establishes prod own independent S3 upload pipeline: Terraform (resources/):
- s3.tf: add upload_s3_bucket with 30-day lifecycle expiry, s3_upload_logging_bucket for access logs, bucket policy granting irsa-cronjob access (NEC DataSync role commented out pending confirmation), and Kubernetes secrets for both buckets
- irsa.tf: add irsa-cronjob module with policies for upload and backup S3 buckets, creating the irsa-s3-cronjob service account
- variables.tf: add logging_enabled and log_path variables Kubernetes:
- cronjob-s3-transfer.yaml: daily CronJob (05:00 UTC) that copies the latest .bak file from the upload bucket to the backup bucket, removes the source file, and cleans up uploads older than 14 days. Mirrors preprod configuration. All resources scoped to prod namespace only.