### PR TITLE
Adding the Entra tenant ID as secret to Secrets Manager

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/secrets.tf
@@ -72,3 +72,28 @@ module "cis_pp_entra_nle_client_id" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
+module "cis_pp_entra_nle_tenant_id" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # Secrets configuration
+  secrets = {
+    "cis-pp-entra-nle-tenant-id" = {
+      description             = "CIS PP Entra NLE Tenant ID" # required
+      recovery_window_in_days = 7                # required
+      k8s_secret_name         = "cis-pp-entra-nle-tenant-id" # the name of the secret in k8s
+    },
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}


### PR DESCRIPTION
## 👀 Purpose

- In relation to: Adding the Entra Tenant ID as secret to Secrets manager

## ♻️ What's changed

- Creating a new secret in Secrets Manager

## 📝 Notes

-