### PR TITLE
Add egress controls module to `hmpps-forge-dev`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
@@ -2,7 +2,7 @@ module "hmpps_egress_controls" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-egress-controls?ref=0.0.2"
 
   enable_envoy_setup     = true
-  enable_egress_controls = false # Stage 2: set to true once the app is confirmed to route via the proxy
+  enable_egress_controls = true
   namespace              = var.namespace
   vpc_name               = var.vpc_name
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
@@ -2,7 +2,7 @@ module "hmpps_egress_controls" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-egress-controls?ref=0.0.3"
 
   enable_envoy_setup     = true
-  enable_egress_controls = true
+  enable_egress_controls = false # Stage 2: set to true once the app is confirmed to route via the proxy
   namespace              = var.namespace
   vpc_name               = var.vpc_name
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
@@ -1,0 +1,8 @@
+module "hmpps_egress_controls" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-egress-controls?ref=0.0.2"
+
+  enable_envoy_setup     = true
+  enable_egress_controls = false # Stage 2: set to true once the app is confirmed to route via the proxy
+  namespace              = var.namespace
+  vpc_name               = var.vpc_name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
@@ -1,5 +1,5 @@
 module "hmpps_egress_controls" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-egress-controls?ref=0.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-egress-controls?ref=0.0.3"
 
   enable_envoy_setup     = true
   enable_egress_controls = false # Stage 2: set to true once the app is confirmed to route via the proxy


### PR DESCRIPTION
- Stage 1 of egress controls rollout: deploys the Envoy proxy and publishes the proxy env secret, without enforcing any egress restrictions yet