### PR TITLE
amend rds to read from CP bucket

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/rds.tf
@@ -16,15 +16,15 @@ module "rds_mssql" {
   db_max_allocated_storage     = "1000"
 
   # SQL Server specifics
-  db_engine            = "sqlserver-web"
-  db_engine_version    = "14.00.3520.4.v1"
-  rds_family           = "sqlserver-web-14.0"
-  db_instance_class    = "db.t3.medium"
-  db_allocated_storage = 20 # minimum of 20GiB for SQL Server
-  option_group_name    = aws_db_option_group.sqlserver_backup_restore.name
-  enable_irsa          = true
-  deletion_protection  = true
-  enable_rds_auto_start_stop = true
+  db_engine                   = "sqlserver-web"
+  db_engine_version           = "14.00.3520.4.v1"
+  rds_family                  = "sqlserver-web-14.0"
+  db_instance_class           = "db.t3.medium"
+  db_allocated_storage        = 20 # minimum of 20GiB for SQL Server
+  option_group_name           = aws_db_option_group.sqlserver_backup_restore.name
+  enable_irsa                 = true
+  deletion_protection         = true
+  enable_rds_auto_start_stop  = true
 
   # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".
@@ -78,28 +78,22 @@ resource "aws_db_option_group" "sqlserver_backup_restore" {
 
   option {
     option_name = "SQLSERVER_BACKUP_RESTORE"
+
     option_settings {
-      name = "IAM_ROLE_ARN"
-      value  = aws_iam_role.rds_s3_backup_restore.arn
+      name  = "IAM_ROLE_ARN"
+      value = aws_iam_role.rds_s3_backup_restore.arn
     }
   }
 }
 
-variable "backup_bucket" { 
-  type = string 
-  default = "tp-dbbackups"
-  description = "S3 bucket that stores SQL Server .bak files" 
-}        
 
-variable "backup_prefix" { 
-  type = string 
-  default = "chaps-dev/"
-  description = "Key prefix within the backup bucket" 
-} 
-
+locals {
+  db_migration_objects_prefix_arn = "${aws_s3_bucket.db_migration.arn}/${local.db_migration_prefix}/*"
+}
 
 resource "aws_iam_role" "rds_s3_backup_restore" {
   name = "${var.namespace}-rds-s3-backup-restore"
+
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [{
@@ -108,12 +102,6 @@ resource "aws_iam_role" "rds_s3_backup_restore" {
       Action   = "sts:AssumeRole"
     }]
   })
-}
-
-
-locals {
-  bucket_arn         = format("arn:aws:s3:::%s", var.backup_bucket)
-  objects_prefix_arn = format("arn:aws:s3:::%s/%s*", var.backup_bucket, var.backup_prefix)
 }
 
 
@@ -129,27 +117,44 @@ resource "aws_iam_role_policy" "rds_s3_backup_restore" {
         Sid      = "BucketLocation"
         Effect   = "Allow"
         Action   = ["s3:GetBucketLocation"]
-        Resource = local.bucket_arn
+        Resource = aws_s3_bucket.db_migration.arn
       },
       {
         Sid             = "ListBucket"
         Effect          = "Allow"
         Action          = ["s3:ListBucket"]
-        Resource        = local.bucket_arn
+        Resource        = aws_s3_bucket.db_migration.arn
         Condition       = {
           StringLike    = { 
             "s3:prefix" = [
-              format("%s*", var.backup_prefix), 
-              var.backup_prefix
+              local.db_migration_prefix,
+              "${local.db_migration_prefix}/*"
             ]
           }
         }
       },
       {
-        Sid      = "RWPrefix",
-        Effect   = "Allow",
-        Action   = ["s3:GetObject","s3:PutObject","s3:DeleteObject"]
-        Resource = local.objects_prefix_arn
+        Sid     = "ReadWriteBackupObjects"
+        Effect  = "Allow"
+        Action  = [
+          "s3:GetObject",
+          "s3:GetObjectAttributes",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:AbortMultipartUpload"
+        ]
+        Resource = local.db_migration_objects_prefix_arn
+      },
+      {
+        Sid     = "UseCpBackupKmsKey"
+        Effect  = "Allow"
+        Action  = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey"
+        ]
+        Resource = aws_kms_key.db_migration.arn
       }
     ]
   })


### PR DESCRIPTION
This pull request updates the RDS SQL Server backup and restore configuration to use a new S3 bucket and KMS key for storing and encrypting database backups. It removes the old `backup_bucket` and `backup_prefix` variables, and instead uses the `db_migration` S3 bucket and prefix. The IAM role and policy are updated to grant the correct permissions for this new setup, including KMS permissions for encryption.

**Backup and storage configuration updates:**

* Removed the `backup_bucket` and `backup_prefix` variables and their associated local values, switching to use the `aws_s3_bucket.db_migration` resource and a new `local.db_migration_objects_prefix_arn` for object ARNs. [[1]](diffhunk://#diff-51400d96465b3dfac08657ec07045bfa1ccbad88e9d13b71f46b8218e98987eaR81-R96) [[2]](diffhunk://#diff-51400d96465b3dfac08657ec07045bfa1ccbad88e9d13b71f46b8218e98987eaL114-L119)
* Updated IAM policy to reference the new S3 bucket and prefix, ensuring the RDS role has the necessary permissions for listing, reading, and writing backup objects in the new location.

**Security and permissions improvements:**

* Expanded the S3 permissions to include additional actions (`GetObjectAttributes`, `ListMultipartUploadParts`, `AbortMultipartUpload`) for more robust backup and restore operations.
* Added a new policy statement to allow the RDS role to use the KMS key (`aws_kms_key.db_migration`) for encrypting and decrypting backup files.