### PR TITLE
Tag octo-strategic-docs-prod Entra secrets with GithubTeam

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/secrets.tf
@@ -12,6 +12,13 @@
 module "secrets_manager_multiple_secrets" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
 
+  # Use the aliased "london" provider so the created secrets inherit the
+  # GithubTeam default tag, which is required for our team to be able to
+  # view/set the secret values via the AWS console.
+  providers = {
+    aws = aws.london
+  }
+
   team_name              = var.team_name
   application            = var.application
   business_unit          = var.business_unit


### PR DESCRIPTION
Fixes a permissions issue where the octo-data-architecture team cannot view/set the two Entra oauth2-proxy secrets (created in #44333) via the AWS console (`DescribeSecret` access error).

The `secrets_manager_multiple_secrets` module was implicitly using the default (untagged) `aws` provider. This namespace already has an aliased `aws.london` provider configured with `default_tags { GithubTeam = "octo-data-architecture" }` (used for console access per the [Cloud Platform docs](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html)), but it wasn't wired into the secrets module.

This adds `providers = { aws = aws.london }` to the module block so the created secrets get the `GithubTeam` tag and become visible/settable in the console for our team.