### PR TITLE
MAPB-576 Add hmpps-prisoner-property-ui session secret (dev)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/prisoner-property-ui-session-secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/prisoner-property-ui-session-secret.tf
@@ -1,0 +1,17 @@
+# Session secret for the hmpps-prisoner-property-ui frontend (Express session store).
+# Consumed by the Helm chart's namespace_secrets as hmpps-prisoner-property-ui-session-secret -> SESSION_SECRET.
+resource "random_password" "prisoner_property_ui_session_secret" {
+  length  = 64
+  special = false
+}
+
+resource "kubernetes_secret" "prisoner_property_ui_session_secret" {
+  metadata {
+    name      = "hmpps-prisoner-property-ui-session-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    SESSION_SECRET = random_password.prisoner_property_ui_session_secret.result
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7.2"
+    }
   }
 }


### PR DESCRIPTION
Adds the \`hmpps-prisoner-property-ui-session-secret\` Kubernetes secret (key \`SESSION_SECRET\`) for the **hmpps-prisoner-property-ui** frontend, generated via \`random_password\`. This was missed from the initial UI resource PRs (#43706/#43707/#43708) and is required by the Helm chart before the app can deploy. Also declares the \`hashicorp/random\` provider in \`versions.tf\`.

JIRA: MAPB-576
Namespace: hmpps-locations-inside-prison-dev (shared with hmpps-prisoner-property-api).