### PR TITLE
Create VS-Code Marketplace Namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vscode-marketplace
+  labels:
+    cloud-platform.justice.gov.uk/environment-name: "production"
+    cloud-platform.justice.gov.uk/is-production: "true"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/application: "VS Code Private Marketplace"
+    cloud-platform.justice.gov.uk/business-unit: "Platforms"
+    cloud-platform.justice.gov.uk/owner: "Dean Longstaff: dean.longstaff@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/vscode-marketplace"
+    cloud-platform.justice.gov.uk/team-name: "vscode-marketplace-admins"
+    cloud-platform.justice.gov.uk/slack-channel: "#vscode-extensions"
+    cloud-platform.justice.gov.uk/review-after: "2026-12-01"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vscode-marketplace-admin
+  namespace: vscode-marketplace
+subjects:
+  - kind: Group
+    name: "github:vscode-marketplace-admins"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: vscode-marketplace
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: vscode-marketplace
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: vscode-marketplace
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: vscode-marketplace
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/ecr.tf
@@ -1,0 +1,43 @@
+# Creates an ECR repository for the curator image and configures OIDC-based
+# push access. The module automatically creates the following GitHub Actions
+# secrets/variables in the specified repositories:
+#   - ECR_ROLE_TO_ASSUME  (secret)
+#   - ECR_REGION          (variable)
+#   - ECR_REPOSITORY      (variable)
+
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.1"
+
+  repo_name = "vscode-marketplace"
+
+  oidc_providers      = ["github"]
+  github_repositories = [var.github_repository]
+
+  lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment_name
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/irsa.tf
@@ -1,0 +1,107 @@
+# IRSA (IAM Roles for Service Accounts): pod identities for S3 access, with no
+# static credentials. Two least-privilege roles, each bound to its own
+# Kubernetes service account (created by the module):
+#
+#   * curator     - read/write/delete on the bucket objects (it publishes and
+#                   prunes VSIX files and writes report artifacts).
+#   * marketplace - read-only (its sidecar only syncs files down).
+#
+# The service account names here MUST match `serviceAccountName` in the curator
+# CronJob and the marketplace Deployment manifests.
+
+locals {
+  policy_tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment_name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+  }
+}
+
+# --- Curator: read / write / delete -------------------------------------------
+
+data "aws_iam_policy_document" "curator_s3" {
+  statement {
+    sid       = "ListBucket"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = [module.s3_bucket.bucket_arn]
+  }
+  statement {
+    sid       = "ReadWriteDeleteObjects"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["${module.s3_bucket.bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "curator_s3" {
+  provider = aws.london
+  name     = "${var.namespace}-curator-s3"
+  policy   = data.aws_iam_policy_document.curator_s3.json
+  tags     = local.policy_tags
+}
+
+module "curator_irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = "vscode-marketplace-curator"
+  role_policy_arns     = { s3 = aws_iam_policy.curator_s3.arn }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment_name
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+# --- Marketplace: read-only ---------------------------------------------------
+
+data "aws_iam_policy_document" "marketplace_s3" {
+  statement {
+    sid       = "ListBucket"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = [module.s3_bucket.bucket_arn]
+  }
+  statement {
+    sid       = "ReadObjects"
+    actions   = ["s3:GetObject"]
+    resources = ["${module.s3_bucket.bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "marketplace_s3" {
+  provider = aws.london
+  name     = "${var.namespace}-marketplace-s3"
+  policy   = data.aws_iam_policy_document.marketplace_s3.json
+  tags     = local.policy_tags
+}
+
+module "marketplace_irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = "vscode-marketplace"
+  role_policy_arns     = { s3 = aws_iam_policy.marketplace_s3.arn }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment_name
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "london"
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = var.eks_cluster_name
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = var.eks_cluster_name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/s3.tf
@@ -1,0 +1,28 @@
+# S3 bucket: the durable source of truth for curated VSIX files and the
+# generated report artifacts.
+#
+# Cloud Platform provides only S3 and EBS storage. EBS is ReadWriteOnce, so it
+# cannot be shared between the separate curator and marketplace pods the way the
+# previous EFS (ReadWriteMany) volume was. Instead the curator writes VSIX
+# objects to this bucket (no shared mount), and the marketplace pod syncs them
+# down to its own local EBS volume via an init container + sidecar.
+
+module "s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+
+  oidc_providers      = ["github"]
+  github_repositories = [var.github_repository]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment_name
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/secrets.tf
@@ -1,0 +1,34 @@
+# Creates an AWS Secrets Manager secret for the curator's GitHub API token,
+# synced into the namespace as a Kubernetes Secret by External Secrets Operator.
+#
+# After this is applied, set the secret value ONCE in the AWS console (Secrets
+# Manager) as JSON so the key lands in the k8s Secret:
+#
+#     {"github-token": "github_pat_xxxxxxxx"}
+#
+# External Secrets then materialises a Kubernetes Secret named
+# `vscode-marketplace-curator` with key `github-token`, which the curator CronJob consumes
+
+module "curator_github_token" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+
+  # EKS configuration (auto-supplied by the cloud-platform-environments pipeline)
+  eks_cluster_name = var.eks_cluster_name
+
+  secrets = {
+    "github-token" = {
+      description             = "GitHub Token (public read-only) for curator repo trust scoring"
+      recovery_window_in_days = 0
+      k8s_secret_name         = "vscode-marketplace-curator"
+    }
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment_name
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/serviceaccount.tf
@@ -1,0 +1,39 @@
+# Creates a Kubernetes service account with deploy permissions for this namespace
+# and automatically populates the following GitHub Actions secrets:
+#   - KUBE_CERT
+#   - KUBE_TOKEN
+#   - KUBE_CLUSTER
+#   - KUBE_NAMESPACE
+
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.eks_cluster_name
+
+  # Populate GitHub Actions secrets in this repository automatically
+  github_repositories = [var.github_repository]
+
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources  = ["pods", "pods/log", "configmaps", "services", "persistentvolumeclaims"]
+      verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+    },
+    {
+      api_groups = ["apps"]
+      resources  = ["deployments"]
+      verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+    },
+    {
+      api_groups = ["batch"]
+      resources  = ["jobs", "cronjobs"]
+      verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+    },
+    {
+      api_groups = ["networking.k8s.io"]
+      resources  = ["ingresses"]
+      verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+    },
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/variables.tf
@@ -1,0 +1,50 @@
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster (auto-supplied by the cloud-platform-environments pipeline)"
+}
+
+variable "namespace" {
+  description = "The Kubernetes namespace"
+  default     = "vscode-marketplace"
+}
+
+variable "github_owner" {
+  description = "GitHub organisation"
+  default     = "ministryofjustice"
+}
+
+variable "github_repository" {
+  description = "GitHub repository name for this project"
+  default     = "vscode-marketplace"
+}
+
+# --- Standard Cloud Platform resource tags
+
+variable "business_unit" {
+  description = "Area of the MoJ responsible for the service"
+  default     = "Justice Digital"
+}
+
+variable "application" {
+  description = "Application name"
+  default     = "VS Code Private Marketplace"
+}
+
+variable "is_production" {
+  description = "Whether this namespace is production"
+  default     = "true"
+}
+
+variable "team_name" {
+  description = "The team responsible for this service"
+  default     = "vscode-marketplace-admins"
+}
+
+variable "environment_name" {
+  description = "Environment name"
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "Team contact for infrastructure support (team-name (team-email))"
+  default     = "Dean Longstaff (dean.longstaff@justice.gov.uk)"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+  }
+  required_version = ">= 1.2.5"
+}


### PR DESCRIPTION
Created a new namespace to host vscode private marketplace with a custom curator. This is a proof-on-concept product that allows us to control the list of vscode extensions that are available for installation across the estate.