### PR TITLE
MEM-672 add laa-info-and-advice-datastore-staging ecr, rds & service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/ecr.tf
@@ -1,0 +1,30 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+
+  # Repository configuration
+  repo_name = var.namespace
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = ["laa-info-and-advice-datastore"]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for read only queries,
+  # uncomment below:
+
+  # enable_irsa = true
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.1"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/rds-postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/rds-postgres.tf
@@ -1,0 +1,48 @@
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  vpc_name = var.vpc_name
+
+  # Engine
+  db_engine         = "postgres"
+  db_engine_version = "18.1"
+  rds_family        = "postgres18"
+
+  # Instance sizing
+  db_instance_class        = "db.t4g.micro"
+  db_max_allocated_storage = "500"
+
+  # Upgrades
+  allow_minor_version_upgrade = true
+  allow_major_version_upgrade = false
+
+  # Cost optimisation (not for prod)
+  enable_rds_auto_start_stop = var.is_production ? false : true
+
+  # Observability
+  performance_insights_enabled = false
+
+  # Tags (required by platform)
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
 
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/serviceaccount.tf
@@ -1,0 +1,11 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_name               = "cd-serviceaccount"
+  serviceaccount_token_rotated_date = "20-03-2026"
+
+  github_repositories = ["laa-info-and-advice-datastore"]
+}


### PR DESCRIPTION
Add resources to laa-info-and-advice-datastore-staging namespace.

*  ecr.tf - ECR container registry with OIDC GitHub Actions auth for building and pushing Docker images
*  rds-postgres.tf - Postgres 18 RDS instance (db.t4g.micro, auto-start/stop enabled)
*  serviceaccount.tf - Kubernetes service account for GitHub Actions CD deployments