### PR TITLE
increase postgres db size in pre prodto keep in line with prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
@@ -12,8 +12,8 @@ module "hmpps_interventions_postgres14" {
 
   rds_family                   = "postgres14"
   db_engine_version = "14.17"
-  db_instance_class            = "db.m5.large"
-  db_allocated_storage         = 20
+  db_instance_class            = "db.m6g.2xlarge"
+  db_allocated_storage         = "50"
   allow_major_version_upgrade  = "false"
   performance_insights_enabled = true
 
@@ -71,8 +71,8 @@ module "hmpps_interventions_postgres14_replica" {
 
   rds_family                  = "postgres14"
   db_engine_version = "14.17"
-  db_instance_class           = "db.m5.large"
-  db_allocated_storage        = 20
+  db_instance_class           = "db.m6g.2xlarge"
+  db_allocated_storage        = "50"
   allow_major_version_upgrade = "false"
 
   replicate_source_db = module.hmpps_interventions_postgres14.db_identifier


### PR DESCRIPTION
- We need to bring the pre-prod DB in line with Prod DB for Refer and Monitor. This is for our clients to do testing with prod like data