### PR TITLE
laa-cla-backend-production - Remove rds_name parameter

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/irsa.tf
@@ -18,6 +18,7 @@ module "irsa" {
     s3_cla_backend_static_files_bucket    = module.cla_backend_static_files_bucket.irsa_policy_arn
     sqs_laa_cla_backend_production_sqs    = module.laa_cla_backend_production_sqs.irsa_policy_arn
     rds_cla_backend_snapshot_restore    = module.cla_backend_snapshot_restore.irsa_policy_arn
+    rds_cla_backend_intermediary = module.cla_backend_intermediary.irsa_policy_arn
   }
 
   # Tags

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -157,7 +157,6 @@ module "cla_backend_snapshot_restore" {
   # Pick the one that defines the postgres version the best
   rds_family = "postgres14"
 
-  rds_name = "cla-backend-snapshot-restore"
   snapshot_identifier = "rds:cloud-platform-3523d8064f052e84-2026-05-14-02-53"
 
   # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate).
@@ -209,7 +208,6 @@ module "cla_backend_intermediary" {
   # Pick the one that defines the postgres version the best
   rds_family = "postgres14"
 
-  rds_name = "cla-backend-intermediary"
   snapshot_identifier = "rds:cloud-platform-3523d8064f052e84-2026-05-15-02-53"
   # This is test instance to restoring deleted records from production, we do not need a final snapshot
   skip_final_snapshot = "true"


### PR DESCRIPTION
Remove rds_name parameter as that is causing the database to be recreated on every config change