### PR TITLE
Restrict CCLF dev SQS IAM policy to least privilege

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-litigator-fees-dev/resources/irsa.tf
@@ -27,17 +27,28 @@ module "irsa" {
 }
 
 data "aws_iam_policy_document" "cclf_claims_policy" {
-  # Provide list of permissions and target AWS account resources to allow access to
+  # Inbound queues: CCLF polls for claims and deletes after processing
   statement {
-    sid  = "CCLFPolicySQSDev"
-    effect = "Allow"
+    sid     = "CCLFPolicySQSDevReceive"
+    effect  = "Allow"
     actions = [
-      "sqs:*",
-      "sts:*"
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
     ]
     resources = [
       "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-cccd-claims-for-cclf",
       "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-cccd-claims-submitted-cclf-dlq",
+    ]
+  }
+
+  # Outbound queues: CCLF sends success/failure responses back to CCCD
+  statement {
+    sid     = "CCLFPolicySQSDevSend"
+    effect  = "Allow"
+    actions = [
+      "sqs:SendMessage",
+    ]
+    resources = [
       "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-responses-for-cccd",
       "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-reponses-for-cccd-dlq",
     ]


### PR DESCRIPTION
Replaces the overly permissive `sqs:*` and `sts:*` wildcard actions with the minimum set required for CCLF to function:

Inbound queues (`claims-for-cclf`, `claims-submitted-cclf-dlq`):
- `sqs:ReceiveMessage` (poll for claim messages)
- `sqs:DeleteMessage` (acknowledge processed messages)

Outbound queues (`responses-for-cccd`, `reponses-for-cccd-dlq`):
- `sqs:SendMessage` (send success/failure responses to CCCD)

Removes `sts:*` entirely.

The queues are also now split into separate statements to enforce that the inbound queues can only be read from and the outbound queues can only be written to.