### PR TITLE
feat: Add Infrastructure as Code for HMPPS Security Assurance Portal

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/hmpps-snyk-discovery.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-prod/resources/hmpps-snyk-discovery.tf
@@ -7,7 +7,7 @@ module "hmpps_snyk_discovery" {
   github_team                   = "hmpps-sre"
   environment                   = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
   reviewer_teams                = ["hmpps-sre"]
-  ≈ true
+  protected_branches_only       = true
   is_production                 = var.is_production
   application_insights_instance = "prod"
   source_template_repo          = "none"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/05-certificates.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: security-assurance-toolkit-dev.hmpps.service.justice.gov.uk
+  namespace: hmpps-security-assurance-toolkit
+spec:
+  secretName: security-assurance-toolkit-dev-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - security-assurance-toolkit-dev.hmpps.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
@@ -1,18 +1,17 @@
-module "hmpps_snyk_discovery" {
+module "hmpps-security-assurance-discovery-agent" {
   source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
   force_rotate_token = true
   custom_token_rotation_date = "2026-03-20"
-  github_repo                   = "hmpps-snyk-discovery"
-  application                   = "hmpps-snyk-discovery"
+  github_repo                   = "hmpps-security-assurance-discovery-agent"
+  application                   = "hmpps-security-assurance-discovery-agent"
   github_team                   = "hmpps-sre"
   environment                   = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
-  reviewer_teams                = ["hmpps-sre"]
-  ≈ true
+  selected_branch_patterns      = ["main", "**/**", "**"] # Optional but required if protected_branches_only is false
+  protected_branches_only       = false                                    # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
-  application_insights_instance = "prod"
+  application_insights_instance = "dev"
   source_template_repo          = "none"
   github_token                  = var.github_token
   namespace                     = var.namespace
   kubernetes_cluster            = var.kubernetes_cluster
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
@@ -1,18 +1,17 @@
-module "hmpps_snyk_discovery" {
+module "hmpps-security-assurance-toolkit" {
   source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
   force_rotate_token = true
   custom_token_rotation_date = "2026-03-20"
-  github_repo                   = "hmpps-snyk-discovery"
-  application                   = "hmpps-snyk-discovery"
+  github_repo                   = "hmpps-security-assurance-toolkit"
+  application                   = "hmpps-security-assurance-toolkit"
   github_team                   = "hmpps-sre"
   environment                   = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
-  reviewer_teams                = ["hmpps-sre"]
-  ≈ true
+  selected_branch_patterns      = ["main", "**/**", "**"] # Optional but required if protected_branches_only is false
+  protected_branches_only       = false                                    # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
-  application_insights_instance = "prod"
+  application_insights_instance = "dev"
   source_template_repo          = "none"
   github_token                  = var.github_token
   namespace                     = var.namespace
   kubernetes_cluster            = var.kubernetes_cluster
 }
-

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
@@ -21,7 +21,6 @@ module "hmpps_security_assurance_toolkit_rds" {
   }
 
 }
-
 resource "kubernetes_secret" "hmpps_security_assurance_toolkit_rds" {
   metadata {
     name      = "rds-instance-output"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
@@ -1,6 +1,6 @@
 module "hmpps_security_assurance_toolkit_rds" {
   source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
-  db_allocated_storage        = 10
+  db_allocated_storage        = 20
   storage_type                = "gp3"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
@@ -1,0 +1,81 @@
+module "hmpps_security_assurance_toolkit_rds" {
+  source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+  db_allocated_storage        = 10
+  storage_type                = "gp3"
+  vpc_name                    = var.vpc_name
+  team_name                   = var.team_name
+  business_unit               = var.business_unit
+  application                 = "hmpps-security-assurance-toolkit"
+  is_production               = var.is_production
+  namespace                   = var.namespace
+  environment_name            = var.environment
+  infrastructure_support      = var.infrastructure_support
+  allow_major_version_upgrade = "false"
+  db_instance_class           = "db.t4g.micro"
+  db_max_allocated_storage    = "500" # maximum storage for autoscaling
+  db_engine_version           = "17"
+  rds_family                  = "postgres17"
+
+  providers = {
+    aws = aws.london
+  }
+
+}
+
+resource "kubernetes_secret" "hmpps_security_assurance_toolkit_rds" {
+  metadata {
+    name      = "rds-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint
+    database_name         = module.hmpps_security_assurance_toolkit_rds.database_name
+    database_username     = module.hmpps_security_assurance_toolkit_rds.database_username
+    database_password     = module.hmpps_security_assurance_toolkit_rds.database_password
+    rds_instance_address  = module.hmpps_security_assurance_toolkit_rds.rds_instance_address
+  }
+}
+
+resource "kubernetes_secret" "hmpps_security_assurance_toolkit_rds-dev" {
+  metadata {
+    name      = "rds-instance-output-dev"
+    namespace = "hmpps-security-assurance-toolkit"
+  }
+
+  data = {
+    rds_instance_endpoint = module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint
+    database_name         = module.hmpps_security_assurance_toolkit_rds.database_name
+    database_username     = module.hmpps_security_assurance_toolkit_rds.database_username
+    database_password     = module.hmpps_security_assurance_toolkit_rds.database_password
+    database_url          = "postgresql://${module.hmpps_security_assurance_toolkit_rds.database_username}:${module.hmpps_security_assurance_toolkit_rds.database_password}@${module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint}:5432/${module.hmpps_security_assurance_toolkit_rds.database_name}"
+    rds_instance_address  = module.hmpps_security_assurance_toolkit_rds.rds_instance_address
+  }
+}
+
+########################################################################################################
+#if there are multiple databases provisioned, then those names should be added in local variable as well. Like
+#rds_databases = {
+# "rdsAlertsDatabases.${module.hmpps_service_catalogue1.db_identifier1}" = "hmpps-service-catalogue-db1"
+# "rdsAlertsDatabases.${module.hmpps_service_catalogue2.db_identifier2}" = "hmpps-service-catalogue-db2"
+#}
+########################################################################################################## 
+
+locals {
+
+  rds_databases = {
+    "rdsAlertsDatabases.${module.hmpps_security_assurance_toolkit_rds.db_identifier}" = "hmpps-service-catalogue-db"
+
+  }
+
+  database_list = flatten([
+    for identifier, desc in local.rds_databases : {
+      identifier = identifier
+      desc       = desc
+    }
+  ])
+
+  database_details = {
+    for m in local.database_list : (m.identifier) => m
+  }
+}


### PR DESCRIPTION
This pull request introduces new infrastructure resources and configuration for the `hmpps-security-assurance-toolkit` namespace, including database provisioning, certificate management, and application deployment modules.

**New resource provisioning and configuration:**

* Added a new RDS PostgreSQL 17 database instance for the `hmpps-security-assurance-toolkit` application using the `cloud-platform-terraform-rds-instance` module, along with associated Kubernetes secrets for storing database credentials and endpoints.
* Introduced a new TLS certificate resource for the `security-assurance-toolkit-dev.hmpps.service.justice.gov.uk` domain, managed by cert-manager and issued via Let's Encrypt.

**Application deployment modules:**

* Added Terraform modules for deploying both the `hmpps-security-assurance-toolkit` and its `discovery-agent` component, with configuration for non-protected branches and forced GitHub token rotation. [[1]](diffhunk://#diff-184e42db5a10c092572f9d3ea7f2ba485ef1da12861f5fac2532110e98fe1d9fR1-R17) [[2]](diffhunk://#diff-3cbb08548008507e8379a2b7509ccf3db017053f485f2f905e76f0dc65f07725R1-R17)
