### PR TITLE
Add Slack alert webhook secrets for dev and preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-dev/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-dev/resources/secrets_manager.tf
@@ -1,0 +1,19 @@
+module "secrets_manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "crime_matching_alerts_dev_webhook" = {
+      description             = "HMPPS Electronic Monitoring Crime Matching dev Alertmanager Slack webhook"
+      recovery_window_in_days = 7
+      k8s_secret_name         = "slack-webhook-alerts-dev"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-preprod/resources/secrets_manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-preprod/resources/secrets_manager.tf
@@ -1,0 +1,19 @@
+module "secrets_manager" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "crime_matching_alerts_preprod_webhook" = {
+      description             = "HMPPS Electronic Monitoring Crime Matching preprod Alertmanager Slack webhook"
+      recovery_window_in_days = 7
+      k8s_secret_name         = "slack-webhook-alerts-preprod"
+    }
+  }
+}


### PR DESCRIPTION
Added secrets_manager modules to the dev and preprod namespaces to provision secrets for new Slack Alertmanager webhooks.

Namespaces:

- hmpps-electronic-monitoring-crime-matching-dev
- hmpps-electronic-monitoring-crime-matching-preprod