### PR TITLE
env-aware prefix

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
@@ -1,6 +1,7 @@
 locals {
-  db_migration_prefix = "native-backups/dev"
-  db_migration_bucket_name = "chaps-dev-db-migration-${data.aws_caller_identity.current.account_id}"
+  db_migration_environment_short_name = "dev"
+  db_migration_prefix = "native-backups/${local.db_migration_environment_short_name}""
+  db_migration_bucket_name = "${var.namespace}-db-migration-${data.aws_caller_identity.current.account_id}"
 
   db_migration_tags = {
     application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
@@ -2,6 +2,7 @@ locals {
   db_migration_environment_short_name = "dev"
   db_migration_prefix = "native-backups/${local.db_migration_environment_short_name}""
   db_migration_bucket_name = "${var.namespace}-db-migration-${data.aws_caller_identity.current.account_id}"
+}
 
   db_migration_tags = {
     application            = var.application

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-development/resources/s3_db_migration.tf
@@ -1,8 +1,8 @@
 locals {
   db_migration_environment_short_name = "dev"
-  db_migration_prefix = "native-backups/${local.db_migration_environment_short_name}""
+  db_migration_prefix = "native-backups/${local.db_migration_environment_short_name}"
   db_migration_bucket_name = "${var.namespace}-db-migration-${data.aws_caller_identity.current.account_id}"
-}
+
 
   db_migration_tags = {
     application            = var.application


### PR DESCRIPTION
This pull request updates the S3 database migration configuration to better support environment-specific naming and improve maintainability. The main changes involve how the S3 bucket name and prefix are constructed, making them more flexible and consistent.

**Improvements to S3 configuration:**

* Introduced a new local variable `db_migration_environment_short_name` to make the environment name configurable in the S3 prefix.
* Updated `db_migration_prefix` to use the new environment variable, improving clarity and flexibility for different environments.
* Changed `db_migration_bucket_name` to use the `namespace` variable instead of a hardcoded value, allowing for more generic and reusable bucket names across different deployments.