### PR TITLE
Enable egress controls enforcement in `hmpps-forge-dev`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-forge-dev/resources/egress-controls.tf
@@ -2,7 +2,7 @@ module "hmpps_egress_controls" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-egress-controls?ref=0.0.2"
 
   enable_envoy_setup     = true
-  enable_egress_controls = false # Stage 2: set to true once the app is confirmed to route via the proxy
+  enable_egress_controls = true
   namespace              = var.namespace
   vpc_name               = var.vpc_name
 }


### PR DESCRIPTION
- Stage 2 of egress controls rollout: enables the Calico default-deny egress policies, requiring all outbound HTTP(S) traffic to go via the Envoy proxy
- Depends on #43205 and on the app being confirmed to route via the proxy