### PR TITLE
Add octo-strategic-docs-prod namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: octo-strategic-docs-prod
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "octo-data-architecture"
+    cloud-platform.justice.gov.uk/application: "OCTO Strategic Documentation"
+    cloud-platform.justice.gov.uk/owner: "OCTO Data Architecture: DataArchitectureJustice@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/octo-strategic-docs"
+    cloud-platform.justice.gov.uk/team-name: "octo-data-architecture"
+    cloud-platform.justice.gov.uk/review-after: "2027-07-23"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: octo-strategic-docs-prod-admin
+  namespace: octo-strategic-docs-prod
+subjects:
+  - kind: Group
+    name: "github:octo-data-architecture-leads"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: octo-strategic-docs-prod
+spec:
+  limits:
+    - default:
+        cpu: 1000m
+        memory: 1000Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 100Mi
+      type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: octo-strategic-docs-prod
+spec:
+  hard:
+    pods: "10"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: octo-strategic-docs-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: octo-strategic-docs-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/ecr.tf
@@ -1,30 +1,20 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.2"
 
-  team_name    = var.team_name
-  repo_name    = "${var.namespace}-ecr"
-  scan_on_push = "true"
+  repo_name = "${var.namespace}-ecr"
 
-  # Creates github actions secrets containing the ECR name, AWS access key,
-  # and AWS secret key, for use in the octo-strategic-docs publish workflow.
+  # OpenID Connect configuration - creates ECR_ROLE_TO_ASSUME/ECR_REGISTRY_URL
+  # secrets and ECR_REGION/ECR_REPOSITORY variables in the octo-strategic-docs
+  # repo for use in the publish workflow. No static AWS keys are created.
+  oidc_providers      = ["github"]
   github_repositories = [var.app_repo]
 
-  github_actions_secret_ecr_name       = var.github_actions_secret_ecr_name
-  github_actions_secret_ecr_url        = var.github_actions_secret_ecr_url
-  github_actions_secret_ecr_access_key = var.github_actions_secret_ecr_access_key
-  github_actions_secret_ecr_secret_key = var.github_actions_secret_ecr_secret_key
-}
-
-resource "kubernetes_secret" "ecr-repo" {
-  metadata {
-    name      = "ecr-repo-${var.namespace}"
-    namespace = var.namespace
-  }
-
-  data = {
-    repo_url          = module.ecr-repo.repo_url
-    access_key_id     = module.ecr-repo.access_key_id
-    secret_access_key = module.ecr-repo.secret_access_key
-    repo_arn          = module.ecr-repo.repo_arn
-  }
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/ecr.tf
@@ -1,0 +1,30 @@
+module "ecr-repo" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.1"
+
+  team_name    = var.team_name
+  repo_name    = "${var.namespace}-ecr"
+  scan_on_push = "true"
+
+  # Creates github actions secrets containing the ECR name, AWS access key,
+  # and AWS secret key, for use in the octo-strategic-docs publish workflow.
+  github_repositories = [var.app_repo]
+
+  github_actions_secret_ecr_name       = var.github_actions_secret_ecr_name
+  github_actions_secret_ecr_url        = var.github_actions_secret_ecr_url
+  github_actions_secret_ecr_access_key = var.github_actions_secret_ecr_access_key
+  github_actions_secret_ecr_secret_key = var.github_actions_secret_ecr_secret_key
+}
+
+resource "kubernetes_secret" "ecr-repo" {
+  metadata {
+    name      = "ecr-repo-${var.namespace}"
+    namespace = var.namespace
+  }
+
+  data = {
+    repo_url          = module.ecr-repo.repo_url
+    access_key_id     = module.ecr-repo.access_key_id
+    secret_access_key = module.ecr-repo.secret_access_key
+    repo_arn          = module.ecr-repo.repo_arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      GithubTeam    = "octo-data-architecture"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/service-account.tf
@@ -1,0 +1,16 @@
+module "serviceaccount" {
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  # Creates github actions secrets containing the ca.crt and token used by
+  # the octo-strategic-docs publish workflow to kubectl apply/deploy.
+  github_repositories = [var.app_repo]
+
+  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
+  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
+
+  serviceaccount_token_rotated_date = "23-07-2026"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/service-account.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/service-account.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source             = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.1.0"
+  source             = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
   namespace          = var.namespace
   kubernetes_cluster = var.kubernetes_cluster
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
@@ -1,0 +1,119 @@
+variable "vpc_name" {
+}
+
+variable "kubernetes_cluster" {
+}
+
+variable "application" {
+  description = "Name of Application you are deploying"
+  type        = string
+  default     = "OCTO Strategic Documentation"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "octo-strategic-docs-prod"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  type        = string
+  default     = "HQ"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  type        = string
+  default     = "octo-data-architecture"
+}
+
+variable "environment" {
+  description = "The type of environment you're deploying to."
+  type        = string
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  type        = string
+  default     = "DataArchitectureJustice@justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "true"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  type        = string
+  default     = "octo-data-architecture"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider."
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  description = "Required by the Github Terraform provider"
+  type        = string
+  default     = ""
+}
+
+variable "app_repo" {
+  description = "Name of application repository"
+  type        = string
+  default     = "octo-strategic-docs"
+}
+
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the kubernetes cluster name"
+  type        = string
+  default     = "KUBE_CLUSTER"
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  type        = string
+  default     = "KUBE_NAMESPACE"
+}
+
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  type        = string
+  default     = "KUBE_CERT"
+}
+
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  type        = string
+  default     = "KUBE_TOKEN"
+}
+
+variable "github_actions_secret_ecr_name" {
+  description = "The name of the github actions secret containing the ECR name"
+  type        = string
+  default     = "ECR_NAME"
+}
+
+variable "github_actions_secret_ecr_url" {
+  description = "The name of the github actions secret containing the ECR URL"
+  type        = string
+  default     = "ECR_URL"
+}
+
+variable "github_actions_secret_ecr_access_key" {
+  description = "The name of the github actions secret containing the ECR AWS access key"
+  type        = string
+  default     = "ECR_AWS_ACCESS_KEY_ID"
+}
+
+variable "github_actions_secret_ecr_secret_key" {
+  description = "The name of the github actions secret containing the ECR AWS secret key"
+  type        = string
+  default     = "ECR_AWS_SECRET_ACCESS_KEY"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
@@ -94,26 +94,3 @@ variable "github_actions_secret_kube_token" {
   default     = "KUBE_TOKEN"
 }
 
-variable "github_actions_secret_ecr_name" {
-  description = "The name of the github actions secret containing the ECR name"
-  type        = string
-  default     = "ECR_NAME"
-}
-
-variable "github_actions_secret_ecr_url" {
-  description = "The name of the github actions secret containing the ECR URL"
-  type        = string
-  default     = "ECR_URL"
-}
-
-variable "github_actions_secret_ecr_access_key" {
-  description = "The name of the github actions secret containing the ECR AWS access key"
-  type        = string
-  default     = "ECR_AWS_ACCESS_KEY_ID"
-}
-
-variable "github_actions_secret_ecr_secret_key" {
-  description = "The name of the github actions secret containing the ECR AWS secret key"
-  type        = string
-  default     = "ECR_AWS_SECRET_ACCESS_KEY"
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/versions.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.78.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.23.0"
-    }
     github = {
       source  = "integrations/github"
       version = "~> 6.6.0"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Requesting a new production namespace to host the `octo-strategic-docs` static documentation site, migrating it from GitHub Pages to Cloud Platform.

## What's included

- `octo-strategic-docs-prod` namespace with standard limit range, resource quota (10 pods), and network policies
- Admin RBAC bound to the `octo-data-architecture-leads` GitHub team
- ECR repository (`octo-strategic-docs-prod-ecr`) with GitHub Actions OIDC push credentials wired to the `octo-strategic-docs` repo
- Kubernetes deploy service account with GitHub Actions secrets (`KUBE_CLUSTER`, `KUBE_NAMESPACE`, `KUBE_CERT`, `KUBE_TOKEN`) for CI-driven deploys

## Contact

- Owner: OCTO Data Architecture (DataArchitectureJustice@justice.gov.uk)
- Slack: #octo-data-architecture
- Source repo: https://github.com/ministryofjustice/octo-strategic-docs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>