### PR TITLE
APG-2382 Update sqs message visibility to 10 mins

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/resources/sqs-domain-events.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-dev/resources/sqs-domain-events.tf
@@ -3,7 +3,7 @@ module "hmpps_mandd_events_queue" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
 
   sqs_name = "hmpps_mandd_events_queue"
-  visibility_timeout_seconds  = 120
+  visibility_timeout_seconds  = 600
   redrive_policy = jsonencode({
     deadLetterTargetArn = module.hmpps_mandd_events_dlq.sqs_arn
     maxReceiveCount     = 3


### PR DESCRIPTION
Our referral imported events that are consumed on this queue call multiple delius and Oasys endpoint on referral creation which can take up to 60 seconds before timing out. 

There are multiple of these endpoints so worse case scenario could be up to 10 mins for all those calls to succeed. We are currently seeing messages timing out and being double processed due to this.