### PR TITLE
ap-6980: add new serviceaccount_github module to cfe-civil-production

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/github-serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/github-serviceaccount.tf
@@ -1,0 +1,18 @@
+module "serviceaccount_github" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace            = var.namespace
+  kubernetes_cluster   = var.kubernetes_cluster
+  serviceaccount_name  = "github-actions"
+  serviceaccount_rules = var.serviceaccount_rules
+  role_name            = "github-actions-role"
+  rolebinding_name     = "github-action-rolebinding"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories                  = [var.repo_name]
+  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
+  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
+  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/rds.tf
@@ -26,7 +26,7 @@ module "rds" {
   # Database configuration
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "18.1"
+  db_engine_version           = "18.3"
   rds_family                  = "postgres18"
   db_instance_class           = "db.t4g.small"
   allow_minor_version_upgrade = "true"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/variables.tf
@@ -130,6 +130,7 @@ variable "serviceaccount_rules" {
       resources = [
         "deployments",
         "ingresses",
+        "cronjobs",
         "replicasets",
         "statefulsets",
         "poddisruptionbudgets",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cfe-civil-production/resources/variables.tf
@@ -62,3 +62,89 @@ variable "service_area" {
   description = "Service area responsible for this service"
   default     = "LAA Civil Apply"
 }
+
+variable "repo_name" {
+  description = "The name of github repo"
+  default     = "cfe-civil"
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  default     = "KUBE_PRODUCTION_NAMESPACE"
+}
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  default     = "KUBE_PRODUCTION_CERT"
+}
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  default     = "KUBE_PRODUCTION_TOKEN"
+}
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the serviceaccount cluster"
+  default     = "KUBE_PRODUCTION_CLUSTER"
+}
+
+variable "serviceaccount_rules" {
+  description = "The capabilities of this serviceaccount"
+
+  type = list(object({
+    api_groups = list(string),
+    resources  = list(string),
+    verbs      = list(string)
+  }))
+
+  # These values are default plus custom to allow for deletion of UAT branches via CI/CD pipeline
+  default = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "pods",
+        "configmaps",
+        "persistentvolumeclaims",
+        "serviceaccounts",
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "monitoring.coreos.com",
+        "policy",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "replicasets",
+        "statefulsets",
+        "poddisruptionbudgets",
+        "servicemonitors",
+        "prometheusrules",
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+  ]
+}


### PR DESCRIPTION
Add new serviceaccount_github module to cfe-civil-production.

Upgrade db_engine_version to reflect actual version and prevent concourse failure.