### PR TITLE
chore(rds): update SQL Server engine version, instance class, and storage allocation

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/rds.tf
@@ -17,13 +17,14 @@ module "rds_mssql" {
 
   # SQL Server specifics
   db_engine            = "sqlserver-web"
-  db_engine_version    = "14.00.3381.3.v1"
+  db_engine_version    = "14.0.3520.4.v1"
   rds_family           = "sqlserver-web-14.0"
-  db_instance_class    = "db.t3.2xlarge"
-  db_allocated_storage = 32 # minimum of 20GiB for SQL Server
+  db_instance_class    = "db.t3.medium"
+  db_allocated_storage = 20 # minimum of 20GiB for SQL Server
   option_group_name    = aws_db_option_group.sqlserver_backup_restore.name
   enable_irsa          = true
   deletion_protection  = true
+  enable_rds_auto_start_stop = true
 
   # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".


### PR DESCRIPTION
This pull request updates the configuration for the RDS SQL Server instance in the `chaps-dotnet-development` environment. The main changes are an engine version upgrade, a reduction in instance size and storage, and the enabling of automatic start/stop for cost optimization.

**RDS SQL Server configuration updates:**

* Upgraded the `db_engine_version` from `14.00.3381.3.v1` to `14.0.3520.4.v1` for improved security and features.
* Reduced the `db_instance_class` from `db.t3.2xlarge` to `db.t3.medium` to lower resource usage and costs.
* Decreased `db_allocated_storage` from 32 GiB to 20 GiB, aligning with the minimum requirement for SQL Server.
* Enabled `enable_rds_auto_start_stop` to allow automatic starting and stopping of the RDS instance, further optimizing costs.