### PR TITLE
feat: updated iam policies for queue and dlq

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/modules/sqs/data.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-api-uat/resources/modules/sqs/data.tf
@@ -1,6 +1,7 @@
 /* --SQS Access Control--
 The two data sources below control access to SQS by looking up the value in the "namespace" tag
 for a specific namespace. */
+# data.tf
 
 data "aws_iam_roles" "sqs_subscriber_roles" {
   name_regex = var.sqs_subscriber_roles_regex_filter
@@ -11,74 +12,79 @@ data "aws_iam_role" "sqs_matching_roles" {
   name     = each.value
 }
 
-#--DLQ Policy
+# Resource-based policy on the DLQ
 data "aws_iam_policy_document" "dlq" {
+  # Only the source queue can redrive messages into the DLQ
   statement {
-    sid    = "Allow"
+    sid    = "AllowRedriveFromSourceQueue"
     effect = "Allow"
     principals {
       type        = "AWS"
       identifiers = ["*"]
     }
-    actions = [
-      "sqs:*"
-    ]
+    actions   = ["sqs:SendMessage"]
     resources = [module.dlq.sqs_arn]
-  }
-}
-
-#--This policy will be constructed from the data sources above and some local transformations to grant SQS access
-data "aws_iam_policy_document" "queue" {
-  statement {
-    sid    = "AllowSend"
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["sns.amazonaws.com"]
-    }
-
-    actions = [
-      "sqs:SendMessage"
-    ]
-
-    resources = [module.queue.sqs_arn]
-
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values = [
-        var.sns_topic_arn
-      ]
+      values   = [module.queue.sqs_arn]
     }
   }
 
+  # Only IRSA roles tagged with an allowed namespace can read/manage the DLQ
   statement {
-    sid    = "AllowReadDelete"
+    sid    = "AllowIRSAAccess"
     effect = "Allow"
-
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = [for role in local.sqs_roles_with_namespace_tag : role.arn]
     }
-
     actions = [
       "sqs:ReceiveMessage",
       "sqs:DeleteMessage",
       "sqs:ChangeMessageVisibility",
       "sqs:GetQueueAttributes",
-      "sqs:GetQueueUrl"
+      "sqs:GetQueueUrl",
+      "sqs:PurgeQueue",
     ]
+    resources = [module.dlq.sqs_arn]
+  }
+}
 
+# Resource-based policy on the main queue
+data "aws_iam_policy_document" "queue" {
+  # Only the SNS topic can send messages
+  statement {
+    sid    = "AllowSNSSend"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+    actions   = ["sqs:SendMessage"]
     resources = [module.queue.sqs_arn]
-
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      
-      values = [
-        for role in local.sqs_roles_with_namespace_tag : role.arn
-      ]
+      values   = [var.sns_topic_arn]
     }
+  }
+
+  # Only IRSA roles tagged with an allowed namespace can consume
+  statement {
+    sid    = "AllowIRSAConsume"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [for role in local.sqs_roles_with_namespace_tag : role.arn]
+    }
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+    ]
+    resources = [module.queue.sqs_arn]
   }
 }


### PR DESCRIPTION
1. Replaced permissive DLQ policy with least-privilege statements:

2. Redrive path: allow only sqs:SendMessage to DLQ from source queue.
 
3. Consumer access: allow only approved IRSA role ARNs for required actions.
 
4. Ensured main queue consumer policy also uses explicit IRSA principals (no wildcard principal for read/delete).
 
5. Terraform formatting applied