### PR TITLE
cis-pp: Add calico access to delete unnecessary network policies

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/01-rbac.yaml
@@ -11,3 +11,17 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cis-pp-calico-np-access
+  namespace: cis-pp
+subjects:
+  - kind: Group
+    name: "github:v1-cis-mod"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: calico-network-policy-access
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Adding role binding to access and delete calico network policies, commented out in [this PR ](https://github.com/ministryofjustice/cloud-platform-environments/pull/43826) that are no longer required.