### PR TITLE
HIA-1234: Renew api gateway client certificate - preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/api_gateway.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/api_gateway.tf
@@ -213,7 +213,12 @@ resource "aws_api_gateway_client_certificate" "api_gateway_client_two" {
 }
 
 resource "aws_api_gateway_client_certificate" "api_gateway_client_three" {
-  description = "Client certificate presented to the backend API expires 04/07/2025"
+  description = "Client certificate presented to the backend API expires 04/07/2026"
+  tags        = local.default_tags
+}
+
+resource "aws_api_gateway_client_certificate" "api_gateway_client_four" {
+  description = "Client certificate presented to the backend API expires 10/06/2027"
   tags        = local.default_tags
 }
 
@@ -222,7 +227,7 @@ resource "aws_api_gateway_stage" "main" {
   deployment_id         = aws_api_gateway_deployment.main.id
   rest_api_id           = aws_api_gateway_rest_api.api_gateway.id
   stage_name            = var.namespace
-  client_certificate_id = aws_api_gateway_client_certificate.api_gateway_client_three.id
+  client_certificate_id = aws_api_gateway_client_certificate.api_gateway_client_four.id
 
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.api_gateway_access_logs.arn

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/kubernetes_secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-integration-api-preprod/resources/kubernetes_secrets.tf
@@ -37,7 +37,7 @@ resource "kubernetes_secret" "client_certificate_auth" {
   }
 
   data = {
-    "ca.crt" = aws_api_gateway_client_certificate.api_gateway_client_three.pem_encoded_certificate
+    "ca.crt" = aws_api_gateway_client_certificate.api_gateway_client_four.pem_encoded_certificate
   }
 }
 


### PR DESCRIPTION
Renewing the `client_certificate_auth` client certificate for api gateway in preprod