### PR TITLE
IR-1741 money-to-prisoners-prod: add github-actions-deploy service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/serviceaccounts.tf
@@ -380,6 +380,78 @@ resource "kubernetes_role_binding" "emails" {
   }
 }
 
+# Service account for the deploy repo's approval-gated "Deploy to prod" GitHub Actions workflow.
+# It promotes app versions in the prod namespace: `manage.py app deploy/promote prod ...` patches
+# the `app-versions` ConfigMap and the app deployments/cronjobs. Its token is exported (via
+# `manage.py app ci-settings deploy`) as a KUBE_CONFIG_DATA secret scoped to the protected `prod`
+# GitHub Environment, so prod-write access is only available to approved prod-deploy runs.
+module "service-account-github-actions-deploy" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_name = "github-actions-deploy"
+  role_name           = "github-actions-deploy"
+  rolebinding_name    = "github-actions-deploy"
+
+  serviceaccount_token_rotated_date = "05-07-2026"
+
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources  = ["configmaps"]
+      verbs      = ["get", "patch"]
+    },
+    {
+      api_groups = ["extensions", "apps"]
+      resources  = ["deployments"]
+      verbs      = ["get", "patch"]
+    },
+    {
+      api_groups = ["batch"]
+      resources  = ["cronjobs"]
+      verbs      = ["get", "patch"]
+    },
+  ]
+}
+
+# Scoped read of just the in-cluster `ecr` secret (kept separate so it can use resource_names,
+# which the shared service-account module rules do not). `manage.py app deploy` reads this to
+# build the image reference before patching.
+resource "kubernetes_role" "github-actions-deploy-ecr" {
+  metadata {
+    namespace = var.namespace
+    name      = "github-actions-deploy-ecr"
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["secrets"]
+    verbs          = ["get"]
+    resource_names = ["ecr"]
+  }
+}
+
+resource "kubernetes_role_binding" "github-actions-deploy-ecr" {
+  metadata {
+    namespace = var.namespace
+    name      = "github-actions-deploy-ecr"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.github-actions-deploy-ecr.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    namespace = var.namespace
+    name      = module.service-account-github-actions-deploy.service_account.name
+  }
+}
+
 resource "kubernetes_role" "github-actions" {
   metadata {
     namespace = var.namespace


### PR DESCRIPTION
## Namespace

`money-to-prisoners-prod`

## What this does

Adds a **prod-only** `github-actions-deploy` Kubernetes service account (plus a scoped `github-actions-deploy-ecr` role/binding) to the `money-to-prisoners-prod` namespace.

This service account backs the money-to-prisoners deploy repo's new approval-gated **"Deploy to prod"** GitHub Actions workflow, replacing the current manual, laptop-bound `./manage.py app deploy prod ...` step.

## Permissions granted

Scoped to exactly what a version deploy needs — nothing more:

- `get`/`patch` on `configmaps` (patches the `app-versions` ConfigMap)
- `get`/`patch` on `deployments` (patches app images)
- `get`/`patch` on `cronjobs` (patches cronjob images)
- `get` on **only** the in-cluster `ecr` secret (`resource_names = ["ecr"]`) — used to build the image reference before patching

It deliberately does **not** grant secret render / `app apply` rights — config/secret changes stay a manual git-crypt-unlocked local operation.

## How it's used

The SA token is exported (via `manage.py app ci-settings deploy`) as a `KUBE_CONFIG_DATA` secret scoped to a protected `prod` GitHub Environment with required reviewers, so prod-write access is only ever available to approved prod-deploy runs.

## Provenance

This file is generated from the money-to-prisoners deploy repo's `environment/templates-environments` Jinja2 templates. Only the additive `github-actions-deploy` block is included here; unrelated template drift was excluded.