### PR TITLE
add dev.reuselibrary.service.justice.gov.uk to tls certificate

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/06-certificate.yml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/reuse-library-prod/06-certificate.yml
@@ -10,3 +10,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
   - reuselibrary.service.justice.gov.uk
+  - dev.reuselibrary.service.justice.gov.uk


### PR DESCRIPTION
Key change:
- Added `dev.reuselibrary.service.justice.gov.uk` to TLS certificate