### PR TITLE
IR-1867 Repoint hmpps-incident-reporting-prod RBAC to manage-safety-live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/00-namespace.yaml
@@ -14,4 +14,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Incident Reporting Service"
     cloud-platform.justice.gov.uk/owner: "HMPPS Incident Reporting Service: incident-reporting-service@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-incident-reporting-api.git,https://github.com/ministryofjustice/hmpps-incident-reporting.git"
-    cloud-platform.justice.gov.uk/team-name: "hmpps-incident-reporting"
+    cloud-platform.justice.gov.uk/team-name: "manage-safety"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/01-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: hmpps-incident-reporting-prod
 subjects:
   - kind: Group
-    name: "github:hmpps-incident-reporting"
+    name: "github:manage-safety-live"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"


### PR DESCRIPTION
Repoints the `hmpps-incident-reporting-prod` namespace RoleBinding from `github:hmpps-incident-reporting` to `github:manage-safety-live`.

Manage Safety is consolidating its seven per-service GitHub teams into two — `manage-safety-devs` for non-production and `manage-safety-live` for preprod and production. This gives the service area an SC-clearance boundary it currently lacks, cuts onboarding from up to seven team additions to two, and shortens the AWS SSO SAML assertion.

**No one loses access.** Every member of `hmpps-incident-reporting` is already a member of `manage-safety-live` — the teams were created in ministryofjustice/hmpps-github-teams#1197 and populated in ministryofjustice/hmpps-github-teams#1198, both merged and applied.

Any other group in the RoleBinding (`github:hmpps-sre`, `github:syscon-devs`, `github:dps-production-releases`) is deliberately left in place.

One of 21 namespace PRs for IR-1867.