### PR TITLE
Data Platform: Add TLS certificate for data-platform-monitoring-development

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-monitoring-development/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-monitoring-development/05-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: monitoring-tls
+  namespace: data-platform-monitoring-development
+spec:
+  secretName: monitoring-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - monitoring.development.data-platform.service.justice.gov.uk


### PR DESCRIPTION
Add a cert-manager Certificate (05-certificate.yaml) for the data-platform-monitoring-development namespace, requesting a letsencrypt-production cert for
monitoring.development.data-platform.service.justice.gov.uk and storing it in the monitoring-tls secret for use by the Grafana ingress.