### PR TITLE
Add IRSA configuration and service pod setup

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/db_migration_copy_irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/db_migration_copy_irsa.tf
@@ -1,9 +1,9 @@
 #This role is for a temporary Kubernetes pod/job that copies ModPlatform S3/KMS → CloudPlatform S3/KMS
 
 locals {
-  mp_db_migration_bucket_name     = "cdpt-chaps-prod-db-migration-653875321404"
-  mp_db_migration_bucket_arn      = "arn:aws:s3:::cdpt-chaps-prod-db-migration-653875321404"
-  mp_db_migration_kms_key_arn     = "arn:aws:kms:eu-west-2:653875321404:key/4edd8792-e61e-4a98-9386-b570c3970f98"
+  mp_db_migration_bucket_name = "cdpt-chaps-prod-db-migration-653875321404"
+  mp_db_migration_bucket_arn  = "arn:aws:s3:::cdpt-chaps-prod-db-migration-653875321404"
+  mp_db_migration_kms_key_arn = "arn:aws:kms:eu-west-2:653875321404:key/4edd8792-e61e-4a98-9386-b570c3970f98"
 }
 
 module "db_migration_copy_irsa" {
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "db_migration_copy" {
     condition {
       test     = "StringLike"
       variable = "s3:prefix"
-      values   = [
+      values = [
         local.db_migration_prefix,
         "${local.db_migration_prefix}/",
         "${local.db_migration_prefix}/*"
@@ -89,9 +89,9 @@ data "aws_iam_policy_document" "db_migration_copy" {
     ]
 
     condition {
-      test      = "StringLike"
-      variable  = "s3:prefix"
-      values    = [
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
         local.db_migration_prefix,
         "${local.db_migration_prefix}/",
         "${local.db_migration_prefix}/*"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/irsa.tf
@@ -29,7 +29,10 @@ module "irsa_service_pod" {
 
   # EKS configuration
   eks_cluster_name = var.eks_cluster_name
-  namespace        = var.namespace # this is also used as a tag
+
+  # IRSA configuration
+  service_account_name = "${var.namespace}-service-account"
+  namespace            = var.namespace # this is also used as a tag
 
   # Policies for AWS resources accessed via the service pod
   role_policy_arns = {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/irsa.tf
@@ -21,30 +21,3 @@ module "irsa" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
-
-# Setting up a service pod
-# irsa configuration is required to use the service pod
-module "irsa_service_pod" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
-
-  # EKS configuration
-  eks_cluster_name = var.eks_cluster_name
-
-  # IRSA configuration
-  service_account_name = "${var.namespace}-service-account"
-  namespace            = var.namespace # this is also used as a tag
-
-  # Policies for AWS resources accessed via the service pod
-  role_policy_arns = {
-    rds = module.rds_mssql.irsa_policy_arn
-    ecr = module.ecr.irsa_policy_arn
-  }
-
-  # Tags
-  business_unit          = var.business_unit
-  application            = var.application
-  is_production          = var.is_production
-  team_name              = var.team_name
-  environment_name       = var.environment
-  infrastructure_support = var.infrastructure_support
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/irsa.tf
@@ -21,3 +21,27 @@ module "irsa" {
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
 }
+
+# Setting up a service pod
+# irsa configuration is required to use the service pod
+module "irsa_service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+  namespace        = var.namespace # this is also used as a tag
+
+  # Policies for AWS resources accessed via the service pod
+  role_policy_arns = {
+    rds = module.rds_mssql.irsa_policy_arn
+    ecr = module.ecr.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
   region = "eu-west-2"
   default_tags {
     tags = {
-      GithubTeam = "central-digital-product-team"
+      GithubTeam    = "central-digital-product-team"
       slack-channel = var.slack_channel
     }
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/rds.tf
@@ -78,8 +78,8 @@ resource "aws_db_option_group" "sqlserver_backup_restore" {
   option {
     option_name = "SQLSERVER_BACKUP_RESTORE"
     option_settings {
-      name = "IAM_ROLE_ARN"
-      value  = aws_iam_role.rds_s3_backup_restore.arn
+      name  = "IAM_ROLE_ARN"
+      value = aws_iam_role.rds_s3_backup_restore.arn
     }
   }
 }
@@ -94,9 +94,9 @@ resource "aws_iam_role" "rds_s3_backup_restore" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [{
-      Effect = "Allow",
+      Effect    = "Allow",
       Principal = { Service = "rds.amazonaws.com" },
-      Action   = "sts:AssumeRole"
+      Action    = "sts:AssumeRole"
     }]
   })
 }
@@ -108,7 +108,7 @@ resource "aws_iam_role_policy" "rds_s3_backup_restore" {
   role = aws_iam_role.rds_s3_backup_restore.id
 
   policy = jsonencode({
-    Version   = "2012-10-17",
+    Version = "2012-10-17",
     Statement = [
       {
         Sid      = "BucketLocation"
@@ -117,12 +117,12 @@ resource "aws_iam_role_policy" "rds_s3_backup_restore" {
         Resource = aws_s3_bucket.db_migration.arn
       },
       {
-        Sid             = "ListBucket"
-        Effect          = "Allow"
-        Action          = ["s3:ListBucket"]
-        Resource        = aws_s3_bucket.db_migration.arn
-        Condition       = {
-          StringLike    = { 
+        Sid      = "ListBucket"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = aws_s3_bucket.db_migration.arn
+        Condition = {
+          StringLike = {
             "s3:prefix" = [
               local.db_migration_prefix,
               "${local.db_migration_prefix}/",
@@ -133,9 +133,9 @@ resource "aws_iam_role_policy" "rds_s3_backup_restore" {
         }
       },
       {
-        Sid     = "ReadWriteBackupObjects"
-        Effect  = "Allow"
-        Action  = [
+        Sid    = "ReadWriteBackupObjects"
+        Effect = "Allow"
+        Action = [
           "s3:GetObject",
           "s3:GetObjectAttributes",
           "s3:ListMultipartUploadParts",
@@ -145,9 +145,9 @@ resource "aws_iam_role_policy" "rds_s3_backup_restore" {
         Resource = local.db_migration_objects_prefix_arn
       },
       {
-        Sid     = "UseCpBackupKmsKey"
-        Effect  = "Allow"
-        Action  = [
+        Sid    = "UseCpBackupKmsKey"
+        Effect = "Allow"
+        Action = [
           "kms:Decrypt",
           "kms:Encrypt",
           "kms:DescribeKey",

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/route53.tf
@@ -20,7 +20,7 @@ resource "kubernetes_secret" "chaps_route53_zone_sec" {
   }
 
   data = {
-    zone_id = aws_route53_zone.chaps_route53_zone.zone_id
+    zone_id     = aws_route53_zone.chaps_route53_zone.zone_id
     nameservers = join("\n", aws_route53_zone.chaps_route53_zone.name_servers)
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/s3_db_migration.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/s3_db_migration.tf
@@ -36,8 +36,8 @@ resource "aws_s3_bucket" "db_migration" {
   bucket = local.db_migration_bucket_name
 
   tags = merge(local.db_migration_tags, {
-    Name     = local.db_migration_bucket_name
-    Purpose  = "CHAPS database migration restore"
+    Name    = local.db_migration_bucket_name
+    Purpose = "CHAPS database migration restore"
   })
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
@@ -1,5 +1,6 @@
 # irsa configuration is required to use the service pod
 module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
   role_policy_arns = {
     # Here you must provide the policy arn(s) for the AWS resources you want to access via the service pod
     rds  = module.rds_mssql.irsa_policy_arn

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
@@ -1,0 +1,17 @@
+# irsa configuration is required to use the service pod
+module "irsa" {
+  role_policy_arns = {
+    # Here you must provide the policy arn(s) for the AWS resources you want to access via the service pod
+    rds  = module.rds_mssql.irsa_policy_arn
+    ecr = module.ecr.irsa_policy_arn
+  }
+}
+
+# set up the service pod
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.1" # use the latest release
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account_name.name # this uses the service account name from the irsa module
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
@@ -1,6 +1,7 @@
 # irsa configuration is required to use the service pod
-module "irsa" {
+module "irsa_service_pod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
   role_policy_arns = {
     # Here you must provide the policy arn(s) for the AWS resources you want to access via the service pod
     rds  = module.rds_mssql.irsa_policy_arn
@@ -14,5 +15,5 @@ module "service_pod" {
 
   # Configuration
   namespace            = var.namespace
-  service_account_name = module.irsa.service_account_name.name # this uses the service account name from the irsa module
+  service_account_name = module.irsa_service_pod.service_account_name.name # this uses the service account name from the irsa module
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
@@ -30,6 +30,6 @@ module "service_pod" {
 
   # Configuration
   namespace            = var.namespace
-  service_account_name = module.irsa_service_pod.service_account_name # this uses the service account name from the irsa module
+  service_account_name = module.irsa_service_pod.service_account_name.name # this uses the service account name from the irsa module
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
@@ -1,4 +1,30 @@
-# set up the service pod
+# Setting up a service pod
+# irsa configuration is required to use the service pod
+module "irsa_service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # IRSA configuration
+  service_account_name = "${var.namespace}-service-account"
+  namespace            = var.namespace # this is also used as a tag
+
+  # Policies for AWS resources accessed via the service pod
+  role_policy_arns = {
+    rds = module.rds_mssql.irsa_policy_arn
+    ecr = module.ecr.irsa_policy_arn
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
 module "service_pod" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.1"
 
@@ -6,3 +32,4 @@ module "service_pod" {
   namespace            = var.namespace
   service_account_name = module.irsa_service_pod.service_account_name # this uses the service account name from the irsa module
 }
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/service-pod.tf
@@ -1,19 +1,8 @@
-# irsa configuration is required to use the service pod
-module "irsa_service_pod" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
-
-  role_policy_arns = {
-    # Here you must provide the policy arn(s) for the AWS resources you want to access via the service pod
-    rds  = module.rds_mssql.irsa_policy_arn
-    ecr = module.ecr.irsa_policy_arn
-  }
-}
-
 # set up the service pod
 module "service_pod" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.1" # use the latest release
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.2.1"
 
   # Configuration
   namespace            = var.namespace
-  service_account_name = module.irsa_service_pod.service_account_name.name # this uses the service account name from the irsa module
+  service_account_name = module.irsa_service_pod.service_account_name # this uses the service account name from the irsa module
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/serviceaccount.tf
@@ -7,7 +7,7 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  github_repositories = ["chaps"]
-  github_environments = [var.environment]
+  github_repositories               = ["chaps"]
+  github_environments               = [var.environment]
   serviceaccount_token_rotated_date = "14-05-2026"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/chaps-dotnet-production/resources/variables.tf
@@ -34,7 +34,7 @@ variable "environment" {
 
 variable "domain" {
   description = "The domain name to use for the Route53 zone."
-  default = "correspondence-handling-and-processing.service.justice.gov.uk"
+  default     = "correspondence-handling-and-processing.service.justice.gov.uk"
 }
 
 variable "infrastructure_support" {


### PR DESCRIPTION
This pull request adds configuration for IRSA (IAM Roles for Service Accounts) and sets up the service pod for the `chaps-dotnet-production` environment. The main changes involve integrating the IRSA module to manage AWS access policies and updating the service pod configuration to use the generated service account.

**IRSA integration:**

* Added a new `irsa` module to configure IAM roles and policies, granting the service pod access to RDS and ECR resources by referencing their respective policy ARNs.

**Service pod setup:**

* Updated the `service_pod` module to use the latest release and configured it to use the service account name provided by the IRSA module, ensuring the pod can assume the necessary IAM roles.