### PR TITLE
resources for s3 db migration staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/db_migration_copy_irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/db_migration_copy_irsa.tf
@@ -1,0 +1,156 @@
+#This role is for a temporary Kubernetes pod/job that copies ModPlatform S3/KMS → CloudPlatform S3/KMS
+
+locals {
+  mp_db_migration_bucket_name     = "cdpt-chaps-staging-db-migration-631213771998"
+  mp_db_migration_bucket_arn      = "arn:aws:s3:::cdpt-chaps-staging-db-migration-631213771998"
+  mp_db_migration_kms_key_arn     = "arn:aws:kms:eu-west-2:631213771998:key/b953332c-1677-4da9-a4db-44f0bccba42d"
+}
+
+module "db_migration_copy_irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = "chaps-db-migration-copy"
+
+  role_policy_arns = {
+    db_migration_copy = aws_iam_policy.db_migration_copy.arn
+  }
+
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  team_name              = var.team_name
+}
+
+
+data "aws_iam_policy_document" "db_migration_copy" {
+  statement {
+    sid = "ListMpMigrationBucket"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      local.mp_db_migration_bucket_arn
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = [
+        local.db_migration_prefix,
+        "${local.db_migration_prefix}/",
+        "${local.db_migration_prefix}/*"
+
+      ]
+    }
+  }
+
+  statement {
+    sid = "ReadMpMigrationBackupObjects"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAttributes"
+    ]
+
+    resources = [
+      "${local.mp_db_migration_bucket_arn}/${local.db_migration_prefix}/*"
+    ]
+  }
+
+  statement {
+    sid = "DecryptMpMigrationBackupObjects"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = [
+      local.mp_db_migration_kms_key_arn
+    ]
+  }
+
+  statement {
+    sid = "ListCpMigrationBucket"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn
+    ]
+
+    condition {
+      test      = "StringLike"
+      variable  = "s3:prefix"
+      values    = [
+        local.db_migration_prefix,
+        "${local.db_migration_prefix}/",
+        "${local.db_migration_prefix}/*"
+
+      ]
+    }
+  }
+
+  statement {
+    sid = "WriteCpMigrationBackupObjects"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAttributes",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts"
+    ]
+
+    resources = [
+      local.db_migration_objects_prefix_arn
+    ]
+  }
+
+  statement {
+    sid = "EncryptCpMigrationBackupObjects"
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey"
+    ]
+
+    resources = [
+      aws_kms_key.db_migration.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "db_migration_copy" {
+  name   = "${var.namespace}-db-migration-copy"
+  policy = data.aws_iam_policy_document.db_migration_copy.json
+
+  tags = local.db_migration_tags
+}
+
+output "db_migration_copy_irsa_role_arn" {
+  value       = module.db_migration_copy_irsa.role_arn
+  description = "IRSA role ARN that MP must allow to read/decrypt the migration backup"
+}
+
+output "db_migration_copy_irsa_role_name" {
+  value       = module.db_migration_copy_irsa.role_name
+  description = "IRSA role name used by the CHAPS DB migration copy service account"
+}
+
+output "db_migration_copy_service_account_name" {
+  value       = module.db_migration_copy_irsa.service_account.name
+  description = "Kubernetes service account used to copy CHAPS DB backups from MP S3 to CP S3"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/rds.tf
@@ -16,14 +16,14 @@ module "rds_mssql" {
   db_max_allocated_storage     = "1000"
 
   # SQL Server specifics
-  db_engine            = "sqlserver-web"
-  db_engine_version    = "14.00.3520.4.v1"
-  rds_family           = "sqlserver-web-14.0"
-  db_instance_class    = "db.t3.large"
-  db_allocated_storage = 32 # minimum of 20GiB for SQL Server
-  option_group_name    = aws_db_option_group.sqlserver_backup_restore.name
-  enable_irsa          = true
-  deletion_protection  = true
+  db_engine                  = "sqlserver-web"
+  db_engine_version          = "14.00.3520.4.v1"
+  rds_family                 = "sqlserver-web-14.0"
+  db_instance_class          = "db.t3.large"
+  db_allocated_storage       = 32 # minimum of 20GiB for SQL Server
+  option_group_name          = aws_db_option_group.sqlserver_backup_restore.name
+  enable_irsa                = true
+  deletion_protection        = true
   enable_rds_auto_start_stop = true
 
   # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
@@ -79,24 +79,15 @@ resource "aws_db_option_group" "sqlserver_backup_restore" {
   option {
     option_name = "SQLSERVER_BACKUP_RESTORE"
     option_settings {
-      name = "IAM_ROLE_ARN"
-      value  = aws_iam_role.rds_s3_backup_restore.arn
+      name  = "IAM_ROLE_ARN"
+      value = aws_iam_role.rds_s3_backup_restore.arn
     }
   }
 }
 
-variable "backup_bucket" { 
-  type = string 
-  default = "tp-dbbackups"
-  description = "S3 bucket that stores SQL Server .bak files" 
-}        
-
-variable "backup_prefix" { 
-  type = string 
-  default = "chaps-dev/"
-  description = "Key prefix within the backup bucket" 
-} 
-
+locals {
+  db_migration_objects_prefix_arn = "${aws_s3_bucket.db_migration.arn}/${local.db_migration_prefix}/*"
+}
 
 resource "aws_iam_role" "rds_s3_backup_restore" {
   name = "${var.namespace}-rds-s3-backup-restore"
@@ -110,13 +101,6 @@ resource "aws_iam_role" "rds_s3_backup_restore" {
   })
 }
 
-
-locals {
-  bucket_arn         = format("arn:aws:s3:::%s", var.backup_bucket)
-  objects_prefix_arn = format("arn:aws:s3:::%s/%s*", var.backup_bucket, var.backup_prefix)
-}
-
-
 # Least-privilege inline policy: list bucket + R/W objects in the prefix
 resource "aws_iam_role_policy" "rds_s3_backup_restore" {
   name = "${var.namespace}-rds-s3-backup-restore"
@@ -129,27 +113,45 @@ resource "aws_iam_role_policy" "rds_s3_backup_restore" {
         Sid      = "BucketLocation"
         Effect   = "Allow"
         Action   = ["s3:GetBucketLocation"]
-        Resource = local.bucket_arn
+        Resource = aws_s3_bucket.db_migration.arn
       },
       {
         Sid             = "ListBucket"
         Effect          = "Allow"
         Action          = ["s3:ListBucket"]
-        Resource        = local.bucket_arn
+        Resource        = aws_s3_bucket.db_migration.arn
         Condition       = {
           StringLike    = { 
             "s3:prefix" = [
-              format("%s*", var.backup_prefix), 
-              var.backup_prefix
+              local.db_migration_prefix,
+              "${local.db_migration_prefix}/",
+              "${local.db_migration_prefix}/*"
             ]
           }
         }
       },
       {
-        Sid      = "RWPrefix",
-        Effect   = "Allow",
-        Action   = ["s3:GetObject","s3:PutObject","s3:DeleteObject"]
-        Resource = local.objects_prefix_arn
+        Sid     = "ReadWriteBackupObjects"
+        Effect  = "Allow"
+        Action  = [
+          "s3:GetObject",
+          "s3:GetObjectAttributes",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:AbortMultipartUpload"
+        ]
+        Resource = local.db_migration_objects_prefix_arn
+      },
+      {
+        Sid     = "UseCpBackupKmsKey"
+        Effect  = "Allow"
+        Action  = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey"
+        ]
+        Resource = aws_kms_key.db_migration.arn
       }
     ]
   })

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/s3_db_migration.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-staging/resources/s3_db_migration.tf
@@ -1,0 +1,157 @@
+locals {
+  db_migration_environment_short_name = "staging"
+  db_migration_prefix = "native-backups/${local.db_migration_environment_short_name}"
+  db_migration_bucket_name = "chaps-${local.db_migration_environment_short_name}-db-migration-${data.aws_caller_identity.current.account_id}"
+
+  db_migration_tags = {
+    application            = var.application
+    business_unit          = var.business_unit
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+    is_production          = var.is_production
+    namespace              = var.namespace
+    team_name              = var.team_name
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "db_migration" {
+  description             = "CHAPS ${var.environment} database migration s3 bucket"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  tags = merge(local.db_migration_tags, {
+    Name    = "${var.namespace}-db-migration"
+    Purpose = "CHAPS database migration restore"
+  })
+}
+
+resource "aws_kms_alias" "db_migration" {
+  name          = "alias/${var.namespace}-db-migration"
+  target_key_id = aws_kms_key.db_migration.key_id
+}
+
+resource "aws_s3_bucket" "db_migration" {
+  bucket     = local.db_migration_bucket_name
+
+  tags = merge(local.db_migration_tags, {
+    Name     = local.db_migration_bucket_name
+    Purpose  = "CHAPS database migration restore"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.db_migration.arn
+    }
+
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  depends_on = [
+    aws_s3_bucket_versioning.db_migration,
+    aws_s3_bucket_server_side_encryption_configuration.db_migration
+  ]
+
+  rule {
+    id     = "expire-db-migration-backups"
+    status = "Enabled"
+
+    filter {
+      prefix = "${local.db_migration_prefix}/"
+    }
+
+    expiration {
+      days = 14
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 14
+    }
+  }
+}
+
+data "aws_iam_policy_document" "db_migration_bucket_policy" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn,
+      "${aws_s3_bucket.db_migration.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+  policy = data.aws_iam_policy_document.db_migration_bucket_policy.json
+}
+
+
+output "db_migration_bucket_name" {
+  value       = aws_s3_bucket.db_migration.bucket
+  description = "CP S3 bucket for CHAPS database migration backups"
+}
+
+output "db_migration_bucket_arn" {
+  value       = aws_s3_bucket.db_migration.arn
+  description = "CP S3 bucket ARN for CHAPS database migration backups"
+}
+
+output "db_migration_kms_key_arn" {
+  value       = aws_kms_key.db_migration.arn
+  description = "CP KMS key ARN for CHAPS database migration backups"
+}
+
+output "db_migration_prefix" {
+  value       = local.db_migration_prefix
+  description = "S3 prefix for CHAPS database migration backups"
+}


### PR DESCRIPTION
This pull request introduces a new, secure workflow for CHAPS database migration backups in the staging environment. It establishes dedicated S3 storage and KMS encryption for migration backups, implements an IAM role and policy for a migration copy job, and updates the RDS backup/restore roles to use these new resources and conventions. The changes improve security, automation, and clarity for database migration processes.

**Database migration backup infrastructure:**

* Adds a new S3 bucket (`aws_s3_bucket.db_migration`) with enforced security, versioning, encryption (KMS), and a 14-day lifecycle for CHAPS database migration backups in staging. Also creates a dedicated KMS key and alias for encryption.
* Defines outputs for the new S3 bucket name, ARN, KMS key ARN, and S3 prefix for use in other modules or documentation.

**IAM roles and policies for migration jobs:**

* Introduces a new IAM role and policy (`db_migration_copy_irsa`) for a Kubernetes service account to securely copy database migration backups between ModPlatform and CloudPlatform S3 buckets, with precise S3 and KMS permissions.
* Adds outputs for the IRSA role ARN, name, and service account name to facilitate integration with the migration copy job.

**RDS backup/restore role updates:**

* Refactors the RDS backup/restore IAM role and policy to use the new S3 bucket, KMS key, and prefix, and removes old variable-based configuration in favor of locals and direct resource references. Updates permissions to match the new backup storage structure and security requirements. [[1]](diffhunk://#diff-628b55a3dd747385a2e82f9b564a0c46e4ae9503b449103804ca65a06b5a66aaL88-L100) [[2]](diffhunk://#diff-628b55a3dd747385a2e82f9b564a0c46e4ae9503b449103804ca65a06b5a66aaL113-L119) [[3]](diffhunk://#diff-628b55a3dd747385a2e82f9b564a0c46e4ae9503b449103804ca65a06b5a66aaL132-R154)