### PR TITLE
Add TXT record for Microsoft Entra ID domain verification

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-prod/resources/route53.tf
@@ -13,6 +13,17 @@ resource "aws_route53_zone" "cap_route53_zone" {
   }
 }
 
+# add a txt record to the zone to verify ownership of the domain with Microsoft Entra ID
+resource "aws_route53_record" "entra_id_verification" {
+  zone_id = aws_route53_zone.cap_route53_zone.zone_id
+  name    = var.domain
+  type    = "TXT"
+  ttl     = 300
+  records = [
+    "MS=ms47915806"
+  ]
+}
+
 resource "kubernetes_secret" "cap_route53_zone_sec" {
   metadata {
     name      = "cap-route53-zone-output"


### PR DESCRIPTION
Add a new DNS TXT record to the Route53 zone for domain ownership verification with Microsoft Entra ID. This is required for integrating the domain with Microsoft services.

DNS configuration for Microsoft Entra ID:

* Added a new `aws_route53_record` resource to create a TXT record (`MS=ms47915806`) in the Route53 zone, enabling domain ownership verification with Microsoft Entra ID.