### PR TITLE
Create Route53 hosted zone for octo-documenation.justice.gov.uk

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/route53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_zone" "octo_strategic_docs_route53_zone" {
+  name = var.domain
+  tags = {
+    team_name              = var.team_name
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.owner
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "octo_strategic_docs_route53_zone_sec" {
+  metadata {
+    name      = "octo-strategic-docs-route53-zone-output"
+    namespace = var.namespace
+  }
+  data = {
+    zone_id     = aws_route53_zone.octo_strategic_docs_route53_zone.zone_id
+    nameservers = join("\n", aws_route53_zone.octo_strategic_docs_route53_zone.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
@@ -31,7 +31,7 @@ variable "team_name" {
 variable "domain" {
   description = "Custom domain for the Route53 hosted zone"
   type        = string
-  default     = "octo-documenation.justice.gov.uk"
+  default     = "octo-documentation.justice.gov.uk"
 }
 
 variable "owner" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/variables.tf
@@ -28,6 +28,18 @@ variable "team_name" {
   default     = "octo-data-architecture"
 }
 
+variable "domain" {
+  description = "Custom domain for the Route53 hosted zone"
+  type        = string
+  default     = "octo-documenation.justice.gov.uk"
+}
+
+variable "owner" {
+  description = "The owner of the domain, used for tagging"
+  type        = string
+  default     = "octo-data-architecture"
+}
+
 variable "environment" {
   description = "The type of environment you're deploying to."
   type        = string

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/octo-strategic-docs-prod/resources/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "integrations/github"
       version = "~> 6.6.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
   }
 }


### PR DESCRIPTION
First step in setting up the custom domain per https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/route53-zone.html.

Creates a dedicated Route53 hosted zone for `octo-documenation.justice.gov.uk` and exposes its zone ID + nameservers via a Kubernetes secret (`octo-strategic-docs-route53-zone-output`) in the namespace, so they can be handed over for delegation from the parent `justice.gov.uk` zone.

Once merged and applied, next steps are:
1. Retrieve nameservers from the new K8s secret and provide them for delegation
2. Once delegated, merge the Certificate PR (#44445) and Ingress PR (#54)