### PR TITLE
Add an additional DNS identity 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-preprod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-identify-remand-periods-preprod/06-certificate.yaml
@@ -10,3 +10,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - identify-remand-periods-preprod.hmpps.service.justice.gov.uk
+    - identify-remand-periods-alt-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
to the identify remand periods project… paving the way for alt-preprod environment for Sentencing Bill end to end preprod testing