### PR TITLE
fix(s3): fix logging bucket creation by managing ownership/ACL outsid…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-redact-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-redact-dev/resources/s3.tf
@@ -1,29 +1,65 @@
-/*
- * Make sure that you use the latest version of the module by changing the
- * `ref=` value in the `source` attribute to the latest version listed on the
- * releases page of this repository.
- *
- */
-
+# -----------------------------------------------------------------------------
 # 1. NEW LOGGING TARGET BUCKET
-# This block creates the actual bucket where your access logs will be sent.
-module "s3_logging_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
-
-  team_name              = var.team_name
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  environment_name       = var.environment
-  infrastructure_support = var.infrastructure_support
-  namespace              = var.namespace
-
-  # CRITICAL: This allows AWS S3 to write access logs into this bucket
-  acl = "log-delivery-write"
+# -----------------------------------------------------------------------------
+resource "random_id" "s3_logging_bucket_suffix" {
+  byte_length = 16
 }
 
+locals {
+  s3_logging_bucket_name = "cloud-platform-${random_id.s3_logging_bucket_suffix.hex}"
+
+  s3_logging_bucket_tags = {
+    "business-unit"          = var.business_unit
+    "application"             = var.application
+    "is-production"           = var.is_production
+    "environment-name"        = var.environment
+    "infrastructure-support"  = var.infrastructure_support
+    "namespace"               = var.namespace
+    "owner"                   = var.team_name
+  }
+}
+
+resource "aws_s3_bucket" "s3_logging_bucket" {
+  bucket        = local.s3_logging_bucket_name
+  force_destroy = true
+
+  tags = local.s3_logging_bucket_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "s3_logging_bucket" {
+  bucket = aws_s3_bucket.s3_logging_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# CRITICAL: Pre-requisite for ACLs in post-April 2023 AWS accounts
+resource "aws_s3_bucket_ownership_controls" "s3_logging_bucket" {
+  bucket = aws_s3_bucket.s3_logging_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+# CRITICAL: Allows S3 delivery log writes
+resource "aws_s3_bucket_acl" "s3_logging_bucket" {
+  bucket = aws_s3_bucket.s3_logging_bucket.id
+  acl    = "log-delivery-write"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.s3_logging_bucket,
+    aws_s3_bucket_public_access_block.s3_logging_bucket,
+  ]
+}
+
+# -----------------------------------------------------------------------------
 # 2. PRIMARY S3 BUCKET
+# -----------------------------------------------------------------------------
 module "s3_bucket" {
+  # Always check for the latest release tag in cloud-platform-terraform-s3-bucket
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
 
   team_name              = var.team_name
@@ -33,143 +69,23 @@ module "s3_bucket" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
-
-  /*
-  * Public Buckets: It is strongly advised to keep buckets 'private' and only make public where necessary.
-                    By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
-
-                    acl                           = "public-read"
-                    enable_allow_block_pub_access = false
-
-                    For more information granting public access to S3 buckets, please see AWS documentation:
-                    https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
-
-  * Converting existing private bucket to public: If amending an existing private bucket that was created using version 4.3 or above then you will need to raise two PRs:
-
-                    (1) First PR to add the var: enable_allow_block_pub_access = false
-                    (2) Second PR to add the var: acl = "public-read"
-
-  * Versioning: By default this is set to false. When set to true multiple versions of an object can be stored
-                For more details on versioning please visit: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
-
-  * Logging: By default set to false. When you enable logging, Amazon S3 delivers access logs for a source bucket to a target bucket that you choose.
-             The target bucket must be in the same AWS Region as the source bucket and must not have a default retention period configuration.
-             For more details on logging please visit: https://docs.aws.amazon.com/AmazonS3/latest/user-guide/server-access-logging.html
-
-  # NOTE: Important note that the target bucket for logging must have its 'acl' property set to 'log-delivery-write'.
-          To apply this to an existing target bucket simply add the following variable to its terraform module:
-          acl = "log-delivery-write"
-  */
-
-  /*
-   * The following example can be used if you need to define CORS rules for your s3 bucket.
-   *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-cors"
-   *
-
-  cors_rule = [
-    {
-      allowed_headers = ["*"]
-      allowed_methods = ["GET"]
-      allowed_origins = ["https://s3-website-test.hashicorp.com"]
-      expose_headers  = ["ETag"]
-      max_age_seconds = 3000
-    },
-    {
-      allowed_headers = ["*"]
-      allowed_methods = ["PUT"]
-      allowed_origins = ["https://s3-website-test.hashicorp.com"]
-      expose_headers  = [""]
-      max_age_seconds = 3000
-    },
-  ]
-  */
-
-  /*
-   * The following example can be used if you need to set a lifecycle for your s3.
-   *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-object-lifecycle"
-   *  "https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html"
-   *
-
-  lifecycle_rule = [
-    {
-      enabled = true
-      id      = "retire exports after 7 days"
-      prefix  = "surveys/export"
-
-      noncurrent_version_expiration = [
-        {
-          days = 7
-        },
-      ]
-
-      expiration = [
-        {
-          days = 7
-        },
-      ]
-    },
-    {
-      enabled = true
-      id      = "retire imports after 10 days"
-      prefix  = "surveys/imports"
-
-      expiration = [
-        {
-          days = 7
-        },
-      ]
-    },
-  ]
-  */
-
-  /*
-   * The following are examples of bucket and user policies. They are treated as
-   * templates. Currently, the only available variable is `$${bucket_arn}`.
-   */
-
-  /*
-   * Allow a user (foobar) from another account (012345678901) to get objects from
-   * this bucket.
-   *
-
-  bucket_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::012345678901:user/foobar"
-      },
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "$${bucket_arn}/*"
-      ]
-    }
-  ]
-}
-EOF
-  */
 
   versioning = true
 
-  # --- Enabled Logging with Dynamic Target Linking ---
+  # Logging configuration
   logging_enabled   = true
-  log_target_bucket = module.s3_logging_bucket.bucket_name
+  log_target_bucket = aws_s3_bucket.s3_logging_bucket.id
   log_path          = "s3-access-logs/"
 
-  /*
-   * OIDC for GitHub Actions
-   * This allows GitHub Actions to access the S3 bucket using OIDC.
-   */
+  # GitHub Actions OIDC integration
   oidc_providers      = ["github"]
   github_repositories = ["justice-redact-frontend", "justice-redact-backend"]
-  github_environments  = ["dev"] # If you're using GH Actions environments
+  github_environments = ["dev"]
 }
 
+# -----------------------------------------------------------------------------
 # 3. KUBERNETES OUTPUT SECRET
+# -----------------------------------------------------------------------------
 resource "kubernetes_secret" "s3_bucket" {
   metadata {
     name      = "s3-bucket-output"
@@ -180,4 +96,6 @@ resource "kubernetes_secret" "s3_bucket" {
     bucket_arn  = module.s3_bucket.bucket_arn
     bucket_name = module.s3_bucket.bucket_name
   }
+
+  type = "Opaque"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-redact-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-redact-dev/resources/versions.tf
@@ -14,5 +14,10 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.0"
     }
+    # Add the github provider constraint here
+    github = {
+      source  = "integrations/github"
+      version = ">= 5.0"
+    }
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-redact-dev/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-redact-dev/resources/versions.tf
@@ -1,17 +1,18 @@
 terraform {
   required_version = ">= 1.2.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.78.0"
-    }
-    github = {
-      source  = "integrations/github"
-      version = "~> 6.6.0"
+      version = ">= 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.23.0"
+      version = ">= 2.20"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
fix(s3): replace logging bucket module with raw resources to fix ACL creation failure.

The cloud-platform-terraform-s3-bucket module sets `acl` directly on bucket creation with no way to control S3 Object Ownership, which collides with AWS's BucketOwnerEnforced default (April 2023) and blocks ACL-based log delivery — both InvalidBucketAclWithObjectOwnership on create and AccessControlListNotSupported on update.

Replace module "s3_logging_bucket" with raw aws_s3_bucket_* resources that explicitly set object_ownership = "BucketOwnerPreferred" before applying acl = "log-delivery-write", matching the working pattern used
for the CloudFront access-logs bucket.

Primary bucket module is unaffected; log_target_bucket now points at the raw resource output instead of the module output.