### PR TITLE
fix: switch RDS to db.t3.micro and gp3 storage for dev availability

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/rds.tf
@@ -4,10 +4,10 @@ module "rds" {
   vpc_name             = var.vpc_name
   db_engine_version    = "16"
   rds_family           = "postgres16"
-  db_instance_class    = "db.t4g.micro"
-  db_allocated_storage = 10
+  db_instance_class        = "db.t3.micro"
+  db_allocated_storage     = 10
   db_max_allocated_storage = 100
-  storage_type         = "gp2"
+  storage_type             = "gp3"
 
   prepare_for_major_upgrade = "false"
   enable_irsa               = true

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/rds.tf
@@ -5,7 +5,7 @@ module "rds" {
   db_engine_version    = "16"
   rds_family           = "postgres16"
   db_instance_class        = "db.t3.micro"
-  db_allocated_storage     = 10
+  db_allocated_storage     = 20
   db_max_allocated_storage = 100
   storage_type             = "gp3"
 


### PR DESCRIPTION
db.t4g.micro with gp2 lacks Multi-AZ capacity in Cloud Platform VPC. db.t3.micro with gp3 is more widely available across availability zones.