### PR TITLE
IR-1867 Repoint hmpps-manage-adjudications-api-dev RBAC to manage-safety-devs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/00-namespace.yaml
@@ -13,5 +13,5 @@ metadata:
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-manage-adjudications-api.git"
     cloud-platform.justice.gov.uk/slack-alert-channel: "maintenance-alerts-non-prod"
     cloud-platform.justice.gov.uk/slack-channel: "dps_adjudications"
-    cloud-platform.justice.gov.uk/team-name: "dps-core"
+    cloud-platform.justice.gov.uk/team-name: "manage-safety"
     cloud-platform.justice.gov.uk/service-area: "Live Support"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-adjudications-api-dev/01-rbac.yaml
@@ -9,7 +9,7 @@ subjects:
     name: "github:dps-production-releases"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
-    name: "github:hmpps-adjudications"
+    name: "github:manage-safety-devs"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"


### PR DESCRIPTION
Repoints the `hmpps-manage-adjudications-api-dev` namespace RoleBinding from `github:hmpps-adjudications` to `github:manage-safety-devs`.

Manage Safety is consolidating its seven per-service GitHub teams into two — `manage-safety-devs` for non-production and `manage-safety-live` for non-production. This gives the service area an SC-clearance boundary it currently lacks, cuts onboarding from up to seven team additions to two, and shortens the AWS SSO SAML assertion.

**No one loses access.** Every member of `hmpps-adjudications` is already a member of `manage-safety-devs` — the teams were created in ministryofjustice/hmpps-github-teams#1197 and populated in ministryofjustice/hmpps-github-teams#1198, both merged and applied.

Any other group in the RoleBinding (`github:hmpps-sre`, `github:syscon-devs`, `github:dps-production-releases`) is deliberately left in place.

One of 21 namespace PRs for IR-1867.