### PR TITLE
add s3 bucket for db migration

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
@@ -1,0 +1,154 @@
+locals {
+  db_migration_prefix = "native-backups/dev"
+  db_migration_bucket_name = "chaps-dev-db-migration-${data.aws_caller_identity.current.account_id}"
+
+  db_migration_tags = {
+    application            = var.application
+    business_unit          = var.business_unit
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+    is_production          = var.is_production
+    namespace              = var.namespace
+    team_name              = var.team_name
+  }
+}
+
+resource "aws_kms_key" "db_migration" {
+  description             = "CHAPS ${var.environment} database migration s3 bucket"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  tags = merge(local.db_migration_tags, {
+    Name    = "${var.namespace}-db-migration"
+    Purpose = "CHAPS database migration restore"
+  })
+}
+
+resource "aws_kms_alias" "db_migration" {
+  name          = "alias/${var.namespace}-db-migration"
+  target_key_id = aws_kms_key.db_migration_key_id
+}
+
+resource "aws_s3_bucket" "db_migration" {
+  bucket     = local.db_migration_bucket_name
+
+  tags = merge(local.db_migration_tags, {
+    Name     = local.db_migration_bucket_name
+    Purpose  = "CHAPS database migration restore"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.db_migration.arn
+    }
+
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  depends_on = [
+    aws_s3_bucket_versioning.db_migration,
+    aws_s3_bucket_server_side_encryption_configuration.db_migration
+  ]
+
+  rule {
+    id     = "expire-db-migration-backups"
+    status = "Enabled"
+
+    filter {
+      prefix = "${local.db_migration_prefix}/"
+    }
+
+    expiration {
+      days = 14
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 14
+    }
+  }
+}
+
+data "aws_iam_policy_document" "db_migration_bucket_policy" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn,
+      "${aws_s3_bucket.db_migration.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+  policy = data.aws_iam_policy_document.db_migration_bucket_policy.json
+}
+
+
+output "db_migration_bucket_name" {
+  value       = aws_s3_bucket.db_migration.bucket
+  description = "CP S3 bucket for CHAPS database migration backups"
+}
+
+output "db_migration_bucket_arn" {
+  value       = aws_s3_bucket.db_migration.arn
+  description = "CP S3 bucket ARN for CHAPS database migration backups"
+}
+
+output "db_migration_kms_key_arn" {
+  value       = aws_kms_key.db_migration.arn
+  description = "CP KMS key ARN for CHAPS database migration backups"
+}
+
+output "db_migration_prefix" {
+  value       = local.db_migration_prefix
+  description = "S3 prefix for CHAPS database migration backups"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
@@ -13,6 +13,8 @@ locals {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_kms_key" "db_migration" {
   description             = "CHAPS ${var.environment} database migration s3 bucket"
   deletion_window_in_days = 30
@@ -26,7 +28,7 @@ resource "aws_kms_key" "db_migration" {
 
 resource "aws_kms_alias" "db_migration" {
   name          = "alias/${var.namespace}-db-migration"
-  target_key_id = aws_kms_key.db_migration_key_id
+  target_key_id = aws_kms_key.db_migration.key_id
 }
 
 resource "aws_s3_bucket" "db_migration" {


### PR DESCRIPTION
This pull request introduces a new Terraform configuration to provision resources for CHAPS database migration backups in the development environment. The changes add a dedicated S3 bucket with strict security controls, lifecycle management, and KMS encryption, along with outputs to expose key resource values.

**Infrastructure provisioning for database migration backups:**

* Added a new `aws_s3_bucket` resource, `db_migration`, for storing CHAPS database migration backups, including associated tags and a unique name based on the AWS account.
* Implemented S3 bucket security best practices: public access is fully blocked, ownership is enforced, versioning is enabled, server-side encryption is configured with a dedicated KMS key, and a bucket policy denies insecure (non-HTTPS) access.

**Data retention and lifecycle management:**

* Configured a lifecycle rule to automatically expire and delete both current and non-current backup objects after 14 days, scoped to a specific prefix.

**Key management:**

* Provisioned a dedicated KMS key (with alias) for encrypting backup data in the S3 bucket, with key rotation enabled and appropriate tagging.

**Outputs for integration:**

* Added Terraform outputs to expose the bucket name, bucket ARN, KMS key ARN, and the S3 prefix for use by other modules or systems.