### PR TITLE
ap-6980: Add role-name to serviceaccount_github module

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/github-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/github-serviceaccount.tf
@@ -5,7 +5,9 @@ module "serviceaccount_github" {
   kubernetes_cluster   = var.kubernetes_cluster
   serviceaccount_name  = "github-actions"
   serviceaccount_rules = var.serviceaccount_rules
-
+  role_name            = "github-actions-role"
+  rolebinding_name     = "github-action-rolebinding"
+  
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories                  = [var.repo_name]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-staging/resources/rds.tf
@@ -26,7 +26,7 @@ module "rds" {
   # Database configuration
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "18.1"
+  db_engine_version           = "18.3"
   rds_family                  = "postgres18"
   db_instance_class           = "db.t4g.micro"
   allow_minor_version_upgrade = "true"


### PR DESCRIPTION
Add role-name and github-action-rolebinding to serviceaccount_github module to fix concourse failure.

Also, update db_engine_version in rds.tf from 18.1 to 18.3 to match actual version as version drift has caused a second concourse failure.