### PR TITLE
Removed e2e token from frontend namepsace 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-manage-dev/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-manage-dev/resources/secret.tf
@@ -34,12 +34,6 @@ module "secrets_manager" {
       k8s_secret_name         = "base-url-map-dev"
     },
 
-    "e2e-github-token" = {
-      description             = "GitHub token for E2E tests in dev environment",
-      recovery_window_in_days = 7,
-      k8s_secret_name         = "e2e-github-token"
-    },
-
     "slack-webhook-url" = {
       description             = "Slack webhook URL for non-production environment",
       recovery_window_in_days = 7,


### PR DESCRIPTION
Removed e2e token from frontend namepsace as the e2e token now sits in our e2e namespace