### PR TITLE
Remove octo-nonlive custom domain test DNS records

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/folarin-dev/resources/route53.tf
@@ -24,28 +24,3 @@ resource "kubernetes_secret" "folarin_dev_route53_zone_sec" {
     nameservers = join("\n", aws_route53_zone.folarin_dev_route53_zone.name_servers)
   }
 }
-
-locals {
-  custom_host = "t3"
-
-  octo_nonlive_acme_target = "${local.custom_host}-acme.octo-nonlive.container-platform.service.justice.gov.uk"
-  octo_nonlive_nlb         = "octo-nonlive-envoy-default-7f403de9005876a3.elb.eu-west-2.amazonaws.com"
-}
-
-# ACME DNS-01 delegation: cert-manager (octo-nonlive) follows this CNAME and writes the
-# challenge TXT at the target, which sits in a zone its Pod Identity IAM can write.
-resource "aws_route53_record" "custom_acme_challenge" {
-  zone_id = aws_route53_zone.folarin_dev_route53_zone.zone_id
-  name    = "_acme-challenge.${local.custom_host}.${var.domain}"
-  type    = "CNAME"
-  ttl     = 300
-  records = [local.octo_nonlive_acme_target]
-}
-
-resource "aws_route53_record" "custom_traffic" {
-  zone_id = aws_route53_zone.folarin_dev_route53_zone.zone_id
-  name    = "${local.custom_host}.${var.domain}"
-  type    = "CNAME"
-  ttl     = 300
-  records = [local.octo_nonlive_nlb]
-}


### PR DESCRIPTION
## What

Removes the `t3` custom-domain test DNS records from the `folarin-dev` namespace zone:

- `_acme-challenge.t3.container-platform-custom-domain-test.service.justice.gov.uk` (CNAME, DNS-01 delegation)
- `t3.container-platform-custom-domain-test.service.justice.gov.uk` (CNAME, traffic to the octo-nonlive Envoy NLB)

Also removes the now-unused `locals` block that fed them.

## Why

These records were added for the custom-TLS acceptance tests. The test is complete and the evidence is captured (AC1 cert issued, AC2 served 200 with a valid chain). Leaving the CNAMEs in place is a dangling-DNS / subdomain-takeover risk, so they are removed as cleanup.
