### PR TITLE
MAPB-452 hmpps-prisoner-property-api resources (hmpps-locations-inside-prison-prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-irsa.tf
@@ -1,0 +1,38 @@
+# Dedicated IRSA service account for hmpps-prisoner-property-api.
+# Scoped to this app rather than sharing the locations-inside-prison-api service account.
+# Grants: publish/subscribe to the hmpps-domain-events SNS topic (via local.sns_policies,
+# already computed in the existing irsa.tf in this folder) and access to its own queue + DLQ.
+# The helm chart must set generic-service.serviceAccountName to match the name below.
+
+module "prisoner_property_irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = "hmpps-prisoner-property-api"
+
+  role_policy_arns = merge(
+    local.sns_policies, # domain-events topic publish/subscribe (shared local from irsa.tf)
+    { (module.prisoner_property_event_queue.sqs_name) = module.prisoner_property_event_queue.irsa_policy_arn },
+    { (module.prisoner_property_event_dlq.sqs_name)   = module.prisoner_property_event_dlq.irsa_policy_arn },
+  )
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "prisoner_property_irsa" {
+  metadata {
+    name      = "hmpps-prisoner-property-api-irsa-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    role_arn             = module.prisoner_property_irsa.role_arn
+    service_account_name = "hmpps-prisoner-property-api"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
@@ -1,0 +1,51 @@
+# RDS Postgres instance for hmpps-prisoner-property-api.
+# Lives in the shared hmpps-locations-inside-prison-<env> namespace alongside the existing
+# dps_rds instance. Modelled on the namespace's existing resources/rds.tf.
+# NOTE: data.aws_security_group.mp_dps_sg is already declared in the existing rds.tf in this
+# folder, so it is reused here (do not redeclare).
+
+module "prisoner_property_rds" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  performance_insights_enabled = true
+
+  db_instance_class           = "db.t4g.large"
+  rds_name                    = "hmpps-prisoner-property-api-prod"
+  rds_family                  = "postgres18"
+  db_engine_version           = "18"
+  deletion_protection         = true
+  allow_major_version_upgrade = "false"
+  allow_minor_version_upgrade = "true"
+
+  providers = {
+    aws = aws.london
+  }
+
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+}
+
+resource "kubernetes_secret" "prisoner_property_rds" {
+  metadata {
+    name      = "prisoner-property-rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    db_identifier         = module.prisoner_property_rds.db_identifier
+    resource_id           = module.prisoner_property_rds.resource_id
+    rds_instance_endpoint = module.prisoner_property_rds.rds_instance_endpoint
+    database_name         = module.prisoner_property_rds.database_name
+    database_username     = module.prisoner_property_rds.database_username
+    database_password     = module.prisoner_property_rds.database_password
+    rds_instance_address  = module.prisoner_property_rds.rds_instance_address
+    url                   = "postgres://${module.prisoner_property_rds.database_username}:${module.prisoner_property_rds.database_password}@${module.prisoner_property_rds.rds_instance_endpoint}/${module.prisoner_property_rds.database_name}"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-sqs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-sqs.tf
@@ -1,0 +1,112 @@
+# Inbound domain-events queue (+ DLQ) for hmpps-prisoner-property-api.
+# Subscribes to the shared hmpps-domain-events SNS topic and is consumed by the app's
+# PrisonerEventListener. Modelled on the namespace's existing resources/sqs.tf
+# (prisoner-event-queue). data.aws_ssm_parameter.hmpps-domain-events-topic-arn is already
+# declared in hmpps-events.tf in this folder, so it is reused here.
+
+resource "aws_sns_topic_subscription" "prisoner_property_event_queue_subscription" {
+  topic_arn = data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value
+  protocol  = "sqs"
+  endpoint  = module.prisoner_property_event_queue.sqs_arn
+  filter_policy = jsonencode({
+    eventType = [
+      "prison-offender-events.prisoner.released",
+      "prison-offender-events.prisoner.received",
+    ]
+  })
+}
+
+module "prisoner_property_event_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name                  = "prisoner-property-event-queue"
+  encrypt_sqs_kms           = "true"
+  message_retention_seconds = 1209600 # 14 days
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.prisoner_property_event_dlq.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "prisoner_property_event_dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name        = "prisoner-property-event-dlq"
+  encrypt_sqs_kms = "true"
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+# Allow the domain-events topic to send messages to the queue.
+data "aws_iam_policy_document" "prisoner_property_event_queue" {
+  policy_id = "${module.prisoner_property_event_queue.sqs_arn}/SQSDefaultPolicy"
+
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [module.prisoner_property_event_queue.sqs_arn]
+    actions   = ["SQS:SendMessage"]
+    condition {
+      variable = "aws:SourceArn"
+      test     = "ArnEquals"
+      values   = [data.aws_ssm_parameter.hmpps-domain-events-topic-arn.value]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "prisoner_property_event_queue" {
+  queue_url = module.prisoner_property_event_queue.sqs_id
+  policy    = data.aws_iam_policy_document.prisoner_property_event_queue.json
+}
+
+resource "kubernetes_secret" "prisoner_property_event_queue" {
+  metadata {
+    name      = "sqs-prisoner-property-event-queue-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    sqs_queue_url  = module.prisoner_property_event_queue.sqs_id
+    sqs_queue_arn  = module.prisoner_property_event_queue.sqs_arn
+    sqs_queue_name = module.prisoner_property_event_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "prisoner_property_event_dlq" {
+  metadata {
+    name      = "sqs-prisoner-property-event-dlq-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    sqs_queue_url  = module.prisoner_property_event_dlq.sqs_id
+    sqs_queue_arn  = module.prisoner_property_event_dlq.sqs_arn
+    sqs_queue_name = module.prisoner_property_event_dlq.sqs_name
+  }
+}


### PR DESCRIPTION
## MAPB-452 — hmpps-prisoner-property-api infrastructure (prod)

Adds resources for the new **hmpps-prisoner-property-api** service into the existing shared
`hmpps-locations-inside-prison-prod` namespace:

- **RDS** — Postgres 18, **`db.t4g.large`**, no auto start/stop (mirrors the existing prod
  `dps_rds`), `rds_name = hmpps-prisoner-property-api-prod`; outputs secret
  `prisoner-property-rds-instance-output`.
- **SQS** — `prisoner-property-event-queue` + DLQ subscribed to `hmpps-domain-events`; secrets
  `sqs-prisoner-property-event-queue-secret` / `-dlq-secret`.
- **IRSA** — dedicated service account `hmpps-prisoner-property-api`.

Reuses existing namespace declarations (`mp_dps_sg`, `hmpps-domain-events-topic-arn`,
`local.sns_policies`). Dev and preprod are separate PRs (one namespace per PR).
