### PR TITLE
Update SAS events subscription filter-policy for SAS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/sas-sqs-domain-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-community-accommodation-dev/resources/sas-sqs-domain-events.tf
@@ -46,6 +46,7 @@ resource "aws_sns_topic_subscription" "sas_domain_events_subscription" {
     eventType = [
       "tier.calculation.changed",
       "person.community.manager.allocated",
+      "core-person-record.probation.address.deleted",
     ]
   })
 }


### PR DESCRIPTION
Listen to the `core-person-record.probation.address.deleted` so we can take action in SAS