### PR TITLE
`hale-platform-prod` Increase traffic spike threshold to 100 req/sec

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/05-prometheus.yaml
@@ -92,12 +92,12 @@ spec:
         severity: hale-platform-alerts
     - alert: TrafficSpike
       annotations:
-        message: High levels of traffic - {{ printf "%0.0f" $value }} requests per second (over 6000/min).
+        message: High levels of traffic - {{ printf "%0.0f" $value }} requests per second (over 3600/min).
         dashboard_url: >-
           https://grafana.live.cloud-platform.service.justice.gov.uk/d/k8s-nginx-ingress-prometheus-ng2/5178fc76-29af-51b9-83a8-cbab85db37a6?orgId=1&refresh=1m&var-controller_class=All&var-pod=All&var-datasource=default&from=now-1h&to=now&var-namespace=All&var-ingress=hale-platform-ingress
       expr: |-
         sum(rate(nginx_ingress_controller_requests{exported_namespace="hale-platform-prod"}[5m])) by (ingress)
-        > 100
+        > 60
       for: 3m
       labels:
         severity: hale-platform-alerts

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/05-prometheus.yaml
@@ -92,12 +92,12 @@ spec:
         severity: hale-platform-alerts
     - alert: TrafficSpike
       annotations:
-        message: High levels of traffic - {{ printf "%0.0f" $value }} requests per second (over 3600/min).
+        message: High levels of traffic - {{ printf "%0.0f" $value }} requests per second (over 6000/min).
         dashboard_url: >-
           https://grafana.live.cloud-platform.service.justice.gov.uk/d/k8s-nginx-ingress-prometheus-ng2/5178fc76-29af-51b9-83a8-cbab85db37a6?orgId=1&refresh=1m&var-controller_class=All&var-pod=All&var-datasource=default&from=now-1h&to=now&var-namespace=All&var-ingress=hale-platform-ingress
       expr: |-
         sum(rate(nginx_ingress_controller_requests{exported_namespace="hale-platform-prod"}[5m])) by (ingress)
-        > 60
+        > 100
       for: 3m
       labels:
         severity: hale-platform-alerts

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/05-prometheus.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/05-prometheus.yaml
@@ -92,12 +92,12 @@ spec:
         severity: hale-platform-alerts
     - alert: TrafficSpike
       annotations:
-        message: High levels of traffic - around 2000 request per minute (30rps).
+        message: High levels of traffic - {{ printf "%0.0f" $value }} requests per second (over 6000/min).
         dashboard_url: >-
           https://grafana.live.cloud-platform.service.justice.gov.uk/d/k8s-nginx-ingress-prometheus-ng2/5178fc76-29af-51b9-83a8-cbab85db37a6?orgId=1&refresh=1m&var-controller_class=All&var-pod=All&var-datasource=default&from=now-1h&to=now&var-namespace=All&var-ingress=hale-platform-ingress
       expr: |-
         sum(rate(nginx_ingress_controller_requests{exported_namespace="hale-platform-prod"}[5m])) by (ingress)
-        > 30
+        > 100
       for: 3m
       labels:
         severity: hale-platform-alerts


### PR DESCRIPTION
~3x the TrafficSpike alert threshold - this is because the current threshold no longer has significance.