### PR TITLE
No longer need resources for the model, only the data

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
@@ -6,7 +6,6 @@ module "irsa" {
   namespace            = var.namespace
 
   role_policy_arns = {
-    models      = module.address_matcher_models_s3.irsa_policy_arn
     lookup_data = module.address_matcher_lookup_data_s3.irsa_policy_arn
   }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/s3.tf
@@ -1,18 +1,3 @@
-module "address_matcher_models_s3" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
-
-  versioning             = true
-  team_name              = var.team_name
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  environment_name       = var.environment
-  infrastructure_support = var.infrastructure_support
-  namespace              = var.namespace
-
-  providers = { aws = aws.london }
-}
-
 module "address_matcher_lookup_data_s3" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
 
@@ -35,8 +20,6 @@ resource "kubernetes_secret" "s3_buckets" {
   }
 
   data = {
-    models_bucket_arn       = module.address_matcher_models_s3.bucket_arn
-    models_bucket_name      = module.address_matcher_models_s3.bucket_name
     lookup_data_bucket_arn  = module.address_matcher_lookup_data_s3.bucket_arn
     lookup_data_bucket_name = module.address_matcher_lookup_data_s3.bucket_name
   }


### PR DESCRIPTION
Removes configuration for the model s3 bucket in the address matcher api project.

The bucket is empty and unused.