### PR TITLE
ESUP-2106 Add manage-online-check-ins UI origin to esupervision dev S…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-dev/resources/s3.tf
@@ -20,6 +20,7 @@ module "s3_data_bucket" {
       "https://esupervision-dev.hmpps.service.justice.gov.uk",
       "https://esupervision-test.hmpps.service.justice.gov.uk",
       "https://manage-people-on-probation-dev.hmpps.service.justice.gov.uk",
+      "https://manage-online-check-ins-ui-dev.hmpps.service.justice.gov.uk",
       "https://probation-check-in-dev.hmpps.service.justice.gov.uk",
       "https://probation-check-in-test.hmpps.service.justice.gov.uk",
       "http://localhost:3000"


### PR DESCRIPTION
…3 CORS config

Photo upload PUT requests from the manage-online-check-ins-ui app were failing CORS preflight against the hmpps-esupervision-dev S3 bucket because its origin was missing from allowed_origins.