### PR TITLE
update Node.js golden signals dashboard to use path label

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-observability/14-dpr-golden-signals-nodejs-dashboard.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-dpr-observability/14-dpr-golden-signals-nodejs-dashboard.yaml
@@ -231,8 +231,8 @@ data:
           "id": 11,
           "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
           "pluginVersion": "11.5.0",
-          "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "editorMode": "code", "expr": "topk(10, histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])) by (route, le)))", "legendFormat": "{{route}}", "range": true, "refId": "A"}],
-          "title": "Latency by Route (p95)",
+          "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "editorMode": "code", "expr": "topk(10, histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])) by (path, le)))", "legendFormat": "{{path}}", "range": true, "refId": "A"}],
+          "title": "Latency by Path (p95)",
           "type": "timeseries"
         },
         {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 15}, "id": 102, "title": "📈 Traffic", "type": "row"},
@@ -256,8 +256,8 @@ data:
           "id": 21,
           "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
           "pluginVersion": "11.5.0",
-          "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "editorMode": "code", "expr": "topk(10, sum(rate(http_server_requests_seconds_count{namespace=~\"$namespace\"}[$__rate_interval])) by (route, method))", "legendFormat": "{{method}} {{route}}", "range": true, "refId": "A"}],
-          "title": "Top 10 Routes by Traffic",
+          "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "editorMode": "code", "expr": "topk(10, sum(rate(http_server_requests_seconds_count{namespace=~\"$namespace\"}[$__rate_interval])) by (path, method))", "legendFormat": "{{method}} {{path}}", "range": true, "refId": "A"}],
+          "title": "Top 10 Paths by Traffic",
           "type": "timeseries"
         },
         {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 24}, "id": 103, "title": "❌ Errors", "type": "row"},


### PR DESCRIPTION
update Node.js golden signals dashboard to use path label instead of route