### PR TITLE
Restrict onboarding optimisation dev network access

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/04-networkpolicy.yaml
@@ -58,8 +58,8 @@ spec:
       - protocol: TCP
         port: 8000
 ---
-# Prometheus is the only caller allowed to reach the dedicated metrics port.
-# Application traffic remains unavailable to the monitoring namespace.
+# Only the trusted Cloud Platform monitoring namespace may reach the dedicated
+# metrics port. Application traffic remains unavailable to that namespace.
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -76,6 +76,7 @@ spec:
         - namespaceSelector:
             matchLabels:
               component: monitoring
+              kubernetes.io/metadata.name: monitoring
       ports:
         - protocol: TCP
           port: 9090

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/05-networkpolicy-egress.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/onboarding-optimisation-dev/05-networkpolicy-egress.yaml
@@ -1,6 +1,4 @@
-# Frontend egress: only what the Next.js pod needs.
-# - 172.20.0.0/16: kube-dns and the backend internal service
-# - Azure AD: server-side token exchange at login (callback/route.ts)
+# Frontend egress: DNS, the internal backend, and Entra token exchange only.
 kind: NetworkPolicy
 apiVersion: projectcalico.org/v3
 metadata:
@@ -11,18 +9,38 @@ spec:
   selector: "app == 'onboarding-optimisation-frontend'"
   egress:
     - action: Allow
+      protocol: UDP
       destination:
+        namespaceSelector: kubernetes.io/metadata.name == "kube-system"
+        selector: k8s-app in {"kube-dns", "coredns"}
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        namespaceSelector: kubernetes.io/metadata.name == "kube-system"
+        selector: k8s-app in {"kube-dns", "coredns"}
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        selector: app == "onboarding-optimisation-backend"
+        ports:
+          - 8000
+    - action: Allow
+      protocol: TCP
+      destination:
+        # Azure AD — token exchange at login.microsoftonline.com/oauth2/v2.0/token
         nets:
-          - 172.20.0.0/16
-          # Azure AD — token exchange at login.microsoftonline.com/oauth2/v2.0/token
           - 20.190.128.0/18
           - 40.126.0.0/18
+        ports:
+          - 443
   types:
     - Egress
 ---
-# Backend egress: all external dependencies.
-# Note: 172.20.0.0/16 covers kube-dns, RDS private IP, and AWS VPC endpoints
-# if configured on this cluster (confirm with Cloud Platform team).
+# Backend egress: DNS, RDS/VPC endpoints, and HTTPS external dependencies.
 kind: NetworkPolicy
 apiVersion: projectcalico.org/v3
 metadata:
@@ -33,10 +51,32 @@ spec:
   selector: "app == 'onboarding-optimisation-backend'"
   egress:
     - action: Allow
+      protocol: UDP
+      destination:
+        namespaceSelector: kubernetes.io/metadata.name == "kube-system"
+        selector: k8s-app in {"kube-dns", "coredns"}
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        namespaceSelector: kubernetes.io/metadata.name == "kube-system"
+        selector: k8s-app in {"kube-dns", "coredns"}
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        # Cloud Platform VPC: PostgreSQL and AWS VPC endpoints only.
+        nets:
+          - 172.20.0.0/16
+        ports:
+          - 443
+          - 5432
+    - action: Allow
+      protocol: TCP
       destination:
         nets:
-          # Cloud Platform VPC: kube-dns, RDS, AWS VPC endpoints
-          - 172.20.0.0/16
           # AWS S3 eu-west-2 public endpoints (document storage bucket)
           # Source: https://ip-ranges.amazonaws.com/ip-ranges.json (service=S3, region=eu-west-2)
           - 1.178.94.0/24
@@ -167,6 +207,8 @@ spec:
           - 191.238.78.0/28
           # HMPPS Integration API — dev.integration-api.hmpps.service.justice.gov.uk
           - 35.179.45.242/32
+        ports:
+          - 443
   types:
     - Egress
 ---


### PR DESCRIPTION
## What changed

- restrict the Prometheus metrics listener to the exact trusted `monitoring` namespace
- allow frontend and backend DNS only to CoreDNS on TCP/UDP 53
- allow frontend-to-backend traffic only on TCP 8000
- restrict Entra, AWS, Azure OpenAI, Analytical Platform, and HMPPS egress to TCP 443
- restrict VPC egress to TCP 443 for endpoints and TCP 5432 for PostgreSQL
- preserve the final deny-all egress policy

## Why

The existing policy had a sound default-deny design, but its CIDR allow rules did not specify protocols or ports. A compromised pod could therefore attempt connections to any port within an allowed range.

## Validation

- parsed all YAML documents successfully
- verified every allow rule has an explicit TCP/UDP protocol and destination port
- verified frontend no longer has a VPC-wide CIDR allowance
- verified Prometheus remains limited to backend TCP 9090 from the monitoring namespace