### PR TITLE
Create prod certificate.yaml for check-my-copilot-ai-credit-usage

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/moj-copilot-ai-credits-dashboard-prod/resources/certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/moj-copilot-ai-credits-dashboard-prod/resources/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cmcaicu-prod-cert
+  namespace: moj-copilot-ai-credits-dashboard-prod
+spec:
+  secretName: cmcaicu-prod-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - check-my-copilot-ai-credits-usage.service.justice.gov.uk


### PR DESCRIPTION
This pull request introduces a new certificate resource for the production environment of the Copilot AI Credits Dashboard. The certificate will enable secure HTTPS for the dashboard's public URL.

Certificate management:

* Added a `Certificate` resource (`certificate.yaml`) in the `moj-copilot-ai-credits-dashboard-prod` namespace to provision TLS for `check-my-copilot-ai-credits-usage.service.justice.gov.uk` using the `letsencrypt-production` issuer.