### PR TITLE
Tag GithubTeam

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/vscode-marketplace/resources/main.tf
@@ -5,6 +5,12 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
   alias  = "london"
+
+  default_tags {
+    tags = {
+      GithubTeam = var.team_name
+    }
+  }
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
Tagging with `GithubTeam` to allow access in AWS console.