### PR TITLE
Claim-criminal-injuries-dev update ECR vars

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/ecr.tf
@@ -15,7 +15,6 @@ module "cica_ecr_credentials" {
   # OpenID Connect configuration
   oidc_providers      = ["circleci", "github"]
   github_repositories = var.repo_name
-  github_environments = [ "dev" ]
 
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/claim-criminal-injuries-compensation-dev/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
   infrastructure_support = var.email
 
   db_engine                    = "postgres"
-  db_engine_version = "14.17"
+  db_engine_version            = "14.22"
   db_instance_class            = "db.t3.small"
   db_allocated_storage         = "5"
   db_name                      = "datacaptureservice"


### PR DESCRIPTION
Fixing my pipeline failure. Only one repo in this namespace has an environment, so concourse was throwing 404's trying to add environment secrets to repos with no environments. Solution: Remove the environments, set them as repo-level secrets for now and adjust this later.