### PR TITLE
MAPA-112 Grant IRSA access to the update-cell-certificate SQS queue (prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/irsa.tf
@@ -24,7 +24,9 @@ module "irsa" {
     { prisoner-event-queue = module.prisoner-event-queue.irsa_policy_arn },
     { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn },
     { (module.update_from_external_system_events_queue.sqs_name) = module.update_from_external_system_events_queue.irsa_policy_arn },
-    { (module.update_from_external_system_events_dlq.sqs_name) = module.update_from_external_system_events_dlq.irsa_policy_arn }
+    { (module.update_from_external_system_events_dlq.sqs_name) = module.update_from_external_system_events_dlq.irsa_policy_arn },
+    { (module.update_cell_certificate_queue.sqs_name) = module.update_cell_certificate_queue.irsa_policy_arn },
+    { (module.update_cell_certificate_dlq.sqs_name) = module.update_cell_certificate_dlq.irsa_policy_arn }
   )
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION


## What

Adds the `update_cell_certificate_queue` and `update_cell_certificate_dlq` IAM policies to the
`hmpps-locations-inside-prison-api` service-account (IRSA) role in the
`hmpps-locations-inside-prison-prod` namespace.

File changed:
`namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/irsa.tf`

## Why

The async cell-certificate upload feature (MAPA-112) introduced a new SQS queue and DLQ
(`hmpps-update-cell-certfiicate-queue.tf`). The queues and their k8s secrets are created
correctly, and the application is wired to consume from them. However, the queues were never
added to the service-account role's `role_policy_arns`, so the pod's IRSA role had **no IAM
permission** for them.

Without a policy attached, the pod cannot make SQS calls against the queue. The awspring SQS
client uses the default `QueueNotFoundStrategy.CREATE`, so when it fails to resolve the existing
queue's attributes it falls back to trying to *create* the queue, and AWS rejects it:

```
SqsException: User: ...assumed-role/cloud-platform-irsa-... is not authorized to perform:
  sqs:createqueue ... (Status Code: 403)
```

This crashes Spring context initialisation and the pod never starts. (It works locally only
because LocalStack grants all actions.)

Attaching the queue and DLQ policies — mirroring the existing `prisoner-event-*` and
`update_from_external_system_events_*` entries — gives the role the standard SQS permissions on
those resources, so the existing queue resolves cleanly and no create is attempted.

This is the prod counterpart of the same fix already applied to dev and preprod.

## Testing

- `terraform plan` for the prod namespace shows only the IRSA role policy attachments being
  added (the two new queue policies), with no other changes.
- After apply and pod restart, the `QueueAttributesResolvingException` / `sqs:createqueue 403`
  no longer occurs and the `updatecellcertificate` listener registers on startup.
