### PR TITLE
fix(preprod): add || true to main grep in s3-transfer to handle empty…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
@@ -68,7 +68,7 @@ spec:
                     | awk '{print $4}' \
                     | grep '\.bak$' \
                     | sort \
-                    | tail -1)
+                    | tail -1 || true)
 
                   if [ -z "$LATEST_BAK" ]; then
                     echo "No .bak files found in s3://$UPLOAD_S3_BUCKET_NAME — nothing to transfer."


### PR DESCRIPTION
… upload bucket

Same fix as prod — prevents pipefail crash when no .bak files exist. Preprod currently has files so this is preventative, but if NEC stops pushing or files are cleaned up, the job would fail without this fix.