### PR TITLE
fix(ecr): update GitHub repository name to match case sensitivity

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/ecr.tf
@@ -4,7 +4,7 @@ module "ecr" {
 
   # OIDC configuration
   oidc_providers      = ["github"]
-  github_repositories = ["chaps"]
+  github_repositories = ["CHAPS"]
 
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
This pull request makes a minor update to the ECR configuration by correcting the casing of the GitHub repository name.

- Updated the `github_repositories` value from `"chaps"` to `"CHAPS"` in `ecr.tf` to match the correct repository name.