### PR TITLE
DSTEW-1524 enable raw_message_delivery on notify subscription (uat)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/sqs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-notify-service-uat/resources/sqs.tf
@@ -71,10 +71,11 @@ resource "aws_sqs_queue_policy" "notify_queue" {
 }
 
 resource "aws_sns_topic_subscription" "notify" {
-  provider  = aws.london
-  topic_arn = data.aws_ssm_parameter.claims_sns_topic_arn.value
-  protocol  = "sqs"
-  endpoint  = module.notify_queue.sqs_arn
+  provider             = aws.london
+  topic_arn            = data.aws_ssm_parameter.claims_sns_topic_arn.value
+  protocol             = "sqs"
+  endpoint             = module.notify_queue.sqs_arn
+  raw_message_delivery = true
 
   filter_policy = jsonencode({
     SubmissionEventType = ["SUBMISSION_VALIDATION_SUCCEEDED"]


### PR DESCRIPTION
- Enables `raw_message_delivery = true` on the UAT notify SNS→SQS subscription. 