### PR TITLE
reverting to original db instance and upgrade engine version to 14.22

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-interventions-preprod/resources/rds-postgres14.tf
@@ -11,9 +11,9 @@ module "hmpps_interventions_postgres14" {
   infrastructure_support = var.infrastructure_support
 
   rds_family                   = "postgres14"
-  db_engine_version = "14.17"
-  db_instance_class            = "db.m6g.2xlarge"
-  db_allocated_storage         = "50"
+  db_engine_version = "14.22"
+  db_instance_class            = "db.m5.large"
+  db_allocated_storage         = 20
   allow_major_version_upgrade  = "false"
   performance_insights_enabled = true
 
@@ -70,9 +70,9 @@ module "hmpps_interventions_postgres14_replica" {
   infrastructure_support = var.infrastructure_support
 
   rds_family                  = "postgres14"
-  db_engine_version = "14.17"
-  db_instance_class           = "db.m6g.2xlarge"
-  db_allocated_storage        = "50"
+  db_engine_version = "14.22"
+  db_instance_class           = "db.m5.large"
+  db_allocated_storage        = 20
   allow_major_version_upgrade = "false"
 
   replicate_source_db = module.hmpps_interventions_postgres14.db_identifier


### PR DESCRIPTION
- Upgrade engine version of refer and monitor preprod to 14.22 and revert the changes for upgrading the postgres db size