### PR TITLE
cis-pp: Set Geo-location to only allow GB for cloudfront

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/variables.tf
@@ -170,13 +170,13 @@ variable "cloudfront_alias" {
 variable "geo_restriction_type" {
   description = "Type of geo restriction (none, whitelist, blacklist)"
   type        = string
-  default     = "none"
+  default     = "whitelist"
 }
 
 variable "geo_restriction_locations" {
   description = "List of country codes for geo restriction"
   type        = list(string)
-  default     = []
+  default     = ["GB"]
 }
 
 variable "tags" {


### PR DESCRIPTION
Sets a whitelist to only allow GB for geolocation for CloudFront, using default Terraform variable values.

Jira: https://dsdmoj.atlassian.net/browse/LGPAS-2126