### PR TITLE
Redirect old dev domain to production :https://reuselibrary.service.justice.gov.uk/

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/06-certificate.yml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/06-certificate.yml
@@ -10,3 +10,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
   - dev.reuselibrary.service.justice.gov.uk
+  - reuselibrary.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/07-redirect_old_url.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-dev/07-redirect_old_url.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: https://reuselibrary.service.justice.gov.uk/$1
+    external-dns.alpha.kubernetes.io/set-identifier: reuse-library-dev-redirect-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+  labels:
+    app: reuse-library-dev
+  name: reuse-library-dev-redirect
+  namespace: reuse-library-dev
+spec:
+  ingressClassName: default
+  rules:
+  - host: dev.reuselibrary.service.justice.gov.uk
+    http:
+      paths:
+      - backend:
+          service:
+            name: reuse-library-dev
+            port:
+              name: http
+        path: /(.*)
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - dev.reuselibrary.service.justice.gov.uk
+    secretName: reuse-library-cert


### PR DESCRIPTION
## What
Redirects all traffic from https://dev.reuselibrary.service.justice.gov.uk/ to https://reuselibrary.service.justice.gov.uk/

## Why
Consolidate services and direct users to the production URL. The dev domain is being deprecated in favor of the primary production domain.

## Changes

- 06-certificate.yml - Added reuselibrary.service.justice.gov.uk to the certificate's dnsNames to support HTTPS for both the old and new domains
- 07-redirect_old_url.yaml— New Ingress resource that performs a 301 permanent redirect using NGINX's rewrite-target annotation

## How it works

- Requests to dev.reuselibrary.service.justice.gov.uk/* are redirected to reuselibrary.service.justice.gov.uk/*
- Uses standard NGINX rewrite pattern consistent with other services in this repository (e.g., make-recall-decision, licences)
- Preserves request paths ($1 regex capture)