### PR TITLE
add new cname for reuse-library-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
@@ -25,4 +25,11 @@ resource "kubernetes_secret" "route53_zone_sec" {
   }
 }
 
-# Todo: add an A record for dev.reuselibrary.service.justice.gov.uk
+resource "aws_route53_record" "delegate_dev" {
+  name    = "dev.reuselibrary.service.justice.gov.uk"
+  zone_id = aws_route53_zone.prod_reuselibrary_team_route53_zone.zone_id
+  type    = "CNAME"
+  ttl     = 300
+
+#  records = ["reuselibrary.service.justice.gov.uk"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/resources/route53.tf
@@ -31,5 +31,5 @@ resource "aws_route53_record" "delegate_dev" {
   type    = "CNAME"
   ttl     = 300
 
-#  records = ["reuselibrary.service.justice.gov.uk"]
+  records = ["reuselibrary.service.justice.gov.uk"]
 }


### PR DESCRIPTION
Key change:
- Adding a new CNAME definition for dev.reuselibrary.service.justice.gov.uk which points to the prod domain.