### PR TITLE
IR-1867 Repoint hmpps-managing-behaviour-prototyping RBAC to manage-safety-devs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-behaviour-prototyping/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-behaviour-prototyping/00-namespace.yaml
@@ -12,5 +12,5 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Managing behaviour prototyping"
     cloud-platform.justice.gov.uk/owner: "Managing Behaviour: incentives-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-incident-reporting-prototype"
-    cloud-platform.justice.gov.uk/team-name: "hmpps-incident-reporting"
+    cloud-platform.justice.gov.uk/team-name: "manage-safety"
     cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-behaviour-prototyping/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-managing-behaviour-prototyping/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-managing-behaviour-prototyping
 subjects:
   - kind: Group
-    name: "github:hmpps-incident-reporting"
+    name: "github:manage-safety-devs"
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Repoints the `hmpps-managing-behaviour-prototyping` namespace RoleBinding from `github:hmpps-incident-reporting` to `github:manage-safety-devs`.

Manage Safety is consolidating its seven per-service GitHub teams into two — `manage-safety-devs` for non-production and `manage-safety-live` for non-production. This gives the service area an SC-clearance boundary it currently lacks, cuts onboarding from up to seven team additions to two, and shortens the AWS SSO SAML assertion.

**No one loses access.** Every member of `hmpps-incident-reporting` is already a member of `manage-safety-devs` — the teams were created in ministryofjustice/hmpps-github-teams#1197 and populated in ministryofjustice/hmpps-github-teams#1198, both merged and applied.

Any other group in the RoleBinding (`github:hmpps-sre`, `github:syscon-devs`, `github:dps-production-releases`) is deliberately left in place.

One of 21 namespace PRs for IR-1867.