### PR TITLE
CPB-1060: Added RDS pre-prod refresh secret configuration for community payback.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-payback-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-payback-preprod/resources/rds-postgresql.tf
@@ -114,6 +114,22 @@ resource "kubernetes_secret" "rds" {
      */
 }
 
+# This places a secret for this preprod RDS instance in the production namespace,
+# this can then be used by a kubernetes job which will refresh the preprod data.
+resource "kubernetes_secret" "rds_refresh_creds" {
+  metadata {
+    name      = "rds-postgresql-instance-output-preprod"
+    namespace = "hmpps-community-payback-prod"
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+}
 
 resource "kubernetes_secret" "read_replica" {
   # default off


### PR DESCRIPTION
Added RDS pre-prod refresh secret configuration for community payback.
This is to get prod data into pre-prod.

Following this:
https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-service/README.md#prison-postgres-database-restore-cronjob

https://github.com/ministryofjustice/cloud-platform-environments/pull/8325