### PR TITLE
laa-data-pact-broker: Add civil apply team to pact broker

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-pact-broker/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-pact-broker/01-rbac.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: laa-data-pact-broker
 subjects:
   - kind: Group
+    name: "github:laa-data-pact-broker"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
     name: "github:laa-data-stewardship-cse-team"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group


### PR DESCRIPTION
Add civil apply team to pact broker

For debugging purposes