### PR TITLE
fix: remove force_ssl parameter unsupported by oracle

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
@@ -13,6 +13,8 @@ module "rds_instance" {
   db_name                  = "cis-rds"
   license_model            = "license-included"
   
+  # Avoid default parameters set by MOJ
+  db_parameter = []
 
   # Tags
   business_unit          = var.business_unit


### PR DESCRIPTION
RDS build failed because force_ssl is not available for oracle RDS. Overwrite the default parameters with an empty list.