### PR TITLE
CPR-1202 Fix eventSource filter for CPR only address events queue

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/cpr-delius-offender-events-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-record-dev/resources/cpr-delius-offender-events-queue.tf
@@ -18,7 +18,8 @@ resource "aws_sns_topic_subscription" "cpr_delius_probation_domain_events_subscr
       "probation-case.alias.deleted"
     ],
     eventSource = [
-      { "eventSource": [{"exists": false},{"anything-but": ["core-person-record"]}]}
+      { "exists" = false },
+      { "anything-but" = ["core-person-record"] }
     ]
   })
 }


### PR DESCRIPTION
Attempts to filter by specific eventSource and where the eventSource is not present.

This fixes the format to what we think it should be based on the hmpps domain event message structure.