### PR TITLE
MAPB-763 Prepare prisoner property RDS for Datahub ingestion

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/prisoner-property-rds.tf
@@ -30,6 +30,38 @@ module "prisoner_property_rds" {
     aws = aws.london
   }
 
+  # Datahub ingestion (MAPB-763). rds.logical_replication and shared_preload_libraries are
+  # pending-reboot, so the instance must be rebooted after this applies before `show wal_level;`
+  # reports `logical` and the pglogical extension will install.
+  # https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
+
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-rds.tf
@@ -30,6 +30,38 @@ module "prisoner_property_rds" {
     aws = aws.london
   }
 
+  # Datahub ingestion (MAPB-763). rds.logical_replication and shared_preload_libraries are
+  # pending-reboot, so the instance must be rebooted after this applies before `show wal_level;`
+  # reports `logical` and the pglogical extension will install.
+  # https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
+
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 }
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
@@ -29,6 +29,114 @@ module "prisoner_property_rds" {
     aws = aws.london
   }
 
+  # Datahub ingestion (MAPB-763). rds.logical_replication and shared_preload_libraries are
+  # pending-reboot, so the instance must be rebooted after this applies before `show wal_level;`
+  # reports `logical` and the pglogical extension will install.
+  # https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
+
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+}
+
+# Read replica for Datahub ingestion (MAPB-763). Datahub's CDC capture reads from here rather than
+# the primary, so its reads cannot affect the operational database. Modelled on the dps_rds_replica
+# in this folder's rds.tf.
+#
+# hot_standby_feedback is required on a replica: without it the replica invalidates the replication
+# slot the DMS process consumes from.
+module "prisoner_property_rds_replica" {
+  count  = 1
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  vpc_name = var.vpc_name
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  # Must match the source instance
+  db_engine         = "postgres"
+  db_engine_version = "18"
+  rds_family        = "postgres18"
+  db_instance_class = "db.t4g.large"
+
+  # Conflicts with replicate_source_db, so must be null on a replica
+  db_name = null
+
+  replicate_source_db = module.prisoner_property_rds.db_identifier
+
+  # No backups or snapshots are taken of a read replica
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    },
+    {
+      name         = "hot_standby_feedback"
+      value        = "1"
+      apply_method = "immediate"
+    }
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 }
 
@@ -47,5 +155,21 @@ resource "kubernetes_secret" "prisoner_property_rds" {
     database_password     = module.prisoner_property_rds.database_password
     rds_instance_address  = module.prisoner_property_rds.rds_instance_address
     url                   = "postgres://${module.prisoner_property_rds.database_username}:${module.prisoner_property_rds.database_password}@${module.prisoner_property_rds.rds_instance_endpoint}/${module.prisoner_property_rds.database_name}"
+  }
+}
+
+# The replica's credentials and database name are the same as the primary, so only the endpoint is
+# published here. Datahub's DMS source endpoint points at this address.
+resource "kubernetes_secret" "prisoner_property_rds_replica" {
+  count = 1
+
+  metadata {
+    name      = "prisoner-property-rds-read-replica-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.prisoner_property_rds_replica[0].rds_instance_endpoint
+    rds_instance_address  = module.prisoner_property_rds_replica[0].rds_instance_address
   }
 }


### PR DESCRIPTION
Prepares the prisoner property databases for HMPPS Datahub ingestion, following
[Configure DPS RDS Service for Datahub Ingestion](https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352).

The property RDS instances live inside the `hmpps-locations-inside-prison-<env>` namespaces
(`resources/prisoner-property-rds.tf`) rather than namespaces of their own. One commit per namespace.

| Environment | Change |
| --- | --- |
| dev | Replication parameters on the primary |
| preprod | Replication parameters on the primary |
| prod | Replication parameters on the primary, **plus a read replica** for Datahub to ingest from |

Modelled on the `dps_rds` / `dps_rds_replica` pair already in each namespace's `rds.tf` — the locations
database went through this same onboarding, and this follows its conventions, including having a replica
in production only.

## Already in place

The Datahub security group (`cloudplatform-mp-dps-sg`) is attached to the property primary in all three
environments, and the engine is Postgres 18, which Datahub supports. So this PR is parameters and the
replica, not connectivity.

## Two things reviewers should know

**These instances need rebooting after the apply.** `rds.logical_replication` and
`shared_preload_libraries` are `pending-reboot`. Until the reboot, `show wal_level;` still reports
`replica` and `create extension pglogical;` fails — which is the most common cause of a stalled Datahub
onboarding.

**`hot_standby_feedback=1` on the replica is load-bearing, not tidiness.** Without it the replica
invalidates the logical replication slot the DMS process consumes from, and the ingestion fails with the
slot showing `wal_status = lost`.

## Production replica

`db.t4g.large`, matching the primary, so it can carry the same load. `db_name` is null (it conflicts
with `replicate_source_db`), no backups are taken of it, and only its endpoint is published as a
secret — credentials and database name are the primary's.

This is new production infrastructure and therefore new cost.

## Not in this PR

The `digital_prison_reporting` database user is created by hand per environment, not in terraform. It is
granted `pg_read_all_data` + `rds_replication` rather than `rds_superuser`, following
[Data Hub ingestion configuration amendments](https://dsdmoj.atlassian.net/wiki/spaces/moveandimprove/pages/6217335041).
The SQL is in the property repo's runbook.

## Testing

`terraform fmt -check` is clean on all three files. Not applied — the plan will run on this PR.