### PR TITLE
IR-1867 Repoint hmpps-non-associations-dev RBAC to manage-safety-devs

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/00-namespace.yaml
@@ -14,4 +14,4 @@ metadata:
     cloud-platform.justice.gov.uk/application: "HMPPS Non-associations Apps"
     cloud-platform.justice.gov.uk/owner: "HMPPS Non-Associations: non-associations-team@digital.justice.gov.uk"
     cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/hmpps-non-associations.git"
-    cloud-platform.justice.gov.uk/team-name: "hmpps-non-associations"
+    cloud-platform.justice.gov.uk/team-name: "manage-safety"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/01-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: hmpps-non-associations-dev
 subjects:
   - kind: Group
-    name: "github:hmpps-non-associations"
+    name: "github:manage-safety-devs"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"


### PR DESCRIPTION
Repoints the `hmpps-non-associations-dev` namespace RoleBinding from `github:hmpps-non-associations` to `github:manage-safety-devs`.

Manage Safety is consolidating its seven per-service GitHub teams into two — `manage-safety-devs` for non-production and `manage-safety-live` for non-production. This gives the service area an SC-clearance boundary it currently lacks, cuts onboarding from up to seven team additions to two, and shortens the AWS SSO SAML assertion.

**No one loses access.** Every member of `hmpps-non-associations` is already a member of `manage-safety-devs` — the teams were created in ministryofjustice/hmpps-github-teams#1197 and populated in ministryofjustice/hmpps-github-teams#1198, both merged and applied.

Any other group in the RoleBinding (`github:hmpps-sre`, `github:syscon-devs`, `github:dps-production-releases`) is deliberately left in place.

One of 21 namespace PRs for IR-1867.