### PR TITLE
cfe-civil-uat: Add github oidc provider for auto secret creation

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/ecr.tf
@@ -10,7 +10,7 @@ module "ecr_credentials" {
   repo_name = "cfe-civil-ecr"
 
   # REQUIRED: OIDC providers to configure, either "github", "circleci", or both
-  oidc_providers = ["circleci"]
+  oidc_providers = ["circleci","github"]
 
   # REQUIRED: GitHub repositories, whose CI will be provided with short-term credentials to access this container repository
   github_repositories = ["cfe-civil", "laa-check-client-qualifies"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-uat/resources/rds.tf
@@ -26,7 +26,7 @@ module "rds" {
   # Database configuration
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "18.1"
+  db_engine_version           = "18.3"
   rds_family                  = "postgres18"
   db_instance_class           = "db.t4g.micro"
   allow_minor_version_upgrade = "true"


### PR DESCRIPTION
Add github oidc provider for auto secret creation

Needed for SaST GHA integration. 

NOTE: This increments db engine version to match the actual current version.
Due to automatic upgrade of the RDS instance, the actual db engine version is 18.3.
This updates the terraform configuration to reflect the actual version
of the db engine in use such that a build will not attempt to downgrade
the DB from 18.3 to 18.1, which is not allowed by AWS and will cause the build to fail.