### PR TITLE
fix(dev): correct business_unit from Platforms to HMPPS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/resources/variables.tf
@@ -23,7 +23,7 @@ variable "namespace" {
 variable "business_unit" {
   description = "Area of the MOJ responsible for this service"
   type        = string
-  default     = "Platforms"
+  default     = "HMPPS"
 }
 
 variable "team_name" {


### PR DESCRIPTION
Aligns the Terraform variable with the namespace label (cloud-platform.justice.gov.uk/business-unit: HMPPS) and preprod. Tag-only change on AWS resources — no resource recreation.