### PR TITLE
add route 53 file

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/resources/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "dev_reuse_library_team_route53_zone" {
+  name = var.domain
+
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.github_owner
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "dev_reuse_library_route53_zone_sec" {
+  metadata {
+    name      = "${var.namespace}-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.dev_reuse_library_team_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.dev_reuse_library_team_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/resources/variables.tf
@@ -77,3 +77,8 @@ variable "github_token" {
 variable "number_cache_clusters" {
   default = "2"
 }
+
+variable "domain" {
+  default = "dev.reuselibrary.service.justice.gov.uk"
+  type    = string
+}


### PR DESCRIPTION
Key change:
* Added route 53 file for reuse-library dev so that the domain, `dev.reuselibrary.service.justice.gov.uk` works correctly.