### PR TITLE
cis-pp: Add GitHub deployment role; k8s secrets for IRSA and Cognito

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cognito.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cognito.tf
@@ -157,3 +157,14 @@ resource "aws_cognito_user_pool_client" "main" {
     refresh_token = "days"
   }
 }
+
+resource "kubernetes_secret" "cognito_user_pool_client" {
+  metadata {
+    name      = "${var.namespace}-cognito-user-pool-client"
+    namespace = var.namespace
+  }
+  data = {
+    client_id     = aws_cognito_user_pool_client.main.id
+    client_secret = aws_cognito_user_pool_client.main.client_secret
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/iam.tf
@@ -50,3 +50,39 @@ resource "aws_iam_policy" "frontend_cloudfront_invalidate" {
     ]
   })
 }
+
+module "github_oidc_iam_role" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+  version = "5.9.2"
+
+  name_prefix = "${var.namespace}-github-oidc"
+  path        = "/cloud-platform/"
+
+  subjects = ["ministryofjustice/${var.github_repository}:*"]
+
+  policies = {
+    s3         = aws_iam_policy.frontend_s3_deploy.arn
+    cloudfront = aws_iam_policy.frontend_cloudfront_invalidate.arn
+  }
+
+  tags = {
+    business_unit          = var.business_unit
+    application            = var.application
+    is_production          = var.is_production
+    team_name              = var.team_name
+    namespace              = var.namespace
+    environment_name       = var.environment
+    infrastructure_support = var.infrastructure_support
+  }
+}
+
+resource "kubernetes_secret" "github_oidc_iam_role" {
+  metadata {
+    name      = "github-oidc-iam-role"
+    namespace = var.namespace
+  }
+
+  data = {
+    role_arn = module.github_oidc_iam_role.arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/iam.tf
@@ -58,7 +58,10 @@ module "github_oidc_iam_role" {
   name_prefix = "${var.namespace}-github-oidc"
   path        = "/cloud-platform/"
 
-  subjects = ["ministryofjustice/${var.github_repository}:*"]
+  # References:
+  # https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-with-reusable-workflows
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html#condition-keys-wif
+  subjects = ["ministryofjustice/${var.github_repository}:job_workflow_ref:ministryofjustice/${var.github_repository}/.github/workflows/application.yml@refs/heads/main"]
 
   policies = {
     s3         = aws_iam_policy.frontend_s3_deploy.arn

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/irsa.tf
@@ -18,3 +18,15 @@ module "irsa" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "${var.namespace}-irsa"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+    rolearn        = module.irsa.role_arn
+  }
+}


### PR DESCRIPTION
Adds an IAM role for deployment via GitHub OIDC, to be used to sync frontend files to our S3 bucket and invalidate the CloudFront cache. Also add k8s secrets for IRSA role and Cognito user pool client.

Jira: https://dsdmoj.atlassian.net/browse/LGPAS-2129 