### PR TITLE
IR-1867 Repoint hmpps-incentives-preprod RBAC to manage-safety-live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/00-namespace.yaml
@@ -14,4 +14,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Incentives Apps"
     cloud-platform.justice.gov.uk/owner: "HMPPS Incentives: incentives-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-incentives-ui.git"
-    cloud-platform.justice.gov.uk/team-name: "hmpps-incentives"
+    cloud-platform.justice.gov.uk/team-name: "manage-safety"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/01-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: hmpps-incentives-preprod
 subjects:
   - kind: Group
-    name: "github:hmpps-incentives"
+    name: "github:manage-safety-live"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"


### PR DESCRIPTION
Repoints the `hmpps-incentives-preprod` namespace RoleBinding from `github:hmpps-incentives` to `github:manage-safety-live`.

Manage Safety is consolidating its seven per-service GitHub teams into two — `manage-safety-devs` for non-production and `manage-safety-live` for preprod and production. This gives the service area an SC-clearance boundary it currently lacks, cuts onboarding from up to seven team additions to two, and shortens the AWS SSO SAML assertion.

**No one loses access.** Every member of `hmpps-incentives` is already a member of `manage-safety-live` — the teams were created in ministryofjustice/hmpps-github-teams#1197 and populated in ministryofjustice/hmpps-github-teams#1198, both merged and applied.

Any other group in the RoleBinding (`github:hmpps-sre`, `github:syscon-devs`, `github:dps-production-releases`) is deliberately left in place.

One of 21 namespace PRs for IR-1867.