### PR TITLE
MEM-672: Scope kube secrets to GitHub environments for laa-info-and-advice-datastore-uat

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/serviceaccount.tf
@@ -8,5 +8,4 @@ module "serviceaccount" {
   serviceaccount_token_rotated_date = "20-03-2026"
 
   github_repositories = ["laa-info-and-advice-datastore"]
-  github_environments = ["staging"]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/serviceaccount.tf
@@ -8,4 +8,5 @@ module "serviceaccount" {
   serviceaccount_token_rotated_date = "20-03-2026"
 
   github_repositories = ["laa-info-and-advice-datastore"]
+  github_environments = ["staging"]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/serviceaccount.tf
@@ -8,4 +8,5 @@ module "serviceaccount" {
   serviceaccount_token_rotated_date = "20-03-2026"
 
   github_repositories = ["laa-info-and-advice-datastore"]
+  github_environments = ["uat"]
 }


### PR DESCRIPTION
Both the UAT and staging  serviceaccount  modules were writing  `KUBE_CERT` ,  `KUBE_TOKEN `,  `KUBE_CLUSTER`  and  `KUBE_NAMESPACE`  as repo-level secrets, causing each Terraform apply to overwrite the other's credentials.

This PR adds  `github_environments`  to the UAT module so secrets are written to the correct GitHub Actions environment instead, preventing them from conflicting.