### PR TITLE
LASB-4859 - Put back reserved memory to 2048Mi

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-dces-drc-integration-prod/02-limitrange.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
     - default:
         cpu: 1000m
-        memory: 1024Mi
+        memory: 2048Mi
       defaultRequest:
         cpu: 10m
         memory: 512Mi


### PR DESCRIPTION
- Rollback change to reduce reserved memory for PROD environment from 2048Mi to 1024Mi