### PR TITLE
IR-1883 Pin hmpps-incentives-prod read replica to Postgres 17.9

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-prod/resources/rds.tf
@@ -89,7 +89,7 @@ module "dps_rds_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "17.6"
+  db_engine_version = "17.9"
   rds_family        = "postgres17"
   db_instance_class = "db.t4g.large"
   # It is mandatory to set the below values to create read replica instance


### PR DESCRIPTION
Follow-up to the earlier IR-1883 PR for this namespace, which pinned the **primary** to 17.9 but missed the **read replica** block — it still specified `"17.6"`.

A replica must run the same engine version as its primary, so the apply on this namespace still fails with:

```
Error: updating RDS DB Instance: api error InvalidParameterCombination:
Cannot upgrade postgres from 17.9 to 17.6
```

The replica fix was authored before the earlier PR merged, but auto-merge landed that PR first, so this commit was left behind. Raising it separately rather than reopening the merged one.

Thanks to Cloud Platform for spotting that the replicas needed the same treatment.

Part of https://dsdmoj.atlassian.net/browse/IR-1883