### PR TITLE
adding new service account to migrate all the k8 credentials

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/serviceacount-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-legal-adviser-api-staging/resources/serviceacount-github.tf
@@ -1,0 +1,12 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["laa-legal-adviser-api"]
+  # GitHub environment in which to create github actions secrets
+  github_environments = ["staging"]
+}


### PR DESCRIPTION
# PR: Request Kubernetes Credentials for GitHub Actions Migration

## Summary

This PR requests new Kubernetes (K8s) credentials required to support the migration of our CI/CD pipeline from CircleCI to GitHub Actions.

The GitHub Actions workflows will require their own Kubernetes credentials to authenticate and deploy to the cluster, as part of the migration away from CircleCI.

repo [[laa-legal-adviser-api](https://github.com/ministryofjustice/laa-legal-adviser-api)](https://github.com/ministryofjustice/laa-legal-adviser-api)
