### PR TITLE
MEM-672: Scope ECR variables to uat GitHub environment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.1"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/ecr.tf
@@ -13,6 +13,7 @@ module "ecr" {
   # OpenID Connect configuration
   oidc_providers      = ["github"]
   github_repositories = ["laa-info-and-advice-datastore"]
+  github_environments = ["uat"]
 
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/rds-postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/rds-postgres.tf
@@ -5,7 +5,7 @@ module "rds" {
 
   # Engine
   db_engine         = "postgres"
-  db_engine_version = "18.1"
+  db_engine_version = "18.3"
   rds_family        = "postgres18"
 
   # Instance sizing


### PR DESCRIPTION
The `ECR` module was writing  `ECR_REGION`  and  `ECR_REPOSITORY`  as repo-level variables, conflicting with the same variables already created by the `STAGING` `ECR` module. 

Adds  `github_environments = ["uat"]`  to scope them to the staging environment instead.

Bumps ecr module version to `8.0.1`

Also bumps `db_engine_version` to match changes made by `allow_minor_version_upgrade`