### PR TITLE
fix(onboarding-optimisation-dev): add pods/log to serviceaccount RBAC

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/serviceaccount.tf
@@ -14,6 +14,7 @@ module "serviceaccount" {
       api_groups = [""]
       resources = [
         "pods/portforward",
+        "pods/log",
         "deployment",
         "secrets",
         "services",


### PR DESCRIPTION
Allows the cd-serviceaccount to read pod logs during GitHub Actions deploy workflows for debugging CrashLoopBackOff failures.