### PR TITLE
Add SAS API and UI to test namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/00-namespace.yaml
@@ -18,5 +18,7 @@ metadata:
       https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui.git,
       https://github.com/ministryofjustice/hmpps-approved-premises-api.git,
       https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui,
-      https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui
+      https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui,
+      https://github.com/ministryofjustice/hmpps-single-accommodation-service-api,
+      https://github.com/ministryofjustice/hmpps-single-accommodation-service-ui
     cloud-platform.justice.gov.uk/team-name: "hmpps-community-accommodation"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/06-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/06-certificates.yaml
@@ -77,3 +77,29 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - community-accommodation-tier-2-bail-test.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-single-accommodation-service-api-test-cert
+  namespace: hmpps-community-accommodation-test
+spec:
+  secretName: hmpps-single-accommodation-service-api-test-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - single-accommodation-service-api-test.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-single-accommodation-service-test-cert
+  namespace: hmpps-community-accommodation-test
+spec:
+  secretName: hmpps-single-accommodation-service-test-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - single-accommodation-service-test.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-single-accommodation-service-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-single-accommodation-service-api.tf
@@ -1,0 +1,18 @@
+module "hmpps_single_accommodation_service_api" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  force_rotate_token = true
+  custom_token_rotation_date = "2026-03-20"
+  github_repo = "hmpps-single-accommodation-service-api"
+  application = "hmpps-single-accommodation-service-api"
+  github_team = "hmpps-community-accommodation"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
+  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation", "hmpps-community-accommodation-devs"] # Optional team that should review deployments to this environment.
+  selected_branch_patterns      = ["*", "*/*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline.
+  # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-single-accommodation-service-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/hmpps-single-accommodation-service-ui.tf
@@ -1,0 +1,18 @@
+module "hmpps_single_accommodation_service_ui" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  force_rotate_token = true
+  custom_token_rotation_date = "2026-03-20"
+  github_repo = "hmpps-single-accommodation-service-ui"
+  application = "hmpps-single-accommodation-service-ui"
+  github_team = "hmpps-community-accommodation"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-development.yaml
+  reviewer_teams                = ["approved-premises-team", "hmpps-community-accommodation", "hmpps-community-accommodation-devs"] # Optional, team that should review deployments to this environment.
+  selected_branch_patterns      = ["*", "*/*"] # Optional -- we allow deploying any branch to test, as it is decoupled from the main pipeline.
+  # protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/irsa.tf
@@ -18,6 +18,8 @@ module "irsa" {
   role_policy_arns = merge(
     { cas-2-sqs           = module.cas-2-domain-events-listener-queue.irsa_policy_arn },
     { cas-2-sqs-dlq = module.cas-2-domain-events-listener-dlq.irsa_policy_arn },
+    { sas-sqs    = module.sas_domain_events_queue.irsa_policy_arn },
+    { sas-sqs-dlq    = module.sas_domain_events_dlq.irsa_policy_arn },
     local.sns_policies
   )
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds-single-accommodation-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/rds-single-accommodation-service.tf
@@ -1,0 +1,67 @@
+module "single_accommodation_service_rds" {
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+  db_allocated_storage        = 20
+  storage_type                = "gp3"
+  vpc_name                    = var.vpc_name
+  team_name                   = var.team_name
+  business_unit               = var.business_unit
+  application                 = var.application
+  is_production               = var.is_production
+  namespace                   = var.namespace
+  environment_name            = var.environment
+  infrastructure_support      = var.infrastructure_support
+  allow_major_version_upgrade = "true"
+  allow_minor_version_upgrade = "true"
+  db_instance_class           = "db.t4g.small"
+  db_engine_version           = "18"
+  db_engine                   = "postgres"
+  rds_family                  = "postgres18"
+  # db_password_rotated_date    = "08-01-2026"
+  prepare_for_major_upgrade   = false
+
+  enable_irsa = true
+
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
+}
+
+
+resource "kubernetes_secret" "single_accommodation_service_rds" {
+  metadata {
+    name      = "single-accommodation-service-rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.single_accommodation_service_rds.rds_instance_endpoint
+    database_name         = module.single_accommodation_service_rds.database_name
+    database_username     = module.single_accommodation_service_rds.database_username
+    database_password     = module.single_accommodation_service_rds.database_password
+    rds_instance_address  = module.single_accommodation_service_rds.rds_instance_address
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/sas-sqs-domain-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/sas-sqs-domain-events.tf
@@ -1,0 +1,78 @@
+module "sas_domain_events_queue" {
+  
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name = "sas_domain_events_queue"
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.sas_domain_events_dlq.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "aws_sqs_queue_policy" "sas_domain_events_queue_policy" {
+  queue_url = module.sas_domain_events_queue.sqs_id
+  policy    = data.aws_iam_policy_document.sns_to_sqs.json
+}
+
+module "sas_domain_events_dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name                  = "sas_domain_events_dlq"
+  message_retention_seconds = 7 * 24 * 3600 # 1 week
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+
+resource "aws_sns_topic_subscription" "sas_domain_events_subscription" {
+  topic_arn = data.aws_sns_topic.hmpps-domain-events.arn
+  protocol  = "sqs"
+  endpoint  = module.sas_domain_events_queue.sqs_arn
+  filter_policy = jsonencode({
+    eventType = [
+      "accommodation.cas3.person.arrived",
+      "approved-premises.person.arrived",
+    ]
+  })
+}
+
+
+resource "kubernetes_secret" "sas_domain_events_queue_secret" {
+  metadata {
+    name      = "sas-domain-events-queue-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    queue_url  = module.sas_domain_events_queue.sqs_id
+    queue_arn  = module.sas_domain_events_queue.sqs_arn
+    queue_name = module.sas_domain_events_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "sas_domain_events_dlq_secret" {
+  metadata {
+    name      = "sas-domain-events-dlq-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    queue_url  = module.sas_domain_events_dlq.sqs_id
+    queue_arn  = module.sas_domain_events_dlq.sqs_arn
+    queue_name = module.sas_domain_events_dlq.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/sas_elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/sas_elasticache.tf
@@ -1,0 +1,36 @@
+module "sas_elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
+  vpc_name               = var.vpc_name
+  application            = var.application
+  environment_name       = var.environment
+  is_production          = var.is_production
+  infrastructure_support = var.infrastructure_support
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  number_cache_clusters  = var.number_cache_clusters
+  node_type              = "cache.t4g.micro"
+  engine_version         = "7.0"
+  parameter_group_name   = "default.redis7"
+  namespace              = var.namespace
+
+  auth_token_rotated_date = "2025-11-25"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "sas_elasticache_redis" {
+  metadata {
+    name      = "sas-elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.sas_elasticache_redis.primary_endpoint_address
+    reader_endpoint_address = module.sas_elasticache_redis.reader_endpoint_address
+    auth_token               = module.sas_elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.sas_elasticache_redis.member_clusters)
+    replication_group_id     = module.sas_elasticache_redis.replication_group_id
+  }
+}


### PR DESCRIPTION
Add SAS UI and API (and associated RDS/Elasticache instances) to the `hmpps-commmunity-accommodation-test` namespace.