### PR TITLE
Add EMDI utils deployment credentials to prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-prod/resources/template-utils.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-data-insights-prod/resources/template-utils.tf
@@ -1,0 +1,17 @@
+module "hmpps_electronic_monitoring_data_insights_utils" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+
+  github_repo                   = "hmpps-electronic-monitoring-data-insights-utils"
+  application                   = "hmpps-electronic-monitoring-data-insights-utils"
+  github_team                   = var.team_name
+  environment                   = var.environment
+  reviewer_teams                = [var.team_name]
+  selected_branch_patterns      = ["main"]
+  is_production                 = var.is_production
+  application_insights_instance = var.environment
+  source_template_repo          = "none"
+  github_token                  = var.github_token
+  namespace                     = var.namespace
+  kubernetes_cluster            = var.kubernetes_cluster
+  github_owner                  = var.github_owner
+}


### PR DESCRIPTION
## Summary

- add the HMPPS template module for hmpps-electronic-monitoring-data-insights-utils in the EMDI prod namespace
- create the prod GitHub deployment environment and deployment credentials
- restrict deployments to main and retain the existing HMPPS EM Probation reviewer team

## Why

This prepares the production namespace for controlled promotion of the read-only Athena toolbox through the standard deployment workflow.

## Security

This does not expose a Service or Ingress and does not grant new Athena permissions. The workload uses the existing namespace service account and read-only EMDI Athena role. Production deployment remains protected by GitHub environment reviewers.

## Testing

- branch created from current main
- terraform formatting and namespace validation will run in CI

## Dependency

Merge this before the corresponding utils repository PR.

This is separate from the preprod change because Cloud Platform validates one namespace per pull request.