### PR TITLE
Fix doubled "update-update" in cell-certificate queue secret name (locations-inside-prison-prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/hmpps-update-cell-certfiicate-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/hmpps-update-cell-certfiicate-queue.tf
@@ -56,7 +56,7 @@ module "update_cell_certificate_dlq" {
 resource "kubernetes_secret" "update_cell_certificate_queue" {
   ## For metadata use - not _
   metadata {
-    name = "sqs-update-update-cell-certificate-queue-secret"
+    name = "sqs-update-cell-certificate-queue-secret"
     ## Name space where the listening service is found
     namespace = "hmpps-locations-inside-prison-prod"
   }


### PR DESCRIPTION
## What

The `kubernetes_secret` for the `update_cell_certificate_queue` in the `hmpps-locations-inside-prison-prod` namespace was named `sqs-update-update-cell-certificate-queue-secret` (doubled `update`), but the application references `sqs-update-cell-certificate-queue-secret`.

## Why

The same typo caused a `CreateContainerConfigError` / crash loop in preprod (fixed separately). This corrects prod proactively so the next prod deploy of the "Asynchronous cell certificate upload" change does not hit the same failure:

```
Error: secret "sqs-update-cell-certificate-queue-secret" not found
```

The DLQ secret (`sqs-update-cell-certificate-dlq-secret`) was already named correctly — only the prod queue secret had the typo.

## Change

Corrected the secret name to match the application's helm values and the existing DLQ naming convention.

Note: applying this will destroy the misnamed secret and recreate it under the correct name (data is derived from the SQS module outputs, so no meaningful data loss).