### PR TITLE
DSTEW-1525: Add laa-data-claims-notify-service-prod to network policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-prod/04-networkpolicy.yaml
@@ -70,3 +70,18 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: laa-amend-a-claim-production
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-claims-notify-service-prod
+  namespace: laa-data-claims-api-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: laa-data-claims-notify-service-prod


### PR DESCRIPTION
- Allows `laa-data-claims-notify-service-prod` to reach `laa-data-claims-api-prod`.