### PR TITLE
[laa-hmrc-interface-api] Add github oidc provider for sast GHA

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/ecr.tf
@@ -2,7 +2,7 @@ module "ecr-repo" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
 
   repo_name           = "${var.namespace}-ecr"
-  oidc_providers      = ["circleci"]
+  oidc_providers      = ["circleci","github"]
   github_repositories = [var.repo_name]
 
   /*


### PR DESCRIPTION
Add github oidc provider for sast GHA

Need to access ecr image for scanning
