### PR TITLE
IR-1741 money-to-prisoners-prod: github-actions-deploy configmap update permission

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/serviceaccounts.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/serviceaccounts.tf
@@ -399,9 +399,11 @@ module "service-account-github-actions-deploy" {
 
   serviceaccount_rules = [
     {
+      # `manage.py app deploy` reads then `kubectl replace`s (update) the app-versions
+      # ConfigMap, and `create`s it on a namespace that has none yet
       api_groups = [""]
       resources  = ["configmaps"]
-      verbs      = ["get", "patch"]
+      verbs      = ["get", "create", "update"]
     },
     {
       api_groups = ["extensions", "apps"]


### PR DESCRIPTION
## Namespace

`money-to-prisoners-prod`

## What & why

Follow-up to the `github-actions-deploy` service account added earlier for the approval-gated "Deploy to prod" GitHub Actions workflow.

That workflow runs `manage.py app deploy prod`, which updates the `app-versions` ConfigMap via `kubectl replace` (the **`update`** verb) — and `kubectl create` for a namespace that has none yet. The SA was granted only `get`/`patch` on configmaps, so the first real prod deploy failed:

```
Error from server (Forbidden): error when replacing "STDIN": configmaps "app-versions" is forbidden:
User "system:serviceaccount:money-to-prisoners-prod:github-actions-deploy" cannot update resource
"configmaps" in API group "" in the namespace "money-to-prisoners-prod"
```

This grants `get`/`create`/`update` on configmaps (dropping the unused `patch`). Deployment/cronjob rules are unchanged — `app deploy` patches those, so `get`/`patch` is already correct.

Generated from the deploy repo's `environment/templates-environments` templates (template updated in the corresponding deploy-repo PR).