### PR TITLE
Restrict CCR dev SQS IAM policy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-crown-court-remuneration-dev/resources/irsa.tf
@@ -25,22 +25,32 @@ module "irsa" {
 }
 
 data "aws_iam_policy_document" "ccr_claims_policy" {
-  # Provide list of permissions and target AWS account resources to allow access to
+  # Inbound queues: CCR polls for claims and deletes after processing
   statement {
-    sid  = "CCRPolicySQSDev"
+    sid  = "CCRPolicySQSDevReceive"
     effect = "Allow"
     actions = [
-      "sqs:*",
-      "sts:*"
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
     ]
     resources = [
       "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-cccd-claims-for-ccr",
       "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-cccd-claims-submitted-ccr-dlq",
+    ]
+  }
+
+  # Outbound queues: CCR sends success/failure responses back to CCCD
+  statement {
+    sid  = "CCRPolicySQSDevSend"
+    effect = "Allow"
+    actions = [
+      "sqs:SendMessage",
+    ]
+    resources = [
       "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-responses-for-cccd",
       "arn:aws:sqs:eu-west-2:754256621582:laa-get-paid-dev-reponses-for-cccd-dlq",
     ]
   }
-
 }
 
 resource "aws_iam_policy" "ccr_policy" {


### PR DESCRIPTION
Replaces the overly permissive `sqs:*` and `sts:*` wildcard actions with the minimum set required for CCR to function:

Inbound queues (`claims-for-ccr`, `claims-submitted-ccr-dlq`):
- `sqs:ReceiveMessage` (poll for claim messages)
- `sqs:DeleteMessage` (acknowledge processed messages)

Outbound queues (`responses-for-cccd`, `responses-for-cccd-dlq`):
- `sqs:SendMessage` (send success/failure responses to CCCD)

Removes `sts:*` entirely as IRSA handles role assumption via the trust policy on the IAM role, not via explicit STS permissions.

The queues are also now split into separate statements to enforce that the inbound queues can only be read from and the outbound queues can only be written to.