### PR TITLE
IR-1867 Repoint hmpps-challenge-support-intervention-plan-preprod RBAC to manage-safety-live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-preprod/00-namespace.yaml
@@ -12,6 +12,6 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Challenge Support Intervention Plan"
     cloud-platform.justice.gov.uk/owner: "Live Services Maintenance: HMPPSLiveServicesMaintenanceTeam@JusticeUK.onmicrosoft.com"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-challenge-support-intervention-plan-api"
-    cloud-platform.justice.gov.uk/team-name: "hmpps-prisons-digital-live-support"
+    cloud-platform.justice.gov.uk/team-name: "manage-safety"
     cloud-platform.justice.gov.uk/slack-alert-channel: "maintenance-alerts-non-prod"
     cloud-platform.justice.gov.uk/service-area: "Live Support"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-challenge-support-intervention-plan-preprod/01-rbac.yaml
@@ -8,7 +8,7 @@ subjects:
     name: "github:hmpps-sre"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
-    name: "github:hmpps-csip-live"
+    name: "github:manage-safety-live"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Repoints the `hmpps-challenge-support-intervention-plan-preprod` namespace RoleBinding from `github:hmpps-csip-live` to `github:manage-safety-live`.

Manage Safety is consolidating its seven per-service GitHub teams into two — `manage-safety-devs` for non-production and `manage-safety-live` for preprod and production. This gives the service area an SC-clearance boundary it currently lacks, cuts onboarding from up to seven team additions to two, and shortens the AWS SSO SAML assertion.

**No one loses access.** Every member of `hmpps-csip-live` is already a member of `manage-safety-live` — the teams were created in ministryofjustice/hmpps-github-teams#1197 and populated in ministryofjustice/hmpps-github-teams#1198, both merged and applied.

Any other group in the RoleBinding (`github:hmpps-sre`, `github:syscon-devs`, `github:dps-production-releases`) is deliberately left in place.

One of 21 namespace PRs for IR-1867.