### PR TITLE
MAPB-452 Add SSL certificates for hmpps-prisoner-property-api

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/06-certificate.yaml
@@ -37,3 +37,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - non-residential-locations-dev.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-prisoner-property-api-dev-cert
+  namespace: hmpps-locations-inside-prison-dev
+spec:
+  secretName: hmpps-prisoner-property-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - prisoner-property-api-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/06-certificate.yaml
@@ -37,3 +37,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - non-residential-locations-preprod.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-prisoner-property-api-preprod-cert
+  namespace: hmpps-locations-inside-prison-preprod
+spec:
+  secretName: hmpps-prisoner-property-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - prisoner-property-api-preprod.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/06-certificate.yaml
@@ -37,3 +37,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - non-residential-locations.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-prisoner-property-api-prod-cert
+  namespace: hmpps-locations-inside-prison-prod
+spec:
+  secretName: hmpps-prisoner-property-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - prisoner-property-api.hmpps.service.justice.gov.uk


### PR DESCRIPTION
## Summary

Adds cert-manager `Certificate` resources for the `hmpps-prisoner-property-api` ingress hostnames across the three `hmpps-locations-inside-prison` namespaces (where the API's RDS/SQS/IRSA already live). These produce the `hmpps-prisoner-property-api-cert` TLS secret referenced by the service's Helm chart (`ingress.tlsSecretName`), which was previously missing.

| Env | Certificate | Hostname |
| --- | --- | --- |
| dev | `hmpps-prisoner-property-api-dev-cert` | prisoner-property-api-dev.hmpps.service.justice.gov.uk |
| preprod | `hmpps-prisoner-property-api-preprod-cert` | prisoner-property-api-preprod.hmpps.service.justice.gov.uk |
| prod | `hmpps-prisoner-property-api-prod-cert` | prisoner-property-api.hmpps.service.justice.gov.uk |

All use `secretName: hmpps-prisoner-property-api-cert` and the `letsencrypt-production` ClusterIssuer, matching the existing certs in these namespaces.

## Verification

- `kubectl apply --dry-run=client` passes on all three `06-certificate.yaml` files; the new certs show as `created`, existing certs unchanged.
- `secretName` matches the app's Helm `ingress.tlsSecretName`.