### PR TITLE
MAPB-763 Prepare prisoner property RDS for Datahub ingestion (prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
@@ -29,6 +29,114 @@ module "prisoner_property_rds" {
     aws = aws.london
   }
 
+  # Datahub ingestion (MAPB-763). rds.logical_replication and shared_preload_libraries are
+  # pending-reboot, so the instance must be rebooted after this applies before `show wal_level;`
+  # reports `logical` and the pglogical extension will install.
+  # https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
+
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+}
+
+# Read replica for Datahub ingestion (MAPB-763). Datahub's CDC capture reads from here rather than
+# the primary, so its reads cannot affect the operational database. Modelled on the dps_rds_replica
+# in this folder's rds.tf.
+#
+# hot_standby_feedback is required on a replica: without it the replica invalidates the replication
+# slot the DMS process consumes from.
+module "prisoner_property_rds_replica" {
+  count  = 1
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  vpc_name = var.vpc_name
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  # Must match the source instance
+  db_engine         = "postgres"
+  db_engine_version = "18"
+  rds_family        = "postgres18"
+  db_instance_class = "db.t4g.large"
+
+  # Conflicts with replicate_source_db, so must be null on a replica
+  db_name = null
+
+  replicate_source_db = module.prisoner_property_rds.db_identifier
+
+  # No backups or snapshots are taken of a read replica
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    },
+    {
+      name         = "hot_standby_feedback"
+      value        = "1"
+      apply_method = "immediate"
+    }
+  ]
+
+  providers = {
+    aws = aws.london
+  }
+
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 }
 
@@ -47,5 +155,21 @@ resource "kubernetes_secret" "prisoner_property_rds" {
     database_password     = module.prisoner_property_rds.database_password
     rds_instance_address  = module.prisoner_property_rds.rds_instance_address
     url                   = "postgres://${module.prisoner_property_rds.database_username}:${module.prisoner_property_rds.database_password}@${module.prisoner_property_rds.rds_instance_endpoint}/${module.prisoner_property_rds.database_name}"
+  }
+}
+
+# The replica's credentials and database name are the same as the primary, so only the endpoint is
+# published here. Datahub's DMS source endpoint points at this address.
+resource "kubernetes_secret" "prisoner_property_rds_replica" {
+  count = 1
+
+  metadata {
+    name      = "prisoner-property-rds-read-replica-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.prisoner_property_rds_replica[0].rds_instance_endpoint
+    rds_instance_address  = module.prisoner_property_rds_replica[0].rds_instance_address
   }
 }


### PR DESCRIPTION
Namespace: **hmpps-locations-inside-prison-prod**

One of three PRs for MAPB-763, split per namespace. **Merge last**, after dev (#44930) and preprod (#44931).

This is the only one of the three that adds infrastructure.

## What this does

Two things, following [Configure DPS RDS Service for Datahub Ingestion](https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352):

1. The parameter group settings HMPPS Datahub's DMS process needs, on the primary.
2. **A read replica** for Datahub to ingest from, so its change-capture reads never touch the
   operational database.

The property RDS instance lives inside the `hmpps-locations-inside-prison-prod` namespace
(`resources/prisoner-property-rds.tf`) — property has no namespace of its own. The replica is modelled
on the `dps_rds_replica` already in this namespace's `rds.tf`, including having a replica in production
only.

## Two things reviewers should know

**The instances need rebooting after the apply.** `rds.logical_replication` and
`shared_preload_libraries` are `pending-reboot` — until the reboot, `show wal_level;` still reports
`replica` and `create extension pglogical;` fails, which is the most common cause of a stalled Datahub
onboarding.

**`hot_standby_feedback=1` on the replica is load-bearing, not tidiness.** Without it the replica
invalidates the logical replication slot the DMS process consumes from, and the ingestion fails with the
slot showing `wal_status = lost`.

## The replica

`db.t4g.large`, matching the primary so it can carry the same load. `db_name` is null (it conflicts with
`replicate_source_db`), no backups are taken of it, and only its endpoint is published as a secret —
credentials and database name are the primary's. It also carries the Datahub security group, since
Datahub connects here rather than to the primary.

**This is new production infrastructure and therefore new cost.**

## Not in this PR

The `digital_prison_reporting` database user is created by hand per environment, not in terraform. It is
granted `pg_read_all_data` + `rds_replication` rather than `rds_superuser`, following
[Data Hub ingestion configuration amendments](https://dsdmoj.atlassian.net/wiki/spaces/moveandimprove/pages/6217335041).
The procedure is in the property repo's runbook (ministryofjustice/hmpps-prisoner-property-api#92).

`terraform fmt -check` clean.