### PR TITLE
Remove management of service account for health-kick from dps-toolkit

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/health-kick.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/dps-toolkit/resources/health-kick.tf
@@ -1,18 +1,21 @@
-module "health-kick" {
-  source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
-  force_rotate_token = true
-  custom_token_rotation_date = "2026-03-20"
-  github_repo = "health-kick"
-  application = "health-kick"
-  github_team = "hmpps-sre"
-  environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
-  reviewer_teams                = ["hmpps-sre", "syscon-devs"] # Optional team that should review deployments to this environment.
-  #selected_branch_patterns      = ["main", "release/*", "feature/*"] # Optional
-  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
-  is_production                 = var.is_production
-  application_insights_instance = "prod" # Either "dev", "preprod" or "prod"
-  source_template_repo          = "none"
-  github_token                  = var.github_token
-  namespace                     = var.namespace
-  kubernetes_cluster            = var.kubernetes_cluster
-}
+# module "health-kick" {
+#   source      = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+#   force_rotate_token = true
+#   custom_token_rotation_date = "2026-03-20"
+#   github_repo = "health-kick"
+#   application = "health-kick"
+#   github_team = "hmpps-sre"
+#   environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+#   reviewer_teams                = ["hmpps-sre", "syscon-devs"] # Optional team that should review deployments to this environment.
+#   #selected_branch_patterns      = ["main", "release/*", "feature/*"] # Optional
+#   #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+#   is_production                 = var.is_production
+#   application_insights_instance = "prod" # Either "dev", "preprod" or "prod"
+#   source_template_repo          = "none"
+#   github_token                  = var.github_token
+#   namespace                     = var.namespace
+#   kubernetes_cluster            = var.kubernetes_cluster
+# }
+
+# This module has been removed as health-kick now lives in the 
+# hmpps-sre-observability-prod namespace.


### PR DESCRIPTION
Related to https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/22855#L6a441a60:27

We are moving health-kick to a new namespace. This PR should remove the configuration of github and service account related to the legacy dps-toolkit namespace.