### PR TITLE
feat: add outbound endpoint resolver

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/data.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/data.tf
@@ -1,0 +1,23 @@
+data "aws_vpc" "this" {
+  filter {
+    name   = "tag:Name"
+    values = [var.vpc_name]
+  }
+}
+
+data "aws_subnets" "this" {
+  filter {
+    name   = "tag:SubnetType"
+    values = ["Private"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+}
+
+data "aws_subnet" "this" {
+  for_each = toset(data.aws_subnets.this.ids)
+  id       = each.value
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/locals.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/locals.tf
@@ -8,4 +8,16 @@ locals {
     infrastructure-support = var.infrastructure_support
     namespace              = var.namespace
   }
+  dns_endpoint_rules = {
+    "TCP_53" : {
+      "from_port" : 53,
+      "to_port" : 53,
+      "protocol" : "TCP"
+    },
+    "UDP_53" : {
+      "from_port" : 53,
+      "to_port" : 53,
+      "protocol" : "UDP"
+    }
+  }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/route53.tf
@@ -43,7 +43,7 @@ resource "aws_security_group_rule" "egress_dns_endpoint_traffic" {
   cidr_blocks       = [data.aws_vpc.shared.cidr_block]
 }
 
-resource "aws_route53_resolver_endpoint" "inbound_api" {
+resource "aws_route53_resolver_endpoint" "outbound_api" {
   name      = "outbound-resolve-mod-plat"
   direction = "OUTBOUND"
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/route53.tf
@@ -16,7 +16,7 @@ resource "aws_route53_zone" "data_validation_route53_zone" {
 resource "aws_security_group" "aws_dns_resolver" {
   name        = "dns-resolver"
   description = "Security Group for DNS resolver request"
-  vpc_id      = data.aws_vpc.shared.id
+  vpc_id      = data.aws_vpc.this.id
 
   tags = local.tags
 }
@@ -29,7 +29,7 @@ resource "aws_security_group_rule" "ingress_dns_endpoint_traffic" {
   security_group_id = aws_security_group.aws_dns_resolver.id
   to_port           = each.value.to_port
   type              = "ingress"
-  cidr_blocks       = [data.aws_vpc.shared.cidr_block]
+  cidr_blocks       = [data.aws_vpc.this.cidr_block]
 }
 
 resource "aws_security_group_rule" "egress_dns_endpoint_traffic" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/route53.tf
@@ -40,7 +40,7 @@ resource "aws_security_group_rule" "egress_dns_endpoint_traffic" {
   security_group_id = aws_security_group.aws_dns_resolver.id
   to_port           = each.value.to_port
   type              = "egress"
-  cidr_blocks       = [data.aws_vpc.shared.cidr_block]
+  cidr_blocks       = [data.aws_vpc.this.cidr_block]
 }
 
 resource "aws_route53_resolver_endpoint" "outbound_api" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-validation-dev/resources/route53.tf
@@ -12,3 +12,49 @@ resource "aws_route53_zone" "data_validation_route53_zone" {
     namespace              = var.namespace
   }
 }
+
+resource "aws_security_group" "aws_dns_resolver" {
+  name        = "dns-resolver"
+  description = "Security Group for DNS resolver request"
+  vpc_id      = data.aws_vpc.shared.id
+
+  tags = local.tags
+}
+
+resource "aws_security_group_rule" "ingress_dns_endpoint_traffic" {
+  for_each          = local.dns_endpoint_rules
+  description       = format("VPC to DNS Endpoint traffic for %s %d", each.value.protocol, each.value.from_port)
+  from_port         = each.value.from_port
+  protocol          = each.value.protocol
+  security_group_id = aws_security_group.aws_dns_resolver.id
+  to_port           = each.value.to_port
+  type              = "ingress"
+  cidr_blocks       = [data.aws_vpc.shared.cidr_block]
+}
+
+resource "aws_security_group_rule" "egress_dns_endpoint_traffic" {
+  for_each          = local.dns_endpoint_rules
+  description       = format("DNS Endpoint to Domain Controller traffic for %s %d", each.value.protocol, each.value.from_port)
+  from_port         = each.value.from_port
+  protocol          = each.value.protocol
+  security_group_id = aws_security_group.aws_dns_resolver.id
+  to_port           = each.value.to_port
+  type              = "egress"
+  cidr_blocks       = [data.aws_vpc.shared.cidr_block]
+}
+
+resource "aws_route53_resolver_endpoint" "inbound_api" {
+  name      = "outbound-resolve-mod-plat"
+  direction = "OUTBOUND"
+
+  security_group_ids = [aws_security_group.aws_dns_resolver.id]
+
+  dynamic "ip_address" {
+    for_each = data.aws_subnet.this
+    content {
+      subnet_id = ip_address.value.id
+    }
+  }
+
+  tags = local.tags
+}


### PR DESCRIPTION
for the em dashboard to be able to interact with the private vpc endpoint `execute-api` in the modernisation platform , we need an outboudn endpoint resolver.
this sets up a security group to do so and then and endpoint to do so.