### PR TITLE
Add journey data elasticache cluster to RCW namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/elasticache_ccq.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/elasticache_ccq.tf
@@ -1,0 +1,36 @@
+module "elasticache_redis_ccq" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
+  vpc_name               = var.vpc_name
+  application            = var.application
+  environment_name       = var.environment
+  is_production          = var.is_production
+  infrastructure_support = var.infrastructure_support
+  team_name              = var.team_name
+  number_cache_clusters  = var.number_cache_clusters
+  business_unit          = var.business_unit
+  node_type              = "cache.t4g.micro"
+  engine_version         = "7.1"
+  parameter_group_name   = "default.redis7"
+  namespace              = var.namespace
+
+  auth_token_rotated_date = "2026-05-13"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis_ccq" {
+  metadata {
+    name      = "elasticache-redis-ccq"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    replication_group_id     = module.elasticache_redis.replication_group_id
+    url                      = "rediss://:${module.elasticache_redis.auth_token}@${module.elasticache_redis.primary_endpoint_address}:6379"
+  }
+}


### PR DESCRIPTION
Adds second elasticache cluster for secondary service (CCQ) deployed to RCW namespace.

- First cluster (RCW) used for session data, including the Entra auth context cache (MSAL).
- Second cluster used for short lived journey data which enables the UI journey in CCQ.

In theory we could do this with namespace key prefixing in Redis, but from a security standpoint, CCQ shouldn't ever have access to the RCW session cache.