### PR TITLE
ESUP-2105 Add manage-online-check-ins UI origin to ESUP S3 CORS config

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/s3.tf
@@ -20,6 +20,7 @@ module "s3_data_bucket" {
       "https://esupervision-dev.hmpps.service.justice.gov.uk",
       "https://esupervision-test.hmpps.service.justice.gov.uk",
       "https://manage-people-on-probation-dev.hmpps.service.justice.gov.uk",
+      "https://manage-online-check-ins-ui-dev.hmpps.service.justice.gov.uk",
       "https://probation-check-in-dev.hmpps.service.justice.gov.uk",
       "https://probation-check-in-test.hmpps.service.justice.gov.uk",
       "http://localhost:3000"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-preprod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-preprod/resources/s3.tf
@@ -16,7 +16,7 @@ module "s3_data_bucket" {
     {
       allowed_headers = ["*"]
       allowed_methods = ["GET", "PUT"]
-      allowed_origins = ["https://esupervision-preprod.hmpps.service.justice.gov.uk","https://manage-people-on-probation-preprod.hmpps.service.justice.gov.uk","https://probation-check-in-preprod.hmpps.service.justice.gov.uk","http://localhost:3000"]
+      allowed_origins = ["https://esupervision-preprod.hmpps.service.justice.gov.uk","https://manage-people-on-probation-preprod.hmpps.service.justice.gov.uk","https://manage-online-check-ins-ui-preprod.hmpps.service.justice.gov.uk","https://probation-check-in-preprod.hmpps.service.justice.gov.uk","http://localhost:3000"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000
     }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/s3.tf
@@ -16,7 +16,7 @@ module "s3_data_bucket" {
     {
       allowed_headers = ["*"]
       allowed_methods = ["GET", "PUT"]
-      allowed_origins = ["https://esupervision.hmpps.service.justice.gov.uk","https://manage-people-on-probation.hmpps.service.justice.gov.uk","https://probation-check-in.hmpps.service.justice.gov.uk"]
+      allowed_origins = ["https://esupervision.hmpps.service.justice.gov.uk","https://manage-people-on-probation.hmpps.service.justice.gov.uk","https://manage-online-check-ins.hmpps.service.justice.gov.uk","https://probation-check-in.hmpps.service.justice.gov.uk"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000
     }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/resources/s3.tf
@@ -16,7 +16,7 @@ module "s3_data_bucket" {
     {
       allowed_headers = ["*"]
       allowed_methods = ["GET", "PUT"]
-      allowed_origins = ["https://esupervision-test.hmpps.service.justice.gov.uk","https://manage-people-on-probation-test.hmpps.service.justice.gov.uk","https://probation-check-in-test.hmpps.service.justice.gov.uk","http://localhost:3000"]
+      allowed_origins = ["https://esupervision-test.hmpps.service.justice.gov.uk","https://manage-people-on-probation-test.hmpps.service.justice.gov.uk","https://manage-online-check-ins-test.hmpps.service.justice.gov.uk","https://probation-check-in-test.hmpps.service.justice.gov.uk","http://localhost:3000"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000
     }


### PR DESCRIPTION
Photo upload PUT requests from the manage-online-check-ins-ui app were failing CORS preflight against the hmpps-esupervision S3 bucket because its origin was missing from allowed_origins. Adds it across dev, test, preprod and prod.