### PR TITLE
DSTEW-1525: Add laa-data-claims-notify-service-staging to network policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-staging/04-networkpolicy.yaml
@@ -70,3 +70,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: laa-amend-a-claim-staging
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-claims-notify-service-staging
+  namespace: laa-data-claims-api-staging
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: laa-data-claims-notify-service-staging


### PR DESCRIPTION
- Allows `laa-data-claims-notify-service-staging` to reach `laa-data-claims-api-staging`.