### PR TITLE
fix prefixes

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/chaps-db-migration-copy-test.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/chaps-db-migration-copy-test.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: chaps-db-migration-copy-test
+  namespace: chaps-dotnet-development
+spec:
+  serviceAccountName: chaps-db-migration-copy
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  containers:
+    - name: awscli
+      image: amazon/aws-cli:2.15.0
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          mkdir -p /tmp/.aws
+          export HOME=/tmp
+          export AWS_CONFIG_FILE=/tmp/.aws/config
+          export AWS_SHARED_CREDENTIALS_FILE=/tmp/.aws/credentials
+          sleep 3600
+      env:
+        - name: HOME
+          value: /tmp
+        - name: AWS_CONFIG_FILE
+          value: /tmp/.aws/config
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /tmp/.aws/credentials
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        capabilities:
+          drop:
+            - ALL

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/db_migration_copy_irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/db_migration_copy_irsa.tf
@@ -44,7 +44,9 @@ data "aws_iam_policy_document" "db_migration_copy" {
       variable = "s3:prefix"
       values   = [
         local.db_migration_prefix,
+        "${local.db_migration_prefix}/",
         "${local.db_migration_prefix}/*"
+
       ]
     }
   }
@@ -92,7 +94,9 @@ data "aws_iam_policy_document" "db_migration_copy" {
       variable  = "s3:prefix"
       values    = [
         local.db_migration_prefix,
+        "${local.db_migration_prefix}/"
         "${local.db_migration_prefix}/*"
+
       ]
     }
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/db_migration_copy_irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/db_migration_copy_irsa.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "db_migration_copy" {
       variable  = "s3:prefix"
       values    = [
         local.db_migration_prefix,
-        "${local.db_migration_prefix}/"
+        "${local.db_migration_prefix}/",
         "${local.db_migration_prefix}/*"
 
       ]


### PR DESCRIPTION
This pull request introduces a new Kubernetes pod definition for testing database migration copy operations and updates the IAM policy document to ensure correct S3 prefix permissions. The main changes focus on enabling and securing database migration testing and refining S3 access controls.

**Kubernetes Pod Addition for DB Migration Testing:**
- Added a new pod manifest `chaps-db-migration-copy-test.yaml` to the `chaps-dotnet-development` namespace. This pod uses the AWS CLI image with a non-root user, strict security context, and environment variables set up for AWS credentials, intended for testing database migration copy operations.

**IAM Policy Document Updates (S3 Prefix Permissions):**
- Updated the `db_migration_copy` IAM policy document to include both the base S3 prefix and its variants with and without trailing slashes, ensuring comprehensive S3 access for migration operations. This change affects both the `s3:prefix` variables in the policy. [[1]](diffhunk://#diff-0ca76df1edf91f2f139e3333166c667e2dbcd6d7b1486240ad9fdef4d9b80d2dR47-R49) [[2]](diffhunk://#diff-0ca76df1edf91f2f139e3333166c667e2dbcd6d7b1486240ad9fdef4d9b80d2dR97-R99)

Note - the chaps-db-migration-copy-test.yaml will be deleted shortly after testing.