### PR TITLE
Allow postgres ingress from laa data factory test env

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-data-factory-uat/resources/security-group.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-data-claims-data-factory-uat/resources/security-group.tf
@@ -15,3 +15,13 @@ resource "aws_security_group" "rds" {
     create_before_destroy = true
   }
 }
+
+# Modernisation Platform: data-factory-laa-test
+resource "aws_security_group_rule" "rds_inbound" {
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  security_group_id = aws_security_group.rds.id
+  cidr_blocks       = ["10.26.96.0/21"]
+}


### PR DESCRIPTION
Allow LAA Data Factory test account/subnet to connect to RDS instance in the laa-data-claims-data-factory-uat.