### PR TITLE
Upgrading RDS version to 19 to handle automatic DB upgrades

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-pp/resources/rds.tf
@@ -6,7 +6,7 @@ module "rds_instance" {
 
   # Database configuration
   db_engine                = "oracle-se2"
-  db_engine_version        = "19.0.0.0.ru-2026-01.rur-2026-01.r3"
+  db_engine_version        = "19"
   rds_family               = "oracle-se2-19"
   db_instance_class        = "db.t3.small"
   db_allocated_storage     = "100"


### PR DESCRIPTION
## 👀 Purpose

- In relation to: Updating RDS version to 19 so that we can handle automatic DB upgrades

## ♻️ What's changed

- Updating RDS version to 19 instead of specific verison

## 📝 Notes

-