### PR TITLE
Raise cell-certificate queue visibility timeout to 30m (locations-inside-prison-dev)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/hmpps-update-cell-certfiicate-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/hmpps-update-cell-certfiicate-queue.tf
@@ -5,7 +5,7 @@ module "update_cell_certificate_queue" {
   sqs_name                   = "update_cell_certificate_queue"
   encrypt_sqs_kms            = "true"
   message_retention_seconds  = 43200 # 12 hours
-  visibility_timeout_seconds = 120   # 2 minutes
+  visibility_timeout_seconds = 1800  # 30 minutes - large prison uploads can take several minutes; must exceed processing time so the message is not redelivered mid-processing
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = module.update_cell_certificate_dlq.sqs_arn


### PR DESCRIPTION
## What

Raise `visibility_timeout_seconds` on the `update_cell_certificate_queue` from **120s to 1800s (30 min)** in the `hmpps-locations-inside-prison-dev` namespace. DLQ and `maxReceiveCount` unchanged.

## Why

Large prison cell-certificate uploads can take several minutes to process. The `@SqsListener` only deletes the message when processing finishes, so with a 2-minute visibility timeout the message became visible again and was redelivered to other pods, processing the same upload concurrently and creating duplicate certificates. A 30-minute timeout lets a normal job ack within a single visibility window.

The application has also been hardened with a pessimistic-lock claim so redelivery can no longer create duplicates; this change removes the redelivery churn at source.