### PR TITLE
Allow ONR access to RDS in preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-preprod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-preprod/resources/main.tf
@@ -51,6 +51,19 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "onr-secrets"
+  region = "eu-west-2"
+
+  assume_role {
+    # Assumes the CP intermediary role (intra-account) which has direct access to the
+    # MP secret via a resource-based policy on the secret. This avoids cross-account
+    # sts:AssumeRole which is blocked by SCPs on the shared manager-concourse user.
+    role_arn     = aws_iam_role.mp_onr_secrets_access.arn
+    session_name = "terraform-onr"
+  }
+}
+
 provider "github" {
   token = var.github_token
   owner = var.github_owner

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-preprod/resources/mp-onr-secrets-access-role.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-preprod/resources/mp-onr-secrets-access-role.tf
@@ -1,0 +1,82 @@
+# CP intermediary IAM role for accessing the Modernisation Platform secret
+# This role is assumed by the manager-concourse user (intra-account, no SCP issue).
+# The MP team must add a resource-based policy on the secret to allow this role ARN:
+
+resource "aws_iam_role" "mp_onr_secrets_access" {
+  name        = "arns-${var.environment}-mp-onr-secrets-access"
+  description = "Intermediary role for Terraform to read MP secrets at provision time"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowConcourseToAssume"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::754256621582:user/cloud-platform/manager-concourse"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    owner                  = var.team_name
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "aws_iam_policy" "mp_onr_secrets_read" {
+  name        = "arns-${var.environment}-mp-onr-secrets-read"
+  description = "Allows reading the DPR cross-account secret from the Modernisation Platform"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadAndUpdateMPSecret"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:UpdateSecret"
+        ]
+        Resource = [
+          "arn:aws:secretsmanager:eu-west-2:450842467489:secret:/postgres/database/hmpps-arns-assessment-view-db-preprod/cloud-platform-config-*"
+        ]
+      },
+      {
+        Sid    = "UseMPKMSKeyForSecret"
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey"
+        ]
+        Resource = "arn:aws:kms:eu-west-2:450842467489:key/*"
+      }
+    ]
+  })
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    owner                  = var.team_name
+    environment-name       = var.environment
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "mp_onr_secrets_read" {
+  role       = aws_iam_role.mp_onr_secrets_access.name
+  policy_arn = aws_iam_policy.mp_onr_secrets_read.arn
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-preprod/resources/rds-assessment-view.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-preprod/resources/rds-assessment-view.tf
@@ -107,6 +107,14 @@ locals {
     db_name            = module.arns_assessment_view_rds.database_name
   }
 
+  onr_db_secret = {
+    username           = postgresql_role.oasys_national_reporting_user.name
+    password           = random_password.onr_password.result
+    endpoint           = module.arns_assessment_view_rds.rds_instance_address
+    port               = module.arns_assessment_view_rds.rds_instance_port
+    db_name            = module.arns_assessment_view_rds.database_name
+  }
+
   dpr_secret_arn = "arn:aws:secretsmanager:eu-west-2:972272129531:secret:external/dpr-pr-assess-view-source-secrets-AnLCsI"
 }
 
@@ -172,3 +180,77 @@ resource "aws_secretsmanager_secret_version" "db" {
 
   secret_string = jsonencode(local.dpr_db_secret)
 }
+
+# ONR User Data
+resource "random_password" "onr_password" {
+  length  = 16
+  special = false
+
+  keepers = {
+    last_changed = "2026-07-15"
+  }
+}
+
+resource "postgresql_role" "oasys_national_reporting_user" {
+  name     = "oasys_national_reporting_user"
+  login    = true
+  password = random_password.onr_password.result
+
+  lifecycle {
+    ignore_changes = [roles]
+  }
+}
+
+resource "postgresql_grant" "onr_database_connect" {
+  database    = module.arns_assessment_view_rds.database_name
+  role        = postgresql_role.oasys_national_reporting_user.name
+  object_type = "database"
+  privileges  = ["CONNECT"]
+}
+
+resource "postgresql_grant" "onr_schema_usage" {
+  database    = module.arns_assessment_view_rds.database_name
+  schema      = "assessment-view"
+  role        = postgresql_role.oasys_national_reporting_user.name
+  object_type = "schema"
+  privileges  = ["USAGE"]
+}
+
+resource "postgresql_grant" "onr_tables_and_views" {
+  database    = module.arns_assessment_view_rds.database_name
+  schema      = "assessment-view"
+  role        = postgresql_role.oasys_national_reporting_user.name
+  object_type = "table"
+  privileges  = ["SELECT"]
+}
+
+# Covers future tables/views created by the specified owner.
+resource "postgresql_default_privileges" "onr_future_tables" {
+  database    = module.arns_assessment_view_rds.database_name
+  schema      = "assessment-view"
+  owner       = module.arns_assessment_view_rds.database_username
+  role        = postgresql_role.oasys_national_reporting_user.name
+  object_type = "table"
+  privileges  = ["SELECT"]
+}
+
+resource "kubernetes_secret_v1" "onr_db_credentials" {
+  metadata {
+    name      = "onr-db-credentials"
+    namespace = var.namespace
+  }
+
+  type = "Opaque"
+
+  data = {
+    for key, value in local.onr_db_secret :
+    key => tostring(value)
+  }
+}
+
+# resource "aws_secretsmanager_secret_version" "onr_db" {
+#   provider  = aws.onr-secrets
+#   secret_id = local.onr_secret_arn
+#
+#   secret_string = jsonencode(local.onr_db_secret)
+# }


### PR DESCRIPTION
- Create role on db, and write credentials to kubernetes secret
- Add policy to allow secret writing in Mod Platform Secrets Manager