### PR TITLE
[CDPTKAN-1143] Fix missing MX priority to Propose Child Arrangements Plan (PRODUCTION) 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-prod/resources/route53.tf
@@ -65,7 +65,7 @@ resource "aws_route53_record" "pcap_route53_mx_record_outlook" {
   name    = "propose-child-arrangements-plan"
   type    = "MX"
   ttl     = "3600"
-  records = ["proposechildarrangementsplan-service-gov-uk01i1c2e.mail.protection.outlook.com"]
+  records = ["0 proposechildarrangementsplan-service-gov-uk01i1c2e.mail.protection.outlook.com"]
 }
 
 resource "aws_route53_record" "entra_id_verification" {


### PR DESCRIPTION
Adds missing priority to the MX record for `care-arrangement-plan-prod` (Propose Child Arrangements Plan) service

TICKET: https://dsdmoj.atlassian.net/browse/CDPTKAN-1143