### PR TITLE
fix(prod): add || true to main grep in s3-transfer to handle empty up…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/cronjob-s3-transfer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/cronjob-s3-transfer.yaml
@@ -68,7 +68,7 @@ spec:
                     | awk '{print $4}' \
                     | grep '\.bak$' \
                     | sort \
-                    | tail -1)
+                    | tail -1 || true)
 
                   if [ -z "$LATEST_BAK" ]; then
                     echo "No .bak files found in s3://$UPLOAD_S3_BUCKET_NAME — nothing to transfer."


### PR DESCRIPTION
…load bucket

When the upload bucket has no .bak files, grep exits non-zero which crashes the script under set -euo pipefail before reaching the empty check. This caused the nightly s3-transfer job to fail with exit code 1 instead of gracefully logging 'No .bak files found' and exiting 0. Root cause confirmed by manual test — job failed immediately after 'Starting S3 transfer' with no further output.