### PR TITLE
cis-pp: Add WAF lifecycle rule to enable destruction

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cloudfront.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cloudfront.tf
@@ -26,7 +26,7 @@ resource "aws_cloudfront_distribution" "frontend" {
   comment             = "${var.environment} Frontend Distribution"
   default_root_object = "index.html"
   price_class         = var.cloudfront_price_class
-  # web_acl_id          = aws_wafv2_web_acl.frontend.arn
+  web_acl_id          = aws_wafv2_web_acl.frontend.arn
 
   # Custom domain aliases - required for CloudFront to respond to custom domain
   aliases = var.use_custom_certificate ? [var.cloudfront_alias] : []

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/main.tf
@@ -16,7 +16,6 @@ provider "aws" {
       service-area  = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam    = var.team_name
     }
   }
 }
@@ -35,7 +34,6 @@ provider "aws" {
       service-area  = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam    = var.team_name
     }
   }
 }
@@ -54,7 +52,6 @@ provider "aws" {
       service-area  = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam    = var.team_name
     }
   }
 }
@@ -71,7 +68,6 @@ provider "aws" {
       service-area  = var.service_area
       source-code   = "github.com/ministryofjustice/cloud-platform-environments"
       slack-channel = var.slack_channel
-      GithubTeam    = var.team_name
     }
   }
   region = "us-east-1"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/waf.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/waf.tf
@@ -1,84 +1,84 @@
-# resource "aws_wafv2_ip_set" "frontend" {
-#   count = length(var.waf_allowed_ips) > 0 ? 1 : 0
+resource "aws_wafv2_ip_set" "frontend" {
+  count = length(var.waf_allowed_ips) > 0 ? 1 : 0
 
-#   provider = aws.virginia
+  provider = aws.virginia
 
-#   name               = "${var.namespace}-frontend-allowed-ips"
-#   description        = "Allowed IPs for ${var.namespace} CloudFront distribution"
-#   scope              = "CLOUDFRONT"
-#   ip_address_version = "IPV4"
-#   addresses          = var.waf_allowed_ips
-# }
+  name               = "${var.namespace}-frontend-allowed-ips"
+  description        = "Allowed IPs for ${var.namespace} CloudFront distribution"
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+  addresses          = var.waf_allowed_ips
+}
 
-# resource "aws_wafv2_web_acl" "frontend" {
-#   provider = aws.virginia
+resource "aws_wafv2_web_acl" "frontend" {
+  provider = aws.virginia
 
-#   name  = "${var.namespace}-frontend-waf"
-#   scope = "CLOUDFRONT"
+  name  = "${var.namespace}-frontend-waf"
+  scope = "CLOUDFRONT"
 
-#   default_action {
-#     dynamic "allow" {
-#       for_each = length(var.waf_allowed_ips) > 0 ? [] : [1]
-#       content {}
-#     }
+  default_action {
+    dynamic "allow" {
+      for_each = length(var.waf_allowed_ips) > 0 ? [] : [1]
+      content {}
+    }
 
-#     dynamic "block" {
-#       for_each = length(var.waf_allowed_ips) > 0 ? [1] : []
-#       content {}
-#     }
-#   }
+    dynamic "block" {
+      for_each = length(var.waf_allowed_ips) > 0 ? [1] : []
+      content {}
+    }
+  }
 
-#   dynamic "rule" {
-#     for_each = length(var.waf_allowed_ips) > 0 ? [1] : []
-#     content {
-#       name     = "AllowListedIPs"
-#       priority = 1
+  dynamic "rule" {
+    for_each = length(var.waf_allowed_ips) > 0 ? [1] : []
+    content {
+      name     = "AllowListedIPs"
+      priority = 1
 
-#       action {
-#         allow {}
-#       }
+      action {
+        allow {}
+      }
 
-#       statement {
-#         ip_set_reference_statement {
-#           arn = aws_wafv2_ip_set.frontend[0].arn
-#         }
-#       }
+      statement {
+        ip_set_reference_statement {
+          arn = aws_wafv2_ip_set.frontend[0].arn
+        }
+      }
 
-#       visibility_config {
-#         cloudwatch_metrics_enabled = true
-#         metric_name                = "${var.namespace}-allowed-ips"
-#         sampled_requests_enabled   = true
-#       }
-#     }
-#   }
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.namespace}-allowed-ips"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
 
-#   rule {
-#     name     = "AWSManagedRulesCommonRuleSet"
-#     priority = length(var.waf_allowed_ips) > 0 ? 2 : 1
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = length(var.waf_allowed_ips) > 0 ? 2 : 1
 
-#     override_action {
-#       none {}
-#     }
+    override_action {
+      none {}
+    }
 
-#     statement {
-#       managed_rule_group_statement {
-#         name        = "AWSManagedRulesCommonRuleSet"
-#         vendor_name = "AWS"
-#       }
-#     }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
 
-#     visibility_config {
-#       cloudwatch_metrics_enabled = true
-#       metric_name                = "${var.namespace}-common-rules"
-#       sampled_requests_enabled   = true
-#     }
-#   }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.namespace}-common-rules"
+      sampled_requests_enabled   = true
+    }
+  }
 
-#   visibility_config {
-#     cloudwatch_metrics_enabled = true
-#     metric_name                = "${var.namespace}-frontend-waf"
-#     sampled_requests_enabled   = true
-#   }
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.namespace}-frontend-waf"
+    sampled_requests_enabled   = true
+  }
 
-#   tags = var.tags
-# }
+  tags = var.tags
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/waf.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/waf.tf
@@ -81,4 +81,8 @@ resource "aws_wafv2_web_acl" "frontend" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
Terraform tries to destroy WAF before removing CloudFront dependency. Add lifecycle rule to work around this.

Also reverts addition of GithubTeam tag to enable WAF to be updated.

Relates to #43399 and #43409.