### PR TITLE
Rename CAS test domain events listener

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/cas-domain-events-listener-queue.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/cas-domain-events-listener-queue.tf
@@ -1,7 +1,7 @@
-resource "aws_sns_topic_subscription" "cas-common-domain-events-listener-queue-subscription" {
+resource "aws_sns_topic_subscription" "cas-domain-events-listener-queue-subscription" {
   topic_arn = data.aws_sns_topic.hmpps-domain-events.arn
   protocol  = "sqs"
-  endpoint  = module.cas-common-domain-events-listener-queue.sqs_arn
+  endpoint  = module.cas-domain-events-listener-queue.sqs_arn
   filter_policy = jsonencode({
     eventType = [
       "tier.calculation.changed"
@@ -9,18 +9,18 @@ resource "aws_sns_topic_subscription" "cas-common-domain-events-listener-queue-s
   })
 }
 
-module "cas-common-domain-events-listener-queue" {
+module "cas-domain-events-listener-queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
 
   # Queue configuration
-  sqs_name = "cas-common-domain-events-listener-queue"
+  sqs_name = "cas-domain-events-listener-queue"
   redrive_policy = jsonencode({
-    deadLetterTargetArn = module.cas-common-domain-events-listener-dlq.sqs_arn
+    deadLetterTargetArn = module.cas-domain-events-listener-dlq.sqs_arn
     maxReceiveCount     = 3
   })
 
   # Tags
-  application            = "cas-common-domain-events-listener"
+  application            = "cas-domain-events-listener"
   business_unit          = var.business_unit
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
@@ -29,21 +29,21 @@ module "cas-common-domain-events-listener-queue" {
   team_name              = var.team_name # also used as queue name prefix
 }
 
-resource "aws_sqs_queue_policy" "cas-common-domain-events-listener-queue-policy" {
-  queue_url = module.cas-common-domain-events-listener-queue.sqs_id
+resource "aws_sqs_queue_policy" "cas-domain-events-listener-queue-policy" {
+  queue_url = module.cas-domain-events-listener-queue.sqs_id
   policy    = data.aws_iam_policy_document.sns_to_sqs.json
 }
 
-module "cas-common-domain-events-listener-dlq" {
+module "cas-domain-events-listener-dlq" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
 
   # Queue configuration
-  sqs_name                  = "cas-common-domain-events-listener-dlq"
+  sqs_name                  = "cas-domain-events-listener-dlq"
   message_retention_seconds = 7 * 24 * 3600 # 1 week
 
   # Tags
   business_unit          = var.business_unit
-  application            = "cas-common-domain-events-listener"
+  application            = "cas-domain-events-listener"
   is_production          = var.is_production
   team_name              = var.team_name # also used as queue name prefix
   namespace              = var.namespace
@@ -51,28 +51,28 @@ module "cas-common-domain-events-listener-dlq" {
   infrastructure_support = var.infrastructure_support
 }
 
-resource "aws_sqs_queue_policy" "cas-common-domain-events-listener-dlq-policy" {
-  queue_url = module.cas-common-domain-events-listener-dlq.sqs_id
+resource "aws_sqs_queue_policy" "cas-domain-events-listener-dlq-policy" {
+  queue_url = module.cas-domain-events-listener-dlq.sqs_id
   policy    = data.aws_iam_policy_document.sns_to_sqs.json
 }
 
-resource "kubernetes_secret" "cas-common-domain-events-listener-queue-secret" {
+resource "kubernetes_secret" "cas-domain-events-listener-queue-secret" {
   metadata {
-    name      = "cas-common-domain-events-listener-queue"
+    name      = "cas-domain-events-listener-queue"
     namespace = var.namespace
   }
   data = {
-    QUEUE_NAME = module.cas-common-domain-events-listener-queue.sqs_name
+    QUEUE_NAME = module.cas-domain-events-listener-queue.sqs_name
   }
 }
 
-resource "kubernetes_secret" "cas-common-domain-events-listener-dlq-secret" {
+resource "kubernetes_secret" "cas-domain-events-listener-dlq-secret" {
   metadata {
-    name      = "cas-common-domain-events-listener-dlq"
+    name      = "cas-domain-events-listener-dlq"
     namespace = var.namespace
   }
 
   data = {
-    QUEUE_NAME = module.cas-common-domain-events-listener-dlq.sqs_name
+    QUEUE_NAME = module.cas-domain-events-listener-dlq.sqs_name
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-test/resources/irsa.tf
@@ -16,8 +16,8 @@ module "irsa" {
   service_account_name = "hmpps-community-accommodation-api-service-account"
   namespace            = var.namespace
   role_policy_arns = merge(
-    { cas-common-sqs      = module.cas-common-domain-events-listener-queue.irsa_policy_arn },
-    { cas-common-sqs-dlq  = module.cas-common-domain-events-listener-dlq.irsa_policy_arn },
+    { cas-sqs      = module.cas-domain-events-listener-queue.irsa_policy_arn },
+    { cas-sqs-dlq  = module.cas-domain-events-listener-dlq.irsa_policy_arn },
     { cas-2-sqs           = module.cas-2-domain-events-listener-queue.irsa_policy_arn },
     { cas-2-sqs-dlq = module.cas-2-domain-events-listener-dlq.irsa_policy_arn },
     { sas-sqs    = module.sas_domain_events_queue.irsa_policy_arn },


### PR DESCRIPTION
This is because in other environments the name was too long once the environment name was added (i.e. > 80 characters)