### PR TITLE
Fixes for RCW UAT namespace 

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/elasticache.ccq.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/elasticache.ccq.tf
@@ -1,7 +1,7 @@
 module "elasticache_redis_ccq" {
   source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
   vpc_name               = var.vpc_name
-  application            = var.application
+  application            = "${var.application} (CCQ)"
   environment_name       = var.environment
   is_production          = var.is_production
   infrastructure_support = var.infrastructure_support

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/elasticache.ccq.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/elasticache.ccq.tf
@@ -27,10 +27,10 @@ resource "kubernetes_secret" "elasticache_redis_ccq" {
   }
 
   data = {
-    primary_endpoint_address = module.elasticache_redis.primary_endpoint_address
-    auth_token               = module.elasticache_redis.auth_token
-    member_clusters          = jsonencode(module.elasticache_redis.member_clusters)
-    replication_group_id     = module.elasticache_redis.replication_group_id
-    url                      = "rediss://:${module.elasticache_redis.auth_token}@${module.elasticache_redis.primary_endpoint_address}:6379"
+    primary_endpoint_address = module.elasticache_redis_ccq.primary_endpoint_address
+    auth_token               = module.elasticache_redis_ccq.auth_token
+    member_clusters          = jsonencode(module.elasticache_redis_ccq.member_clusters)
+    replication_group_id     = module.elasticache_redis_ccq.replication_group_id
+    url                      = "rediss://:${module.elasticache_redis_ccq.auth_token}@${module.elasticache_redis_ccq.primary_endpoint_address}:6379"
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/elasticache.rcw.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/elasticache.rcw.tf
@@ -1,7 +1,7 @@
 module "elasticache_redis" {
   source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
   vpc_name               = var.vpc_name
-  application            = var.application
+  application            = "${var.application} (RCW)"
   environment_name       = var.environment
   is_production          = var.is_production
   infrastructure_support = var.infrastructure_support

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/variables.tf
@@ -11,7 +11,7 @@ variable "kubernetes_cluster" {
 variable "application" {
   description = "Name of the application you are deploying"
   type        = string
-  default     = "Record controlled work"
+  default     = "ui"
 }
 
 variable "namespace" {
@@ -41,7 +41,7 @@ variable "team_name" {
 variable "environment" {
   description = "Name of the environment type for this service"
   type        = string
-  default     = "development"
+  default     = "uat"
 }
 
 variable "infrastructure_support" {


### PR DESCRIPTION
- Fixes redis secret references for CCQ journey data redis cache which were wrongly pointing at the session redis module
- Change application references so the redis instances can be identified more easily
- Update baseline application and environment variables to be more accurate/readable as tags in AWS