### PR TITLE
Chore: Bump RDS engine version to 18.3 for laa-hmrc-interface-staging

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-staging/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-hmrc-interface-staging/resources/rds.tf
@@ -17,7 +17,7 @@ module "rds" {
   # Database configuration
   prepare_for_major_upgrade   = false
   db_engine                   = "postgres"
-  db_engine_version           = "18.1"
+  db_engine_version           = "18.3"
   db_instance_class           = "db.t4g.small"
   rds_family                  = "postgres18"
   allow_minor_version_upgrade = "true"


### PR DESCRIPTION
Fix error whereby pipeline attempts to downgrade the RDS engine version from 18.3 to 18.1, which is not allowed.

```
Error: updating RDS DB Instance (cloud-platform-1e4a3d0841d520eb): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 29d33f8e-0eee-46c9-b889-2ab7d6438ee7, api error InvalidParameterCombination: Cannot upgrade postgres from 18.3 to 18.1
```
