### PR TITLE
[AD-1526] Add Decide API Auth Scope for laa-civil-decide in UAT 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-uat/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-uat/resources/secret.tf
@@ -39,5 +39,11 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "data-store-auth-scope-uat"
     },
+
+    "decide_api_auth_scope" = {
+      description             = "Auth scope for integration with Civil Decide API",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "decide-api-auth-scope-uat"
+    },
   }
 }


### PR DESCRIPTION
Add Decide API Auth Scope for laa-civil-decide in UAT, allows frontend to authenticate with appropriate scopes with Civil Decide API.