### PR TITLE
IR-1883 Pin hmpps-non-associations-prod RDS to Postgres major version 17

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
@@ -17,7 +17,7 @@ module "dps_rds" {
   prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.large"
   rds_family                  = "postgres17"
-  db_engine_version           = "17"
+  db_engine_version           = "17.9"
   deletion_protection         = true
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
@@ -17,7 +17,7 @@ module "dps_rds" {
   prepare_for_major_upgrade   = false
   db_instance_class           = "db.t4g.large"
   rds_family                  = "postgres17"
-  db_engine_version           = "17.6"
+  db_engine_version           = "17"
   deletion_protection         = true
   allow_major_version_upgrade = "false"
   allow_minor_version_upgrade = "true"


### PR DESCRIPTION
Changes `db_engine_version` from `"17.6"` to `"17"` in `hmpps-non-associations-prod/resources/rds.tf`.

## Why

AWS has auto-upgraded this instance to **17.9**. The config still pins **17.6**, so Terraform tries to downgrade it on every apply and RDS refuses:

```
Error: updating RDS DB Instance: api error InvalidParameterCombination:
Cannot upgrade postgres from 17.9 to 17.6
  with module.dps_rds.aws_db_instance.rds
```

Until this is fixed, every future change to this namespace fails the apply pipeline regardless of what the change is. This is pre-existing drift — it surfaced when the IR-1867 RBAC PRs triggered an apply here.

## Why the major version only

Pinning `"17"` lets AWS apply minor upgrades without creating drift, so this cannot recur. It is already the convention in this repo — `hmpps-challenge-support-intervention-plan-dev/resources/rds-postgresql.tf` pins `"17"`, and those namespaces did not fail.

**The database is unchanged.** This only stops Terraform attempting a downgrade, aligning the config with the version AWS is actually running.

One of 10 namespace PRs for https://dsdmoj.atlassian.net/browse/IR-1883