### PR TITLE
Data Hub: Additional permissions for the service account for the development namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/data-platform-datahub-catalogue-dev/resources/serviceaccount.tf
@@ -48,6 +48,8 @@ module "serviceaccount" {
       ]
       resources = [
         "deployments",
+        "deployments/scale",
+        "deployments/status",
         "ingresses",
         "cronjobs",
         "jobs",
@@ -59,6 +61,23 @@ module "serviceaccount" {
         "roles",
         "rolebindings",
         "horizontalpodautoscalers",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "keda.sh",
+      ]
+      resources = [
+        "scaledobjects",
       ]
       verbs = [
         "get",


### PR DESCRIPTION
Needed to solve this issue in the workflow: https://github.com/ministryofjustice/data-catalogue/actions/runs/28872028530/job/85637093950