### PR TITLE
feat(preprod): add resource requests/limits to all db_restore.yaml co…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
@@ -33,6 +33,13 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
               env:
                 - name: HOME
                   value: /tmp
@@ -89,6 +96,13 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
               volumeMounts:
                 - name: backup-info
                   mountPath: /backup-info
@@ -141,6 +155,13 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
               ports:
                 - containerPort: 1433
               env:
@@ -177,6 +198,13 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
               volumeMounts:
                 - name: backup-info
                   mountPath: /backup-info


### PR DESCRIPTION
…ntainers

- create-rds-snapshot init: 10m-250m CPU, 64Mi-256Mi memory
- find-backup-file init: 10m-250m CPU, 64Mi-256Mi memory
- port-forward sidecar: 10m-100m CPU, 32Mi-128Mi memory
- db-restore main: 10m-500m CPU, 256Mi-1Gi memory Mirrors prod resource limits. Prevents unbounded resource usage.