### PR TITLE
feat/add-infra-prisoner-monies-sendmoney-ui: add  infra config based …

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/00-namespace.yaml
@@ -14,4 +14,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Prisoner Monies"
     cloud-platform.justice.gov.uk/owner: "HMPPS Community of Practice: dps-hmpps@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-prisoner-monies-send-money-ui"
-    cloud-platform.justice.gov.uk/team-name: "hmpps-prisoner-monies"
+    cloud-platform.justice.gov.uk/team-name: "prisoner-money"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/00-namespace.yaml
@@ -14,4 +14,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Prisoner Monies"
     cloud-platform.justice.gov.uk/owner: "HMPPS Community of Practice: dps-hmpps@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-prisoner-monies-send-money-ui"
-    cloud-platform.justice.gov.uk/team-name: "prisoner-money"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-prisoner-monies"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-prisoner-monies-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps_prisoner_monies_devs"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "hmpps_prisoner_monies_alerts_non_prod"
+    cloud-platform.justice.gov.uk/application: "HMPPS Prisoner Monies"
+    cloud-platform.justice.gov.uk/owner: "HMPPS Community of Practice: dps-hmpps@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-prisoner-monies-send-money-ui"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-prisoner-monies"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/01-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: hmpps-prisoner-monies-dev
 subjects:
   - kind: Group
-    name: "github:hmpps-prisoner-monies"
+    name: "github:hmpps-prisoner-monies-dev"
     apiGroup: rbac.authorization.k8s.io
 ############## COPY - DO NOT REPLACE ##############
   - kind: Group
@@ -37,6 +37,9 @@ metadata:
 subjects:
   - kind: Group
     name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-prisoner-monies-dev"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/01-rbac.yaml
@@ -1,0 +1,53 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-prisoner-monies-dev-admin
+  namespace: hmpps-prisoner-monies-dev
+subjects:
+  - kind: Group
+    name: "github:hmpps-kotlin"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-typescript"
+    apiGroup: rbac.authorization.k8s.io
+############## COPY - DO NOT REPLACE ##############
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+# hmpps-sre group is required for support functions
+###################################################
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ephemeral-container-access
+  namespace: hmpps-prisoner-monies-dev
+rules:
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["get", "patch", "update", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ephemeral-container-access-binding
+  namespace: hmpps-prisoner-monies-dev
+subjects:
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-kotlin"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-typescript"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: ephemeral-container-access
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/01-rbac.yaml
@@ -6,10 +6,7 @@ metadata:
   namespace: hmpps-prisoner-monies-dev
 subjects:
   - kind: Group
-    name: "github:hmpps-kotlin"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: "github:hmpps-typescript"
+    name: "github:hmpps-prisoner-monies"
     apiGroup: rbac.authorization.k8s.io
 ############## COPY - DO NOT REPLACE ##############
   - kind: Group
@@ -40,12 +37,6 @@ metadata:
 subjects:
   - kind: Group
     name: "github:hmpps-sre"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: "github:hmpps-kotlin"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: "github:hmpps-typescript"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/02-limitrange.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-prisoner-monies-dev
+spec:
+  limits:
+    - default:
+        cpu: 1000m
+        memory: 1024Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 128Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-prisoner-monies-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-prisoner-monies-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-prisoner-monies-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/06-certificate.yaml
@@ -10,18 +10,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - prisoner-monies-api-dev.hmpps.service.justice.gov.uk
-
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: hmpps-prisoner-monies-cert
-  namespace: hmpps-prisoner-monies-dev
-spec:
-  secretName: hmpps-prisoner-monies-cert
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
     - prisoner-monies-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/06-certificate.yaml
@@ -2,12 +2,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: hmpps-prisoner-monies-cert
+  name: hmpps-prisoner-monies-send-money-cert
   namespace: hmpps-prisoner-monies-dev
 spec:
-  secretName: hmpps-prisoner-monies-cert
+  secretName: hmpps-prisoner-monies-send-money-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - prisoner-monies-dev.hmpps.service.justice.gov.uk
+    - prisoner-monies-send-money-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/06-certificate.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-prisoner-monies-cert
+  namespace: hmpps-prisoner-monies-dev
+spec:
+  secretName: hmpps-prisoner-monies-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - prisoner-monies-api-dev.hmpps.service.justice.gov.uk
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-prisoner-monies-cert
+  namespace: hmpps-prisoner-monies-dev
+spec:
+  secretName: hmpps-prisoner-monies-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - prisoner-monies-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/07-rbac-haar-client-admin-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/07-rbac-haar-client-admin-team.yaml
@@ -1,0 +1,39 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-prisoner-monies-dev
+rules:
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "issuers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [ "", "extensions" ]
+    resources: [ "services", "ingresses", "configmaps", "pods/log" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: [ "get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-prisoner-monies-dev
+subjects:
+  - kind: Group
+    name: "github:hmpps-haar-client-admin"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: hmpps-haar-client-admin-team
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      application   = var.application
+      business-unit = var.business_unit
+      GithubTeam    = var.team_name
+      is-production = var.is_production
+      namespace     = var.namespace
+      owner         = var.team_name
+      service-area  = var.service_area
+      slack-channel = var.slack_channel
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      application   = var.application
+      business-unit = var.business_unit
+      GithubTeam    = var.team_name
+      is-production = var.is_production
+      namespace     = var.namespace
+      owner         = var.team_name
+      service-area  = var.service_area
+      slack-channel = var.slack_channel
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      application   = var.application
+      business-unit = var.business_unit
+      GithubTeam    = var.team_name
+      is-production = var.is_production
+      namespace     = var.namespace
+      owner         = var.team_name
+      service-area  = var.service_area
+      slack-channel = var.slack_channel
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+    }
+  }
+}
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-send-money-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-send-money-ui.tf
@@ -8,6 +8,8 @@ module "hmpps_prisoner_monies_send_money_ui" {
   github_team = "hmpps-prisoner-monies"
   environment = var.environment 
   #reviewer_teams                = ["hmpps-dev-team-1", "hmpps-dev-team-2"]
+  #selected_branch_patterns      = ["main", "release/*", "feature/*"] # Optional
+  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev"
   source_template_repo          = "hmpps-template-typescript"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-ui.tf
@@ -5,7 +5,7 @@ module "hmpps_prisoner_monies_send_money_ui" {
   custom_token_rotation_date = "2026-03-20"
   github_repo = "hmpps-prisoner-monies-send-money-ui"
   application = "hmpps-prisoner-monies-send-money-ui"
-  github_team = "prisoner-money"
+  github_team = "hmpps-prisoner-monies"
   environment = var.environment 
   #reviewer_teams                = ["hmpps-dev-team-1", "hmpps-dev-team-2"]
   is_production                 = var.is_production

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-ui.tf
@@ -19,7 +19,7 @@ module "hmpps_prisoner_monies_send_money_ui" {
 
 # Note, redis is a requirement for hmpps-template-typescript application.
 module "elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-ui.tf
@@ -1,0 +1,55 @@
+
+module "hmpps_prisoner_monies_send_money_ui" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  force_rotate_token = true
+  custom_token_rotation_date = "2026-03-20"
+  github_repo = "hmpps-prisoner-monies-send-money-ui"
+  application = "hmpps-prisoner-monies-send-money-ui"
+  github_team = "hmpps-prisoner-monies"
+  environment = var.environment 
+  #reviewer_teams                = ["hmpps-dev-team-1", "hmpps-dev-team-2"]
+  is_production                 = var.is_production
+  application_insights_instance = "dev"
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}
+
+
+# Note, redis is a requirement for hmpps-template-typescript application.
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = module.hmpps_prisoner_monies_send_money_ui.application
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  number_cache_clusters = var.number_cache_clusters
+  # sized for micro in dev, preprod, suggest small for production
+  node_type            = "cache.t4g.micro"
+  engine_version       = "7.0"
+  parameter_group_name = "default.redis7"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "${module.hmpps_prisoner_monies_send_money_ui.application}-elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    replication_group_id     = module.elasticache_redis.replication_group_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/prisoner-monies-ui.tf
@@ -5,7 +5,7 @@ module "hmpps_prisoner_monies_send_money_ui" {
   custom_token_rotation_date = "2026-03-20"
   github_repo = "hmpps-prisoner-monies-send-money-ui"
   application = "hmpps-prisoner-monies-send-money-ui"
-  github_team = "hmpps-prisoner-monies"
+  github_team = "prisoner-money"
   environment = var.environment 
   #reviewer_teams                = ["hmpps-dev-team-1", "hmpps-dev-team-2"]
   is_production                 = var.is_production

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/variables.tf
@@ -1,0 +1,62 @@
+variable "vpc_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "HMPPS Prisoner Monies"
+}
+
+variable "namespace" {
+  default = "hmpps-prisoner-monies-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-prisoner-monies"
+}
+
+
+####################################################################################################################
+### Change this environment to the environment name corresponding to this namespace (as per helm/values-ENV.dev) ###
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "dev"
+}
+####################################################################################################################
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "dps-hmpps@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "hmpps_prisoner_monies_devs"
+}
+
+variable "number_cache_clusters" {
+  default = "2"
+}
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/variables.tf
@@ -60,3 +60,9 @@ variable "github_token" {
   description = "Required by the GitHub Terraform provider"
   default     = ""
 }
+
+variable "service_area" {
+  type        = string
+  description = "Service Area"
+  default     = "Prisoner Finance and Activities"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-monies-dev/resources/versions.tf
@@ -1,0 +1,18 @@
+
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
This will add the infra for the new Prisoner Money service that will hold apps migrated from Send Money to Prisoners, eventually including (but not limited to) the services: api, send money, bank admin, noms-ops, and others.

Currently we are migrating the Send Money (public facing) app - which is what this PR will configure.
We also have a non-templated project for Playwright Testing Suite which I believe doesnt need to be deployed.

We will add the Kotlin API config when needed.

I followed prisoner-finance as an example:
https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-finance-dev

Though I wasnt sure if my `main.tf` was correct. 