### PR TITLE
fix(prod): scope CronJobStatusFailed alert to jobs started within 2 h…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/05-prometheusrules.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-prod/05-prometheusrules.yaml
@@ -50,10 +50,14 @@ spec:
 
     - alert: CronJobStatusFailed
       expr: |-
-        kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-prod"} > 0
+        max(
+          (kube_job_status_failed{namespace="hmpps-manage-and-deliver-accredited-programmes-prod"} > 0)
+          + on(job_name, namespace)
+          ((time() - kube_job_status_start_time{namespace="hmpps-manage-and-deliver-accredited-programmes-prod"}) < 7200)
+        ) by (job_name, namespace) > 0
       for: 1m
       labels:
         severity: hmpps-accredited-programmes-manage-and-deliver-alerts-prod
       annotations:
-        message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed
+        message: Namespace {{ $labels.namespace }} - CronJob {{ $labels.job_name }} has failed (started within the last 2 hours)
 


### PR DESCRIPTION
…ours

The previous expression fires on all historical failed Job objects in Kubernetes job history (failedJobsHistoryLimit: 5), including jobs from weeks ago — causing false positives (e.g. old s3-transfer pre-fix runs, one-off restore job).
Fix joins kube_job_status_failed with a 2-hour start-time window using the check-my-diary-prod arithmetic pattern, so only genuinely recent failures alert. Covers db-restore (up to 90 min) and s3-transfer (~3 min). Mirrors fix already applied to preprod in APG-2245/preprod-prometheus-cronjob-alert-fix.