### PR TITLE
Add onboarding optimisation network policies

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/05-networkpolicy-egress.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/05-networkpolicy-egress.yaml
@@ -52,8 +52,12 @@ spec:
           - 52.95.150.0/24
           - 52.95.191.0/24
           - 52.219.219.0/24
+          # AWS STS eu-west-2 (IRSA credential exchange)
+          # Source: AMAZON service tag, region=eu-west-2, covering sts.eu-west-2.amazonaws.com
+          - 13.43.48.0/23
           # AWS STS eu-west-1 (role assumption for Analytical Platform access)
           # Source: AMAZON service tag, region=eu-west-1, covering sts.eu-west-1.amazonaws.com
+          - 3.253.220.0/22
           - 3.253.224.0/22
           # AWS S3 eu-west-1 (Analytical Platform data buckets: alpha-*, mojap-*)
           # Source: https://ip-ranges.amazonaws.com/ip-ranges.json (service=S3, region=eu-west-1)


### PR DESCRIPTION
## Summary

- restrict ingress so the backend is reachable only from the frontend
- add pod-specific egress allow-lists followed by deny-all egress
- allow the AWS, Azure AD, Azure OpenAI and HMPPS endpoints required by the application
- allow current eu-west-2 and eu-west-1 AWS STS ranges used for IRSA and Analytical Platform role assumption

## Root cause

Visitor search requests returned a gateway timeout because botocore could reach S3 but could not refresh IRSA credentials. The backend pod resolved `sts.eu-west-2.amazonaws.com` to an address in `13.43.48.0/23`, while the policy allowed only `3.253.224.0/22`. The eu-west-1 endpoint currently resolves within `3.253.220.0/22`, which was also absent.

The STS connection retried for roughly two minutes before the backend returned an error, by which point the frontend gateway had already timed out.

## Impact

This preserves deny-by-default egress while allowing the backend to obtain temporary AWS credentials through STS. It does not add unrestricted outbound access.

## Validation

- parsed `05-networkpolicy-egress.yaml` successfully as YAML
- verified the observed eu-west-2 and eu-west-1 STS endpoint IPs fall within the added CIDRs
- confirmed from the running dev pod that S3 was reachable while STS timed out before this policy change
