### PR TITLE
Comment out GitHub integrations in staging ECR to prevent 409 collision

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-redact-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-redact-staging/resources/ecr.tf
@@ -8,8 +8,9 @@ module "ecr" {
   deletion_protection = false
 
   # OpenID Connect configuration
-  oidc_providers      = ["github"]
-  github_repositories = ["justice-redact-frontend", "justice-redact-backend"]
+  # Commented out to completely stop the 409 GitHub Variable collisions
+  # oidc_providers      = ["github"]
+  # github_repositories = ["justice-redact-frontend", "justice-redact-backend"]
 
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
Fixing Concourse apply failure on staging environment caused by duplicate GitHub action variables