### PR TITLE
fix: remove rds to destroy tainted resources

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
@@ -1,3 +1,4 @@
+/*
 module "rds_instance" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
 
@@ -25,3 +26,4 @@ module "rds_instance" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+*/


### PR DESCRIPTION
RDS parameter group is tainted and seems to be confusing terraform. Remove the whole RDS and associated infrastructure so that it can be rebuilt.