### PR TITLE
Fix version in `db_engine_version`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds_mssql" {
 
   # SQL Server specifics
   db_engine            = "sqlserver-web"
-  db_engine_version    = "14.0.3520.4.v1"
+  db_engine_version    = "14.00.3520.4.v1"
   rds_family           = "sqlserver-web-14.0"
   db_instance_class    = "db.t3.medium"
   db_allocated_storage = 20 # minimum of 20GiB for SQL Server


### PR DESCRIPTION
This pull request makes a minor correction to the SQL Server engine version in the RDS module configuration. The change ensures the version string is formatted correctly for compatibility.

* Corrected the `db_engine_version` value in the `rds_mssql` module by adding a leading zero to the minor version segment, changing `"14.0.3520.4.v1"` to `"14.00.3520.4.v1"` in `rds.tf`.