### PR TITLE
AP-7047: laa-apply-for-legalaid-production - Add github oidc provider

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/ecr.tf
@@ -2,7 +2,7 @@ module "ecr_credentials" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=6.1.0"
 
   repo_name           = "${var.namespace}-ecr"
-  oidc_providers      = ["circleci"]
+  oidc_providers      = ["circleci","github"]
   github_repositories = [var.repo_name]
 
   lifecycle_policy = <<EOF

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-apply-for-legalaid-production/resources/rds.tf
@@ -19,7 +19,7 @@ module "apply-for-legal-aid-rds" {
   # Database configuration
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "18.1"
+  db_engine_version           = "18.3"
   rds_family                  = "postgres18"
   db_instance_class           = "db.t4g.small"
   db_name                     = "apply_for_legal_aid_production"


### PR DESCRIPTION

Add github oidc provider for auto secret creation

Needed for SaST GHA integration. 

NOTE: This increments db engine version to match the actual current version.
Due to automatic upgrade of the RDS instance, the actual db engine version is 18.3.
This updates the terraform configuration to reflect the actual version
of the db engine in use such that a build will not attempt to downgrade
the DB from 18.3 to 18.1, which is not allowed by AWS and will cause the build to fail.

- **AP-7047: Add GitHub OIDC provider to ECR credentials module**
- **Increment db engine version to actual curent version**
