### PR TITLE
laa-hmrc-interface-uat: Bump configuration to match current version of RDS 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-uat/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds" {
   # Database configuration
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "18.1"
+  db_engine_version           = "18.3"
   db_instance_class           = "db.t4g.small"
   rds_family                  = "postgres18"
   allow_minor_version_upgrade = "true"


### PR DESCRIPTION
laa-hmrc-interface-uat: Bump configuration to match current version of RDS

Already on version 18.3 via auto minor upgrades setting
but changing anything now tries to downgrade to 18.1 which
is not allowed.
