### PR TITLE
feat(prod): add resource requests/limits to all db_restore.yaml conta…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/db_restore.yaml
@@ -34,6 +34,13 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
               env:
                 - name: HOME
                   value: /tmp
@@ -90,6 +97,13 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
               volumeMounts:
                 - name: backup-info
                   mountPath: /backup-info
@@ -133,6 +147,13 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
               ports:
                 - containerPort: 1433
               env:
@@ -164,6 +185,13 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
               volumeMounts:
                 - name: backup-info
                   mountPath: /backup-info


### PR DESCRIPTION
…iners

- create-rds-snapshot init: 10m-250m CPU, 64Mi-256Mi memory
- find-backup-file init: 10m-250m CPU, 64Mi-256Mi memory
- port-forward sidecar: 10m-100m CPU, 32Mi-128Mi memory
- db-restore main: 10m-500m CPU, 128Mi-512Mi memory Prevents unbounded resource usage and improves pod scheduling. Preprod db_restore.yaml will be updated in a separate PR.