### PR TITLE
Added auth for LTF app

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/london-task-force-dev/resources/basic-auth.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/london-task-force-dev/resources/basic-auth.tf
@@ -1,4 +1,4 @@
-# Username and password for the prototype kit website's http basic
+# Username and password for the demo website's nginx ingress http basic
 # authentication
 resource "kubernetes_secret" "basic-auth" {
   metadata {
@@ -6,8 +6,15 @@ resource "kubernetes_secret" "basic-auth" {
     namespace = var.namespace
   }
 
+  # nginx ingress basic auth expects a single "auth" key in htpasswd format:
+  # "<username>:<bcrypt-hashed-password>"
   data = {
-    username = var.basic-auth-username
-    password = var.basic-auth-password
+    auth = "${var.basic-auth-username}:${bcrypt(var.basic-auth-password)}"
+  }
+
+  lifecycle {
+    # bcrypt() generates a new salt on every run, which would otherwise force
+    # the secret to be recreated on each apply.
+    ignore_changes = [data]
   }
 }


### PR DESCRIPTION
This pull request updates the way HTTP basic authentication credentials are stored for the demo website's nginx ingress. Instead of storing the username and password separately, it now stores them together in htpasswd format with a bcrypt-hashed password, and prevents unnecessary secret recreation due to bcrypt's random salt.

Authentication secret improvements:

* Changed the `kubernetes_secret` for basic auth to use a single `auth` key in htpasswd format (`<username>:<bcrypt-hashed-password>`) instead of separate `username` and `password` keys.
* Added a `lifecycle` block with `ignore_changes = [data]` to prevent the secret from being unnecessarily recreated on each apply due to bcrypt's random salt generation.