### PR TITLE
MAPB-452 hmpps-prisoner-property-api CD service account (hmpps-locations-inside-prison-dev)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/github.tf
@@ -51,3 +51,19 @@ module "hmpps-non-residential-locations-ui" {
   kubernetes_cluster            = var.kubernetes_cluster
   github_owner                  = var.github_owner
 }
+
+module "hmpps-prisoner-property-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  github_repo                   = "hmpps-prisoner-property-api"
+  application                   = "hmpps-prisoner-property-api"
+  github_team                   = var.team_name
+  environment                   = var.deployment_environment
+  is_production                 = var.is_production
+  protected_branches_only       = true
+  application_insights_instance = var.deployment_environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+}


### PR DESCRIPTION
## MAPB-452 — hmpps-prisoner-property-api CD service account (dev)

Adds the `cloud-platform-terraform-hmpps-template` module block for
**hmpps-prisoner-property-api** to the shared `hmpps-locations-inside-prison-dev` namespace.

This creates the GitHub Actions deploy service account (`cd-serviceaccount`) and writes the
`KUBE_CLUSTER` / `KUBE_NAMESPACE` / `KUBE_CERT` / `KUBE_TOKEN` secrets into the repo's `dev`
GitHub environment. Without it the pipeline's deploy step fails configuring kubectl (empty
cluster/namespace). The RDS, SQS and IRSA resources for this service were added in earlier PRs.

Preprod and prod follow in separate PRs (one namespace per PR).
