### PR TITLE
LGA-4177: add new secret to secret-manager for cla_backend

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/secretsmanager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-production/resources/secretsmanager.tf
@@ -11,6 +11,11 @@ module "secret" {
       recovery_window_in_days = 7                # required
       k8s_secret_name         = "rate-limit-slack-webhook" # the name of the secret in k8s
     },
+    "diversity-mcc-passphrase" = {
+      description             = "CLA Backend production MCC diversity private key passphrase"
+      recovery_window_in_days = 7
+      k8s_secret_name         = "diversity-mcc-passphrase"
+    }
   }
 
   # Tags


### PR DESCRIPTION
We have added a new endpoint to read diversity data, the data needs the passphrase to get decrypted. 