### PR TITLE
IR-1782 money-to-prisoners-prod: disable ECR deletion protection

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/ecr.tf
@@ -16,6 +16,11 @@ module "ecr" {
 
   repo_name = var.application
 
+  # the images have all moved to GHCR, so this ECR is being retired. the module protects a
+  # non-empty registry from deletion by default, which the ecr-deletion-check workflow
+  # enforces on the PR that removes this file: it has to be disabled and applied first.
+  deletion_protection = false
+
   github_repositories = [
     "money-to-prisoners-deploy",
     "money-to-prisoners-common",


### PR DESCRIPTION
The images have all moved to GHCR and the ECR is being retired, but the ecr-credentials module defaults deletion_protection to true for a non-empty registry. The ecr-deletion-check workflow enforces that on the PR removing ecr.tf, so this has to be set to false and applied first.
