### PR TITLE
Add dev observability and tighten document IRSA

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/04-networkpolicy.yaml
@@ -54,3 +54,28 @@ spec:
     - podSelector:
         matchLabels:
           app: onboarding-optimisation-frontend
+    ports:
+      - protocol: TCP
+        port: 8000
+---
+# Prometheus is the only caller allowed to reach the dedicated metrics port.
+# Application traffic remains unavailable to the monitoring namespace.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-to-backend-metrics
+  namespace: onboarding-optimisation-dev
+spec:
+  podSelector:
+    matchLabels:
+      app: onboarding-optimisation-backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              component: monitoring
+      ports:
+        - protocol: TCP
+          port: 9090

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/06-servicemonitor.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/06-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: onboarding-optimisation-backend
+  namespace: onboarding-optimisation-dev
+spec:
+  selector:
+    matchLabels:
+      app: onboarding-optimisation-backend
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/resources/irsa.tf
@@ -6,7 +6,7 @@ module "irsa" {
   service_account_name = "${var.application}-${var.environment}-sa"
 
   role_policy_arns = {
-    s3 = module.s3_bucket.irsa_policy_arn
+    document_storage = aws_iam_policy.document_storage.arn
   }
 
   business_unit          = var.business_unit
@@ -15,6 +15,39 @@ module "irsa" {
   team_name              = var.team_name
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+}
+
+data "aws_iam_policy_document" "document_storage" {
+  provider = aws.london
+
+  statement {
+    sid    = "DocumentStorageObjects"
+    effect = "Allow"
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["${module.s3_bucket.bucket_arn}/documents/*"]
+  }
+}
+
+resource "aws_iam_policy" "document_storage" {
+  provider = aws.london
+
+  name_prefix = "${var.application}-${var.environment}-documents-"
+  description = "Least-privilege document storage access for ${var.namespace}"
+  policy      = data.aws_iam_policy_document.document_storage.json
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+    owner                  = var.team_name
+  }
 }
 
 resource "github_actions_environment_variable" "app_role_arn" {


### PR DESCRIPTION
Allow the Cloud Platform monitoring namespace to scrape the backend's dedicated metrics port and register the dev backend through a ServiceMonitor.

Replace the generated broad S3 policy attachment with an explicit least-privilege policy limited to GetObject, PutObject, and DeleteObject operations under the document bucket's documents prefix.