### PR TITLE
MEM-1138: Add IRSA to info and advice datastore - staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/irsa.tf
@@ -1,0 +1,30 @@
+module "irsa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = var.namespace
+
+  role_policy_arns = {
+    rds = module.rds.irsa_policy_arn
+  }
+
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  team_name              = var.team_name
+}
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "irsa-output"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+    rolearn        = module.irsa.role_arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/main.tf
@@ -62,3 +62,13 @@ provider "github" {
 }
 
 provider "kubernetes" {}
+
+provider "postgresql" {
+  host      = module.rds.rds_instance_address
+  port      = module.rds.rds_instance_port
+  database  = module.rds.database_name
+  username  = module.rds.database_username
+  password  = module.rds.database_password
+  sslmode   = "require"
+  superuser = false
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/rds-postgres.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/rds-postgres.tf
@@ -19,6 +19,9 @@ module "rds" {
   # Cost optimisation (not for prod)
   enable_rds_auto_start_stop = var.is_production ? false : true
 
+  # IAM authentication
+  enable_irsa = true
+
   # Observability
   performance_insights_enabled = false
 
@@ -45,4 +48,9 @@ resource "kubernetes_secret" "rds" {
     database_password     = module.rds.database_password
     rds_instance_address  = module.rds.rds_instance_address
   }
+}
+
+resource "postgresql_grant_role" "rds_iam" {
+  role       = module.rds.database_username
+  grant_role = "rds_iam"
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/secrets.tf
@@ -1,0 +1,21 @@
+module "secrets_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+
+  eks_cluster_name = var.eks_cluster_name
+
+  secrets = {
+    "laa-info-and-advice-datastore-entra-staging" = {
+      description             = "Microsoft Entra OAuth2 config for laa-info-and-advice-datastore staging"
+      recovery_window_in_days = 7
+      k8s_secret_name         = "laa-info-and-advice-datastore-entra"
+    }
+  }
+
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/variables.tf
@@ -8,6 +8,11 @@ variable "kubernetes_cluster" {
   type        = string
 }
 
+variable "eks_cluster_name" {
+  description = "EKS cluster name, used by the IRSA and Secrets Manager modules to create IAM role trust policies"
+  type        = string
+}
+
 variable "application" {
   description = "Name of the application you are deploying"
   type        = string

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/resources/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23.0"
     }
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "~> 1.26.0"
+    }
   }
 }


### PR DESCRIPTION
Adds RDS IAM authentication and moves the Microsoft Entra OAuth2 config into
AWS Secrets Manager for the staging environment.

- `rds-postgres.tf` -- enables IAM auth on the RDS instance (`enable_irsa = true`)
  and grants the `rds_iam` role to the database user
- `irsa.tf` (new) -- creates a Kubernetes service account annotated with an IAM
  role scoped to `rds-db:connect` for this instance
- `versions.tf` / `main.tf` -- adds the `cyrilgdn/postgresql` provider
- `variables.tf` -- adds `eks_cluster_name`, required by the IRSA module

The existing `rds-postgresql-instance-output` k8s secret is unchanged -- username
and password remain available for dev access to these environments.