### PR TITLE
SMTPS-12 Align money-to-prisoners-test RDS engine version with the instance

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/money-to-prisoners-test/resources/rds.tf
@@ -18,7 +18,7 @@ module "rds" {
 
   rds_family           = "postgres16"
   db_engine            = "postgres"
-  db_engine_version    = "16.8"
+  db_engine_version    = "16.13"
   db_instance_class    = "db.t4g.small"
   db_allocated_storage = 20
   db_name              = "mtp_api"


### PR DESCRIPTION
Namespace: `money-to-prisoners-test`

AWS has already moved this instance to **16.13**, but `rds.tf` still declares `16.8`.
Terraform therefore plans a downgrade, which RDS rejects:

```
InvalidParameterCombination: Cannot find upgrade path from 16.13 to 16.8
```

`money-to-prisoners-prod` hit exactly this in [build 23352](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/23352) and was fixed in #44633. `money-to-prisoners-test` has the identical drift and will fail the same way on the next apply that touches it — this is pre-emptive rather than a response to a red build.

### Verified, not assumed

Queried the running instance through the API pod in the namespace:

```
SHOW server_version -> 16.13
```

### Why this recurred

`allow_minor_version_upgrade = false` is set, which is easy to read as "this cannot happen".
It does not prevent RDS applying a **mandatory** minor upgrade once a version reaches the end of
standard support, so the configuration can drift away from the instance without anyone changing it.
Following the instance is the correct fix; expect this to need repeating.

### Scope

One namespace, one line, no other resources touched. `terraform plan` should show no change for this
attribute once applied.
