### PR TITLE
ESWE-1889 Disable ECR deletion protection in preprod prior to removing namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-person-on-probation-user-service-preprod/resources/ecr.tf
@@ -19,4 +19,6 @@ module "ecr" {
   namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
   environment_name       = var.environment
   infrastructure_support = var.infrastructure_support
+
+  deletion_protection = false
 }


### PR DESCRIPTION
Disabled deletion protection for ECR cluster in `hmpps-person-on-probation-user-service-preprod`