### PR TITLE
Namespace/reporting hub develop

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "reporting-hub-develop"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "project-ultron"
+    cloud-platform.justice.gov.uk/application: "reporting-and-visualisation-hub"
+    cloud-platform.justice.gov.uk/owner: "Reporting and Visualisation: performance-dashboard@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/reporting-hub-backend"
+    cloud-platform.justice.gov.uk/team-name: "reporting-and-visualisation-hub"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: reporting-hub-develop-admin
+  namespace: reporting-hub-develop
+subjects:
+  - kind: Group
+    name: "github:reporting-and-visualisation-hub"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: reporting-hub-develop
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: reporting-hub-develop
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: reporting-hub-develop
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: reporting-hub-develop
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/ecr.tf
@@ -1,0 +1,38 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.1"
+
+  # Repository configuration
+  repo_name = var.namespace
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = ["reporting-hub-backend"]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  github_environments    = [var.environment]
+}
+
+resource "kubernetes_secret" "ecr" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_arn = module.ecr.repo_arn
+    repo_url = module.ecr.repo_url
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/rds-postgresql.tf
@@ -5,7 +5,7 @@
  *
  */
 module "rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
 
   # VPC configuration
   vpc_name = var.vpc_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/rds-postgresql.tf
@@ -1,0 +1,64 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.3.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = false
+  db_max_allocated_storage     = "500"
+  # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
+  # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
+
+  # PostgreSQL specifics
+  db_engine         = "postgres"
+  db_engine_version = "16" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family        = "postgres16"
+  db_instance_class = "db.t4g.micro"
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for CLI queries,
+  # uncomment below:
+
+  # enable_irsa = true
+
+  # If you want to enable Cloudwatch logging for this postgres RDS instance, uncomment the code below:
+  # opt_in_xsiam_logging = true
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+  /* You can replace all of the above with the following, if you prefer to
+     * use a single database URL value in your application code:
+     *
+     * url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+     *
+     */
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/rds-postgresql.tf
@@ -62,3 +62,18 @@ resource "kubernetes_secret" "rds" {
      *
      */
 }
+
+
+# Configmap to store non-sensitive data related to the RDS instance
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/s3.tf
@@ -1,0 +1,171 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  /*
+
+  * Public Buckets: It is strongly advised to keep buckets 'private' and only make public where necessary.
+                    By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
+
+                    acl                           = "public-read"
+                    enable_allow_block_pub_access = false
+
+                    For more information granting public access to S3 buckets, please see AWS documentation:
+                    https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+
+  * Converting existing private bucket to public: If amending an existing private bucket that was created using version 4.3 or above then you will need to raise two PRs:
+
+                    (1) First PR to add the var: enable_allow_block_pub_access = false
+                    (2) Second PR to add the var: acl = "public-read"
+
+  * Versioning: By default this is set to false. When set to true multiple versions of an object can be stored
+                For more details on versioning please visit: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
+
+  versioning             = true
+
+  * Logging: By default set to false. When you enable logging, Amazon S3 delivers access logs for a source bucket to a target bucket that you choose.
+             The target bucket must be in the same AWS Region as the source bucket and must not have a default retention period configuration.
+             For more details on logging please vist: https://docs.aws.amazon.com/AmazonS3/latest/user-guide/server-access-logging.html
+
+  logging_enabled        = true
+  log_target_bucket      = "<TARGET_BUCKET_NAME>"
+
+  # NOTE: Important note that the target bucket for logging must have it's 'acl' property set to 'log-delivery-write'.
+          To apply this to an existing target bucket simply add the followng variable to its terraform module
+          acl = "log-delivery-write"
+
+  log_path               = "<LOG_PATH>" e.g log/
+
+*/
+
+  /*
+   * The following example can be used if you need to define CORS rules for your s3 bucket.
+   *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-cors"
+   *
+
+  cors_rule =[
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET"]
+      allowed_origins = ["https://s3-website-test.hashicorp.com"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    },
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["PUT"]
+      allowed_origins = ["https://s3-website-test.hashicorp.com"]
+      expose_headers  = [""]
+      max_age_seconds = 3000
+    },
+  ]
+
+
+  /*
+   * The following example can be used if you need to set a lifecycle for your s3.
+   *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-object-lifecycle"
+   *  "https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html"
+   *
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "retire exports after 7 days"
+      prefix  = "surveys/export"
+
+      noncurrent_version_expiration = [
+        {
+          days = 7
+        },
+      ]
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+    {
+      enabled = true
+      id      = "retire imports after 10 days"
+      prefix  = "surveys/imports"
+
+      expiration = [
+        {
+          days = 7
+        },
+      ]
+    },
+  ]
+
+  */
+
+  /*
+   * The following are examples of bucket and user policies. They are treated as
+   * templates. Currently, the only available variable is `$${bucket_arn}`.
+   *
+   */
+
+  /*
+   * Allow a user (foobar) from another account (012345678901) to get objects from
+   * this bucket.
+   *
+
+   bucket_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::012345678901:user/foobar"
+      },
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "$${bucket_arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+*/
+
+  /*
+   * OIDC for GitHub Actions
+   * This allows GitHub Actions to access the S3 bucket using OIDC.
+   *
+   *
+  oidc_providers = ["github"]
+  github_repositories = ["my-moj-repo"]
+  github_environments = ["dev"]   # If you're using GH Actions environments
+
+*/
+}
+
+
+
+resource "kubernetes_secret" "s3_bucket" {
+  metadata {
+    name      = "s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.s3_bucket.bucket_arn
+    bucket_name = module.s3_bucket.bucket_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/service.account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/service.account.tf
@@ -4,8 +4,6 @@ module "serviceaccount" {
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
 
-  serviceaccount_token_rotated_date = "20-03-2026"
-
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
   github_repositories = ["reporting-hub-backend"]

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/service.account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/service.account.tf
@@ -1,0 +1,13 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "20-03-2026"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  github_repositories = ["reporting-hub-backend"]
+  github_environments = [var.environment]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/variables.tf
@@ -1,0 +1,75 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "reporting-and-visualisation-hub"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "reporting-hub-develop"
+}
+
+variable "service_area" {
+  description = "Service area responsible for this service"
+  type        = string
+  default     = "Reporting and Visualisation Hub"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HQ"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "reporting-and-visualisation-hub"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "performance-dashboard@justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "project-ultron"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reporting-hub-develop/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
New namespace `reporting-hub-develop`

- namespace via CLI
- RDS (postgres) vis CLI
- S3 via CLI

- Removed the read replica for postgres (seems overkill for what I'm doing)
- Added ecr
- Added service account

_NOTE - also bumped rds to version 9.2.0 as CI said I should. the postgres example is only for the old one so I'm assuming its compatible but cant really check._