### PR TITLE
Add deligation for dev and preprod dns

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/resources/route53.tf
@@ -12,15 +12,3 @@ resource "aws_route53_zone" "dev_reuse_library_team_route53_zone" {
     namespace              = var.namespace
   }
 }
-
-resource "kubernetes_secret" "dev_reuse_library_route53_zone_sec" {
-  metadata {
-    name      = "${var.namespace}-route53-zone-output"
-    namespace = var.namespace
-  }
-
-  data = {
-    zone_id     = aws_route53_zone.dev_reuse_library_team_route53_zone.zone_id
-    nameservers = join("\n", aws_route53_zone.dev_reuse_library_team_route53_zone.name_servers)
-  }
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-preprod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-preprod/resources/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "preprod_reuselibrary_team_route53_zone" {
-  name = "preprod.reuselibrary.service.justice.gov.uk"
+  name = var.domain
 
   tags = {
     team_name              = var.team_name
@@ -10,17 +10,5 @@ resource "aws_route53_zone" "preprod_reuselibrary_team_route53_zone" {
     owner                  = var.github_owner
     infrastructure_support = var.infrastructure_support
     namespace              = var.namespace
-  }
-}
-
-resource "kubernetes_secret" "route53_zone_sec" {
-  metadata {
-    name      = "route53-zone-output"
-    namespace = var.namespace
-  }
-
-  data = {
-    zone_id     = aws_route53_zone.preprod_reuselibrary_team_route53_zone.zone_id
-    nameservers = join("\n", aws_route53_zone.preprod_reuselibrary_team_route53_zone.name_servers)
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-preprod/resources/variables.tf
@@ -77,3 +77,12 @@ variable "github_token" {
 variable "eks_cluster_name" {
   description = "The name of the eks cluster to retrieve the OIDC information"
 }
+
+variable "number_cache_clusters" {
+  default = "2"
+}
+
+variable "domain" {
+  default = "preprod.reuselibrary.service.justice.gov.uk"
+  type    = string
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
@@ -24,3 +24,21 @@ resource "kubernetes_secret" "route53_zone_sec" {
     nameservers = join("\n", aws_route53_zone.prod_reuselibrary_team_route53_zone.name_servers)
   }
 }
+
+resource "aws_route53_record" "delegate_dev" {
+  zone_id = aws_route53_zone.prod_reuselibrary_team_route53_zone.zone_id
+  name    = "dev.reuselibrary.service.justice.gov.uk"
+  type    = "NS"
+  ttl     = 300
+
+  records = aws_route53_zone.dev_reuse_library_team_route53_zone.name_servers
+}
+
+resource "aws_route53_record" "delegate_preprod" {
+  zone_id = aws_route53_zone.prod_reuselibrary_team_route53_zone.zone_id
+  name    = "preprod.reuselibrary.service.justice.gov.uk"
+  type    = "NS"
+  ttl     = 300
+
+  records = aws_route53_zone.preprod_reuselibrary_team_route53_zone.name_servers
+}


### PR DESCRIPTION
Key change:
* Adding DNS delegation records in production to delegate subdomains to the dev and preprod zones.