### PR TITLE
cica: upgrade opensearch cluster instance type to m6g.large.search

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/opensearch.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cica-review-case-documents-dev/resources/opensearch.tf
@@ -27,7 +27,7 @@ module "opensearch" {
   # Non-production cluster configuration
   cluster_config = {
     instance_count = 2
-    instance_type  = "t3.medium.search"
+    instance_type  = "m6g.large.search"
   }
 
   ebs_options = {


### PR DESCRIPTION
This should address the issue of CPU credit exhaustion on a burstable t3 instance during a blue/green deployment.