### PR TITLE
Civil Decide API: Add ADS auth config secret UAT

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-api-uat/resources/secret.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-civil-decide-api-uat/resources/secret.tf
@@ -35,6 +35,11 @@ module "secrets_manager" {
       recovery_window_in_days = 7,
       k8s_secret_name         = "api-entra-auth-config-uat"
     },
+    "ads-auth-config" = {
+      description             = "ADS Auth Configuration for UAT",
+      recovery_window_in_days = 7,
+      k8s_secret_name         = "ads-auth-config-uat"
+    },
     "grant_email_template_id" = {
       description             = "Template ID for sending grant emails for UAT",
       recovery_window_in_days = 7,


### PR DESCRIPTION
Add ADS auth config secret in laa-civil-decide-api for UAT