### PR TITLE
Manage datastore assume role in code rather than parameter

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/cross-iam-role-sa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/cross-iam-role-sa.tf
@@ -6,7 +6,7 @@ module "irsa" {
   role_policy_arns = merge(
     local.sqs_policies,
     {
-      ssm = aws_iam_policy.ssm_access.arn
+      athena = aws_iam_policy.athena_access.arn
       rds = module.rds.irsa_policy_arn
       email_notifications_queue = module.email_notifications_queue.irsa_policy_arn
       email_notifications_dlq = module.email_notifications_dlq.irsa_policy_arn
@@ -30,7 +30,7 @@ module "crime_matching_algorithm_irsa" {
   namespace            = var.namespace
 
   role_policy_arns = {
-    # athena = aws_iam_policy.athena_access.arn
+    athena = aws_iam_policy.athena_access.arn
     matching_notifications_queue = module.matching_notifications_queue.irsa_policy_arn
     matching_notifications_dlq = module.matching_notifications_dlq.irsa_policy_arn
   }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/iam-policies.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/iam-policies.tf
@@ -1,35 +1,16 @@
-data "aws_iam_policy_document" "ssm_policy" {
+data "aws_iam_policy_document" "athena_policy" {
   statement {
     actions = [
-      "ssm:GetParameter",
-      "ssm:GetParameters",
-      "ssm:PutParameter"
+      "sts:AssumeRole"
     ]
     resources = [
-      "arn:aws:ssm:eu-west-2:754256621582:parameter/${var.namespace}/athena_general_role_arn"
+      var.datastore_role
     ]
   }
 }
 
-resource "aws_iam_policy" "ssm_access" {
-  name   = "${var.namespace}-ssm-policy"
-  policy = data.aws_iam_policy_document.ssm_policy.json
+resource "aws_iam_policy" "athena_access" {
+  name   = "${var.namespace}-athena-policy-general"
+  policy = data.aws_iam_policy_document.athena_policy.json
   tags = local.tags
 }
-
-# data "aws_iam_policy_document" "athena_policy" {
-#   statement {
-#     actions = [
-#       "sts:AssumeRole"
-#     ]
-#     resources = [
-#       data.aws_ssm_parameter.athena_general_role_arn.value
-#     ]
-#   }
-# }
-
-# resource "aws_iam_policy" "athena_access" {
-#   name   = "${var.namespace}-athena-policy-general"
-#   policy = data.aws_iam_policy_document.athena_policy.json
-#   tags = local.tags
-# }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/kubernetes-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/kubernetes-secrets.tf
@@ -19,3 +19,14 @@ resource "kubernetes_secret" "crime_matching_algorithm_irsa" {
     serviceaccount = module.crime_matching_algorithm_irsa.service_account.name
   }
 }
+
+resource "kubernetes_secret" "athena_roles" {
+  metadata {
+    name      = "athena-roles"
+    namespace = var.namespace
+  }
+  type = "Opaque"
+  data = {
+    general_role_arn = var.datastore_role
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/ssm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/ssm.tf
@@ -2,22 +2,3 @@ data "aws_ssm_parameter" "irsa_policy_arns_sqs" {
   for_each = local.sqs_queues
   name     = "/${each.value}/sqs/${each.key}/irsa-policy-arn"
 }
-
-# data "aws_ssm_parameter" "athena_general_role_arn" {
-#   name = "/${var.namespace}/athena_general_role_arn"
-#   with_decryption = true
-# }
-
-resource "aws_ssm_parameter" "athena_general_role_arn" {
-  name        = "/${var.namespace}/athena_general_role_arn"
-  type        = "SecureString"
-  # This value must be replaced with a genuine role ARN using AWS CLI
-  value       = "arn:aws:iam::0000000000000:role/general-placeholder"
-  description = "ARN of the role used to query Athena for general EM order data"
-  tags        = local.tags
-  lifecycle {
-    ignore_changes = [
-      value
-    ]
-  }
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-electronic-monitoring-crime-matching-prod/resources/variables.tf
@@ -82,3 +82,9 @@ variable "email_bucket_name" {
 variable "email_rule_set_name" {
   default = "email-receiving-rules"
 }
+
+variable "datastore_role" {
+  type = string
+  description = "Role assumed by the API and Algorithm to access the Electronic Monitoring Data Store"
+  default = "arn:aws:iam::976799291502:role/ac_read_emds_data_prod"
+}


### PR DESCRIPTION
Replicate #43307 in prod environment.

- Previously we stored the role to assume in an SSM parameter
- This caused issues when needing to update it as we'd have to first update the parameter, then rerun the terraform in this namespace to update the IAM policy
- AWS Account Numbers and Role names are not secret so shouldn't be hidden behind parameters.