### PR TITLE
fix failing build, set db upgrade to false

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds-pre-sentence-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-dev/resources/rds-pre-sentence-service.tf
@@ -14,7 +14,8 @@ module "pre_sentence_service_rds" {
   db_instance_class           = "db.t3.small"
   db_engine_version           = "14.17"
   prepare_for_major_upgrade   = false
-  allow_major_version_upgrade = true
+  # To upgrade major DB see Cloud Platform user guide
+  allow_major_version_upgrade = false # Setting to true can break teraform build.
   enable_rds_auto_start_stop  = true
 
   providers = {


### PR DESCRIPTION
Fix failing concourse build, cause by it attempting to upgrade the DB.

Key change:
  * Set `allow_major_version_upgrade` to `false` by default and added a comment explaining the reasoning and where to find upgrade instructions.