### PR TITLE
MAPA-308 Bump hmpps-cell-sharing-risk-assessment-preprod RDS to db.t4g.small

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/rds-postgresql.tf
@@ -22,7 +22,7 @@ module "rds" {
   db_engine         = "postgres"
   db_engine_version = "18" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres18"
-  db_instance_class = "db.t4g.micro"
+  db_instance_class = "db.t4g.small"
   prepare_for_major_upgrade = false
 
   # Tags


### PR DESCRIPTION
## What

`hmpps-cell-sharing-risk-assessment-preprod`: `db_instance_class` `db.t4g.micro` → `db.t4g.small`.

One namespace per PR; the other two CSRA environments are raised separately. Matches the team's sizing convention (as hmpps-prisoner-property: dev/preprod `t4g.small`, prod `t4g.large`).

## Why

A `t4g.micro` caps at ~85 Postgres connections — hmpps-change-someones-cell-api just proved in prod (see #45008) that this cannot survive a rolling deploy once a service runs a few replicas with normal connection pools. Resizing CSRA before it hits the same rollout crashloop.

## Impact

Instance class change = a modify with a short interruption when applied; connection pools reconnect.