### PR TITLE
Add private ECR for EMDI utils

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/00-namespace.yaml
@@ -13,5 +13,5 @@ metadata:
     cloud-platform.justice.gov.uk/slack-alert-channel: "hmpps_electronic_monitoring_data_insights_alerts_noprod"
     cloud-platform.justice.gov.uk/application: "Electronic Monitoring for probation officers"
     cloud-platform.justice.gov.uk/owner: "HMPPS Electronic Monitoring for Probation: john.asafo@justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-api,https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-ui,https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-utils"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-api,https://github.com/ministryofjustice/hmpps-electronic-monitoring-data-insights-ui"
     cloud-platform.justice.gov.uk/team-name: "hmpps-em-probation-devs"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/template-utils.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-dev/resources/template-utils.tf
@@ -1,10 +1,14 @@
+locals {
+  data_insights_utils_repo = "hmpps-electronic-monitoring-data-insights-utils"
+}
+
 module "hmpps_electronic_monitoring_data_insights_utils" {
   source                     = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
   force_rotate_token         = true
   custom_token_rotation_date = "2026-03-20"
 
-  github_repo                   = "hmpps-electronic-monitoring-data-insights-utils"
-  application                   = "hmpps-electronic-monitoring-data-insights-utils"
+  github_repo                   = local.data_insights_utils_repo
+  application                   = local.data_insights_utils_repo
   github_team                   = "hmpps-em-probation-devs"
   environment                   = var.environment
   selected_branch_patterns      = ["main"]
@@ -14,4 +18,21 @@ module "hmpps_electronic_monitoring_data_insights_utils" {
   github_token                  = var.github_token
   namespace                     = var.namespace
   kubernetes_cluster            = var.kubernetes_cluster
+}
+
+module "hmpps_electronic_monitoring_data_insights_utils_container_repository" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.2"
+
+  repo_name = local.data_insights_utils_repo
+
+  oidc_providers      = ["github"]
+  github_repositories = [local.data_insights_utils_repo]
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
 }


### PR DESCRIPTION
## Summary

- create a private ECR repository for hmpps-electronic-monitoring-data-insights-utils
- configure GitHub OIDC access so its workflow can publish images without long-lived AWS credentials
- remove the private utils repository from the namespace source-code annotation, which only accepts publicly accessible repositories

## Why

The utils repository and its container image should remain private. Kubernetes currently receives a 401 when it tries to pull the private GHCR image. This follows the established ECR approach used by the internal crime-matching algorithm repository.

## Deployment order

Merge and allow this Cloud Platform change to apply before merging the corresponding utils repository PR. The ECR repository and generated GitHub credentials must exist before the utils main workflow attempts to publish its image.

## Testing

- verified all inputs against cloud-platform-terraform-ecr-credentials v8.0.2
- checked the Terraform diff for whitespace errors
- compared the configuration with the existing crime-matching ECR setup