### PR TITLE
ESUP-2107 Add manage-online-check-ins UI origin to esupervision test …

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-test/resources/s3.tf
@@ -16,7 +16,7 @@ module "s3_data_bucket" {
     {
       allowed_headers = ["*"]
       allowed_methods = ["GET", "PUT"]
-      allowed_origins = ["https://esupervision-test.hmpps.service.justice.gov.uk","https://manage-people-on-probation-test.hmpps.service.justice.gov.uk","https://probation-check-in-test.hmpps.service.justice.gov.uk","http://localhost:3000"]
+      allowed_origins = ["https://esupervision-test.hmpps.service.justice.gov.uk","https://manage-people-on-probation-test.hmpps.service.justice.gov.uk","https://manage-online-check-ins-test.hmpps.service.justice.gov.uk","https://probation-check-in-test.hmpps.service.justice.gov.uk","http://localhost:3000"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000
     }


### PR DESCRIPTION
…S3 CORS config

Photo upload PUT requests from the manage-online-check-ins-ui app were failing CORS preflight against the hmpps-esupervision-test S3 bucket because its origin was missing from allowed_origins.