### PR TITLE
Fix GithubTeam tag on octo-strategic-docs-prod Entra secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/main.tf
@@ -12,7 +12,12 @@ provider "aws" {
   region = "eu-west-2"
   default_tags {
     tags = {
-      GithubTeam    = "octo-data-architecture"
+      # Must match a GitHub team actually registered via a RoleBinding in
+      # 01-rbac.yaml for this namespace (octo-data-architecture-leads),
+      # otherwise the Cloud Platform AWS console's team-filter service
+      # strips the team out of the user's session tags entirely, causing
+      # "DescribeSecret access" errors even for team members.
+      GithubTeam    = "octo-data-architecture-leads"
       slack-channel = var.slack_channel
     }
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/secrets.tf
@@ -13,8 +13,9 @@ module "secrets_manager_multiple_secrets" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
 
   # Use the aliased "london" provider so the created secrets inherit the
-  # GithubTeam default tag, which is required for our team to be able to
-  # view/set the secret values via the AWS console.
+  # GithubTeam default tag (octo-data-architecture-leads, matching the
+  # RBAC group registered for this namespace), which is required for our
+  # team to be able to view/set the secret values via the AWS console.
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
Follow-up to #44337, which added a `GithubTeam` tag but used the wrong value.

**Root cause:** the Cloud Platform AWS console's read-only access relies on a [team-filter microservice](https://github.com/ministryofjustice/cloud-platform-github-teams-filter) that strips any GitHub team out of a user's AWS session tags unless that team is registered via a Kubernetes RoleBinding somewhere in the cluster. This namespace's `01-rbac.yaml` registers `octo-data-architecture-leads` (not `octo-data-architecture`), so the tag value set in #44337 was being silently filtered out of session tags — causing `DescribeSecret` permission errors for team members even though GitHub team membership and the resource tag otherwise matched.

**Fix:** changed the `GithubTeam` tag on the aliased `aws.london` provider (used only by the Entra secrets module) to `octo-data-architecture-leads`, matching the group actually registered for this namespace.