### PR TITLE
fix(preprod): add || true to grep in s3-transfer cleanup to prevent p…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
@@ -91,7 +91,7 @@ spec:
                   # Tidy up any remaining .bak files older than 14 days from the upload bucket,
                   # but only if there is more than one file remaining — never delete the last one.
                   CUTOFF=$(date -d '14 days ago' +%Y-%m-%d 2>/dev/null || date -v-14d +%Y-%m-%d)
-                  ALL_BAKS=$(aws s3 ls "s3://$UPLOAD_S3_BUCKET_NAME/" | grep '\.bak$')
+                  ALL_BAKS=$(aws s3 ls "s3://$UPLOAD_S3_BUCKET_NAME/" | grep '\.bak$' || true)
                   BAK_COUNT=$(echo "$ALL_BAKS" | grep -c '\.bak' || true)
 
                   if [ "${BAK_COUNT:-0}" -gt 1 ]; then


### PR DESCRIPTION
…ipefail exit

The cleanup section greps for remaining .bak files after the transfer. If no .bak files remain (e.g. the transferred file was the last one), grep exits non-zero which causes the script to fail under set -euo pipefail. Adding || true allows the empty result to be handled gracefully by the BAK_COUNT check that follows. Mirrors the fix already applied to prod.