### PR TITLE
`justice-gov-uk-production` Remove CDN DNS records.

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/acm.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/acm.tf
@@ -23,25 +23,3 @@ resource "aws_acm_certificate" "cloudfront_alias_cert" {
     create_before_destroy = true
   }
 }
-
-# aws_acm_certificate_validation for the CloudFront alias.
-# This is part of the validation workflow and not a a real-world entity in AWS.
-# The resource is used together with aws_route53_record and aws_acm_certificate
-# to request a DNS validated certificate, deploy the required validation records 
-# and wait for validation to complete.
-
-resource "aws_acm_certificate_validation" "cloudfront_alias_cert_validation" {
-  certificate_arn         = aws_acm_certificate.cloudfront_alias_cert.arn
-  validation_record_fqdns = aws_route53_record.cert_validations[*].fqdn 
-
-  provider = aws.virginia
-
-  timeouts {
-    create = "10m"
-  }
-
-  depends_on = [
-    aws_acm_certificate.cloudfront_alias_cert,
-    aws_route53_record.cert_validations
-  ]
-}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/pingdom.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/pingdom.tf
@@ -12,7 +12,7 @@ resource "pingdom_check" "justice-gov-uk-production" {
   url                      = "/"
   encryption               = true
   port                     = 443
-  tags                     = "businessunit_${var.business_unit},application_${var.application},component_ping,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.application}"
+  tags                     = "businessunit_${lower(var.business_unit)},application_${var.application},component_ping,isproduction_${var.is_production},environment_${var.environment},infrastructuresupport_${var.application}"
   probefilters             = "region:EU"
   integrationids           = [133317]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/rds.tf
@@ -12,7 +12,7 @@ module "rds" {
 
   # general options
   db_engine                   = "mariadb"
-  db_engine_version           = "10.11.13"
+  db_engine_version           = "10.11.16"
   rds_family                  = "mariadb10.11"
   db_instance_class           = "db.t4g.large"
   db_allocated_storage        = "100"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/justice-gov-uk-production/resources/route53.tf
@@ -91,30 +91,3 @@ resource "kubernetes_secret" "route53_zone_sec" {
     name_servers = join("\n", aws_route53_zone.www_justice_gov_uk_route53_zone.name_servers)
   }
 }
-
-# Create an A record in the hosted zone for the CloudFront alias.
-# Note, the zone_id parameter is set to the zone_id from the www.justice.gov.uk route53 zone.
-# And the alias.zone_id parameter is set to the CloudFront hosted zone id.
-resource "aws_route53_record" "data" {
-  zone_id = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
-  name    = var.cloudfront_alias
-  type    = "A"
-
-  alias {
-    evaluate_target_health = false
-    name                   = module.cloudfront.cloudfront_url
-    zone_id                = module.cloudfront.cloudfront_hosted_zone_id
-  }
-}
-
-# In acm.tf, an aws_acm_certificate resource is created for the CloudFront alias.
-# As the validation method is set to DNS, a route53 record is created here for the certificate validation.
-resource "aws_route53_record" "cert_validations" {
-  count           = length(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options)
-  zone_id         = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
-  name            = element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_name, count.index)
-  type            = element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_type, count.index)
-  records         = [element(aws_acm_certificate.cloudfront_alias_cert.domain_validation_options[*].resource_record_value, count.index)]
-  ttl             = 60
-  allow_overwrite = true
-}


### PR DESCRIPTION
This PR removes the route53 records for the cdn.justice.gov.uk domain.

This means that we can move the route53 zone from this namespace to hale-platform-prod without issue.

Later, this namespace will be deleted, so there is no rush to delete cloudfront.tf now.