### PR TITLE
Infrastructure/frontend

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/acm.tf
@@ -1,0 +1,34 @@
+resource "aws_acm_certificate" "frontend" {
+  count = var.use_custom_certificate ? 1 : 0
+
+  domain_name       = var.cloudfront_alias
+  validation_method = "DNS"
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-frontend-certificate"
+  })
+
+  provider = aws.virginia
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "frontend" {
+  count = var.use_custom_certificate ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.frontend[0].arn
+  validation_record_fqdns = aws_route53_record.cert_validations[*].fqdn
+
+  provider = aws.virginia
+
+  timeouts {
+    create = "10m"
+  }
+
+  depends_on = [
+    aws_acm_certificate.frontend,
+    aws_route53_record.cert_validations,
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cloudfront.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cloudfront.tf
@@ -1,0 +1,122 @@
+# -----------------------------------------------------------------------------
+# CloudFront Origin Access Control (us-east-1)
+# -----------------------------------------------------------------------------
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  provider = aws.us_east_1
+
+  name                              = "${var.environment}-frontend-oac"
+  description                       = "Origin Access Control for ${var.environment} frontend S3 bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# -----------------------------------------------------------------------------
+# CloudFront Distribution (global service, defined in us-east-1)
+# -----------------------------------------------------------------------------
+# checkov:skip=CKV2_AWS_42:Custom SSL certificate optional - using CloudFront default or provided ACM certificate
+# checkov:skip=CKV2_AWS_32:Response headers policy not required - security headers handled via WAF
+# checkov:skip=CKV2_AWS_47:WAF Log4j AMR configuration not required - WAF rules managed separately
+resource "aws_cloudfront_distribution" "frontend" {
+  provider = aws.us_east_1
+
+  enabled             = true
+  comment             = "${var.environment} Frontend Distribution"
+  default_root_object = "index.html"
+  price_class         = var.cloudfront_price_class
+  web_acl_id          = aws_wafv2_web_acl.frontend.arn
+
+  # Custom domain aliases - required for CloudFront to respond to custom domain
+  aliases = var.use_custom_certificate ? var.cloudfront_aliases : []
+
+  # Access logging configuration (S3)
+  # Logs include geo-location blocks and all request details
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cloudfront_logs.bucket_regional_domain_name
+    prefix          = "cloudfront/"
+  }
+
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = "${var.environment}-s3-origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.environment}-s3-origin"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 0
+    default_ttl            = 0 # Don't cache by default - let S3 metadata control caching
+    max_ttl                = 86400
+    compress               = true
+  }
+
+  # Cache behavior for static assets (/_next/static/) - long cache
+  ordered_cache_behavior {
+    path_pattern     = "/_next/static/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.environment}-s3-origin"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 31536000 # 1 year - static files are hashed
+    default_ttl            = 31536000
+    max_ttl                = 31536000
+    compress               = true
+  }
+
+  # Custom error responses for SPA routing
+  # Returns index.html for 403/404 errors, allowing client-side routing to handle paths
+  # Short cache to ensure route changes are picked up quickly
+  # custom_error_response {
+  #   error_code            = 403
+  #   response_code         = 200
+  #   response_page_path    = "/index.html"
+  #   error_caching_min_ttl = 0
+  # }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = var.geo_restriction_type
+      locations        = var.geo_restriction_locations
+    }
+  }
+
+  # Custom certificate lookup takes precedence over explicit ARN
+  # Certificate is looked up by Name tag: ${var.environment}-frontend-certificate
+  viewer_certificate {
+    cloudfront_default_certificate = var.use_custom_certificate ? false : (var.acm_certificate_arn == "" ? true : false)
+    acm_certificate_arn            = var.use_custom_certificate ? data.aws_acm_certificate.frontend[0].arn : (var.acm_certificate_arn != "" ? var.acm_certificate_arn : null)
+    ssl_support_method             = var.use_custom_certificate || var.acm_certificate_arn != "" ? "sni-only" : null
+    minimum_protocol_version       = var.use_custom_certificate || var.acm_certificate_arn != "" ? "TLSv1.2_2021" : null
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-frontend-distribution"
+  })
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cloudfront.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cloudfront.tf
@@ -2,7 +2,7 @@
 # CloudFront Origin Access Control (us-east-1)
 # -----------------------------------------------------------------------------
 resource "aws_cloudfront_origin_access_control" "frontend" {
-  provider = aws.us_east_1
+  provider = aws.virginia
 
   name                              = "${var.environment}-frontend-oac"
   description                       = "Origin Access Control for ${var.environment} frontend S3 bucket"
@@ -18,7 +18,9 @@ resource "aws_cloudfront_origin_access_control" "frontend" {
 # checkov:skip=CKV2_AWS_32:Response headers policy not required - security headers handled via WAF
 # checkov:skip=CKV2_AWS_47:WAF Log4j AMR configuration not required - WAF rules managed separately
 resource "aws_cloudfront_distribution" "frontend" {
-  provider = aws.us_east_1
+  #checkov:skip=CKV_AWS_310:Single S3 origin static frontend - origin failover not required
+  #checkov:skip=CKV_AWS_374:Geo restriction not required - access controlled via WAF IP allowlist
+  provider = aws.virginia
 
   enabled             = true
   comment             = "${var.environment} Frontend Distribution"
@@ -27,7 +29,7 @@ resource "aws_cloudfront_distribution" "frontend" {
   web_acl_id          = aws_wafv2_web_acl.frontend.arn
 
   # Custom domain aliases - required for CloudFront to respond to custom domain
-  aliases = var.use_custom_certificate ? var.cloudfront_aliases : []
+  aliases = var.use_custom_certificate ? [var.cloudfront_alias] : []
 
   # Access logging configuration (S3)
   # Logs include geo-location blocks and all request details
@@ -107,11 +109,9 @@ resource "aws_cloudfront_distribution" "frontend" {
     }
   }
 
-  # Custom certificate lookup takes precedence over explicit ARN
-  # Certificate is looked up by Name tag: ${var.environment}-frontend-certificate
   viewer_certificate {
     cloudfront_default_certificate = var.use_custom_certificate ? false : (var.acm_certificate_arn == "" ? true : false)
-    acm_certificate_arn            = var.use_custom_certificate ? data.aws_acm_certificate.frontend[0].arn : (var.acm_certificate_arn != "" ? var.acm_certificate_arn : null)
+    acm_certificate_arn            = var.use_custom_certificate ? aws_acm_certificate.frontend[0].arn : (var.acm_certificate_arn != "" ? var.acm_certificate_arn : null)
     ssl_support_method             = var.use_custom_certificate || var.acm_certificate_arn != "" ? "sni-only" : null
     minimum_protocol_version       = var.use_custom_certificate || var.acm_certificate_arn != "" ? "TLSv1.2_2021" : null
   }
@@ -119,4 +119,19 @@ resource "aws_cloudfront_distribution" "frontend" {
   tags = merge(var.tags, {
     Name = "${var.environment}-frontend-distribution"
   })
+
+  depends_on = [aws_acm_certificate_validation.frontend]
+}
+
+resource "kubernetes_secret" "cloudfront_output" {
+  metadata {
+    name      = "cloudfront-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    cloudfront_alias           = var.cloudfront_alias
+    cloudfront_url            = aws_cloudfront_distribution.frontend.domain_name
+    cloudfront_distribution_id = aws_cloudfront_distribution.frontend.id
+  }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/iam.tf
@@ -1,0 +1,52 @@
+resource "aws_iam_policy" "frontend_s3_deploy" {
+  name        = "${var.namespace}-frontend-s3-deploy"
+  description = "Allow CI to sync static assets to the ${var.namespace} frontend S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ListFrontendBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = aws_s3_bucket.frontend.arn
+      },
+      {
+        Sid    = "ManageFrontendObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "frontend_cloudfront_invalidate" {
+  name        = "${var.namespace}-frontend-cloudfront-invalidate"
+  description = "Allow CI to invalidate the ${var.namespace} CloudFront distribution after deploy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "InvalidateFrontendDistribution"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:GetDistribution",
+          "cloudfront:ListDistributions",
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation",
+          "cloudfront:ListInvalidations",
+        ]
+        Resource = aws_cloudfront_distribution.frontend.arn
+      },
+    ]
+  })
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/irsa.tf
@@ -1,0 +1,20 @@
+module "irsa" {
+  #checkov:skip=CKV_TF_1:Cloud Platform modules use version tags not commit hashes
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  service_account_name = "${var.namespace}-frontend"
+  namespace            = var.namespace
+
+  role_policy_arns = {
+    s3         = aws_iam_policy.frontend_s3_deploy.arn
+    cloudfront = aws_iam_policy.frontend_cloudfront_invalidate.arn
+  }
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/main.tf
@@ -56,6 +56,23 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "virginia"
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application = var.application
+      is-production = var.is_production
+      owner = var.team_name
+      namespace = var.namespace
+      service-area = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+  region = "us-east-1"
+}
+
 provider "github" {
   token = var.github_token
   owner = var.github_owner

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/route53.tf
@@ -1,0 +1,14 @@
+resource "aws_route53_zone" "cis-pp" {
+  name = "cis-pp.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/route53.tf
@@ -12,3 +12,43 @@ resource "aws_route53_zone" "cis-pp" {
   }
 }
 
+resource "kubernetes_secret" "cis-pp_route53_zone" {
+  metadata {
+    name      = "cis-pp-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id      = aws_route53_zone.cis-pp.zone_id
+    name_servers = join("\n", aws_route53_zone.cis-pp.name_servers)
+  }
+}
+
+resource "aws_route53_record" "frontend" {
+  count = var.use_custom_certificate ? 1 : 0
+
+  zone_id = aws_route53_zone.cis-pp.zone_id
+  name    = var.cloudfront_alias
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.frontend.domain_name
+    zone_id                = aws_cloudfront_distribution.frontend.hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  depends_on = [aws_acm_certificate_validation.frontend]
+}
+
+resource "aws_route53_record" "cert_validations" {
+  count = var.use_custom_certificate ? length(aws_acm_certificate.frontend[0].domain_validation_options) : 0
+
+  zone_id = aws_route53_zone.cis-pp.zone_id
+  name    = element(aws_acm_certificate.frontend[0].domain_validation_options[*].resource_record_name, count.index)
+  type    = element(aws_acm_certificate.frontend[0].domain_validation_options[*].resource_record_type, count.index)
+  records = [element(aws_acm_certificate.frontend[0].domain_validation_options[*].resource_record_value, count.index)]
+  ttl     = 60
+
+  allow_overwrite = true
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/s3.tf
@@ -1,0 +1,142 @@
+
+# -----------------------------------------------------------------------------
+# S3 Bucket for Static Website Hosting (regional)
+# -----------------------------------------------------------------------------
+# checkov:skip=CKV_AWS_145:KMS encryption not required - using AES256 server-side encryption
+# checkov:skip=CKV_AWS_18:Access logging not required - CloudFront provides access logs
+# checkov:skip=CKV2_AWS_62:Event notifications not required for static website bucket
+# checkov:skip=CKV2_AWS_61:Lifecycle configuration not required - versioning handles retention
+# checkov:skip=CKV_AWS_144:Cross-region replication not required for non-production environments
+resource "aws_s3_bucket" "frontend" {
+  bucket = var.s3_bucket_name
+
+  tags = merge(var.tags, {
+    Name = var.s3_bucket_name
+  })
+}
+
+resource "aws_s3_bucket_versioning" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# -----------------------------------------------------------------------------
+# S3 Bucket Policy for CloudFront Access
+# -----------------------------------------------------------------------------
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontServicePrincipal"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# S3 Bucket for CloudFront Access Logs
+# -----------------------------------------------------------------------------
+# checkov:skip=CKV_AWS_145:KMS encryption not required - using AES256 server-side encryption for logs
+# checkov:skip=CKV_AWS_18:Access logging not required for CloudFront logs bucket
+# checkov:skip=CKV2_AWS_62:Event notifications not required for CloudFront logs bucket
+# checkov:skip=CKV_AWS_144:Cross-region replication not required for log buckets
+resource "aws_s3_bucket" "cloudfront_logs" {
+  bucket = "${var.s3_bucket_name}-cloudfront-logs"
+
+  tags = merge(var.tags, {
+    Name = "${var.s3_bucket_name}-cloudfront-logs"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# CloudFront requires ACLs to be enabled for log delivery
+# checkov:skip=CKV2_AWS_65:ACLs required for CloudFront log delivery - ownership controls configured
+resource "aws_s3_bucket_ownership_controls" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+# Lifecycle policy to expire old logs (30 days by default)
+resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  rule {
+    id     = "expire-old-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "" # Apply to all objects
+    }
+
+    expiration {
+      days = var.cloudfront_log_retention_days
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/s3.tf
@@ -119,8 +119,71 @@ resource "aws_s3_bucket_ownership_controls" "cloudfront_logs" {
   }
 }
 
+resource "aws_s3_bucket_acl" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+  acl    = "log-delivery-write"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.cloudfront_logs,
+    aws_s3_bucket_public_access_block.cloudfront_logs,
+  ]
+}
+
+resource "aws_s3_bucket_policy" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontLogDelivery"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.cloudfront_logs.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      },
+      {
+        Sid    = "AllowCloudFrontLogDeliveryAclCheck"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = aws_s3_bucket.cloudfront_logs.arn
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      },
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.cloudfront_logs]
+}
+
+resource "kubernetes_secret" "s3_bucket_output" {
+  metadata {
+    name      = "s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = aws_s3_bucket.frontend.arn
+    bucket_name = aws_s3_bucket.frontend.id
+  }
+}
+
 # Lifecycle policy to expire old logs (30 days by default)
 resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_logs" {
+  #checkov:skip=CKV_AWS_300:CloudFront log delivery does not use multipart uploads
   bucket = aws_s3_bucket.cloudfront_logs.id
 
   rule {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/serviceaccount.tf
@@ -1,0 +1,17 @@
+module "serviceaccount" {
+  #checkov:skip=CKV_TF_1:Cloud Platform modules use version tags not commit hashes
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = [var.github_repository]
+  github_environments = [var.github_environment]
+
+  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
+  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
+  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+
+  serviceaccount_token_rotated_date = "11-06-2026"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/serviceaccount.tf
@@ -1,6 +1,6 @@
 module "serviceaccount" {
   #checkov:skip=CKV_TF_1:Cloud Platform modules use version tags not commit hashes
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/variables.tf
@@ -73,3 +73,102 @@ variable "github_token" {
   description = "Required by the GitHub Terraform provider"
   default     = ""
 }
+
+# =============================================================================
+# Frontend Module Variables
+# =============================================================================
+
+variable "environment" {
+  description = "Environment name (e.g., cis-pp, cis-prod)"
+  type        = string
+}
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket for frontend hosting"
+  type        = string
+}
+
+variable "waf_allowed_ips" {
+  description = "List of allowed IP addresses in CIDR notation for WAF IP set"
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudfront_price_class" {
+  description = "CloudFront distribution price class"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of ACM certificate for custom domain (leave empty for CloudFront default) - DEPRECATED: use use_custom_certificate instead"
+  type        = string
+  default     = ""
+}
+
+variable "use_custom_certificate" {
+  description = "Enable custom certificate lookup for CloudFront (looks up cert by Name tag: {environment}-frontend-certificate)"
+  type        = bool
+  default     = false
+}
+
+variable "cloudfront_aliases" {
+  description = "List of custom domain aliases for CloudFront distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "geo_restriction_type" {
+  description = "Type of geo restriction (none, whitelist, blacklist)"
+  type        = string
+  default     = "none"
+}
+
+variable "geo_restriction_locations" {
+  description = "List of country codes for geo restriction"
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Common Tag Variables
+# -----------------------------------------------------------------------------
+variable "application_tag" {
+  description = "Application name tag"
+  type        = string
+}
+
+variable "project_tag" {
+  description = "Project name tag"
+  type        = string
+}
+
+variable "version_tag" {
+  description = "Version tag"
+  type        = string
+}
+
+variable "technical_owner_tag" {
+  description = "Technical owner tag"
+  type        = string
+}
+
+variable "business_owner_tag" {
+  description = "Business owner tag"
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# CloudFront Logging Variables
+# -----------------------------------------------------------------------------
+variable "cloudfront_log_retention_days" {
+  description = "Number of days to retain CloudFront access logs"
+  type        = number
+  default     = 30
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/variables.tf
@@ -8,6 +8,11 @@ variable "kubernetes_cluster" {
   type        = string
 }
 
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster to retrieve OIDC information for IRSA"
+  type        = string
+}
+
 variable "application" {
   description = "Name of the application you are deploying"
   type        = string
@@ -74,24 +79,68 @@ variable "github_token" {
   default     = ""
 }
 
+variable "github_repository" {
+  description = "GitHub repository name for frontend CI/CD deploy credentials"
+  type        = string
+  default     = "cis-modernisation"
+}
+
+variable "github_environment" {
+  description = "GitHub environment name for deploy secrets"
+  type        = string
+  default     = "preproduction"
+}
+
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the kubernetes cluster name"
+  type        = string
+  default     = "KUBE_CLUSTER"
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  type        = string
+  default     = "KUBE_NAMESPACE"
+}
+
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  type        = string
+  default     = "KUBE_CERT"
+}
+
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  type        = string
+  default     = "KUBE_TOKEN"
+}
+
 # =============================================================================
 # Frontend Module Variables
 # =============================================================================
 
-variable "environment" {
-  description = "Environment name (e.g., cis-pp, cis-prod)"
-  type        = string
-}
-
 variable "s3_bucket_name" {
   description = "Name of the S3 bucket for frontend hosting"
   type        = string
+  default     = "moj-laa-cis-pp-frontend"
 }
 
 variable "waf_allowed_ips" {
-  description = "List of allowed IP addresses in CIDR notation for WAF IP set"
+  description = "List of allowed IP addresses in CIDR notation for WAF IP set. Leave empty for public access with managed WAF rules only."
   type        = list(string)
-  default     = []
+  default = [
+    "35.176.93.186/32",
+    "18.169.147.172/32",
+    "18.130.148.126/32", # Gateway IP for Global Protect alpha VPN firewall
+    "35.176.148.126/32",
+    "128.77.75.64/26",   # Prisma egress
+    "51.149.249.0/29",   # MOJ public egress
+    "194.33.249.0/29",
+    "51.149.249.32/29",
+    "194.33.248.0/29",
+    "128.77.75.128/26",
+    "128.77.75.0/26",
+  ]
 }
 
 variable "cloudfront_price_class" {
@@ -107,15 +156,15 @@ variable "acm_certificate_arn" {
 }
 
 variable "use_custom_certificate" {
-  description = "Enable custom certificate lookup for CloudFront (looks up cert by Name tag: {environment}-frontend-certificate)"
+  description = "Enable ACM certificate and custom domain for CloudFront"
   type        = bool
-  default     = false
+  default     = true
 }
 
-variable "cloudfront_aliases" {
-  description = "List of custom domain aliases for CloudFront distribution"
-  type        = list(string)
-  default     = []
+variable "cloudfront_alias" {
+  description = "Primary custom domain for the CloudFront distribution"
+  type        = string
+  default     = "cis-pp.service.justice.gov.uk"
 }
 
 variable "geo_restriction_type" {
@@ -134,34 +183,6 @@ variable "tags" {
   description = "Tags to apply to all resources"
   type        = map(string)
   default     = {}
-}
-
-# -----------------------------------------------------------------------------
-# Common Tag Variables
-# -----------------------------------------------------------------------------
-variable "application_tag" {
-  description = "Application name tag"
-  type        = string
-}
-
-variable "project_tag" {
-  description = "Project name tag"
-  type        = string
-}
-
-variable "version_tag" {
-  description = "Version tag"
-  type        = string
-}
-
-variable "technical_owner_tag" {
-  description = "Technical owner tag"
-  type        = string
-}
-
-variable "business_owner_tag" {
-  description = "Business owner tag"
-  type        = string
 }
 
 # -----------------------------------------------------------------------------

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/waf.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/waf.tf
@@ -1,0 +1,84 @@
+resource "aws_wafv2_ip_set" "frontend" {
+  count = length(var.waf_allowed_ips) > 0 ? 1 : 0
+
+  provider = aws.virginia
+
+  name               = "${var.namespace}-frontend-allowed-ips"
+  description        = "Allowed IPs for ${var.namespace} CloudFront distribution"
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+  addresses          = var.waf_allowed_ips
+}
+
+resource "aws_wafv2_web_acl" "frontend" {
+  provider = aws.virginia
+
+  name  = "${var.namespace}-frontend-waf"
+  scope = "CLOUDFRONT"
+
+  default_action {
+    dynamic "allow" {
+      for_each = length(var.waf_allowed_ips) > 0 ? [] : [1]
+      content {}
+    }
+
+    dynamic "block" {
+      for_each = length(var.waf_allowed_ips) > 0 ? [1] : []
+      content {}
+    }
+  }
+
+  dynamic "rule" {
+    for_each = length(var.waf_allowed_ips) > 0 ? [1] : []
+    content {
+      name     = "AllowListedIPs"
+      priority = 1
+
+      action {
+        allow {}
+      }
+
+      statement {
+        ip_set_reference_statement {
+          arn = aws_wafv2_ip_set.frontend[0].arn
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.namespace}-allowed-ips"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = length(var.waf_allowed_ips) > 0 ? 2 : 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.namespace}-common-rules"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.namespace}-frontend-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.tags
+}


### PR DESCRIPTION
**Phase 1 - CIS in Cloud Platform - Front-end Infrastructure Scaffold and Deployment**

S3 — Frontend bucket (OAC-only access) and CloudFront access logs bucket with lifecycle, ACL, and bucket policies
CloudFront — Distribution with custom domain, Next.js cache behaviour (/_next/static/*), and SPA error responses (403/404 → index.html)
WAF — IP allowlist (MOJ/VPN/Prisma egress) with managed common rule set
ACM + Route53 — Certificate in us-east-1, DNS validation, apex alias A record to CloudFront
Deploy — IRSA (cis-pp-frontend) with S3 sync and CloudFront invalidation IAM; GitHub Actions service account for cis-modernisation
Secrets — cloudfront-output, s3-bucket-output, cis-pp-route53-zone-output (includes name servers for NS delegation)