### PR TITLE
cis-pp: limiting egress to live-1 vpc

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/04-networkpolicy.yaml
@@ -23,4 +23,33 @@ spec:
     - namespaceSelector:
         matchLabels:
           component: ingress-controllers
-
+---
+kind: NetworkPolicy
+apiVersion: projectcalico.org/v3
+metadata:
+  name: allow-egress-ip
+  namespace: cis-pp
+spec:
+  order: 49.0
+  selector: all()
+  egress:
+  - action: Allow
+    destination:
+      nets:
+        - 172.20.0.0/16
+        # live-1 vpc cidr
+  types:
+  - Egress
+---
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: deny-egress-order
+  namespace: cis-pp
+spec:
+  order: 50.0
+  selector: all()
+  egress:
+  - action: Deny
+  types:
+  - Egress


### PR DESCRIPTION
Limiting egress for pods in namespace cis-pp as per ticket https://dsdmoj.atlassian.net/browse/LGPAS-2157