### PR TITLE
SMTPS-12 money-to-prisoners-prod: match RDS engine version to AWS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-prod/resources/rds.tf
@@ -18,7 +18,7 @@ module "rds" {
 
   rds_family           = "postgres16"
   db_engine            = "postgres"
-  db_engine_version    = "16.8"
+  db_engine_version    = "16.13"
   db_instance_class    = "db.m6g.xlarge"
   db_allocated_storage = 200
   db_name              = "mtp_api"


### PR DESCRIPTION
AWS moved the prod instance to Postgres **16.13**, but this namespace still pinned **16.8**, so every apply proposed a downgrade and RDS rejected it:

```
Error: updating RDS DB Instance (cloud-platform-ad84929cdc3ee730):
api error InvalidParameterCombination: Cannot find upgrade path from 16.13 to 16.8
  with module.rds.aws_db_instance.rds
```

This has been blocking **all** applies to `money-to-prisoners-prod`, not just the one that surfaced it — most recently [build 23352](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/23352), the apply for #44209 (ECR retirement). That apply died during the RDS modify, so the ECR teardown in #44209 has **not** been applied yet; this unblocks it.

Note `allow_minor_version_upgrade = false` does not prevent this — AWS force-upgrades minor versions that reach end of standard support.

## Scope

One namespace, `money-to-prisoners-prod`, in one commit. Pinning the version AWS already runs is a no-op against the instance; it only stops terraform proposing an impossible downgrade.

Same fix as ccd5fe388dfd7a08d5981e209d08f16eab49164d, which moved 16.1 → 16.8 for the same reason in May 2025.

## Follow-ups

- `money-to-prisoners-deploy` generates this file, so its template is being bumped in parallel to stop regeneration reverting this.
- `money-to-prisoners-test` carries the same 16.8 pin and will need the same treatment if its instance was also bumped — separate PR, per the multi-namespace check.