### PR TITLE
`hale-platform-prod` Move Justice route53 zone

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-justice.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-justice.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_zone" "www_justice_gov_uk_route53_zone" {
+resource "aws_route53_zone" "justice_route53_zone" {
   name = "www.justice.gov.uk"
 
   tags = {
@@ -12,8 +12,8 @@ resource "aws_route53_zone" "www_justice_gov_uk_route53_zone" {
   }
 }
 
-resource "aws_route53_record" "mx" {
-  zone_id = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
+resource "aws_route53_record" "justice_mx" {
+  zone_id = aws_route53_zone.justice_route53_zone.zone_id
   name    = "www.justice.gov.uk."
   type    = "MX"
   ttl     = 1800
@@ -22,8 +22,8 @@ resource "aws_route53_record" "mx" {
   ]
 }
 
-resource "aws_route53_record" "spf" {
-  zone_id = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
+resource "aws_route53_record" "justice_spf" {
+  zone_id = aws_route53_zone.justice_route53_zone.zone_id
   name    = "www.justice.gov.uk."
   type    = "TXT"
   ttl     = 300
@@ -32,8 +32,8 @@ resource "aws_route53_record" "spf" {
   ]
 }
 
-resource "aws_route53_record" "dmarc" {
-  zone_id = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
+resource "aws_route53_record" "justice_dmarc" {
+  zone_id = aws_route53_zone.justice_route53_zone.zone_id
   name    = "_dmarc.www.justice.gov.uk."
   type    = "TXT"
   ttl     = 300
@@ -42,8 +42,8 @@ resource "aws_route53_record" "dmarc" {
   ]
 }
 
-resource "aws_route53_record" "domain_key" {
-  zone_id = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
+resource "aws_route53_record" "justice_domain_key" {
+  zone_id = aws_route53_zone.justice_route53_zone.zone_id
   name    = "*._domainkey.www.justice.gov.uk."
   type    = "TXT"
   ttl     = 300
@@ -52,8 +52,8 @@ resource "aws_route53_record" "domain_key" {
   ]
 }
 
-resource "aws_route53_record" "github_challenge_moj" {
-  zone_id = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
+resource "aws_route53_record" "justice_github_challenge_moj" {
+  zone_id = aws_route53_zone.justice_route53_zone.zone_id
   name    = "_github-challenge-ministryofjustice.www.justice.gov.uk."
   type    = "TXT"
   ttl     = 300
@@ -62,8 +62,8 @@ resource "aws_route53_record" "github_challenge_moj" {
   ]
 }
 
-resource "aws_route53_record" "github_challenge_moj_as" {
-  zone_id = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
+resource "aws_route53_record" "justice_github_challenge_moj_as" {
+  zone_id = aws_route53_zone.justice_route53_zone.zone_id
   name    = "_github-challenge-moj-analytical-services.www.justice.gov.uk."
   type    = "TXT"
   ttl     = 300
@@ -72,22 +72,22 @@ resource "aws_route53_record" "github_challenge_moj_as" {
   ]
 }
 
-resource "aws_route53_record" "github_pages_cname" {
-  zone_id = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
+resource "aws_route53_record" "justice_github_pages_cname" {
+  zone_id = aws_route53_zone.justice_route53_zone.zone_id
   name    = "howto-admin.www.justice.gov.uk."
   type    = "CNAME"
   ttl     = "300"
   records = ["ministryofjustice.github.io"]
 }
 
-resource "kubernetes_secret" "www_justice_gov_uk_route53_zone" {
+resource "kubernetes_secret" "justice_route53_zone" {
   metadata {
     name      = "justice-route53-zone-output"
     namespace = var.namespace
   }
 
   data = {
-    zone_id      = aws_route53_zone.www_justice_gov_uk_route53_zone.zone_id
-    name_servers = join("\n", aws_route53_zone.www_justice_gov_uk_route53_zone.name_servers)
+    zone_id      = aws_route53_zone.justice_route53_zone.zone_id
+    name_servers = join("\n", aws_route53_zone.justice_route53_zone.name_servers)
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-justice.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/route53-justice.tf
@@ -80,9 +80,9 @@ resource "aws_route53_record" "github_pages_cname" {
   records = ["ministryofjustice.github.io"]
 }
 
-resource "kubernetes_secret" "route53_zone_sec" {
+resource "kubernetes_secret" "www_justice_gov_uk_route53_zone" {
   metadata {
-    name      = "route53-zone-output"
+    name      = "justice-route53-zone-output"
     namespace = var.namespace
   }
 


### PR DESCRIPTION
Post migration step, the service for www.justice.gov.uk previously ran in `justice-gov-uk-porduction` namespace, it has been migrated to `hale-platform-prod`.

This PR moves the reoue53 zone from the legacy namespace, to the current one.

**The zone should be transferred, and should not be destroyed and recreated. It's important that the DNS records stay intact since they are for a live service.**

This approach has previously been ok'd by @sj-williams - he said that it will need some manual action by a Cloud Platform team member to edit terraform state.