### PR TITLE
MAPB-766 Restore pg_tle and pg_stat_statements in shared_preload_libraries (property prod)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
@@ -47,8 +47,12 @@ module "prisoner_property_rds" {
       apply_method = "pending-reboot"
     },
     {
+      # As with rds.force_ssl above, this list replaces the engine default rather than merging
+      # with it. Listing only pglogical silently dropped pg_tle and pg_stat_statements, which
+      # Performance Insights needs for query-level detail.
+      # RDS re-adds rdsutils and rds_casts itself, so they do not need listing.
       name         = "shared_preload_libraries"
-      value        = "pglogical"
+      value        = "pg_tle,pg_stat_statements,pglogical"
       apply_method = "pending-reboot"
     },
     {
@@ -121,8 +125,12 @@ module "prisoner_property_rds_replica" {
       apply_method = "pending-reboot"
     },
     {
+      # As with rds.force_ssl above, this list replaces the engine default rather than merging
+      # with it. Listing only pglogical silently dropped pg_tle and pg_stat_statements, which
+      # Performance Insights needs for query-level detail.
+      # RDS re-adds rdsutils and rds_casts itself, so they do not need listing.
       name         = "shared_preload_libraries"
-      value        = "pglogical"
+      value        = "pg_tle,pg_stat_statements,pglogical"
       apply_method = "pending-reboot"
     },
     {


### PR DESCRIPTION
## What

Sets `shared_preload_libraries` to `pg_tle,pg_stat_statements,pglogical` on the property production
RDS instances, rather than just `pglogical`.

Namespace: `hmpps-locations-inside-prison-prod`. One of three PRs (dev / preprod / prod).

Two blocks change here — the primary (`hmpps-prisoner-property-api-prod`) and the Datahub read
replica (`cloud-platform-53896d40e2b8d9eb`). The replica carries its own copy of the parameter list
and lost the same two libraries.

## Why

The Datahub ingestion work (MAPB-763) set `shared_preload_libraries = "pglogical"`. That list
**replaces** the engine default rather than merging with it, so `pg_tle` and `pg_stat_statements`
stopped being preloaded.

The parameter is `pending-reboot`, so nothing changed until the instances were rebooted this week
to pick up `rds.logical_replication`. Querying the databases before and after the reboot:

| | before reboot | after reboot |
|---|---|---|
| `shared_preload_libraries` | `rdsutils,pg_tle,pg_stat_statements,rds_casts` | `rdsutils,pglogical,rds_casts` |

`rdsutils` and `rds_casts` survived because RDS re-adds those itself; `pg_tle` and
`pg_stat_statements` came from the default value and were overwritten.

Performance Insights is enabled on these instances and relies on `pg_stat_statements` for
query-level / Top SQL detail — so this degrades database monitoring silently, with nothing failing
to signal it.

This is the same replace-not-merge trap that dropped `rds.force_ssl` in MAPB-763. The block now
carries a comment saying so, to stop the next person hitting it a third time.

## Deployment note

`shared_preload_libraries` is `pending-reboot`, so **applying this PR alone changes nothing** — the
instance needs another reboot before the libraries load. Being raised with the Cloud Platform team
separately once these are merged.

## Checks

- `terraform fmt -check` clean
- No other parameters touched
- `rds.force_ssl` in both blocks left exactly as-is
- Both instances are `db.t4g.large` with Performance Insights enabled, so this is the pair where
  losing `pg_stat_statements` costs the most
- Reboot the primary before the replica
