### PR TITLE
MAPA-277: add change someones cell api ECR and RDS - preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/00-namespace.yaml
@@ -13,5 +13,5 @@ metadata:
     cloud-platform.justice.gov.uk/slack-alert-channel: "dps_alerts_non_prod"
     cloud-platform.justice.gov.uk/application: "HMPPS Prisoner cell allocation"
     cloud-platform.justice.gov.uk/owner: "moveaprisoner@digital.justice.gov.uk"
-    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-change-someones-cell.git"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-change-someones-cell.git,https://github.com/ministryofjustice/hmpps-change-someones-cell-api"
     cloud-platform.justice.gov.uk/team-name: "Move a Prisoner"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/00-namespace.yaml
@@ -14,4 +14,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Prisoner cell allocation"
     cloud-platform.justice.gov.uk/owner: "moveaprisoner@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-change-someones-cell.git,https://github.com/ministryofjustice/hmpps-change-someones-cell-api"
-    cloud-platform.justice.gov.uk/team-name: "Move a Prisoner"
+    cloud-platform.justice.gov.uk/team-name: "move-a-prisoner"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/06-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/06-certificate.yaml
@@ -11,3 +11,16 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - change-someones-cell-preprod.prison.service.justice.gov.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hmpps-change-someones-cell-api-cert
+  namespace: hmpps-prisoner-cell-allocation-preprod
+spec:
+  secretName: hmpps-change-someones-cell-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - change-someones-cell-api-preprod.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/github.tf
@@ -16,3 +16,22 @@ module "hmpps-change-someones-cell" {
   github_owner                  = var.github_owner
   reviewer_teams                = [var.github_deployment_team]
 }
+
+module "hmpps-change-someones-cell-api" {
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  force_rotate_token            = true
+  custom_token_rotation_date    = "2026-03-20"
+  github_repo                   = "hmpps-change-someones-cell-api"
+  application                   = "hmpps-change-someones-cell-api"
+  github_team                   = var.github_review_team
+  environment                   = var.deployment_environment
+  is_production                 = var.is_production
+  protected_branches_only       = true
+  application_insights_instance = var.deployment_environment
+  source_template_repo          = "hmpps-template-kotlin"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+  reviewer_teams                = [var.github_deployment_team]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/rds-postgresql.tf
@@ -1,0 +1,66 @@
+/*
+ * Postgres for hmpps-change-someones-cell-api, which takes over cell move orchestration from
+ * whereabouts-api. An RDS instance previously existed in this namespace for the retired
+ * hmpps-prisoner-cell-allocation-api and was removed in 14b0db32ab (MAP-1366); this largely
+ * restores it.
+ *
+ * Make sure that you use the latest version of the module by changing the `ref=` value in the
+ * `source` attribute to the latest version listed on the releases page of this repository.
+ */
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = false
+  db_max_allocated_storage     = "500"
+  enable_rds_auto_start_stop   = true
+
+  # PostgreSQL specifics
+  db_engine                 = "postgres"
+  db_engine_version         = "18"
+  rds_family                = "postgres18"
+  db_instance_class         = "db.t4g.micro"
+  prepare_for_major_upgrade = false
+
+  # Tags
+  application            = "hmpps-change-someones-cell-api"
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+}
+
+# Configmap to store non-sensitive data related to the RDS instance
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}


### PR DESCRIPTION
Adds the resources for a **second component** in this existing namespace: `hmpps-change-someones-cell-api`, a new Kotlin API that takes over cell move orchestration from `whereabouts-api`, which is being decommissioned.

The API deliberately **reuses the UI's namespace** rather than getting its own, since it is the same product (DPS059) and the same team.

Follows [#44922](https://github.com/ministryofjustice/cloud-platform-environments/pull/44922), which did dev. **That change is proven** — the API now deploys and reports healthy in dev, with Flyway having migrated the real RDS instance.

## Changes

- **`resources/github.tf`** — a second `cloud-platform-terraform-hmpps-template` module for `hmpps-change-someones-cell-api`, with `source_template_repo = "hmpps-template-kotlin"` and `reviewer_teams = [var.github_deployment_team]` to match the existing UI module in this environment. This provisions the GitHub Actions deploy environment and its `KUBE_*` secrets.
- **`resources/rds-postgresql.tf`** — Postgres 18 on `db.t4g.micro`, plus the `rds-postgresql-instance-output` secret and configmap. Modelled on the `hmpps-cell-sharing-risk-assessment` instances owned by the same team.
- **`00-namespace.yaml`** — appends the new repo to the `source-code` annotation, and fixes the `team-name` annotation (see below).
- **`06-certificate.yaml`** — certificate for the API hostname.

## The team-name fix

`annotation-check` resolves `cloud-platform.justice.gov.uk/team-name` against the GitHub API as a **team slug**, and this namespace had `"Move a Prisoner"` — a display name — so the lookup 404s.

This is **pre-existing** and unrelated to the new API; it surfaced because this is the first change to `00-namespace.yaml` since that check was added. Corrected to the `move-a-prisoner` slug, which exists and is what the `hmpps-cell-sharing-risk-assessment-*` namespaces already use. Same fix as merged for dev.

## Notes for review

An RDS instance existed in this namespace until [`14b0db32ab`](https://github.com/ministryofjustice/cloud-platform-environments/commit/14b0db32ab) ("MAP-1366 removing hmpps-prisoner-cell-allocation-api"), which removed it along with the retired API. This largely restores what that commit deleted.

Existing terraform formatting in `github.tf` is left as it was — it was already non-`fmt`-clean before this change.

Related: `ministryofjustice/hmpps-change-someones-cell-api`, JIRA MAPA-277 under epic MAPA-275.
