### PR TITLE
Disable delete protection

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/london-task-force-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/london-task-force-dev/resources/ecr.tf
@@ -27,4 +27,6 @@ module "ecr" {
   # uncomment below:
 
   enable_irsa = true
+
+  deletion_protection = false 
 }


### PR DESCRIPTION
This pull request makes a small update to the ECR module configuration by explicitly disabling deletion protection. This change ensures that the ECR repository can be deleted without additional safeguards.

* Set `deletion_protection` to `false` in the `ecr.tf` file to allow easier deletion of the ECR repository.