### PR TITLE
fix(prod): correct business_unit, NEC role ARN, and grep bug in s3-tr…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/cronjob-s3-transfer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/cronjob-s3-transfer.yaml
@@ -91,7 +91,7 @@ spec:
                   # Tidy up any remaining .bak files older than 14 days from the upload bucket,
                   # but only if there is more than one file remaining — never delete the last one.
                   CUTOFF=$(date -d '14 days ago' +%Y-%m-%d 2>/dev/null || date -v-14d +%Y-%m-%d)
-                  ALL_BAKS=$(aws s3 ls "s3://$UPLOAD_S3_BUCKET_NAME/" | grep '\.bak$')
+                  ALL_BAKS=$(aws s3 ls "s3://$UPLOAD_S3_BUCKET_NAME/" | grep '\.bak$' || true)
                   BAK_COUNT=$(echo "$ALL_BAKS" | grep -c '\.bak' || true)
 
                   if [ "${BAK_COUNT:-0}" -gt 1 ]; then

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/s3.tf
@@ -127,8 +127,9 @@ resource "aws_s3_bucket_policy" "upload_s3_bucket_policy" {
         Principal = {
           AWS = [
             module.irsa-cronjob.role_arn,
-            # NEC prod DataSync role — uncomment once NEC confirm the role has been created.
-            # "arn:aws:iam::778742069978:role/im-production-s3-datasync-prod"
+            # NEC DataSync role — uncomment once NEC confirm prod should receive files directly.
+            # This is the same role currently active in preprod's upload bucket policy.
+            # "arn:aws:iam::778742069978:role/im-production-s3-datasync"
           ]
         }
         Action = [

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/resources/variables.tf
@@ -23,7 +23,7 @@ variable "namespace" {
 variable "business_unit" {
   description = "Area of the MOJ responsible for this service"
   type        = string
-  default     = "Platforms"
+  default     = "HMPPS"
 }
 
 variable "team_name" {


### PR DESCRIPTION
…ansfer

- variables.tf: change business_unit from Platforms to HMPPS to match namespace label and preprod (dev also has this mismatch - separate fix)
- s3.tf: correct commented NEC DataSync role from im-production-s3-datasync-prod to im-production-s3-datasync (matches the role currently active in preprod)
- cronjob-s3-transfer.yaml: add || true to grep in cleanup section to prevent set -euo pipefail exit when no .bak files remain after transfer