### PR TITLE
Add egress controls module to hmpps-templates-dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/egress-controls.tf
@@ -7,9 +7,8 @@ module "hmpps_egress_controls" {
 
   enable_envoy_setup     = true
   
-  # Add known external endpoint/suffixes your apps in this namespace 
-  # need to connect to (egress only) and then set this to true to secure
-  # your namespace from unexpected egress 
+  # Follow the guidance in the link above to configure your app to use the proxy
+  # then set this to true when ready to apply egress denial 
   enable_egress_controls = false 
 
   namespace = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/egress-controls.tf
@@ -1,0 +1,23 @@
+# Egress controls for hmpps-templates namespace
+# Deploys Envoy HTTPS forward proxy and creates proxy environment secret
+# For guidance see: https://tech-docs.hmpps.service.justice.gov.uk/how-to-guides/retrofitting-egress-controls-with-envoy-proxy
+
+module "hmpps_egress_controls" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-egress-controls?ref=0.0.3"
+
+  # Stage 1: Deploy proxy without enforcement (no Calico network policies yet)
+  # This allows applications to be configured to use the proxy before enforcement is enabled
+  enable_envoy_setup     = true
+  enable_egress_controls = false
+
+  namespace = var.namespace
+  vpc_name  = var.vpc_name
+
+  # Optional: Add additional allowed hosts/suffixes as needed
+  # envoy_extra_allowed_hosts_exact = [
+  #   "api.example.com",
+  # ]
+  # envoy_extra_allowed_hosts_suffixes = [
+  #   ".example.com",
+  # ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/egress-controls.tf
@@ -5,15 +5,17 @@
 module "hmpps_egress_controls" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-egress-controls?ref=0.0.3"
 
-  # Stage 1: Deploy proxy without enforcement (no Calico network policies yet)
-  # This allows applications to be configured to use the proxy before enforcement is enabled
   enable_envoy_setup     = true
-  enable_egress_controls = false
+  
+  # Add known external endpoint/suffixes your apps in this namespace 
+  # need to connect to (egress only) and then set this to true to secure
+  # your namespace from unexpected egress 
+  enable_egress_controls = false 
 
   namespace = var.namespace
   vpc_name  = var.vpc_name
 
-  # Optional: Add additional allowed hosts/suffixes as needed
+  # Optional: Add additional allowed hosts/suffixes used by apps in this namespace
   # envoy_extra_allowed_hosts_exact = [
   #   "api.example.com",
   # ]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/egress-controls.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/egress-controls.tf
@@ -14,11 +14,4 @@ module "hmpps_egress_controls" {
   namespace = var.namespace
   vpc_name  = var.vpc_name
 
-  # Optional: Add additional allowed hosts/suffixes used by apps in this namespace
-  # envoy_extra_allowed_hosts_exact = [
-  #   "api.example.com",
-  # ]
-  # envoy_extra_allowed_hosts_suffixes = [
-  #   ".example.com",
-  # ]
 }


### PR DESCRIPTION
## Summary

Add the `cloud-platform-terraform-hmpps-egress-controls` module to the hmpps-templates-dev namespace as a separate `egress-controls.tf` file.

## Configuration

- **enable_envoy_setup = true** - Deploys Envoy proxy and creates proxy environment secret
- **enable_egress_controls = false** - Network enforcement disabled by default

## Rationale

This provides proxy infrastructure for new services while allowing teams to configure applications before enabling enforcement. One proxy deployment serves the entire namespace regardless of number of applications.

## Documentation

See: https://tech-docs.hmpps.service.justice.gov.uk/how-to-guides/retrofitting-egress-controls-with-envoy-proxy

## Testing

This follows the same pattern already deployed in james-dev namespace (see `james-dev/resources/egress-controls.tf`).