### PR TITLE
MEM-1136: add default-deny-all network policy to laa-info-and-advice-datastore-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-staging/04-networkpolicy.yaml
@@ -1,27 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default
+  name: default-deny-all
   namespace: laa-info-and-advice-datastore-staging
 spec:
   podSelector: {}
   policyTypes:
-  - Ingress
-  ingress:
-  - from:
-    - podSelector: {}
----
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: allow-ingress-controllers
-  namespace: laa-info-and-advice-datastore-staging
-spec:
-  podSelector: {}
-  policyTypes:
-  - Ingress
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          component: ingress-controllers
+    - Ingress
+    - Egress


### PR DESCRIPTION


Introduces a default-deny for all ingress and egress as the baseline before adding minimum-privilege allow rules via the app helm chart.