### PR TITLE
MAPB-576 Add hmpps-prisoner-property-ui resources (preprod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/06-certificate.yaml
@@ -50,3 +50,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - prisoner-property-api-preprod.hmpps.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-prisoner-property-ui-preprod-cert
+  namespace: hmpps-locations-inside-prison-preprod
+spec:
+  secretName: hmpps-prisoner-property-ui-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - prisoner-property-preprod.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-ui.tf
@@ -1,0 +1,56 @@
+# Cloud Platform resources for the hmpps-prisoner-property-ui frontend.
+# Deploys into the shared hmpps-locations-inside-prison namespace alongside hmpps-prisoner-property-api.
+
+# GitHub repo deploy access + application-insights secret (hmpps-prisoner-property-ui-application-insights)
+module "hmpps-prisoner-property-ui" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  github_repo                   = "hmpps-prisoner-property-ui"
+  application                   = "hmpps-prisoner-property-ui"
+  github_team                   = var.team_name
+  environment                   = var.deployment_environment
+  is_production                 = var.is_production
+  protected_branches_only       = true
+  application_insights_instance = var.deployment_environment
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.review_team_name]
+}
+
+# Redis (Elasticache) for the frontend's session store
+module "prisoner_property_ui_elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  node_type             = "cache.t4g.micro"
+  engine_version        = "7.1"
+  parameter_group_name  = "default.redis7"
+  number_cache_clusters = "2"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "prisoner_property_ui_elasticache_redis" {
+  metadata {
+    name      = "hmpps-prisoner-property-ui-elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.prisoner_property_ui_elasticache_redis.primary_endpoint_address
+    auth_token               = module.prisoner_property_ui_elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.prisoner_property_ui_elasticache_redis.member_clusters)
+    replication_group_id     = module.prisoner_property_ui_elasticache_redis.replication_group_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-ui.tf
@@ -21,7 +21,7 @@ module "hmpps-prisoner-property-ui" {
 
 # Redis (Elasticache) for the frontend's session store
 module "prisoner_property_ui_elasticache_redis" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.0.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business_unit          = var.business_unit


### PR DESCRIPTION
Provisions the **hmpps-prisoner-property-ui** frontend in the shared `hmpps-locations-inside-prison-preprod` namespace (deploys alongside `hmpps-prisoner-property-api`, already in this namespace).

Adds `namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-ui.tf`:
- **cloud-platform-terraform-hmpps-template** github module (`source_template_repo = hmpps-template-typescript`) → deploy access + `hmpps-prisoner-property-ui-application-insights` secret.
- **Elasticache Redis** + `kubernetes_secret "hmpps-prisoner-property-ui-elasticache-redis"` (session store).

Mirrors the existing `hmpps-non-residential-locations-ui` frontend and the `hmpps-prisoner-property-api` module in this namespace.

**Not in this PR** (provisioned out-of-band, as for other frontends): `auth-code` / `client-creds` secrets (HMPPS Auth team) and `session-secret` (manual).

Part of a per-environment set: dev / preprod / prod. App PR: ministryofjustice/hmpps-prisoner-property-ui#1