### PR TITLE
cis-pp: Update allowed workflow for GitHub Actions frontend deployment

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/variables.tf
@@ -329,7 +329,7 @@ variable "oidc_role_provider_url" {
 variable "oidc_role_workflow_file" {
   description = "The name of the workflow file that is allowed to assume this role. This is used in the job_workflow_ref condition key."
   type        = string
-  default     = ".github/workflows/application.yml"
+  default     = ".github/workflows/deploy_preprod.yml"
 }
 
 variable "oidc_role_workflow_branch" {


### PR DESCRIPTION
Update the value of the workflow file that is allowed to assume the OIDC role to enable deployment of our frontend via GitHub Actions, as the file has been renamed.