### PR TITLE
add decrypt permissions

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/db_migration_copy_irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/db_migration_copy_irsa.tf
@@ -122,6 +122,7 @@ data "aws_iam_policy_document" "db_migration_copy" {
 
     actions = [
       "kms:Encrypt",
+      "kms:Decrypt",
       "kms:GenerateDataKey",
       "kms:DescribeKey"
     ]


### PR DESCRIPTION
This pull request makes a minor update to the IAM policy for database migration by adding the `kms:Decrypt` permission. This ensures that the policy allows decryption operations with AWS KMS, which may be required for certain migration tasks.