### PR TITLE
MAPA-304 Bump hmpps-prisoner-cell-allocation-preprod RDS to db.t4g.small

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-prisoner-cell-allocation-preprod/resources/rds-postgresql.tf
@@ -24,7 +24,7 @@ module "rds" {
   db_engine                 = "postgres"
   db_engine_version         = "18"
   rds_family                = "postgres18"
-  db_instance_class         = "db.t4g.micro"
+  db_instance_class         = "db.t4g.small"
   prepare_for_major_upgrade = false
 
   # Tags


### PR DESCRIPTION
## What

`hmpps-prisoner-cell-allocation-preprod`: `db_instance_class` `db.t4g.micro` → `db.t4g.small`.

One namespace per PR; dev (→ `t4g.small`) and prod (→ `t4g.large`, #45008) are raised separately. Matches the team's sizing convention (as hmpps-prisoner-property: dev/preprod `t4g.small`, prod `t4g.large`).

## Impact

Short interruption on apply; the API's pools reconnect.