### PR TITLE
Add missing GithubTeam tag to resources

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/main.tf
@@ -16,6 +16,7 @@ provider "aws" {
       service-area  = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
     }
   }
 }
@@ -34,6 +35,7 @@ provider "aws" {
       service-area  = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
     }
   }
 }
@@ -52,6 +54,7 @@ provider "aws" {
       service-area  = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
     }
   }
 }
@@ -68,6 +71,7 @@ provider "aws" {
       service-area  = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
     }
   }
   region = "us-east-1"


### PR DESCRIPTION
GithubTeam tag was not set for resources, causing user permission issues.