### PR TITLE
feat(staging): add Kubernetes namespace, RBAC, resource quotas, and network policies for chaps-dotnet-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chaps-dotnet-staging
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "staging"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "cdpt-chaps"
+    cloud-platform.justice.gov.uk/application: "CHAPS"
+    cloud-platform.justice.gov.uk/owner: "CDPT: chaps-support@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/chaps"
+    cloud-platform.justice.gov.uk/team-name: "central-digital-product-team"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/01-rbac.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: chaps-dotnet-staging-admin
+  namespace: chaps-dotnet-staging
+subjects:
+  - kind: Group
+    name: "github:dotnet"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:central-digital-product-team"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: chaps-dotnet-staging
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 500m
+      memory: 500Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: chaps-dotnet-staging
+spec:
+  hard:
+    pods: "12"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: chaps-dotnet-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: chaps-dotnet-staging
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/irsa.tf
@@ -1,0 +1,23 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "${var.namespace}-service-account"
+  namespace            = var.namespace # this is also used as a tag
+
+  # Attach the approprate policies using a key => value map
+  # If you're using Cloud Platform provided modules (e.g. SNS, S3), 
+  # these provide an output called `irsa_policy_arn` that can be used.
+  role_policy_arns = {}
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      slack-channel = var.slack_channel
+    }
+  }
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/rds.tf
@@ -1,0 +1,155 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+*/
+module "rds_mssql" {
+  source       = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+  storage_type = "gp3"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  performance_insights_enabled = true
+  db_max_allocated_storage     = "1000"
+
+  # SQL Server specifics
+  db_engine            = "sqlserver-web"
+  db_engine_version    = "14.00.3381.3.v1"
+  rds_family           = "sqlserver-web-14.0"
+  db_instance_class    = "db.t3.2xlarge"
+  db_allocated_storage = 32 # minimum of 20GiB for SQL Server
+  option_group_name    = aws_db_option_group.sqlserver_backup_restore.name
+  enable_irsa          = true
+  deletion_protection  = true
+
+  # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
+  # You will need to specify "pending-reboot" here, as default is set to "immediate".
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+
+  ]
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+resource "kubernetes_secret" "rds_mssql" {
+  metadata {
+    name      = "rds-mssql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_username = module.rds_mssql.database_username
+    database_password = module.rds_mssql.database_password
+  }
+}
+
+resource "kubernetes_config_map" "rds_mssql" {
+  metadata {
+    name      = "rds-mssql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds_mssql.rds_instance_endpoint
+    rds_instance_address  = module.rds_mssql.rds_instance_address
+  }
+}
+
+resource "aws_db_option_group" "sqlserver_backup_restore" {
+  name                 = "${var.namespace}-sqlserver-14-backup-restore"
+  engine_name          = "sqlserver-web"
+  major_engine_version = "14.00"
+
+  option {
+    option_name = "SQLSERVER_BACKUP_RESTORE"
+    option_settings {
+      name = "IAM_ROLE_ARN"
+      value  = aws_iam_role.rds_s3_backup_restore.arn
+    }
+  }
+}
+
+variable "backup_bucket" { 
+  type = string 
+  default = "tp-dbbackups"
+  description = "S3 bucket that stores SQL Server .bak files" 
+}        
+
+variable "backup_prefix" { 
+  type = string 
+  default = "chaps-dev/"
+  description = "Key prefix within the backup bucket" 
+} 
+
+
+resource "aws_iam_role" "rds_s3_backup_restore" {
+  name = "${var.namespace}-rds-s3-backup-restore"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = { Service = "rds.amazonaws.com" },
+      Action   = "sts:AssumeRole"
+    }]
+  })
+}
+
+
+locals {
+  bucket_arn         = format("arn:aws:s3:::%s", var.backup_bucket)
+  objects_prefix_arn = format("arn:aws:s3:::%s/%s*", var.backup_bucket, var.backup_prefix)
+}
+
+
+# Least-privilege inline policy: list bucket + R/W objects in the prefix
+resource "aws_iam_role_policy" "rds_s3_backup_restore" {
+  name = "${var.namespace}-rds-s3-backup-restore"
+  role = aws_iam_role.rds_s3_backup_restore.id
+
+  policy = jsonencode({
+    Version   = "2012-10-17",
+    Statement = [
+      {
+        Sid      = "BucketLocation"
+        Effect   = "Allow"
+        Action   = ["s3:GetBucketLocation"]
+        Resource = local.bucket_arn
+      },
+      {
+        Sid             = "ListBucket"
+        Effect          = "Allow"
+        Action          = ["s3:ListBucket"]
+        Resource        = local.bucket_arn
+        Condition       = {
+          StringLike    = { 
+            "s3:prefix" = [
+              format("%s*", var.backup_prefix), 
+              var.backup_prefix
+            ]
+          }
+        }
+      },
+      {
+        Sid      = "RWPrefix",
+        Effect   = "Allow",
+        Action   = ["s3:GetObject","s3:PutObject","s3:DeleteObject"]
+        Resource = local.objects_prefix_arn
+      }
+    ]
+  })
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/serviceaccount.tf
@@ -1,0 +1,13 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace            = var.namespace
+  kubernetes_cluster   = var.kubernetes_cluster
+  serviceaccount_rules = var.service_account_rules
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["chaps"]
+  github_environments = [var.environment]
+  serviceaccount_token_rotated_date = "14-05-2026"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/variables.tf
@@ -1,0 +1,124 @@
+variable "vpc_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "Correspondence Handling and Processing System"
+}
+
+variable "namespace" {
+  default = "chaps-dotnet-staging"
+}
+
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HQ"
+}
+
+variable "service_area" {
+  description = "The service area of the MOJ responsible for the service."
+  default     = "Central, Victims and Vulnerability"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "central-digital-product-team"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "staging"
+}
+
+variable "domain" {
+  description = "The domain name to use for the Route53 zone."
+  default = "correspondence-handling-and-processing.service.justice.gov.uk"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "chaps-support@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "cdpt-chaps"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  default     = ""
+}
+
+variable "service_account_rules" {
+  description = "The capabilities of this service account"
+
+  type = list(object({
+    api_groups = list(string),
+    resources  = list(string),
+    verbs      = list(string)
+  }))
+
+  # These values are usually sufficient for a CI/CD pipeline
+  default = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+        "certificates"
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "delete",
+        "list",
+        "watch",
+        "update",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "networking.k8s.io",
+        "cert-manager.io"
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "certificates"
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Kubernetes namespace and associated infrastructure for the `chaps-dotnet-staging` environment in the Cloud Platform. It sets up the namespace, access controls, resource limits, network policies, and supporting AWS/Terraform infrastructure, including RDS (SQL Server), IAM roles, and service accounts. These changes lay the groundwork for deploying and managing the CHAPS application in a secure and controlled staging environment.

Key changes include:

**Kubernetes Namespace & Policies**
- Created the `chaps-dotnet-staging` namespace with relevant labels and annotations for environment, team, and ownership metadata.
- Defined RoleBindings to grant admin access to the `github:dotnet` and `github:central-digital-product-team` groups.
- Set up resource constraints with a `LimitRange` (default/request CPU and memory) and a `ResourceQuota` (max 12 pods). [[1]](diffhunk://#diff-02339db7adf580739f8a1621879f1f946ef5d63d9b4b1ddccfe824055858ffb7R1-R14) [[2]](diffhunk://#diff-c60a331ec324d7006808fa387244dadb1b3ad0440096b88d5573d683cfcafd8aR1-R8)
- Established network policies to restrict ingress traffic, only allowing traffic from within the namespace and from ingress controllers.

**Terraform Infrastructure**
- Added Terraform configuration for AWS and GitHub providers, including backend setup and default resource tagging. [[1]](diffhunk://#diff-a65dbf07804083ef442b66e1ff7057890f6ccd7f7292ffc6843ca42f5f2cced0R1-R42) [[2]](diffhunk://#diff-6c1517c6449172db04affa95dfa0c66b664b4db34f9104d89ecbc1033ce52797R1-R17)
- Defined variables for environment configuration, including VPC, cluster, application, and team details.

**AWS Resources & Integrations**
- Provisioned an RDS SQL Server instance with backup/restore capabilities to S3, including necessary IAM roles and policies for least-privilege access.
- Integrated IRSA (IAM Roles for Service Accounts) for secure AWS access from Kubernetes workloads.
- Created a service account module with scoped permissions and GitHub Actions integration for CI/CD.