### PR TITLE
Chore update reviewer_teams on pre-sentence-service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/court-event-github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/court-probation-prod/resources/court-event-github.tf
@@ -51,7 +51,7 @@ module "pre-sentence-service" {
   namespace                     = var.namespace
   kubernetes_cluster            = var.kubernetes_cluster
   github_owner                  = var.github_owner
-  reviewer_teams                = ["probation-integration"]
+  reviewer_teams                = ["probation-in-court-live", "probation-in-court-devs", "probation-integration"]
 }
 
 module "prepare-a-case" {


### PR DESCRIPTION
The aim is to fix the restriction on Github Actions pipeline where it asks `probation-integration` team for approval to deploy instead of our team which maintain the product.

Key change:
- Chore update `reviewer_teams` on `pre-sentence-service`