### PR TITLE
CRIMAPP-2203 Rotate Datastore API staging secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/api-auth-secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-criminal-applications-datastore-staging/resources/api-auth-secrets.tf
@@ -4,11 +4,11 @@ locals {
   datastore_api_consumers = {
     "crime_apply" = {
       namespace  = "laa-apply-for-criminal-legal-aid-staging"
-      rotated_at = "2026-04-20"
+      rotated_at = "2026-08-26"
     }
     "crime_review" = {
       namespace  = "laa-review-criminal-legal-aid-staging"
-      rotated_at = "2026-04-20"
+      rotated_at = "2026-08-26"
     }
     #
     # Other MAAT non-prod consumers without direct datastore equivalence
@@ -16,11 +16,11 @@ locals {
     #
     "maat_adapter_dev" = {
       namespace  = "laa-crime-applications-adaptor-dev"
-      rotated_at = "2026-04-20"
+      rotated_at = "2026-08-26"
     }
     "maat_adapter_uat" = {
       namespace  = "laa-crime-applications-adaptor-uat"
-      rotated_at = "2026-04-20"
+      rotated_at = "2026-08-26"
     }
   }
 }


### PR DESCRIPTION
Rotate the Datastore API secrets generated by `random_password` for all staging consumers. This creates/updates a `datastore-api-auth-secret` secret in each consumer's namespace.