### PR TITLE
Add cert-manager Certificate for octo-strategic-docs custom domain

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: octo.service.justice.gov.uk
+  name: octo-documenation.justice.gov.uk
   namespace: octo-strategic-docs-prod
 spec:
   secretName: octo-strategic-docs-custom-domain-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - octo.service.justice.gov.uk
+    - octo-documenation.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: octo-strategic-docs.service.justice.gov.uk
+  name: octo.service.justice.gov.uk
   namespace: octo-strategic-docs-prod
 spec:
   secretName: octo-strategic-docs-custom-domain-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - octo-strategic-docs.service.justice.gov.uk
+    - octo.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: octo-documenation.justice.gov.uk
+  name: octo-documentation.justice.gov.uk
   namespace: octo-strategic-docs-prod
 spec:
   secretName: octo-strategic-docs-custom-domain-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - octo-documenation.justice.gov.uk
+    - octo-documentation.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: octo-strategic-docs.justice.gov.uk
+  name: octo-strategic-docs.service.justice.gov.uk
   namespace: octo-strategic-docs-prod
 spec:
   secretName: octo-strategic-docs-custom-domain-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - octo-strategic-docs.justice.gov.uk
+    - octo-strategic-docs.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: octo-strategic-docs.service.justice.gov.uk
+  namespace: octo-strategic-docs-prod
+spec:
+  secretName: octo-strategic-docs-custom-domain-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - octo-strategic-docs.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/05-certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: octo-strategic-docs.service.justice.gov.uk
+  name: octo-strategic-docs.justice.gov.uk
   namespace: octo-strategic-docs-prod
 spec:
   secretName: octo-strategic-docs-custom-domain-cert
@@ -9,4 +9,4 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - octo-strategic-docs.service.justice.gov.uk
+    - octo-strategic-docs.justice.gov.uk


### PR DESCRIPTION
Adds a `cert-manager.io/v1 Certificate` resource requesting a Let's Encrypt cert for `octo-documentation.justice.gov.uk`.

Part of moving `octo-strategic-docs` off the cluster-bound `apps.live...` hostname onto its own custom domain. This depends on cloud-platform-environments#44456 (Route53 zone creation + delegation from the parent `justice.gov.uk` zone) being merged and delegated first, so the ACME HTTP-01 challenge can resolve.

Follow-up PRs: octo-strategic-docs#54 (Ingress) and staff-identity-idam-entra-infra#709 (Entra redirect URI).