### PR TITLE
CLA_BACKEND PROD: increase snapshot retention period for cla backend DB

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/rds.tf
@@ -23,6 +23,8 @@ module "cla_backend_rds_postgres_14" {
   db_allocated_storage         = "30"
   db_max_allocated_storage     = "1000"
   performance_insights_enabled = true
+  # increase retention period to 21 days while dealing with a data loss incident
+  db_backup_retention_period   = "21"
 
   # change the postgres version as you see fit.
   db_engine_version      = "14"


### PR DESCRIPTION
we are dealing with a data loss incident that occurred last thursday evening, the current snapshot is due to be deleted in the next 24 hours and we want to keep it around a bit longer until we are sure we have restored the data. My assumption is that this PR will ensure the snapshot remains available until next thursday.