### PR TITLE
revert: postgres storage to gp2

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
@@ -1,7 +1,7 @@
 module "hmpps_security_assurance_toolkit_rds" {
   source                      = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
   db_allocated_storage        = 20
-  storage_type                = "gp3"
+  storage_type                = "gp2"
   vpc_name                    = var.vpc_name
   team_name                   = var.team_name
   business_unit               = var.business_unit
@@ -63,7 +63,7 @@ resource "kubernetes_secret" "hmpps_security_assurance_toolkit_rds-dev" {
 locals {
 
   rds_databases = {
-    "rdsAlertsDatabases.${module.hmpps_security_assurance_toolkit_rds.db_identifier}" = "hmpps-service-catalogue-db"
+    "rdsAlertsDatabases.${module.hmpps_security_assurance_toolkit_rds.db_identifier}" = "hmpps-security-assurance-toolkit-db"
 
   }
 


### PR DESCRIPTION
This pull request makes two small but important changes to the RDS configuration for the `hmpps-security-assurance-toolkit` service. The storage type for the RDS instance is changed, and the database name in the Kubernetes secret is updated to match the service.

Most important changes:

**RDS Storage Configuration:**
* Changed the RDS storage type from `gp3` to `gp2` in the `hmpps_security_assurance_toolkit_rds` module, likely to address compatibility or cost considerations.

**Kubernetes Secret Database Name:**
* Updated the database name in the `rds_databases` local from `hmpps-service-catalogue-db` to `hmpps-security-assurance-toolkit-db` to reflect the correct database used by the service.