### PR TITLE
Fix doubled "update-update" in cell-certificate queue secret name (locations-inside-prison preprod + prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/hmpps-update-cell-certfiicate-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/hmpps-update-cell-certfiicate-queue.tf
@@ -56,7 +56,7 @@ module "update_cell_certificate_dlq" {
 resource "kubernetes_secret" "update_cell_certificate_queue" {
   ## For metadata use - not _
   metadata {
-    name = "sqs-update-update-cell-certificate-queue-secret"
+    name = "sqs-update-cell-certificate-queue-secret"
     ## Name space where the listening service is found
     namespace = "hmpps-locations-inside-prison-preprod"
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/hmpps-update-cell-certfiicate-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/hmpps-update-cell-certfiicate-queue.tf
@@ -56,7 +56,7 @@ module "update_cell_certificate_dlq" {
 resource "kubernetes_secret" "update_cell_certificate_queue" {
   ## For metadata use - not _
   metadata {
-    name = "sqs-update-update-cell-certificate-queue-secret"
+    name = "sqs-update-cell-certificate-queue-secret"
     ## Name space where the listening service is found
     namespace = "hmpps-locations-inside-prison-prod"
   }


### PR DESCRIPTION
## What

The `kubernetes_secret` for the `update_cell_certificate_queue` in the `hmpps-locations-inside-prison-preprod` and `-prod` namespaces was named `sqs-update-update-cell-certificate-queue-secret` (doubled `update`), but the application references `sqs-update-cell-certificate-queue-secret`.

## Why

This mismatch caused the `hmpps-locations-inside-prison-api` pods to fail with `CreateContainerConfigError` / crash loop in preprod after the "Asynchronous cell certificate upload" change was deployed:

```
Error: secret "sqs-update-cell-certificate-queue-secret" not found
```

The DLQ secret (`sqs-update-cell-certificate-dlq-secret`) and the dev namespace were already named correctly — only the preprod and prod queue secret had the typo.

## Change

Corrected the secret name in preprod and prod to match the application's helm values and the existing DLQ naming convention.

Note: applying this will destroy the misnamed secret and recreate it under the correct name (data is derived from the SQS module outputs, so no meaningful data loss). After apply, the API pods will pick up the secret and start cleanly.