### PR TITLE
Add query logs s3 bucket to address_matcher

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
@@ -1,3 +1,39 @@
+data "aws_iam_policy_document" "query_logs_write_only" {
+  statement {
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.address_matcher_query_logs_s3.bucket_arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "query_logs_put_only" {
+  name   = "address-matcher-query-logs-put-only"
+  policy = data.aws_iam_policy_document.query_logs_put_only.json
+}
+
+
+data "aws_iam_policy_document" "query_logs_read_only" {
+  statement {
+    actions = ["s3:GetObject"]
+    resources = [
+      "${module.address_matcher_query_logs_s3.bucket_arn}/*"
+    ]
+  }
+
+  statement {
+    actions = ["s3:ListBucket"]
+    resources = [
+      module.address_matcher_query_logs_s3.bucket_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "query_logs_read_only" {
+  name   = "address-matcher-query-logs-read-only"
+  policy = data.aws_iam_policy_document.query_logs_read_only.json
+}
+
 module "irsa" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
 
@@ -6,8 +42,10 @@ module "irsa" {
   namespace            = var.namespace
 
   role_policy_arns = {
-    models      = module.address_matcher_models_s3.irsa_policy_arn
-    lookup_data = module.address_matcher_lookup_data_s3.irsa_policy_arn
+    models           = module.address_matcher_models_s3.irsa_policy_arn
+    lookup_data      = module.address_matcher_lookup_data_s3.irsa_policy_arn
+    query_logs_write = aws_iam_policy.query_logs_write_only.arn
+    query_logs_read  = aws_iam_policy.query_logs_read_only.arn
   }
 
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
@@ -1,37 +1,23 @@
-data "aws_iam_policy_document" "query_logs_write_only" {
+data "aws_iam_policy_document" "query_logs" {
   statement {
-    actions = ["s3:PutObject"]
-    resources = [
-      "${module.address_matcher_query_logs_s3.bucket_arn}/*"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
     ]
-  }
-}
-
-resource "aws_iam_policy" "query_logs_put_only" {
-  name   = "address-matcher-query-logs-put-only"
-  policy = data.aws_iam_policy_document.query_logs_put_only.json
-}
-
-
-data "aws_iam_policy_document" "query_logs_read_only" {
-  statement {
-    actions = ["s3:GetObject"]
     resources = [
       "${module.address_matcher_query_logs_s3.bucket_arn}/*"
     ]
   }
 
   statement {
-    actions = ["s3:ListBucket"]
-    resources = [
-      module.address_matcher_query_logs_s3.bucket_arn
-    ]
+    actions   = ["s3:ListBucket"]
+    resources = [module.address_matcher_query_logs_s3.bucket_arn]
   }
 }
 
-resource "aws_iam_policy" "query_logs_read_only" {
-  name   = "address-matcher-query-logs-read-only"
-  policy = data.aws_iam_policy_document.query_logs_read_only.json
+resource "aws_iam_policy" "query_logs" {
+  name   = "address-matcher-query-logs"
+  policy = data.aws_iam_policy_document.query_logs.json
 }
 
 module "irsa" {
@@ -42,10 +28,8 @@ module "irsa" {
   namespace            = var.namespace
 
   role_policy_arns = {
-    models           = module.address_matcher_models_s3.irsa_policy_arn
-    lookup_data      = module.address_matcher_lookup_data_s3.irsa_policy_arn
-    query_logs_write = aws_iam_policy.query_logs_write_only.arn
-    query_logs_read  = aws_iam_policy.query_logs_read_only.arn
+    lookup_data = module.address_matcher_lookup_data_s3.irsa_policy_arn
+    query_logs  = aws_iam_policy.query_logs.arn
   }
 
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/s3.tf
@@ -45,12 +45,10 @@ module "address_matcher_query_logs_s3" {
 
   lifecycle_rule = [
     {
-      enabled = true
-      id      = "expire-after-1-year"
-      prefix  = "logs/"
-      expiration = {
-        days = 365
-      }
+      enabled    = true
+      id         = "expire-after-1-year"
+      prefix     = "logs/"
+      expiration = [{ days = 365 }]
     }
   ]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/s3.tf
@@ -28,6 +28,33 @@ module "address_matcher_lookup_data_s3" {
   providers = { aws = aws.london }
 }
 
+module "address_matcher_query_logs_s3" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+
+  versioning             = true
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  providers = { aws = aws.london }
+
+
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "expire-after-1-year"
+      prefix  = "logs/"
+      expiration = {
+        days = 365
+      }
+    }
+  ]
+}
+
 resource "kubernetes_secret" "s3_buckets" {
   metadata {
     name      = "s3-bucket-output"
@@ -39,5 +66,7 @@ resource "kubernetes_secret" "s3_buckets" {
     models_bucket_name      = module.address_matcher_models_s3.bucket_name
     lookup_data_bucket_arn  = module.address_matcher_lookup_data_s3.bucket_arn
     lookup_data_bucket_name = module.address_matcher_lookup_data_s3.bucket_name
+    query_logs_bucket_arn = module.address_matcher_query_logs_s3.bucket_arn
+    query_logs_bucket_name = module.address_matcher_query_logs_s3.bucket_name
   }
 }


### PR DESCRIPTION
Adding an additional s3 bucket for analytics and logging to the hosted Address Matcher app