### PR TITLE
Update TXT record for domain verification in Route53

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-prod/resources/route53.tf
@@ -16,7 +16,7 @@ resource "aws_route53_zone" "cap_route53_zone" {
 # add a txt record to the zone to verify ownership of the domain with Microsoft Entra ID
 resource "aws_route53_record" "entra_id_verification" {
   zone_id = aws_route53_zone.cap_route53_zone.zone_id
-  name    = var.domain
+  name    = "propose-child-arrangements-plan.service.gov.uk"
   type    = "TXT"
   ttl     = 300
   records = [


### PR DESCRIPTION
This pull request makes a small update to the Route 53 TXT record configuration for domain verification with Microsoft Entra ID. The change sets the record name to a specific domain instead of using a variable.

* The `name` field in the `aws_route53_record.entra_id_verification` resource was changed from `var.domain` to the explicit string `"propose-child-arrangements-plan.service.gov.uk"` in `route53.tf`.