### PR TITLE
MAPA-304 Bump hmpps-prisoner-cell-allocation-prod RDS to db.t4g.large

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-prod/resources/rds-postgresql.tf
@@ -24,7 +24,7 @@ module "rds" {
   db_engine                 = "postgres"
   db_engine_version         = "18"
   rds_family                = "postgres18"
-  db_instance_class         = "db.t4g.micro"
+  db_instance_class         = "db.t4g.large"
   prepare_for_major_upgrade = false
 
   # Tags


### PR DESCRIPTION
## What

`hmpps-prisoner-cell-allocation-prod`: `db_instance_class` `db.t4g.micro` → `db.t4g.large`.

One namespace per PR; dev and preprod (both → `t4g.small`) are raised separately. Matches the team's sizing convention (as hmpps-prisoner-property: dev/preprod `t4g.small`, prod `t4g.large`) and comparable DPS services (hmpps-incentives, hmpps-non-associations, hmpps-locations-inside-prison).

## Why

Postgres caps a `t4g.micro` at ~85 connections. `hmpps-change-someones-cell-api` runs 4 replicas in prod, and a rolling deploy briefly doubles the pods holding connection pools — the instance exhausted its slots and every prod rollout crashlooped on `FATAL: remaining connection slots are reserved` before Flyway could obtain a connection. Also gives the upcoming one-off whereabouts data backfill sensible headroom.

## Impact

Instance class change = a modify with a short interruption when applied. The API tolerates it (pools reconnect); fine to apply at any quiet moment.