### PR TITLE
feat: update for additional pod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/00-namespace.yaml
@@ -13,5 +13,5 @@ metadata:
     cloud-platform.justice.gov.uk/slack-alert-channel: "hmpps_electronic_monitoring_data_insights_alerts_noprod"
     cloud-platform.justice.gov.uk/application: "Electronic Monitoring for probation officers"
     cloud-platform.justice.gov.uk/owner: "HMPPS Electronic Monitoring for Probation: john.asafo@justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-api,https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-ui"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-api,https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-ui,https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-utils"
     cloud-platform.justice.gov.uk/team-name: "hmpps-em-probation-devs"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/iam-policies.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/iam-policies.tf
@@ -2,8 +2,7 @@ data "aws_iam_policy_document" "ssm_policy" {
   statement {
     actions = [
       "ssm:GetParameter",
-      "ssm:GetParameters",
-      "ssm:PutParameter"
+      "ssm:GetParameters"
     ]
     resources = [
       "arn:aws:ssm:eu-west-2:754256621582:parameter/${var.namespace}/athena_general_role_arn"
@@ -14,7 +13,7 @@ data "aws_iam_policy_document" "ssm_policy" {
 resource "aws_iam_policy" "ssm_access" {
   name   = "${var.namespace}-ssm-policy"
   policy = data.aws_iam_policy_document.ssm_policy.json
-  tags = local.tags
+  tags   = local.tags
 }
 
 data "aws_iam_policy_document" "athena_policy" {
@@ -31,5 +30,5 @@ data "aws_iam_policy_document" "athena_policy" {
 resource "aws_iam_policy" "athena_access" {
   name   = "${var.namespace}-athena-policy-general"
   policy = data.aws_iam_policy_document.athena_policy.json
-  tags = local.tags
+  tags   = local.tags
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/kubernetes-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/kubernetes-secrets.tf
@@ -19,4 +19,3 @@ resource "kubernetes_secret" "athena_roles" {
     general_role_arn = "arn:aws:iam::800964199911:role/emdi_read_emds_data_dev"
   }
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/template-utils.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/template-utils.tf
@@ -1,0 +1,17 @@
+module "hmpps_electronic_monitoring_data_insights_utils" {
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  force_rotate_token         = true
+  custom_token_rotation_date = "2026-03-20"
+
+  github_repo                   = "hmpps-electronic-monitoring-data-insights-utils"
+  application                   = "hmpps-electronic-monitoring-data-insights-utils"
+  github_team                   = "hmpps-em-probation-devs"
+  environment                   = var.environment
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "none"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/variables.tf
@@ -19,8 +19,8 @@ variable "eks_cluster_name" {
 
 variable "namespace-short" {
   description = "Short-form version of namespace name to get around string-length issues"
-  type = string
-  default = "hmpps-em-data-insights-dev"
+  type        = string
+  default     = "hmpps-em-data-insights-dev"
 }
 
 variable "business_unit" {
@@ -69,4 +69,3 @@ variable "github_token" {
   description = "Required by the GitHub Terraform provider"
   default     = ""
 }
-


### PR DESCRIPTION
## Summary

Adds Cloud Platform configuration so the `hmpps-electronic-monitoring-data-insights-utils` repository can deploy a pod into the EMDI development namespace and run Python utilities against the development Athena data.

This is currently limited to **development**. Pre-production and production access are not included.

## Changes

- Adds `hmpps-electronic-monitoring-data-insights-utils` as a repository managed by the EMDI development namespace.
- Creates the GitHub `dev` environment and Kubernetes deployment credentials for the utils repository.
- Adds the utils repository to the namespace source-code annotation.
- Configures the development Athena role:
  - `arn:aws:iam::800964199911:role/emdi_read_emds_data_dev`
- Allows the namespace IRSA role to assume the Athena data role.
- Stores the configured Athena role ARN in SSM and exposes it through the existing `athena-roles` Kubernetes secret.
- Removes the previous placeholder/manual SSM parameter update approach.
- Removes unnecessary `ssm:PutParameter` permission.

## Why

The EMDI data scientists need to run Python utilities against Athena data to verify analytical output.

Running the utilities inside Cloud Platform means:

- Athena is accessed from within the AWS infrastructure.
- Developers and data scientists do not need local AWS credentials.
- Access uses the namespace service account and an explicitly configured read-only Athena role.
- The same utilities can later be run as a controlled pod or Kubernetes Job.

The initial connectivity test confirmed that a pod in the development namespace can assume the development Athena role and successfully execute an Athena query.

## Testing

- Terraform formatting and validation completed successfully.
- Confirmed that the development namespace can assume `emdi_read_emds_data_dev`.
- Successfully executed `SELECT 1` against the development Athena workgroup from a pod running in the namespace.

