### PR TITLE
Add empty Entra oauth2-proxy secrets for octo-strategic-docs-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/secrets.tf
@@ -1,0 +1,36 @@
+## Entra ID / oauth2-proxy secrets
+##
+## This creates *empty* placeholder secrets in AWS Secrets Manager,
+## synced into Kubernetes secrets in this namespace. The actual secret
+## values (client-id, client-secret, tenant-id, cookie-secret) are NOT
+## managed by Terraform/committed to git - they must be populated
+## directly into AWS Secrets Manager out-of-band by a namespace admin,
+## after this resource has been applied. See the Entra app
+## registration at ministryofjustice/staff-identity-idam-entra-infra#702
+## for the client-id/tenant-id, and generate a client secret via the
+## Entra admin center's "Certificates & secrets" blade.
+module "secrets_manager_multiple_secrets" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+
+  team_name              = var.team_name
+  application            = var.application
+  business_unit          = var.business_unit
+  is_production          = var.is_production
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  eks_cluster_name       = var.eks_cluster_name
+
+  secrets = {
+    "entra-oauth2-proxy" = {
+      description             = "Entra ID OAuth2 client details for oauth2-proxy (client-id, client-secret, tenant-id)"
+      recovery_window_in_days = 0
+      k8s_secret_name         = "entra-oauth2-proxy"
+    },
+    "oauth2-proxy-cookie-secret" = {
+      description             = "oauth2-proxy cookie signing secret"
+      recovery_window_in_days = 0
+      k8s_secret_name         = "oauth2-proxy-cookie-secret"
+    },
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
@@ -94,3 +94,8 @@ variable "github_actions_secret_kube_token" {
   default     = "KUBE_TOKEN"
 }
 
+variable "eks_cluster_name" {
+  description = "The name of the eks cluster to retrieve the OIDC information"
+  type        = string
+}
+


### PR DESCRIPTION
## Purpose

Adds placeholder AWS Secrets Manager secrets (synced to Kubernetes secrets in `octo-strategic-docs-prod`) to hold the Entra ID app registration details needed to put [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy) in front of the OCTO Strategic Docs site.

The Entra app registration itself was added in ministryofjustice/staff-identity-idam-entra-infra#702 (merged).

## What this creates

Using `cloud-platform-terraform-secrets-manager` (v3.0.7):

- `entra-oauth2-proxy` k8s secret - will hold `client-id`, `client-secret`, `tenant-id`
- `oauth2-proxy-cookie-secret` k8s secret - oauth2-proxy's session cookie signing key

**Note:** Terraform only creates the empty secret containers here - no real secret values are stored in git or Terraform state. Once this is merged and applied, we'll populate the actual values directly into AWS Secrets Manager out-of-band.

Ran `terraform fmt` and `terraform validate` locally (clean, only pre-existing deprecation warnings from the shared module itself).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>