### PR TITLE
[CDTPKAN-1143] Alter DNS record values for Propose Child Arrangements Plan (PRODUCTION)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/care-arrangement-plan-prod/resources/route53.tf
@@ -62,7 +62,7 @@ resource "aws_route53_record" "pcap_route53_cname_record_autodiscover" {
 
 resource "aws_route53_record" "pcap_route53_mx_record_outlook" {
   zone_id = aws_route53_zone.pcap_zone.zone_id
-  name    = var.alias
+  name    = "propose-child-arrangements-plan.service.gov.uk"
   type    = "MX"
   ttl     = "3600"
   records = ["0 proposechildarrangementsplan-service-gov-uk01i1c2e.mail.protection.outlook.com"]
@@ -70,8 +70,8 @@ resource "aws_route53_record" "pcap_route53_mx_record_outlook" {
 
 resource "aws_route53_record" "entra_id_verification" {
   zone_id = aws_route53_zone.pcap_zone.zone_id
-  name    = var.alias
+  name    = "propose-child-arrangements-plan.service.gov.uk"
   type    = "TXT"
-  ttl     = 3600
+  ttl     = "3600"
   records = ["MS=ms47915806", "v=spf1 include:spf.protection.outlook.com -all"]
 }


### PR DESCRIPTION
TICKET: https://dsdmoj.atlassian.net/browse/CDPTKAN-1143

Alters new DNS record entries to allow Entra verification. Changing to use hard-coded values because MX/TXT records are not appearing as expected.