### PR TITLE
chore(env): add env to service account

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-fee-calculator-dev/resources/serviceaccount.tf
@@ -18,7 +18,7 @@ module "serviceaccount" {
   github_repositories = ["laa-fee-calculator"]
 
   # commenting next line out to see if its needed
-  # github_environments = ["dev"] 
+  github_environments = ["dev"] 
 
   github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
   github_actions_secret_kube_token     = var.github_actions_secret_kube_token


### PR DESCRIPTION
Add env to service account to (hopefully) trigger secret creations in the correct space