### PR TITLE
cica: upgrade uat opensearch to t3.medium

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-uat/resources/opensearch.tf
@@ -27,7 +27,7 @@ module "opensearch" {
   # Non-production cluster configuration
   cluster_config = {
     instance_count = 2
-    instance_type  = "t3.small.search"
+    instance_type  = "t3.medium.search"
   }
 
   ebs_options = {


### PR DESCRIPTION
NOTE: this project already has a APPLY_PIPELINE_SKIP_THIS_NAMESPACE file, this will be removed after this job completes.