### PR TITLE
infra: add  to networkpolicy

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-cla-backend-uat/04-networkpolicy.yaml
@@ -55,4 +55,7 @@ spec:
     - namespaceSelector:
         matchLabels:
           cloud-platform.justice.gov.uk/namespace: laa-manage-your-civil-cases-uat
+    - namespaceSelector:
+        matchLabels:
+          cloud-platform.justice.gov.uk/namespace: laa-cla-operator-app-uat
           


### PR DESCRIPTION
We are hooking up `laa-cla-operator-app` with `laa-cla-backend`, part of the process is to allow the frontend app to be able to call backend using ingress 