### PR TITLE
Add TXT record for Entra ID domain verification

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/connecting-services-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/connecting-services-prod/resources/route53.tf
@@ -13,6 +13,17 @@ resource "aws_route53_zone" "pfl_cs_route53_zone" {
   }
 }
 
+# add a txt record to the zone to verify ownership of the domain with Entra ID
+resource "aws_route53_record" "entra_id_verification" {
+  zone_id = aws_route53_zone.pfl_cs_route53_zone.zone_id
+  name    = var.domain
+  type    = "TXT"
+  ttl     = 300
+  records = [
+    "MS=ms72370887"
+  ]
+}
+
 resource "kubernetes_secret" "pfl_cs_route53_zone_sec" {
   metadata {
     name      = "pfl-cs-route53-zone-output"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/connecting-services-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/connecting-services-prod/resources/route53.tf
@@ -13,7 +13,7 @@ resource "aws_route53_zone" "pfl_cs_route53_zone" {
   }
 }
 
-# add a txt record to the zone to verify ownership of the domain with Entra ID
+# add a txt record to the zone to verify ownership of the domain with Microsoft Entra ID
 resource "aws_route53_record" "entra_id_verification" {
   zone_id = aws_route53_zone.pfl_cs_route53_zone.zone_id
   name    = var.domain


### PR DESCRIPTION
Add a DNS TXT record to verify domain ownership with Microsoft Entra ID. The main change is the introduction of a new `aws_route53_record` resource in the Terraform configuration.

DNS verification:

* Added a new `aws_route53_record` named `entra_id_verification` to create a TXT record (`MS=ms72370887`) in the Route53 zone for domain ownership verification with Microsoft Entra ID.