### PR TITLE
Fix the ecr repo link

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/performance-information-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/performance-information-dev/resources/ecr.tf
@@ -12,7 +12,7 @@ module "ecr" {
 
   # OpenID Connect configuration
   oidc_providers      = ["github"]
-  github_repositories = ["performance-information-intelligence-system-demo"]
+  github_repositories = ["performance-information-intelligence-system"]
 
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
This pull request updates the ECR (Elastic Container Registry) configuration to reference the correct GitHub repository for OpenID Connect authentication.

* Changed the `github_repositories` value in `ecr.tf` to use `performance-information-intelligence-system` instead of the demo repository, ensuring the ECR is linked to the correct production repository.