### PR TITLE
Add sre-observability configs.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/00-namespace.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hmpps-sre-observability-dev
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HMPPS"
+    cloud-platform.justice.gov.uk/slack-channel: "hmpps-digital-sre"
+    cloud-platform.justice.gov.uk/slack-alert-channel: "hmpps-sre-alerts-nonprod"
+    cloud-platform.justice.gov.uk/application: "HMPPS SRE Observability Apps"
+    cloud-platform.justice.gov.uk/owner: "HMPPS SRE: HMPPSSRE@JusticeUK.onmicrosoft.com"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/health-kick/"
+    cloud-platform.justice.gov.uk/team-name: "hmpps-sre"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/01-rbac.yaml
@@ -1,0 +1,44 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-sre-observability-dev-admin
+  namespace: hmpps-sre-observability-dev
+subjects:
+############## COPY - DO NOT REPLACE ##############
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+# hmpps-sre group is required for support functions
+###################################################
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ephemeral-container-access
+  namespace: hmpps-sre-observability-dev
+rules:
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["get", "patch", "update", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ephemeral-container-access-binding
+  namespace: hmpps-sre-observability-dev
+subjects:
+  - kind: Group
+    name: "github:hmpps-sre"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "github:hmpps-typescript"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: ephemeral-container-access
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/02-limitrange.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: hmpps-sre-observability-dev
+spec:
+  limits:
+    - default:
+        cpu: 2000m
+        memory: 1024Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 512Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/03-resourcequota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: hmpps-sre-observability-dev
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/04-networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: hmpps-sre-observability-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: hmpps-sre-observability-dev
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/06-certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-sre-observability-dev-cert
+  namespace: hmpps-sre-observability-dev
+spec:
+  secretName: hmpps-sre-observability-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - health-kick-dev.hmpps.service.justice.gov.uk
+    - '*.health-kick-dev.hmpps.service.justice.gov.uk'

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/07-rbac-haar-client-admin-team.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/07-rbac-haar-client-admin-team.yaml
@@ -1,0 +1,39 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-sre-observability-dev
+rules:
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "issuers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [ "", "extensions" ]
+    resources: [ "services", "ingresses", "configmaps", "pods/log" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: [ "get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hmpps-haar-client-admin-team
+  namespace: hmpps-sre-observability-dev
+subjects:
+  - kind: Group
+    name: "github:hmpps-haar-client-admin"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: hmpps-haar-client-admin-team
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/hmpps-sre-observability-dev.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/hmpps-sre-observability-dev.tf
@@ -1,0 +1,60 @@
+# For Cloud Platform deployed projects based on the hmpps-template-typescript template:
+# Make a copy of this file in your namespace, then modify according to the instructions here:
+# https://tech-docs.hmpps.service.justice.gov.uk/creating-new-services/creating-resources-in-cloud-platform
+
+module "hmpps_template_typescript" {
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  force_rotate_token = true
+  custom_token_rotation_date = "2026-03-20"
+  github_repo = "health-kick"
+  application = "health-kick"
+  github_team = "hmpps-sre"
+  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  #reviewer_teams                = ["hmpps-dev-team-1", "hmpps-dev-team-2"] # Optional team that should review deployments to this environment.
+  #selected_branch_patterns      = ["main", "release/*", "feature/*"] # Optional
+  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                 = var.is_production
+  application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
+  source_template_repo          = "hmpps-template-typescript"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}
+
+
+# Note, redis is a requirement for hmpps-template-typescript application.
+module "elasticache_redis" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
+  vpc_name               = var.vpc_name
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = module.hmpps_template_typescript.application
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  number_cache_clusters = var.number_cache_clusters
+  # sized for micro in dev, preprod, suggest small for production
+  node_type            = "cache.t4g.micro"
+  engine_version       = "7.0"
+  parameter_group_name = "default.redis7"
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "elasticache_redis" {
+  metadata {
+    name      = "${module.hmpps_template_typescript.application}-elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
+    auth_token               = module.elasticache_redis.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
+    replication_group_id     = module.elasticache_redis.replication_group_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      application   = var.application
+      business-unit = var.business_unit
+      GithubTeam    = var.team_name
+      is-production = var.is_production
+      namespace     = var.namespace
+      owner         = var.team_name
+      service-area  = var.service_area
+      slack-channel = var.slack_channel
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      application   = var.application
+      business-unit = var.business_unit
+      GithubTeam    = var.team_name
+      is-production = var.is_production
+      namespace     = var.namespace
+      owner         = var.team_name
+      service-area  = var.service_area
+      slack-channel = var.slack_channel
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      # see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+      application   = var.application
+      business-unit = var.business_unit
+      GithubTeam    = var.team_name
+      is-production = var.is_production
+      namespace     = var.namespace
+      owner         = var.team_name
+      service-area  = var.service_area
+      slack-channel = var.slack_channel
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+    }
+  }
+}
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/variables.tf
@@ -1,0 +1,66 @@
+variable "vpc_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "HMPPS SRE Observability Apps"
+}
+
+variable "namespace" {
+  default = "hmpps-sre-observability-dev"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "HMPPS"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "hmpps-sre"
+}
+
+variable "service_area" {
+  description = "Service area responsible for this service"
+  default     = "SRE"
+}
+
+####################################################################################################################
+### Change this environment to the environment name corresponding to this namespace (as per helm/values-ENV.dev) ###
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  default     = "dev"
+}
+####################################################################################################################
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "HMPPSSRE@JusticeUK.onmicrosoft.com"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "hmpps-digital-sre"
+}
+
+variable "number_cache_clusters" {
+  default = "2"
+}
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/versions.tf
@@ -1,0 +1,18 @@
+
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
We're moving namespace for where we host health-kick to:
1. allow for a dev environment with a meaningful name
2. modify the URL (will now have hmpps.service rather than just prisons.service) 
 