### PR TITLE
feat(rds): update SQL Server version and instance class, enable auto start/stop

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/rds.tf
@@ -17,13 +17,14 @@ module "rds_mssql" {
 
   # SQL Server specifics
   db_engine            = "sqlserver-web"
-  db_engine_version    = "14.00.3381.3.v1"
+  db_engine_version    = "14.0.3520.4.v1"
   rds_family           = "sqlserver-web-14.0"
-  db_instance_class    = "db.t3.2xlarge"
+  db_instance_class    = "db.t3.large"
   db_allocated_storage = 32 # minimum of 20GiB for SQL Server
   option_group_name    = aws_db_option_group.sqlserver_backup_restore.name
   enable_irsa          = true
   deletion_protection  = true
+  enable_rds_auto_start_stop = true
 
   # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds_mssql" {
 
   # SQL Server specifics
   db_engine            = "sqlserver-web"
-  db_engine_version    = "14.0.3520.4.v1"
+  db_engine_version    = "14.00.3520.4.v1"
   rds_family           = "sqlserver-web-14.0"
   db_instance_class    = "db.t3.large"
   db_allocated_storage = 32 # minimum of 20GiB for SQL Server


### PR DESCRIPTION
This pull request updates the configuration for the `rds_mssql` module in the `chaps-dotnet-staging` environment. The main changes involve upgrading the SQL Server engine version, reducing the instance size, and enabling automatic start/stop for the RDS instance.

**RDS configuration updates:**

* Upgraded the SQL Server engine version from `14.00.3381.3.v1` to `14.0.3520.4.v1` to ensure the database is running a more recent and potentially more secure version.
* Reduced the RDS instance class from `db.t3.2xlarge` to `db.t3.large` to lower resource allocation and likely reduce costs.
* Enabled the `enable_rds_auto_start_stop` option to allow the RDS instance to automatically start and stop, which can help save costs during periods of inactivity.