### PR TITLE
cis-prd: LGPAS-2182 replicating-cis-pp-namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "cis-prd"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "true"
+    cloud-platform.justice.gov.uk/environment-name: "production"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "LAA"
+    cloud-platform.justice.gov.uk/slack-channel: "cis-cloud-platform"
+    cloud-platform.justice.gov.uk/application: "Corporate Information System v2.0"
+    cloud-platform.justice.gov.uk/owner: "Payments: liam.rundle@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cis-modernisation"
+    cloud-platform.justice.gov.uk/team-name: "v1-cis-mod"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/01-rbac.yaml
@@ -1,0 +1,27 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cis-prd-admin
+  namespace: cis-prd
+subjects:
+  - kind: Group
+    name: "github:v1-cis-mod"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cis-prd-calico-np-access
+  namespace: cis-prd
+subjects:
+  - kind: Group
+    name: "github:v1-cis-mod"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: calico-network-policy-access
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: cis-prd
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: cis-prd
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/04-networkpolicy.yaml
@@ -1,0 +1,55 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: cis-prd
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress: []
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: cis-prd
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers
+# ---
+# kind: NetworkPolicy
+# apiVersion: projectcalico.org/v3
+# metadata:
+#   name: allow-egress-ip
+#   namespace: cis-prd
+# spec:
+#   order: 49.0
+#   selector: all()
+#   egress:
+#   - action: Allow
+#     destination:
+#       nets:
+#         - 172.20.0.0/16
+#         # live-1 vpc cidr
+#   types:
+#   - Egress
+# ---
+# apiVersion: projectcalico.org/v3
+# kind: NetworkPolicy
+# metadata:
+#   name: deny-egress-order
+#   namespace: cis-prd
+# spec:
+#   order: 50.0
+#   selector: all()
+#   egress:
+#   - action: Deny
+#   types:
+#   - Egress

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api.cis.service.justice.gov.uk
+  namespace: cis-prd
+spec:
+  secretName: cis-prd-api-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - api.cis.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/acm.tf
@@ -1,0 +1,34 @@
+resource "aws_acm_certificate" "frontend" {
+  count = var.use_custom_certificate ? 1 : 0
+
+  domain_name       = var.cloudfront_alias
+  validation_method = "DNS"
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-frontend-certificate"
+  })
+
+  provider = aws.virginia
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "frontend" {
+  count = var.use_custom_certificate ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.frontend[0].arn
+  validation_record_fqdns = aws_route53_record.cert_validations[*].fqdn
+
+  provider = aws.virginia
+
+  timeouts {
+    create = "10m"
+  }
+
+  depends_on = [
+    aws_acm_certificate.frontend,
+    aws_route53_record.cert_validations,
+  ]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/cloudfront.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/cloudfront.tf
@@ -1,0 +1,137 @@
+# -----------------------------------------------------------------------------
+# CloudFront Origin Access Control (us-east-1)
+# -----------------------------------------------------------------------------
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  provider = aws.virginia
+
+  name                              = "${var.environment}-frontend-oac"
+  description                       = "Origin Access Control for ${var.environment} frontend S3 bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# -----------------------------------------------------------------------------
+# CloudFront Distribution (global service, defined in us-east-1)
+# -----------------------------------------------------------------------------
+# checkov:skip=CKV2_AWS_42:Custom SSL certificate optional - using CloudFront default or provided ACM certificate
+# checkov:skip=CKV2_AWS_32:Response headers policy not required - security headers handled via WAF
+# checkov:skip=CKV2_AWS_47:WAF Log4j AMR configuration not required - WAF rules managed separately
+resource "aws_cloudfront_distribution" "frontend" {
+  #checkov:skip=CKV_AWS_310:Single S3 origin static frontend - origin failover not required
+  #checkov:skip=CKV_AWS_374:Geo restriction not required - access controlled via WAF IP allowlist
+  provider = aws.virginia
+
+  enabled             = true
+  comment             = "${var.environment} Frontend Distribution"
+  default_root_object = "index.html"
+  price_class         = var.cloudfront_price_class
+  web_acl_id          = aws_wafv2_web_acl.frontend.arn
+
+  # Custom domain aliases - required for CloudFront to respond to custom domain
+  aliases = var.use_custom_certificate ? [var.cloudfront_alias] : []
+
+  # Access logging configuration (S3)
+  # Logs include geo-location blocks and all request details
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cloudfront_logs.bucket_regional_domain_name
+    prefix          = "cloudfront/"
+  }
+
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = "${var.environment}-s3-origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.environment}-s3-origin"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 0
+    default_ttl            = 0 # Don't cache by default - let S3 metadata control caching
+    max_ttl                = 86400
+    compress               = true
+  }
+
+  # Cache behavior for static assets (/_next/static/) - long cache
+  ordered_cache_behavior {
+    path_pattern     = "/_next/static/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.environment}-s3-origin"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 31536000 # 1 year - static files are hashed
+    default_ttl            = 31536000
+    max_ttl                = 31536000
+    compress               = true
+  }
+
+  # Custom error responses for SPA routing
+  # Returns index.html for 403/404 errors, allowing client-side routing to handle paths
+  # Short cache to ensure route changes are picked up quickly
+  # custom_error_response {
+  #   error_code            = 403
+  #   response_code         = 200
+  #   response_page_path    = "/index.html"
+  #   error_caching_min_ttl = 0
+  # }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = var.geo_restriction_type
+      locations        = var.geo_restriction_locations
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = var.use_custom_certificate ? false : (var.acm_certificate_arn == "" ? true : false)
+    acm_certificate_arn            = var.use_custom_certificate ? aws_acm_certificate.frontend[0].arn : (var.acm_certificate_arn != "" ? var.acm_certificate_arn : null)
+    ssl_support_method             = var.use_custom_certificate || var.acm_certificate_arn != "" ? "sni-only" : null
+    minimum_protocol_version       = var.use_custom_certificate || var.acm_certificate_arn != "" ? "TLSv1.2_2021" : null
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-frontend-distribution"
+  })
+
+  depends_on = [aws_acm_certificate_validation.frontend]
+}
+
+resource "kubernetes_secret" "cloudfront_output" {
+  metadata {
+    name      = "cloudfront-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    cloudfront_alias           = var.cloudfront_alias
+    cloudfront_url             = aws_cloudfront_distribution.frontend.domain_name
+    cloudfront_distribution_id = aws_cloudfront_distribution.frontend.id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/cognito.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/cognito.tf
@@ -172,7 +172,7 @@ resource "kubernetes_secret" "cognito_user_pool_client" {
 }
 
 data "aws_secretsmanager_secret" "cognito_test_user" {
-  name = module.cis_pp_entra_prod_external_client_secret.secret_names["cis-prd-cognito-test-user-secret"]
+  name = module.cis_prd_entra_prod_external_client_secret.secret_names["cis-prd-cognito-test-user-secret"]
 }
 
 data "aws_secretsmanager_secret_version" "cognito_test_user" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/cognito.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/cognito.tf
@@ -1,0 +1,240 @@
+# =============================================================================
+# Auth Module - Cognito User Pool & Amplify
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Cognito User Pool
+# -----------------------------------------------------------------------------
+resource "aws_cognito_user_pool" "main" {
+  name           = var.user_pool_name
+  user_pool_tier = "PLUS"
+  # User pool add-ons
+  user_pool_add_ons {
+    advanced_security_mode = "ENFORCED"
+  }
+
+  # Account recovery
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  # Password policy
+  password_policy {
+    minimum_length                   = var.password_minimum_length
+    require_lowercase                = var.password_require_lowercase
+    require_uppercase                = var.password_require_uppercase
+    require_numbers                  = var.password_require_numbers
+    require_symbols                  = var.password_require_symbols
+    temporary_password_validity_days = var.temporary_password_validity_days
+  }
+
+  # Passwordless sign-in policy
+  sign_in_policy {
+    allowed_first_auth_factors = var.allowed_auth_factors
+  }
+
+  # User attribute configuration
+  auto_verified_attributes = ["email"]
+  username_attributes      = ["email"]
+
+  # Email configuration — SES DEVELOPER mode removes the 50 emails/day limit
+  email_configuration {
+    email_sending_account = "COGNITO_DEFAULT"
+    #source_arn            = aws_sesv2_email_identity.main.arn
+    #from_email_address    = "noreply@${var.ses_domain}"
+  }
+
+  # Schema attributes
+  schema {
+    name                = "email"
+    attribute_data_type = "String"
+    required            = true
+    mutable             = true
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 256
+    }
+  }
+
+  schema {
+    name                     = "name"
+    attribute_data_type      = "String"
+    required                 = false
+    mutable                  = true
+    developer_only_attribute = false
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 256
+    }
+  }
+
+  # Custom attribute: cis-role (mandatory for role-based access control)
+  schema {
+    name                     = "cis-role"
+    attribute_data_type      = "String"
+    required                 = false # Custom attributes cannot be required at pool level
+    mutable                  = true
+    developer_only_attribute = false
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 256
+    }
+  }
+
+  # MFA configuration
+  mfa_configuration = var.mfa_configuration
+
+  dynamic "software_token_mfa_configuration" {
+    for_each = var.mfa_configuration != "OFF" ? [1] : []
+    content {
+      enabled = true
+    }
+  }
+
+  # Admin create user config
+  admin_create_user_config {
+    allow_admin_create_user_only = var.allow_admin_create_user_only
+
+    invite_message_template {
+      email_subject = "Your ${var.environment} CIS account"
+      email_message = "Your username is {username} and temporary password is {####}."
+      sms_message   = "Your username is {username} and temporary password is {####}."
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cognito User Pool Domain
+# -----------------------------------------------------------------------------
+resource "aws_cognito_user_pool_domain" "main" {
+  domain       = var.cognito_domain
+  user_pool_id = aws_cognito_user_pool.main.id
+}
+
+# -----------------------------------------------------------------------------
+# Cognito User Pool Client
+# -----------------------------------------------------------------------------
+resource "aws_cognito_user_pool_client" "main" {
+  name         = "${var.environment}-app-client"
+  user_pool_id = aws_cognito_user_pool.main.id
+
+  generate_secret = false
+
+  explicit_auth_flows = [
+    "ALLOW_USER_AUTH", # Required for passwordless (email OTP, passkeys)
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH"
+  ]
+
+  supported_identity_providers = ["EntraID"]
+
+  callback_urls = var.callback_urls
+  logout_urls   = var.logout_urls
+
+  allowed_oauth_flows                  = ["code", "implicit"]
+  allowed_oauth_scopes                 = ["email", "openid", "profile"]
+  allowed_oauth_flows_user_pool_client = true
+
+  prevent_user_existence_errors = "ENABLED"
+
+  # Attribute permissions - allow read/write of custom attributes
+  read_attributes  = ["email", "name", "custom:cis-role"]
+  write_attributes = ["email", "name", "custom:cis-role"]
+
+  access_token_validity  = var.access_token_validity
+  id_token_validity      = var.id_token_validity
+  refresh_token_validity = var.refresh_token_validity
+
+  token_validity_units {
+    access_token  = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
+  }
+
+  depends_on = [aws_cognito_identity_provider.entra]
+}
+
+resource "kubernetes_secret" "cognito_user_pool_client" {
+  metadata {
+    name      = "${var.namespace}-cognito-user-pool-client"
+    namespace = var.namespace
+  }
+  data = {
+    client_id     = aws_cognito_user_pool_client.main.id
+    client_secret = aws_cognito_user_pool_client.main.client_secret
+  }
+}
+
+data "aws_secretsmanager_secret" "cognito_test_user" {
+  name = module.cis_pp_entra_prod_external_client_secret.secret_names["cis-prd-cognito-test-user-secret"]
+}
+
+data "aws_secretsmanager_secret_version" "cognito_test_user" {
+  secret_id = data.aws_secretsmanager_secret.cognito_test_user.id
+}
+
+resource "aws_cognito_user" "test" {
+  user_pool_id = aws_cognito_user_pool.main.id
+  username     = "ollie.evanstest@justice.gov.uk"
+
+  attributes = {
+    cis-role       = "CIS - Viewer"
+    email          = "ollie.evanstest@justice.gov.uk"
+    email_verified = "true"
+  }
+
+  password       = jsondecode(data.aws_secretsmanager_secret_version.cognito_test_user.secret_string)["CIS_PRD_COGNITO_TEST_USER_PASS"]
+  message_action = "SUPPRESS"
+}
+
+# -----------------------------------------------------------------------------
+# Entra ID (OIDC) Identity Provider
+# -----------------------------------------------------------------------------
+data "aws_secretsmanager_secret" "entra_prod_external_client_id" {
+  name = module.cis_prd_entra_prod_external_client_secret.secret_names["cis-prd-entra-prod-external-client-id"]
+}
+
+data "aws_secretsmanager_secret_version" "entra_prod_external_client_id" {
+  secret_id = data.aws_secretsmanager_secret.entra_prod_external_client_id.id
+}
+
+data "aws_secretsmanager_secret" "entra_prod_external_client_secret" {
+  name = module.cis_prd_entra_prod_external_client_secret.secret_names["cis-prd-entra-prod-external-client-secret"]
+}
+
+data "aws_secretsmanager_secret_version" "entra_prod_external_client_secret" {
+  secret_id = data.aws_secretsmanager_secret.entra_prod_external_client_secret.id
+}
+
+data "aws_secretsmanager_secret" "entra_prod_external_tenant_id" {
+  name = module.cis_prd_entra_prod_external_client_secret.secret_names["cis-prd-entra-prod-external-tenant-id"]
+}
+
+data "aws_secretsmanager_secret_version" "entra_prod_external_tenant_id" {
+  secret_id = data.aws_secretsmanager_secret.entra_prod_external_tenant_id.id
+}
+
+resource "aws_cognito_identity_provider" "entra" {
+  user_pool_id  = aws_cognito_user_pool.main.id
+  provider_name = "EntraID"
+  provider_type = "OIDC"
+
+  provider_details = {
+    client_id                 = jsondecode(data.aws_secretsmanager_secret_version.entra_prod_external_client_id.secret_string)["CIS_PRD_ENTRA_PROD_EXTERNAL_CLIENT_ID"]
+    client_secret             = jsondecode(data.aws_secretsmanager_secret_version.entra_prod_external_client_secret.secret_string)["CIS_PRD_ENTRA_PROD_EXTERNAL_CLIENT_SECRET"]
+    authorize_scopes          = "openid email profile"
+    attributes_request_method = "GET"
+    oidc_issuer               = "https://login.microsoftonline.com/${jsondecode(data.aws_secretsmanager_secret_version.entra_prod_external_tenant_id.secret_string)["CIS_PRD_ENTRA_PROD_EXTERNAL_TENANT_ID"]}/v2.0"
+  }
+
+  attribute_mapping = {
+    email             = "USER_EMAIL"
+    "custom:cis-role" = "LAA_APP_ROLES"
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/ecr.tf
@@ -1,0 +1,30 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "ecr" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.1"
+
+  # Repository configuration
+  repo_name = var.namespace
+
+  # OpenID Connect configuration
+  oidc_providers      = ["github"]
+  github_repositories = [var.github_repository]
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name # also used for naming the container repository
+  namespace              = var.namespace # also used for creating a Kubernetes ConfigMap
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for read only queries,
+  # uncomment below:
+
+  #enable_irsa = true
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/ecr.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=8.0.2"
 
   # Repository configuration
   repo_name = var.namespace

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/iam.tf
@@ -1,0 +1,145 @@
+resource "aws_iam_policy" "frontend_s3_deploy" {
+  name        = "${var.namespace}-frontend-s3-deploy"
+  description = "Allow CI to sync static assets to the ${var.namespace} frontend S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ListFrontendBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = aws_s3_bucket.frontend.arn
+      },
+      {
+        Sid    = "ManageFrontendObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "frontend_cloudfront_invalidate" {
+  name        = "${var.namespace}-frontend-cloudfront-invalidate"
+  description = "Allow CI to invalidate the ${var.namespace} CloudFront distribution after deploy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "InvalidateFrontendDistribution"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:GetDistribution",
+          "cloudfront:ListDistributions",
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation",
+          "cloudfront:ListInvalidations",
+        ]
+        Resource = aws_cloudfront_distribution.frontend.arn
+      },
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# GitHub OIDC Role
+#
+# Allows GitHub Actions to assume an IAM role via OIDC to deploy the frontend application.
+#
+# Modified from the terraform-aws-modules/iam/aws//modules/iam-github-oidc-role module to allow for more flexible
+# configuration of the trust policy, as the module does not currently support the `job_workflow_ref` condition
+# key which is used to restrict access to specific workflow(s) on specific branch(es)
+#
+# References:
+# https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-with-reusable-workflows
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html#condition-keys-wif
+# https://registry.terraform.io/modules/terraform-aws-modules/iam/aws/5.9.2/submodules/iam-github-oidc-role 
+# -----------------------------------------------------------------------------
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Just extra safety incase someone passes in a url with `https://`
+  provider_url = replace(var.oidc_role_provider_url, "https://", "")
+  account_id   = data.aws_caller_identity.current.account_id
+  partition    = data.aws_partition.current.partition
+}
+
+data "aws_iam_policy_document" "github_oidc_policy" {
+  statement {
+    sid    = "GithubOidcAuth"
+    effect = "Allow"
+    actions = [
+      "sts:TagSession",
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:${local.partition}:iam::${local.account_id}:oidc-provider/${local.provider_url}"]
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "${local.provider_url}:iss"
+      values   = ["https://${local.provider_url}"]
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "${local.provider_url}:aud"
+      values   = [var.oidc_role_audience]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.provider_url}:sub"
+      values   = ["repo:ministryofjustice/${var.github_repository}:environment:${var.environment}"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.provider_url}:job_workflow_ref"
+      values   = ["ministryofjustice/${var.github_repository}/${var.oidc_role_workflow_file}@refs/heads/${var.oidc_role_workflow_branch}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_oidc_iam_role" {
+  name_prefix = "${var.namespace}-github-oidc"
+  path        = var.oidc_role_path
+
+  assume_role_policy    = data.aws_iam_policy_document.github_oidc_policy.json
+  force_detach_policies = var.oidc_role_force_detach_policies
+}
+
+resource "aws_iam_role_policy_attachment" "github_oidc_policy_attach_s3" {
+  role       = aws_iam_role.github_oidc_iam_role.name
+  policy_arn = aws_iam_policy.frontend_s3_deploy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "github_oidc_policy_attach_cloudfront" {
+  role       = aws_iam_role.github_oidc_iam_role.name
+  policy_arn = aws_iam_policy.frontend_cloudfront_invalidate.arn
+}
+
+resource "kubernetes_secret" "github_oidc_iam_role" {
+  metadata {
+    name      = "github-oidc-iam-role"
+    namespace = var.namespace
+  }
+
+  data = {
+    role_arn = aws_iam_role.github_oidc_iam_role.arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/iam.tf
@@ -77,8 +77,8 @@ locals {
 
 data "aws_iam_policy_document" "github_oidc_policy" {
   statement {
-    sid    = "GithubOidcAuth"
-    effect = "Allow"
+    sid     = "GithubOidcAuth"
+    effect  = "Allow"
     actions = [
       "sts:TagSession",
       "sts:AssumeRoleWithWebIdentity"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/iam.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/iam.tf
@@ -77,8 +77,8 @@ locals {
 
 data "aws_iam_policy_document" "github_oidc_policy" {
   statement {
-    sid     = "GithubOidcAuth"
-    effect  = "Allow"
+    sid    = "GithubOidcAuth"
+    effect = "Allow"
     actions = [
       "sts:TagSession",
       "sts:AssumeRoleWithWebIdentity"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/irsa.tf
@@ -1,0 +1,32 @@
+module "irsa" {
+  #checkov:skip=CKV_TF_1:Cloud Platform modules use version tags not commit hashes
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  service_account_name = "${var.namespace}-frontend"
+  namespace            = var.namespace
+
+  role_policy_arns = {
+    s3         = aws_iam_policy.frontend_s3_deploy.arn
+    cloudfront = aws_iam_policy.frontend_cloudfront_invalidate.arn
+  }
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "irsa" {
+  metadata {
+    name      = "${var.namespace}-irsa"
+    namespace = var.namespace
+  }
+  data = {
+    role           = module.irsa.role_name
+    serviceaccount = module.irsa.service_account.name
+    rolearn        = module.irsa.role_arn
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
+    }
+  }
+}
+
+provider "aws" {
+  alias = "virginia"
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+      GithubTeam    = var.team_name
+    }
+  }
+  region = "us-east-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/rds.tf
@@ -1,0 +1,44 @@
+module "rds_instance" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # Database configuration
+  db_engine                = "oracle-se2"
+  db_engine_version        = "19"
+  rds_family               = "oracle-se2-19"
+  db_instance_class        = "db.t3.small"
+  db_allocated_storage     = "100"
+  rds_name                 = "cis-rds-prd"
+  db_name                  = "CIS"
+  license_model            = "license-included"
+  
+  # Avoid default parameters set by MOJ
+  db_parameter = []
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "cis-rds-details"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds_instance.rds_instance_endpoint
+    database_name         = module.rds_instance.database_name
+    database_username     = module.rds_instance.database_username
+    database_password     = module.rds_instance.database_password
+    database_address      = module.rds_instance.rds_instance_address
+    database_port         = module.rds_instance.rds_instance_port
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/route53.tf
@@ -1,0 +1,54 @@
+resource "aws_route53_zone" "cis-prd" {
+  name = "cis.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "cis-prd_route53_zone" {
+  metadata {
+    name      = "cis-prd-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id      = aws_route53_zone.cis-prd.zone_id
+    name_servers = join("\n", aws_route53_zone.cis-prd.name_servers)
+  }
+}
+
+resource "aws_route53_record" "frontend" {
+  count = var.use_custom_certificate ? 1 : 0
+
+  zone_id = aws_route53_zone.cis-prd.zone_id
+  name    = var.cloudfront_alias
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.frontend.domain_name
+    zone_id                = aws_cloudfront_distribution.frontend.hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  depends_on = [aws_acm_certificate_validation.frontend]
+}
+
+resource "aws_route53_record" "cert_validations" {
+  count = var.use_custom_certificate ? length(aws_acm_certificate.frontend[0].domain_validation_options) : 0
+
+  zone_id = aws_route53_zone.cis-prd.zone_id
+  name    = element(aws_acm_certificate.frontend[0].domain_validation_options[*].resource_record_name, count.index)
+  type    = element(aws_acm_certificate.frontend[0].domain_validation_options[*].resource_record_type, count.index)
+  records = [element(aws_acm_certificate.frontend[0].domain_validation_options[*].resource_record_value, count.index)]
+  ttl     = 60
+
+  allow_overwrite = true
+}
+

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/s3.tf
@@ -1,0 +1,205 @@
+
+# -----------------------------------------------------------------------------
+# S3 Bucket for Static Website Hosting (regional)
+# -----------------------------------------------------------------------------
+# checkov:skip=CKV_AWS_145:KMS encryption not required - using AES256 server-side encryption
+# checkov:skip=CKV_AWS_18:Access logging not required - CloudFront provides access logs
+# checkov:skip=CKV2_AWS_62:Event notifications not required for static website bucket
+# checkov:skip=CKV2_AWS_61:Lifecycle configuration not required - versioning handles retention
+# checkov:skip=CKV_AWS_144:Cross-region replication not required for non-production environments
+resource "aws_s3_bucket" "frontend" {
+  bucket = var.s3_bucket_name
+
+  tags = merge(var.tags, {
+    Name = var.s3_bucket_name
+  })
+}
+
+resource "aws_s3_bucket_versioning" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# -----------------------------------------------------------------------------
+# S3 Bucket Policy for CloudFront Access
+# -----------------------------------------------------------------------------
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontServicePrincipal"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# S3 Bucket for CloudFront Access Logs
+# -----------------------------------------------------------------------------
+# checkov:skip=CKV_AWS_145:KMS encryption not required - using AES256 server-side encryption for logs
+# checkov:skip=CKV_AWS_18:Access logging not required for CloudFront logs bucket
+# checkov:skip=CKV2_AWS_62:Event notifications not required for CloudFront logs bucket
+# checkov:skip=CKV_AWS_144:Cross-region replication not required for log buckets
+resource "aws_s3_bucket" "cloudfront_logs" {
+  bucket = "${var.s3_bucket_name}-cloudfront-logs"
+
+  tags = merge(var.tags, {
+    Name = "${var.s3_bucket_name}-cloudfront-logs"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# CloudFront requires ACLs to be enabled for log delivery
+# checkov:skip=CKV2_AWS_65:ACLs required for CloudFront log delivery - ownership controls configured
+resource "aws_s3_bucket_ownership_controls" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+  acl    = "log-delivery-write"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.cloudfront_logs,
+    aws_s3_bucket_public_access_block.cloudfront_logs,
+  ]
+}
+
+resource "aws_s3_bucket_policy" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontLogDelivery"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.cloudfront_logs.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      },
+      {
+        Sid    = "AllowCloudFrontLogDeliveryAclCheck"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = aws_s3_bucket.cloudfront_logs.arn
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      },
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.cloudfront_logs]
+}
+
+resource "kubernetes_secret" "s3_bucket_output" {
+  metadata {
+    name      = "s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = aws_s3_bucket.frontend.arn
+    bucket_name = aws_s3_bucket.frontend.id
+  }
+}
+
+# Lifecycle policy to expire old logs (30 days by default)
+resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_logs" {
+  #checkov:skip=CKV_AWS_300:CloudFront log delivery does not use multipart uploads
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  rule {
+    id     = "expire-old-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "" # Apply to all objects
+    }
+
+    expiration {
+      days = var.cloudfront_log_retention_days
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/secrets.tf
@@ -1,0 +1,39 @@
+module "cis_prd_entra_prod_external_client_secret" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+
+  # EKS configuration
+  eks_cluster_name = var.eks_cluster_name
+
+  # Secrets configuration
+  secrets = {
+    "cis-prd-entra-prod-external-client-secret" = {
+      description             = "CIS PRD Entra Prod External Client Secret" # required
+      recovery_window_in_days = 7                                          # required
+      k8s_secret_name         = "cis-prd-entra-prod-external-client-secret" # the name of the secret in k8s
+    },
+    "cis-prd-entra-prod-external-client-id" = {
+      description             = "CIS PRD Entra Prod External Client ID" # required
+      recovery_window_in_days = 7                                      # required
+      k8s_secret_name         = "cis-prd-entra-prod-external-client-id" # the name of the secret in k8s
+    },
+    "cis-prd-entra-prod-external-tenant-id" = {
+      description             = "CIS PRD Entra Prod External Tenant ID" # required
+      recovery_window_in_days = 7                                      # required
+      k8s_secret_name         = "cis-prd-entra-prod-external-tenant-id" # the name of the secret in k8s
+    },
+    "cis-prd-cognito-test-user-secret" = {
+      description             = "CIS PRD Cognito Test User Secret" # required
+      recovery_window_in_days = 7                                 # required
+      k8s_secret_name         = "cis-prd-cognito-test-user-secret" # the name of the secret in k8s
+    }
+  }
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/serviceaccount.tf
@@ -1,0 +1,17 @@
+module "serviceaccount" {
+  #checkov:skip=CKV_TF_1:Cloud Platform modules use version tags not commit hashes
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace          = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  github_repositories = [var.github_repository]
+  github_environments = [var.github_environment]
+
+  github_actions_secret_kube_cert      = var.github_actions_secret_kube_cert
+  github_actions_secret_kube_token     = var.github_actions_secret_kube_token
+  github_actions_secret_kube_cluster   = var.github_actions_secret_kube_cluster
+  github_actions_secret_kube_namespace = var.github_actions_secret_kube_namespace
+
+  serviceaccount_token_rotated_date = "11-06-2026"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/variables.tf
@@ -1,0 +1,339 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "eks_cluster_name" {
+  description = "The name of the EKS cluster to retrieve OIDC information for IRSA"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Corporate Information System v2.0"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "cis-prd"
+}
+
+variable "service_area" {
+  description = "Service area responsible for this service"
+  type        = string
+  default     = "Hosting"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "LAA"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "v1-cis-mod"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "production"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "liam.rundle@justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "true"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "cis-cloud-platform"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+
+variable "github_repository" {
+  description = "GitHub repository name for frontend CI/CD deploy credentials"
+  type        = string
+  default     = "cis-modernisation"
+}
+
+variable "github_environment" {
+  description = "GitHub environment name for deploy secrets"
+  type        = string
+  default     = "production"
+}
+
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the kubernetes cluster name"
+  type        = string
+  default     = "KUBE_CLUSTER"
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  type        = string
+  default     = "KUBE_NAMESPACE"
+}
+
+variable "github_actions_secret_kube_cert" {
+  description = "The name of the github actions secret containing the serviceaccount ca.crt"
+  type        = string
+  default     = "KUBE_CERT"
+}
+
+variable "github_actions_secret_kube_token" {
+  description = "The name of the github actions secret containing the serviceaccount token"
+  type        = string
+  default     = "KUBE_TOKEN"
+}
+
+# =============================================================================
+# Frontend Module Variables
+# =============================================================================
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket for frontend hosting"
+  type        = string
+  default     = "moj-laa-cis-prd-frontend"
+}
+
+variable "waf_allowed_ips" {
+  description = "List of allowed IP addresses in CIDR notation for WAF IP set. Leave empty for public access with managed WAF rules only."
+  type        = list(string)
+  default = [
+    "35.176.93.186/32",
+    "18.169.147.172/32",
+    "18.130.148.126/32", # Gateway IP for Global Protect alpha VPN firewall
+    "35.176.148.126/32",
+    "128.77.75.64/26", # Prisma egress
+    "51.149.249.0/29", # MOJ public egress
+    "194.33.249.0/29",
+    "51.149.249.32/29",
+    "194.33.248.0/29",
+    "128.77.75.128/26",
+    "128.77.75.0/26",
+  ]
+}
+
+variable "cloudfront_price_class" {
+  description = "CloudFront distribution price class"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of ACM certificate for custom domain (leave empty for CloudFront default) - DEPRECATED: use use_custom_certificate instead"
+  type        = string
+  default     = ""
+}
+
+variable "use_custom_certificate" {
+  description = "Enable ACM certificate and custom domain for CloudFront"
+  type        = bool
+  default     = true
+}
+
+variable "cloudfront_alias" {
+  description = "Primary custom domain for the CloudFront distribution"
+  type        = string
+  default     = "cis.service.justice.gov.uk"
+}
+
+variable "geo_restriction_type" {
+  description = "Type of geo restriction (none, whitelist, blacklist)"
+  type        = string
+  default     = "whitelist"
+}
+
+variable "geo_restriction_locations" {
+  description = "List of country codes for geo restriction"
+  type        = list(string)
+  default     = ["GB"]
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# CloudFront Logging Variables
+# -----------------------------------------------------------------------------
+variable "cloudfront_log_retention_days" {
+  description = "Number of days to retain CloudFront access logs"
+  type        = number
+  default     = 30
+}
+
+variable "waf_log_retention_days" {
+  description = "Number of days to retain WAF CloudWatch logs"
+  type        = number
+  default     = 30
+}
+
+# -----------------------------------------------------------------------------
+# Cognito User Pool Variables
+# -----------------------------------------------------------------------------
+variable "user_pool_name" {
+  description = "Name of the Cognito User Pool"
+  type        = string
+  default     = "cis-prd-user-pool"
+}
+
+variable "cognito_domain" {
+  description = "Domain prefix for the Cognito hosted UI"
+  type        = string
+  default     = "cis-prd-auth"
+}
+
+variable "password_minimum_length" {
+  description = "Minimum password length"
+  type        = number
+  default     = 12
+}
+
+variable "password_require_lowercase" {
+  description = "Require lowercase characters in password"
+  type        = bool
+  default     = true
+}
+
+variable "password_require_uppercase" {
+  description = "Require uppercase characters in password"
+  type        = bool
+  default     = true
+}
+
+variable "password_require_numbers" {
+  description = "Require numbers in password"
+  type        = bool
+  default     = true
+}
+
+variable "password_require_symbols" {
+  description = "Require symbols in password"
+  type        = bool
+  default     = true
+}
+
+variable "temporary_password_validity_days" {
+  description = "Number of days temporary password is valid"
+  type        = number
+  default     = 7
+}
+
+variable "mfa_configuration" {
+  description = "MFA configuration (OFF, ON, OPTIONAL)"
+  type        = string
+  default     = "OFF"
+}
+
+variable "allow_admin_create_user_only" {
+  description = "Only allow admins to create users"
+  type        = bool
+  default     = true
+}
+
+variable "allowed_auth_factors" {
+  description = "Allowed first authentication factors for passwordless sign-in. Options: PASSWORD, EMAIL_OTP, WEB_AUTHN"
+  type        = list(string)
+  default     = ["PASSWORD", "EMAIL_OTP"]
+}
+
+variable "callback_urls" {
+  description = "List of allowed callback URLs for the app client"
+  type        = list(string)
+  default     = ["http://localhost:3000/", "https://cis.service.justice.gov.uk/callback/index.html"]
+}
+
+variable "logout_urls" {
+  description = "List of allowed logout URLs for the app client"
+  type        = list(string)
+  default     = ["http://localhost:3000/", "https://cis.service.justice.gov.uk/"]
+}
+
+variable "access_token_validity" {
+  description = "Access token validity in hours"
+  type        = number
+  default     = 1
+}
+
+variable "id_token_validity" {
+  description = "ID token validity in hours"
+  type        = number
+  default     = 1
+}
+
+variable "refresh_token_validity" {
+  description = "Refresh token validity in days"
+  type        = number
+  default     = 30
+}
+
+# -----------------------------------------------------------------------------
+# GitHub OIDC Role Variables
+# -----------------------------------------------------------------------------
+variable "oidc_role_path" {
+  description = "Path of IAM role"
+  type        = string
+  default     = "/cloud-platform/"
+}
+
+variable "oidc_role_force_detach_policies" {
+  description = "Whether policies should be detached from this role when destroying"
+  type        = bool
+  default     = true
+}
+
+variable "oidc_role_audience" {
+  description = "Audience to use for OIDC role."
+  type        = string
+  default     = "sts.amazonaws.com"
+}
+
+variable "oidc_role_provider_url" {
+  description = "The URL of the identity provider. Corresponds to the iss claim. This is the URL of the OIDC provider for GitHub Actions, and omits the https:// prefix."
+  type        = string
+  default     = "token.actions.githubusercontent.com"
+}
+
+variable "oidc_role_workflow_file" {
+  description = "The name of the workflow file that is allowed to assume this role. This is used in the job_workflow_ref condition key."
+  type        = string
+  default     = ".github/workflows/deploy_production.yml"
+}
+
+variable "oidc_role_workflow_branch" {
+  description = "The branch of the workflow file that is allowed to assume this role. This is used in the job_workflow_ref condition key."
+  type        = string
+  default     = "prd"
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.50.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/waf.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cis-prd/resources/waf.tf
@@ -1,0 +1,126 @@
+resource "aws_wafv2_ip_set" "frontend" {
+  count = length(var.waf_allowed_ips) > 0 ? 1 : 0
+
+  provider = aws.virginia
+
+  name               = "${var.namespace}-frontend-allowed-ips"
+  description        = "Allowed IPs for ${var.namespace} CloudFront distribution"
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+  addresses          = var.waf_allowed_ips
+}
+
+resource "aws_wafv2_web_acl" "frontend" {
+  provider = aws.virginia
+
+  name  = "${var.namespace}-frontend-waf"
+  scope = "CLOUDFRONT"
+
+  default_action {
+    dynamic "allow" {
+      for_each = length(var.waf_allowed_ips) > 0 ? [] : [1]
+      content {}
+    }
+
+    dynamic "block" {
+      for_each = length(var.waf_allowed_ips) > 0 ? [1] : []
+      content {}
+    }
+  }
+
+  dynamic "rule" {
+    for_each = length(var.waf_allowed_ips) > 0 ? [1] : []
+    content {
+      name     = "AllowListedIPs"
+      priority = 1
+
+      action {
+        allow {}
+      }
+
+      statement {
+        ip_set_reference_statement {
+          arn = aws_wafv2_ip_set.frontend[0].arn
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.namespace}-allowed-ips"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = length(var.waf_allowed_ips) > 0 ? 2 : 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.namespace}-common-rules"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.namespace}-frontend-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# WAF CloudWatch Logging
+# Log group names must start with aws-waf-logs-
+# -----------------------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "waf" {
+  provider = aws.virginia
+
+  name              = "aws-waf-logs-${var.namespace}-frontend"
+  retention_in_days = var.waf_log_retention_days
+
+  tags = merge(var.tags, {
+    Name = "${var.namespace}-frontend-waf-logs"
+  })
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "frontend" {
+  provider = aws.virginia
+
+  log_destination_configs = [aws_cloudwatch_log_group.waf.arn]
+  resource_arn            = aws_wafv2_web_acl.frontend.arn
+
+  logging_filter {
+    default_behavior = "KEEP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+}


### PR DESCRIPTION
Creating new cis-prd folder by copying files from cis-pp folder to create equivalent production environment and namespace, as per LGPAS-2182 ticket.
Variables and values have been edited from 'cis-pp' to 'cis-prd', 'preproduction' to 'production' etc. where appropriate.