### PR TITLE
fix: nonexistant parameter group name for MCC UAT's redis instance

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-uat/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-manage-your-civil-cases-uat/resources/elasticache.tf
@@ -10,7 +10,7 @@ module "elasticache_redis" {
   business_unit          = var.business_unit
   node_type              = "cache.t4g.micro"
   engine_version         = "9.0"
-  parameter_group_name   = "default.redis9"
+  parameter_group_name   = "default.valkey9.cluster.on"
   namespace              = var.namespace
 
   auth_token_rotated_date = "2023-02-14"


### PR DESCRIPTION
In the previous attempt to upgrade to Redis 9.0, the parameter group name chosen didn't exist. See https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/ParameterGroups.Engine.html#ParameterGroups.Valkey.9.0

According to those docs, the parameter group name for this version should be either:
- `default.valkey9` – Default parameter group for Valkey 9.0 (cluster mode disabled).
- `default.valkey9.cluster.on` – Default parameter group for Valkey 9.0 with cluster mode enabled.

I have picked `default.valkey9.cluster.on` because `number_cache_clusters` is set to `2`.