### PR TITLE
MAPA-112 Fix is in irsa.tf

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/irsa.tf
@@ -21,7 +21,9 @@ module "irsa" {
     { prisoner-event-queue = module.prisoner-event-queue.irsa_policy_arn },
     { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn },
     { (module.update_from_external_system_events_queue.sqs_name) = module.update_from_external_system_events_queue.irsa_policy_arn },
-    { (module.update_from_external_system_events_dlq.sqs_name) = module.update_from_external_system_events_dlq.irsa_policy_arn }
+    { (module.update_from_external_system_events_dlq.sqs_name) = module.update_from_external_system_events_dlq.irsa_policy_arn },
+    { (module.update_cell_certificate_queue.sqs_name) = module.update_cell_certificate_queue.irsa_policy_arn },
+    { (module.update_cell_certificate_dlq.sqs_name) = module.update_cell_certificate_dlq.irsa_policy_arn }
   )
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
The fix is in irsa.tf — the IRSA service-account role now attaches the IAM policies for both the update_cell_certificate_queue and its DLQ, mirroring the existing                  
update_from_external_system_events entries.

**Summary of what was wrong and what this fixes:**

The queue itself, its DLQ, and the k8s secrets that inject the queue name were all set up correctly. The missing piece was the IAM permission: the pod's IRSA role had no policy granting
it access to the new queue. The awspring SQS client (default QueueNotFoundStrategy.CREATE) couldn't resolve the existing queue's attributes, fell back to trying to create it, and AWS    
returned 403 sqs:createqueue — which aborted Spring context startup. It worked locally only because LocalStack grants all actions.                                                        
