### PR TITLE
DSTEW-1525 expose claims events SNS topic ARN via SSM (prod).

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-prod/resources/sns.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-prod/resources/sns.tf
@@ -32,6 +32,22 @@ resource "kubernetes_secret" "claims_events_sns_topic" {
   }
 }
 
+resource "aws_ssm_parameter" "claims_events_sns_topic_arn" {
+  type        = "String"
+  name        = "/${var.namespace}/topic-arn"
+  value       = module.claims_events_sns_topic.topic_arn
+  description = "Claims events SNS topic ARN"
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    owner                  = var.team_name
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
 ###
 ########### SNS subscriptions ###########
 ###


### PR DESCRIPTION
- added  `laa-data-claims-api-prod` SNS topic ARN at SSM `/laa-data-claims-api-prod/topic-arn`
- Publishes the prod claims-events SNS topic ARN to SSM so other namespaces (notify-service-prod etc) can subscribe without hard-coding the ARN. 