### PR TITLE
Creating Cognito user and fetching creds from Secrets Manager

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cognito.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/cognito.tf
@@ -168,3 +168,24 @@ resource "kubernetes_secret" "cognito_user_pool_client" {
     client_secret = aws_cognito_user_pool_client.main.client_secret
   }
 }
+
+data "aws_secretsmanager_secret" "cognito_test_user" {
+  name = module.cis_pp_cognito_test_user_secret.secret_names["cis-pp-cognito-test-user-secret"]
+}
+
+data "aws_secretsmanager_secret_version" "cognito_test_user" {
+  secret_id = data.aws_secretsmanager_secret.cognito_test_user.id
+}
+
+resource "aws_cognito_user" "test" {
+  user_pool_id = aws_cognito_user_pool.main.id
+  username     = "stefan.hristov1@justice.gov.uk"
+
+  attributes = {
+    email          = "stefan.hristov1@justice.gov.uk"
+    email_verified = "true"
+  }
+
+  temporary_password = jsondecode(data.aws_secretsmanager_secret_version.cognito_test_user.secret_string)["CIS_PP_COGNITO_TEST_USER_PASS"]
+  message_action     = "SUPPRESS"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
@@ -11,7 +11,7 @@ module "rds_instance" {
   db_instance_class        = "db.t3.small"
   db_allocated_storage     = "100"
   rds_name                 = "cis-rds"
-  db_name                  = "cis"
+  db_name                  = "CIS"
   license_model            = "license-included"
   
   # Avoid default parameters set by MOJ


### PR DESCRIPTION
## 👀 Purpose

- In relation to: Creating Cognito user to test auth on CIS

## ♻️ What's changed

- Creating Cognito user via Terraform
- Fetching secrets for Cognito user from Secrets manager

## 📝 Notes

-