### PR TITLE
IR-1883 Pin hmpps-incident-reporting-prod RDS and read replica to Postgres 17.9

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
@@ -17,7 +17,7 @@ module "dps_rds" {
   prepare_for_major_upgrade = false
   db_instance_class           = "db.t4g.large"
   rds_family                  = "postgres17"
-  db_engine_version           = "17.6"
+  db_engine_version           = "17"
   deletion_protection         = true
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
@@ -87,7 +87,7 @@ module "dps_rds_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "17.6"
+  db_engine_version = "17.9"
   rds_family        = "postgres17"
   db_instance_class = "db.t4g.large"
   # It is mandatory to set the below values to create read replica instance

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incident-reporting-prod/resources/rds.tf
@@ -17,7 +17,7 @@ module "dps_rds" {
   prepare_for_major_upgrade = false
   db_instance_class           = "db.t4g.large"
   rds_family                  = "postgres17"
-  db_engine_version           = "17"
+  db_engine_version           = "17.9"
   deletion_protection         = true
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"


### PR DESCRIPTION
Changes `db_engine_version` from `"17.6"` to `"17.9"` in `hmpps-incident-reporting-prod/resources/rds.tf`, for **both the primary and the read replica**.

## Why

AWS has auto-upgraded these instances to **17.9**. The config still pinned **17.6**, so Terraform tried to downgrade on every apply and RDS refused:

```
Error: updating RDS DB Instance: api error InvalidParameterCombination:
Cannot upgrade postgres from 17.9 to 17.6
```

Until this lands, every change to this namespace fails the apply pipeline regardless of what the change is. This is pre-existing drift — it surfaced when the IR-1867 RBAC PRs triggered an apply here. Those RBAC changes themselves applied cleanly; only the Terraform stage that follows was failing.

## Both primary and replica

The read replica block also pinned 17.6. A replica must run the same engine version as its primary, so both are pinned to 17.9 here. Thanks to Cloud Platform for catching that — an earlier revision of this PR changed the primary only.

## Note for the future

This unblocks the pipeline but does not prevent recurrence. The namespace still pairs an exact minor pin with `allow_minor_version_upgrade = "true"`, so the same failure returns at the next AWS 17.x upgrade. Raised with Cloud Platform as a platform-wide question rather than fixed here.

One of 10 namespace PRs for https://dsdmoj.atlassian.net/browse/IR-1883