### PR TITLE
Add cluster choice to avoid availability issues in zone b

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cfo-case-assessment-tracking-system-dev/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cfo-case-assessment-tracking-system-dev/resources/elasticache.tf
@@ -10,6 +10,9 @@ module "elasticache_redis" {
   parameter_group_name    = "default.redis7"
   auth_token_rotated_date = "2026-07-13"
 
+  # Specify AZs to skip eu-west-2b (which has capacity issues causing create-failed)
+  preferred_cache_cluster_azs = ["eu-west-2a", "eu-west-2c"]
+
   # Tags
   business_unit          = var.business_unit
   application            = var.application


### PR DESCRIPTION
This pull request makes a targeted improvement to the ElastiCache Redis configuration by specifying which availability zones (AZs) to use. This helps avoid known capacity issues in one problematic AZ.

