### PR TITLE
PDHD-260 Increased default and defaultRequest memory to 2Gi and 1Gi respectively

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-digital-prison-reporting-mi-dev/02-limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
   - default:
       cpu: 1000m
-      memory: 1000Mi
+      memory: 2Gi
     defaultRequest:
       cpu: 10m
-      memory: 512Mi
+      memory: 1Gi
     type: Container


### PR DESCRIPTION
Our app is already running close to the 1000Mi limit in a normal state with certain reports pushing it above the limit as we have been receiving some OOM errors with Kubernetes killing the containers, so increasing this to give more space and alleviate this issue.