### PR TITLE
MAPB-763 Prepare prisoner property RDS for Datahub ingestion (dev)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/prisoner-property-rds.tf
@@ -30,6 +30,38 @@ module "prisoner_property_rds" {
     aws = aws.london
   }
 
+  # Datahub ingestion (MAPB-763). rds.logical_replication and shared_preload_libraries are
+  # pending-reboot, so the instance must be rebooted after this applies before `show wal_level;`
+  # reports `logical` and the pglogical extension will install.
+  # https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
+
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 }
 


### PR DESCRIPTION
Namespace: **hmpps-locations-inside-prison-dev**

One of three PRs for MAPB-763, split per namespace. **Merge order: this one, then preprod, then prod.**

- dev — this PR
- preprod — see the matching MAPB-763 PR
- prod — see the matching MAPB-763 PR (also adds a read replica)

## What this does

Adds the parameter group settings HMPPS Datahub's DMS process needs to the prisoner property database,
following [Configure DPS RDS Service for Datahub Ingestion](https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352).

The property RDS instance lives inside the `hmpps-locations-inside-prison-dev` namespace
(`resources/prisoner-property-rds.tf`) — property has no namespace of its own. Modelled on the
`dps_rds` instance already in this namespace's `rds.tf`, which went through the same onboarding.

## Already in place

The Datahub security group (`cloudplatform-mp-dps-sg`) is attached to this instance, and the engine is
Postgres 18, which Datahub supports. So this is the parameters only.

## After the apply

**The instance needs rebooting.** `rds.logical_replication` and `shared_preload_libraries` are
`pending-reboot` — until the reboot, `show wal_level;` still reports `replica` and
`create extension pglogical;` fails, which is the most common cause of a stalled Datahub onboarding.

There is no read replica in dev, so Datahub ingests from the primary here. That is what the guidance
asks for in environments without one, so connectivity can be tested before production.

`terraform fmt -check` clean.