### PR TITLE
resources for db backup

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/db_migration_copy_irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/db_migration_copy_irsa.tf
@@ -1,0 +1,155 @@
+#This role is for a temporary Kubernetes pod/job that copies ModPlatform S3/KMS → CloudPlatform S3/KMS
+
+locals {
+  mp_db_migration_bucket_name     = "cdpt-chaps-prod-db-migration-653875321404"
+  mp_db_migration_bucket_arn      = "arn:aws:s3:::cdpt-chaps-prod-db-migration-653875321404"
+  mp_db_migration_kms_key_arn     = "arn:aws:kms:eu-west-2:653875321404:key/4edd8792-e61e-4a98-9386-b570c3970f98"
+}
+
+module "db_migration_copy_irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = "chaps-db-migration-copy"
+
+  role_policy_arns = {
+    db_migration_copy = aws_iam_policy.db_migration_copy.arn
+  }
+
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  team_name              = var.team_name
+}
+
+
+data "aws_iam_policy_document" "db_migration_copy" {
+  statement {
+    sid = "ListMpMigrationBucket"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      local.mp_db_migration_bucket_arn
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = [
+        local.db_migration_prefix,
+        "${local.db_migration_prefix}/",
+        "${local.db_migration_prefix}/*"
+      ]
+    }
+  }
+
+  statement {
+    sid = "ReadMpMigrationBackupObjects"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAttributes"
+    ]
+
+    resources = [
+      "${local.mp_db_migration_bucket_arn}/${local.db_migration_prefix}/*"
+    ]
+  }
+
+  statement {
+    sid = "DecryptMpMigrationBackupObjects"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = [
+      local.mp_db_migration_kms_key_arn
+    ]
+  }
+
+  statement {
+    sid = "ListCpMigrationBucket"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn
+    ]
+
+    condition {
+      test      = "StringLike"
+      variable  = "s3:prefix"
+      values    = [
+        local.db_migration_prefix,
+        "${local.db_migration_prefix}/",
+        "${local.db_migration_prefix}/*"
+
+      ]
+    }
+  }
+
+  statement {
+    sid = "WriteCpMigrationBackupObjects"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAttributes",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts"
+    ]
+
+    resources = [
+      local.db_migration_objects_prefix_arn
+    ]
+  }
+
+  statement {
+    sid = "UseCpMigrationBackupKmsKey"
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey"
+    ]
+
+    resources = [
+      aws_kms_key.db_migration.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "db_migration_copy" {
+  name   = "${var.namespace}-db-migration-copy"
+  policy = data.aws_iam_policy_document.db_migration_copy.json
+
+  tags = local.db_migration_tags
+}
+
+output "db_migration_copy_irsa_role_arn" {
+  value       = module.db_migration_copy_irsa.role_arn
+  description = "IRSA role ARN that MP must allow to read/decrypt the migration backup"
+}
+
+output "db_migration_copy_irsa_role_name" {
+  value       = module.db_migration_copy_irsa.role_name
+  description = "IRSA role name used by the CHAPS DB migration copy service account"
+}
+
+output "db_migration_copy_service_account_name" {
+  value       = module.db_migration_copy_irsa.service_account.name
+  description = "Kubernetes service account used to copy CHAPS DB backups from MP S3 to CP S3"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/rds.tf
@@ -84,17 +84,9 @@ resource "aws_db_option_group" "sqlserver_backup_restore" {
   }
 }
 
-variable "backup_bucket" { 
-  type = string 
-  default = "tp-dbbackups"
-  description = "S3 bucket that stores SQL Server .bak files" 
-}        
-
-variable "backup_prefix" { 
-  type = string 
-  default = "chaps-dev/"
-  description = "Key prefix within the backup bucket" 
-} 
+locals {
+  db_migration_objects_prefix_arn = "${aws_s3_bucket.db_migration.arn}/${local.db_migration_prefix}/*"
+}
 
 
 resource "aws_iam_role" "rds_s3_backup_restore" {
@@ -110,12 +102,6 @@ resource "aws_iam_role" "rds_s3_backup_restore" {
 }
 
 
-locals {
-  bucket_arn         = format("arn:aws:s3:::%s", var.backup_bucket)
-  objects_prefix_arn = format("arn:aws:s3:::%s/%s*", var.backup_bucket, var.backup_prefix)
-}
-
-
 # Least-privilege inline policy: list bucket + R/W objects in the prefix
 resource "aws_iam_role_policy" "rds_s3_backup_restore" {
   name = "${var.namespace}-rds-s3-backup-restore"
@@ -128,28 +114,48 @@ resource "aws_iam_role_policy" "rds_s3_backup_restore" {
         Sid      = "BucketLocation"
         Effect   = "Allow"
         Action   = ["s3:GetBucketLocation"]
-        Resource = local.bucket_arn
+        Resource = aws_s3_bucket.db_migration.arn
       },
       {
         Sid             = "ListBucket"
         Effect          = "Allow"
         Action          = ["s3:ListBucket"]
-        Resource        = local.bucket_arn
+        Resource        = aws_s3_bucket.db_migration.arn
         Condition       = {
           StringLike    = { 
             "s3:prefix" = [
-              format("%s*", var.backup_prefix), 
-              var.backup_prefix
+              local.db_migration_prefix,
+              "${local.db_migration_prefix}/",
+              "${local.db_migration_prefix}/*"
+
             ]
           }
         }
       },
       {
-        Sid      = "RWPrefix",
-        Effect   = "Allow",
-        Action   = ["s3:GetObject","s3:PutObject","s3:DeleteObject"]
-        Resource = local.objects_prefix_arn
+        Sid     = "ReadWriteBackupObjects"
+        Effect  = "Allow"
+        Action  = [
+          "s3:GetObject",
+          "s3:GetObjectAttributes",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:AbortMultipartUpload"
+        ]
+        Resource = local.db_migration_objects_prefix_arn
+      },
+      {
+        Sid     = "UseCpBackupKmsKey"
+        Effect  = "Allow"
+        Action  = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey"
+        ]
+        Resource = aws_kms_key.db_migration.arn
       }
     ]
   })
 }
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/s3_db_migration.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/s3_db_migration.tf
@@ -1,0 +1,157 @@
+locals {
+  db_migration_environment_short_name = "prod"
+  db_migration_prefix                 = "native-backups/${local.db_migration_environment_short_name}"
+  db_migration_bucket_name            = "chaps-${local.db_migration_environment_short_name}-db-migration-${data.aws_caller_identity.current.account_id}"
+
+  db_migration_tags = {
+    application            = var.application
+    business_unit          = var.business_unit
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+    is_production          = var.is_production
+    namespace              = var.namespace
+    team_name              = var.team_name
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "db_migration" {
+  description             = "CHAPS ${var.environment} database migration s3 bucket"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  tags = merge(local.db_migration_tags, {
+    Name    = "${var.namespace}-db-migration"
+    Purpose = "CHAPS database migration restore"
+  })
+}
+
+resource "aws_kms_alias" "db_migration" {
+  name          = "alias/${var.namespace}-db-migration"
+  target_key_id = aws_kms_key.db_migration.key_id
+}
+
+resource "aws_s3_bucket" "db_migration" {
+  bucket = local.db_migration_bucket_name
+
+  tags = merge(local.db_migration_tags, {
+    Name     = local.db_migration_bucket_name
+    Purpose  = "CHAPS database migration restore"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.db_migration.arn
+    }
+
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  depends_on = [
+    aws_s3_bucket_versioning.db_migration,
+    aws_s3_bucket_server_side_encryption_configuration.db_migration
+  ]
+
+  rule {
+    id     = "expire-db-migration-backups"
+    status = "Enabled"
+
+    filter {
+      prefix = "${local.db_migration_prefix}/"
+    }
+
+    expiration {
+      days = 14
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 14
+    }
+  }
+}
+
+data "aws_iam_policy_document" "db_migration_bucket_policy" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn,
+      "${aws_s3_bucket.db_migration.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+  policy = data.aws_iam_policy_document.db_migration_bucket_policy.json
+}
+
+
+output "db_migration_bucket_name" {
+  value       = aws_s3_bucket.db_migration.bucket
+  description = "CP S3 bucket for CHAPS database migration backups"
+}
+
+output "db_migration_bucket_arn" {
+  value       = aws_s3_bucket.db_migration.arn
+  description = "CP S3 bucket ARN for CHAPS database migration backups"
+}
+
+output "db_migration_kms_key_arn" {
+  value       = aws_kms_key.db_migration.arn
+  description = "CP KMS key ARN for CHAPS database migration backups"
+}
+
+output "db_migration_prefix" {
+  value       = local.db_migration_prefix
+  description = "S3 prefix for CHAPS database migration backups"
+}


### PR DESCRIPTION
This pull request introduces a new, secure infrastructure for handling CHAPS database migration backups in the production environment. It creates a dedicated S3 bucket and KMS key for migration backups, sets up appropriate IAM roles and policies for both the migration copy process and RDS backup/restore, and enforces best practices for security and lifecycle management.

The most important changes are:

**New Infrastructure for Database Migration Backups:**

* Added a new Terraform module (`s3_db_migration.tf`) to provision a dedicated S3 bucket (`aws_s3_bucket.db_migration`) and KMS key (`aws_kms_key.db_migration`) for CHAPS database migration backups, including secure access policies, versioning, encryption, and a lifecycle policy for automatic expiration of old backups.

**IAM Roles and Policies for Migration Process:**

* Introduced a new IRSA (IAM Roles for Service Accounts) role and associated IAM policy (`db_migration_copy_irsa.tf`) to enable a Kubernetes job to securely copy database backups from ModPlatform S3/KMS to CloudPlatform S3/KMS, with fine-grained permissions for both source and destination resources.

**Refactoring and Standardization of IAM Policies:**

* Refactored IAM policy resources in `rds.tf` to use the new S3 bucket and KMS key, and standardized S3 prefix handling by replacing hardcoded variables with new locals for consistent resource referencing. [[1]](diffhunk://#diff-77fdc0f8a665edb5c2e03d987bf6bb71d8d1792e2ab776258279e1bd5cb59a61L87-R88) [[2]](diffhunk://#diff-77fdc0f8a665edb5c2e03d987bf6bb71d8d1792e2ab776258279e1bd5cb59a61L113-L118) [[3]](diffhunk://#diff-77fdc0f8a665edb5c2e03d987bf6bb71d8d1792e2ab776258279e1bd5cb59a61L131-R161)

These changes collectively improve the security, maintainability, and clarity of the database migration backup process in the production environment.