### PR TITLE
OV-862 : fix build failure

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-official-visits-dev/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-official-visits-dev/resources/rds-postgresql.tf
@@ -94,7 +94,7 @@ module "read_replica" {
   db_max_allocated_storage     = "500"
   enable_rds_auto_start_stop   = true # Dev database is stopped overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
-  prepare_for_major_upgrade = false
+  prepare_for_major_upgrade = true
 
   # PostgreSQL specifics
   db_engine         = "postgres"


### PR DESCRIPTION
Fixing the build failure
`Error: creating RDS DB Parameter Group (cloud-platform-44e7cfdcc6a98cdc): operation error RDS: CreateDBParameterGroup, https response error StatusCode: 400, RequestID: 9d91bda6-0021-4a7e-96e4-740114325fa5, DBParameterGroupAlreadyExists: Parameter group cloud-platform-44e7cfdcc6a98cdc already exists`
