### PR TITLE
Fix DPR parameter group on manage-offences-api dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-offences-api-dev/resources/rds.tf
@@ -11,7 +11,7 @@ module "manage_offences_rds" {
   environment_name            = var.environment
   infrastructure_support      = var.infrastructure_support
   rds_family                  = var.rds_family
-  prepare_for_major_upgrade   = true
+  prepare_for_major_upgrade   = false
   allow_major_version_upgrade = "true"
   db_instance_class           = "db.t4g.micro"
   db_max_allocated_storage    = "500"


### PR DESCRIPTION
## Summary

- Set `prepare_for_major_upgrade = false` on manage-offences-api dev RDS
- The CP RDS module attaches `default.postgres18` when this flag is `true`, so the custom parameter group with DPR settings (`rds.logical_replication`, `pglogical`, etc.) was never applied to the instance despite PR #43310 merging successfully
- PG18 upgrade is complete; this flag was left over from that work

## After merge

- CP apply will attach the custom parameter group to the instance
- RDS **reboot required** for `pending-reboot` params to take effect
- Re-verify in DBeaver:
  - `rds.logical_replication` = on
  - `shared_preload_libraries` includes `pglogical`

## Test plan

- [ ] Merge and wait for `apply-namespace-changes-live` to succeed
- [ ] Reboot RDS instance (or ask CP)
- [ ] Confirm `pg_settings` shows DPR params active


Made with [Cursor](https://cursor.com)