### PR TITLE
Allowing data from data-engineering-exports

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/address-matcher-api/resources/irsa.tf
@@ -20,6 +20,28 @@ resource "aws_iam_policy" "query_logs" {
   policy = data.aws_iam_policy_document.query_logs.json
 }
 
+# Read-only access to the Analytical Platform pull bucket that holds the
+# canonical lookup data (data-engineering-exports pull dataset
+# "address-matcher-lookup-data"). Cross-account S3 requires a policy on BOTH
+# sides: the AP-side bucket policy (managed via pull_arns) plus this identity
+# policy on our CP role. Lets the pod copy the data into the CP lookup bucket.
+data "aws_iam_policy_document" "lookup_data_source" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::mojap-address-matcher-lookup-data/*"]
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::mojap-address-matcher-lookup-data"]
+  }
+}
+
+resource "aws_iam_policy" "lookup_data_source" {
+  name   = "address-matcher-lookup-data-source"
+  policy = data.aws_iam_policy_document.lookup_data_source.json
+}
+
 module "irsa" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
 
@@ -28,8 +50,9 @@ module "irsa" {
   namespace            = var.namespace
 
   role_policy_arns = {
-    lookup_data = module.address_matcher_lookup_data_s3.irsa_policy_arn
-    query_logs  = aws_iam_policy.query_logs.arn
+    lookup_data        = module.address_matcher_lookup_data_s3.irsa_policy_arn
+    lookup_data_source = aws_iam_policy.lookup_data_source.arn
+    query_logs         = aws_iam_policy.query_logs.arn
   }
 
   business_unit          = var.business_unit


### PR DESCRIPTION
The `address-matcher-api-s3` IRSA role can't read the canonical lookup data we need for the api to function without fictional data.

The data lands in the Analytical Platform pull bucket `mojap-address-matcher-lookup-data` (data-engineering-exports pull dataset). Cross-account S3 needs a policy on **both** sides: the AP-side bucket policy (already granted via `pull_arns`) **and** an identity policy on our CP role. Only the AP side exists, so the pod's copy job failed with `AccessDenied` on
`s3:ListBucket`.

This PR should correct that and allow the copy.