### PR TITLE
update-aurora-version-to-match-actual-values

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/rds-aurora.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/rds-aurora.tf
@@ -6,7 +6,7 @@ module "rds_aurora" {
 
   # Database configuration
   engine         = "aurora-postgresql"
-  engine_version = "17.5"
+  engine_version = "17.7"
   engine_mode    = "provisioned"
   instance_type  = "db.serverless"
   serverlessv2_scaling_configuration = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/rds-legacy.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-intelligence-prod/resources/rds-legacy.tf
@@ -6,7 +6,7 @@ module "rds_aurora_legacy" {
 
   # Database configuration
   engine         = "aurora-postgresql"
-  engine_version = "17.5"
+  engine_version = "17.7"
   engine_mode    = "provisioned"
   instance_type  = "db.serverless"
   serverlessv2_scaling_configuration = {


### PR DESCRIPTION
The previous build failed, reporting that the aurora version in the config is is behind the actual, see error below:

`Error: updating RDS Cluster... : operation error RDS: ModifyDBCluster, https response error StatusCode: 400,... api error InvalidParameterCombination: Cannot upgrade aurora-postgresql from 17.7 to 17.5`