### PR TITLE
MAPB-452 hmpps-prisoner-property-api CD service account (hmpps-locations-inside-prison-prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/github.tf
@@ -55,3 +55,20 @@ module "hmpps-non-residential-locations-ui" {
   github_owner                  = var.github_owner
   reviewer_teams                = [var.review_team_name]
 }
+
+module "hmpps-prisoner-property-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  github_repo                   = "hmpps-prisoner-property-api"
+  application                   = "hmpps-prisoner-property-api"
+  github_team                   = var.team_name
+  environment                   = var.deployment_environment
+  is_production                 = var.is_production
+  protected_branches_only       = true
+  application_insights_instance = var.deployment_environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.review_team_name]
+}


### PR DESCRIPTION
## MAPB-452 — hmpps-prisoner-property-api CD service account (prod)

Adds the `cloud-platform-terraform-hmpps-template` module block for
**hmpps-prisoner-property-api** to the shared `hmpps-locations-inside-prison-dev` namespace.

This creates the GitHub Actions deploy service account (`cd-serviceaccount`) and writes the
`KUBE_CLUSTER` / `KUBE_NAMESPACE` / `KUBE_CERT` / `KUBE_TOKEN` secrets into the repo's `prod`
GitHub environment. Without it the pipeline's deploy step fails configuring kubectl (empty
cluster/namespace). The RDS, SQS and IRSA resources for this service were added in earlier PRs.

Dev and preprod are separate PRs (one namespace per PR).
