### PR TITLE
MAPB-763 Restore rds.force_ssl on the property database (dev)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-dev/resources/prisoner-property-rds.tf
@@ -36,6 +36,13 @@ module "prisoner_property_rds" {
   # https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352
   db_parameter = [
     {
+      # The module's db_parameter default is a single rds.force_ssl entry, and supplying our own list
+      # replaces it rather than merging - so this must be restated here or TLS stops being enforced.
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "immediate"
+    },
+    {
       name         = "rds.logical_replication"
       value        = "1"
       apply_method = "pending-reboot"


### PR DESCRIPTION
Namespace: **hmpps-locations-inside-prison-dev**. One of three, split per namespace.

**Restores `rds.force_ssl = 1`, which the Datahub parameter change removed without anyone asking it to.**

## What happened

The RDS module's `db_parameter` variable defaults to exactly one entry:

```hcl
default = [
  { name = "rds.force_ssl", value = "1", apply_method = "immediate" }
]
```

Supplying our own list **replaces** that default rather than merging with it. So MAPB-763, which added
the five Datahub replication parameters, silently dropped the setting that forces TLS on connections to
the property database. It shows in the production plan as:

```
- parameter {
    - name  = "rds.force_ssl" -> null
    - value = "1" -> null
  }
```

and that modification applied successfully, so the setting is currently off.

This PR restates the parameter alongside the Datahub ones, with a comment explaining why it has to be
there, so the next person adding a parameter does not remove it again.

## Worth knowing more widely

This is not unique to property — **149 of the 348 files in this repo that set `db_parameter` omit
`rds.force_ssl`**, including the `dps_rds` instance in this same namespace. Anyone who has ever added a
custom parameter has probably turned it off. Might be worth raising with Cloud Platform, either as a
merge rather than a replace in the module, or as a `conftest` rule in this repo.
