### PR TITLE
MAPB-452 Add SSL certificate for hmpps-prisoner-property-api (prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/06-certificate.yaml
@@ -37,3 +37,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - non-residential-locations.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-prisoner-property-api-prod-cert
+  namespace: hmpps-locations-inside-prison-prod
+spec:
+  secretName: hmpps-prisoner-property-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - prisoner-property-api.hmpps.service.justice.gov.uk


### PR DESCRIPTION
## Summary

Adds a cert-manager `Certificate` for the `hmpps-prisoner-property-api` ingress hostname in the **prod** `hmpps-locations-inside-prison` namespace. This produces the `hmpps-prisoner-property-api-cert` TLS secret referenced by the service's Helm chart (`ingress.tlsSecretName`), which was previously missing.

| Certificate | Hostname |
| --- | --- |
| `hmpps-prisoner-property-api-prod-cert` | prisoner-property-api.hmpps.service.justice.gov.uk |

Uses `secretName: hmpps-prisoner-property-api-cert` and the `letsencrypt-production` ClusterIssuer, matching the existing certs in this namespace.

Part of MAPB-452 (dev and preprod raised as separate PRs).

## Verification

- `kubectl apply --dry-run=client` passes; the new cert shows as `created`, existing certs unchanged.
- `secretName` matches the app's Helm `ingress.tlsSecretName`.