### PR TITLE
fix: :bug: Fixing broken Pingdom integrations caused by incorrect host and invalid routing setup (MEM-846)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-record-controlled-work-uat/resources/pingdom.tf
@@ -4,29 +4,14 @@ provider "pingdom" {
 resource "pingdom_check" "laa-record-controlled-work-rcw-uat" {
   type             = "http"
   name             = "Record controlled work (RCW) - UAT"
-  host             = "laa-record-controlled-work.cloud-platform.service.justice.gov.uk"
+  host             = "laa-record-controlled-work-uat.cloud-platform.service.justice.gov.uk"
   resolution       = 1
   notifywhenbackup = true
   notifyagainevery = 0
-  url              = "/"
+  url              = "/status"
   encryption       = true
   port             = 443
   tags             = "businessunit_${var.business_unit},application_${var.application},component_rcw,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.application},laa,record-controlled-work"
-  probefilters     = "region:EU"
-  integrationids   = [148660]
-}
-
-resource "pingdom_check" "laa-record-controlled-work-ccq-uat" {
-  type             = "http"
-  name             = "Record controlled work (CCQ) - UAT"
-  host             = "laa-record-controlled-work.cloud-platform.service.justice.gov.uk"
-  resolution       = 1
-  notifywhenbackup = true
-  notifyagainevery = 0
-  url              = "/"
-  encryption       = true
-  port             = 443
-  tags             = "businessunit_${var.business_unit},application_${var.application},component_ccq,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.application},laa,record-controlled-work"
   probefilters     = "region:EU"
   integrationids   = [148660]
 }


### PR DESCRIPTION
```
Record controlled work (RCW) - UAT is down
laa-record-controlled-work.cloud-platform.service.justice.gov.uk • View details
```

Issue caused by incorrect host used for RCW integration. Removing CCQ integration due to inability to route to the embedded component at this time