### PR TITLE
Add custom domains for sop-derived-organogram dev and prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-dev/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-dev/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: moj-org-chart-dev-cert
+  namespace: sop-derived-organogram-dev
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - moj-org-chart-dev.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-dev/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "sop-derived-organogram-dev" {
+  name = "moj-org-chart-dev.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "sop-derived-organogram-dev_sec" {
+  metadata {
+    name      = "sop-derived-organogram-dev-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.sop-derived-organogram-dev.zone_id
+    nameservers = join("\n", aws_route53_zone.sop-derived-organogram-dev.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-prod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-prod/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: moj-org-chart-prod-cert
+  namespace: sop-derived-organogram-prod
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - moj-org-chart.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-prod/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "sop-derived-organogram-prod" {
+  name = "moj-org-chart.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "sop-derived-organogram-prod_sec" {
+  metadata {
+    name      = "sop-derived-organogram-prod-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.sop-derived-organogram-prod.zone_id
+    nameservers = join("\n", aws_route53_zone.sop-derived-organogram-prod.name_servers)
+  }
+}


### PR DESCRIPTION
## What

Adds Route53 hosted zones and cert-manager `Certificate`s to give the two organogram apps custom domains, following the `check-my-diary-prod` pattern.

| Env | Namespace | Custom domain |
|---|---|---|
| Prod | `sop-derived-organogram-prod` | `moj-org-chart.service.justice.gov.uk` |
| Dev | `sop-derived-organogram-dev` | `moj-org-chart-dev.service.justice.gov.uk` (sibling, not nested) |

### Files added
- `sop-derived-organogram-prod/resources/route53.tf` — hosted zone + `sop-derived-organogram-prod-zone-output` secret (zone_id + nameservers)
- `sop-derived-organogram-prod/05-certificate.yaml` — cert via `letsencrypt-production`
- `sop-derived-organogram-dev/resources/route53.tf` — hosted zone + `sop-derived-organogram-dev-zone-output` secret
- `sop-derived-organogram-dev/05-certificate.yaml` — cert via `letsencrypt-production`

## Follow-up (after merge/apply)
1. Retrieve the 4 nameservers per zone from the `*-zone-output` secrets.
2. Request NS delegation from the central `service.justice.gov.uk` zone via #ask-cloud-platform.
3. Add the custom host + `tls-certificate` secret to each app's Ingress in the deployment repo (external-dns creates the records).