### PR TITLE
Add custom domain for sop-derived-organogram-dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-dev/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-dev/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: moj-org-chart-dev-cert
+  namespace: sop-derived-organogram-dev
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - moj-org-chart-dev.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-dev/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "sop-derived-organogram-dev" {
+  name = "moj-org-chart-dev.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "sop-derived-organogram-dev_sec" {
+  metadata {
+    name      = "sop-derived-organogram-dev-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.sop-derived-organogram-dev.zone_id
+    nameservers = join("\n", aws_route53_zone.sop-derived-organogram-dev.name_servers)
+  }
+}


### PR DESCRIPTION
## What

Adds a Route53 hosted zone and cert-manager `Certificate` for the dev org-chart app, following the `check-my-diary-prod` pattern.

- Domain: `moj-org-chart-dev.service.justice.gov.uk` (sibling of prod, not nested)
- Namespace: `sop-derived-organogram-dev`

### Files
- `resources/route53.tf` — hosted zone + `sop-derived-organogram-dev-zone-output` secret (zone_id + nameservers)
- `05-certificate.yaml` — cert via `letsencrypt-production`

Prod equivalent is in a separate PR (one namespace per PR).

## Follow-up (after merge/apply)
1. Get the 4 nameservers from the `sop-derived-organogram-dev-zone-output` secret.
2. Request NS delegation from the central `service.justice.gov.uk` zone via #ask-cloud-platform.
3. Add the custom host + `tls-certificate` secret to the app's Ingress.