### PR TITLE
DSTEW-1525: Add laa-data-claims-notify-service-uat to network policy.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/04-networkpolicy.yaml
@@ -85,3 +85,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: laa-amend-a-claim-uat
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-claims-notify-service-uat
+  namespace: laa-data-claims-api-uat
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: laa-data-claims-notify-service-uat


### PR DESCRIPTION
- Allows `laa-data-claims-notify-service-uat` to reach `laa-data-claims-api-uat`.