### PR TITLE
ESUP-2109 Add manage-online-check-ins UI origin to esupervision prod …

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-esupervision-prod/resources/s3.tf
@@ -16,7 +16,7 @@ module "s3_data_bucket" {
     {
       allowed_headers = ["*"]
       allowed_methods = ["GET", "PUT"]
-      allowed_origins = ["https://esupervision.hmpps.service.justice.gov.uk","https://manage-people-on-probation.hmpps.service.justice.gov.uk","https://probation-check-in.hmpps.service.justice.gov.uk"]
+      allowed_origins = ["https://esupervision.hmpps.service.justice.gov.uk","https://manage-people-on-probation.hmpps.service.justice.gov.uk","https://manage-online-check-ins.hmpps.service.justice.gov.uk","https://probation-check-in.hmpps.service.justice.gov.uk"]
       expose_headers  = ["ETag"]
       max_age_seconds = 3000
     }


### PR DESCRIPTION
…S3 CORS config

Photo upload PUT requests from the manage-online-check-ins-ui app were failing CORS preflight against the hmpps-esupervision-prod S3 bucket because its origin was missing from allowed_origins.