### PR TITLE
fix: change default name for secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cccd-dev/resources/variables.tf
@@ -73,26 +73,26 @@ variable "github_team" {
 
 variable "github_actions_secret_kube_cluster" {
   description = "The name of the github actions secret containing the kubernetes cluster name"
-  default     = "KUBE_CLUSTER_STAGING"
+  default     = "KUBE_CLUSTER_DEV"
   type        = string
 }
 
 variable "github_actions_secret_kube_namespace" {
   description = "The name of the github actions secret containing the kubernetes namespace name"
-  default     = "KUBE_NAMESPACE_STAGING"
+  default     = "KUBE_NAMESPACE_DEV"
   type        = string
 }
 
 variable "github_actions_secret_kube_cert" {
   description = "The name of the github actions secret containing the serviceaccount ca.crt"
-  default     = "KUBE_CERT_STAGING"
+  default     = "KUBE_CERT_DEV"
   type        = string
   sensitive   = true
 }
 
 variable "github_actions_secret_kube_token" {
   description = "The name of the github actions secret containing the serviceaccount token"
-  default     = "KUBE_TOKEN_STAGING"
+  default     = "KUBE_TOKEN_DEV"
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
amending so that each env gets correctly named variables