### PR TITLE
LAA SDS add bucket for data access client in uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-test/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-sds-test/resources/variables.tf
@@ -142,7 +142,7 @@ variable "serviceaccount_rules" {
 
 variable "bucket_names" {
   type = list(string)
-  default = ["laa-sds-internal", "laa-sds-inquests"]
+  default = ["laa-sds-internal", "laa-sds-inquests", "laa-sds-data-access-api"]
 }
 
 variable "service_area" {


### PR DESCRIPTION
Adds a new S3 bucket for the data access client in our test environment.