### PR TITLE
Add S3, RDS, and IRSA resources to onboarding-optimisation-dev namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/irsa.tf
@@ -1,0 +1,25 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = var.application
+
+  role_policy_arns = {
+    s3 = module.s3_bucket.irsa_policy_arn
+  }
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "github_actions_environment_variable" "app_role_arn" {
+  repository    = "onboarding-optimisation"
+  environment   = "dev"
+  variable_name = "APP_ROLE_ARN"
+  value         = module.irsa.role_arn
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/main.tf
@@ -14,6 +14,18 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
 provider "github" {
   token = var.github_token
   owner = var.github_owner

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/rds.tf
@@ -1,0 +1,33 @@
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  vpc_name             = var.vpc_name
+  db_engine_version    = "16"
+  rds_family           = "postgres16"
+  db_instance_class    = "db.t4g.micro"
+  db_allocated_storage = 10
+  db_max_allocated_storage = 100
+  storage_type         = "gp2"
+
+  prepare_for_major_upgrade = "false"
+  enable_irsa               = true
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "github_actions_environment_secret" "database_connection_string" {
+  repository      = "onboarding-optimisation"
+  environment     = "dev"
+  secret_name     = "DATABASE_CONNECTION_STRING"
+  plaintext_value = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/s3.tf
@@ -1,0 +1,24 @@
+module "s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+
+  providers = {
+    aws = aws.london
+  }
+
+  team_name              = var.team_name
+  acl                    = "private"
+  versioning             = false
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+}
+
+resource "github_actions_environment_variable" "s3_bucket_name" {
+  repository    = "onboarding-optimisation"
+  environment   = "dev"
+  variable_name = "S3_BUCKET_NAME"
+  value         = module.s3_bucket.bucket_name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/variables.tf
@@ -3,6 +3,16 @@ variable "kubernetes_cluster" {
   type        = string
 }
 
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the RDS module"
+  type        = string
+}
+
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster to retrieve the OIDC information for IRSA"
+  type        = string
+}
+
 variable "namespace" {
   description = "Name of the namespace these resources are part of"
   type        = string


### PR DESCRIPTION
- S3 bucket for document storage; bucket name written to GitHub Actions dev environment
- PostgreSQL 16 RDS instance; connection string written as GitHub Actions secret
- IRSA module granting pod S3 access; role ARN written to GitHub Actions dev environment
- Add aws.london provider alias required by S3 and RDS modules
- Add vpc_name and eks_cluster_name variables required by RDS and IRSA modules