### PR TITLE
Add dns records for dev and preprod in reuse library prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
@@ -28,17 +28,17 @@ resource "kubernetes_secret" "route53_zone_sec" {
 resource "aws_route53_record" "delegate_dev" {
   zone_id = aws_route53_zone.prod_reuselibrary_team_route53_zone.zone_id
   name    = "dev.reuselibrary.service.justice.gov.uk"
-  type    = "NS"
+  type    = "CNAME"
   ttl     = 300
 
-  records = aws_route53_zone.dev_reuse_library_team_route53_zone.name_servers
+  records = ["reuse-library-dev.apps.live.cloud-platform.service.justice.gov.uk"]
 }
 
 resource "aws_route53_record" "delegate_preprod" {
   zone_id = aws_route53_zone.prod_reuselibrary_team_route53_zone.zone_id
   name    = "preprod.reuselibrary.service.justice.gov.uk"
-  type    = "NS"
+  type    = "CNAME"
   ttl     = 300
 
-  records = aws_route53_zone.preprod_reuselibrary_team_route53_zone.name_servers
+  records = ["reuse-library-preprod.apps.live.cloud-platform.service.justice.gov.uk"]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
@@ -24,3 +24,21 @@ resource "kubernetes_secret" "route53_zone_sec" {
     nameservers = join("\n", aws_route53_zone.prod_reuselibrary_team_route53_zone.name_servers)
   }
 }
+
+resource "aws_route53_record" "delegate_dev" {
+  zone_id = aws_route53_zone.prod_reuselibrary_team_route53_zone.zone_id
+  name    = "dev.reuselibrary.service.justice.gov.uk"
+  type    = "NS"
+  ttl     = 300
+
+  records = aws_route53_zone.dev_reuse_library_team_route53_zone.name_servers
+}
+
+resource "aws_route53_record" "delegate_preprod" {
+  zone_id = aws_route53_zone.prod_reuselibrary_team_route53_zone.zone_id
+  name    = "preprod.reuselibrary.service.justice.gov.uk"
+  type    = "NS"
+  ttl     = 300
+
+  records = aws_route53_zone.preprod_reuselibrary_team_route53_zone.name_servers
+}


### PR DESCRIPTION
Key change:
* Add dns records for dev and preprod in reuse library prod
* Using cname records