### PR TITLE
feat: skip final snapshot to avoid naming conflict

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
@@ -13,6 +13,8 @@ module "rds_instance" {
   rds_name                 = "cis-rds"
   db_name                  = "cis"
   license_model            = "license-included"
+
+  skip_final_snapshot        = "true"
   
   # Avoid default parameters set by MOJ
   db_parameter = []


### PR DESCRIPTION
Database is blank placeholder, so no possibility of meaningful data loss