### PR TITLE
IR-1897 Enable Data Hub CDC on hmpps-non-associations-prod RDS

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
@@ -28,6 +28,37 @@ module "dps_rds" {
   providers = {
     aws = aws.london
   }
+
+  db_parameter = [
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
+
+  # Add security groups for DPR
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance
@@ -97,6 +128,11 @@ module "dps_rds_replica" {
     {
       name         = "max_slot_wal_keep_size"
       value        = "40000"
+      apply_method = "immediate"
+    },
+    {
+      name         = "hot_standby_feedback"
+      value        = "1"
       apply_method = "immediate"
     }
   ]


### PR DESCRIPTION
## What

Adds the HMPPS Data Hub CDC configuration to the **primary** RDS instance in `hmpps-non-associations-prod`, and `hot_standby_feedback` to its read replica.

- `module "dps_rds"` (primary): `db_parameter` block (`rds.logical_replication`, `shared_preload_libraries = pglogical`, `max_wal_size`, `wal_sender_timeout`, `max_slot_wal_keep_size`) and `vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]`
- `module "dps_rds_replica"`: adds `hot_standby_feedback = 1` to the existing `db_parameter` list

## Why

Both were present on the read replica only. Dev, preprod and all three `hmpps-incentives-*` environments are already configured correctly, so this namespace was the one out of step.

The replica having the parameter block is necessary but not sufficient. `wal_level` is set on the primary and inherited through the WAL stream, and `rds.logical_replication = 1` is what raises it to `logical` — so with the parameter absent on the primary, the replica ships WAL containing no logical decoding information and a DMS task pointed at it has nothing to read.

Without `hot_standby_feedback` the replica invalidates the replication slot DMS uses; the slot shows `wal_status = lost` in `pg_replication_slots` and the task fails. This is called out explicitly in the Data Hub onboarding guidance and in DPR ADR #12.

Follows steps 1 and 2 of *Configure DPS RDS Service for Datahub Ingestion* (Confluence, DPR space). Copied from `hmpps-incentives-prod/resources/rds.tf`, which is already correct on both instances.

## After merge

**The primary needs a reboot.** `rds.logical_replication` and `shared_preload_libraries` are both `apply_method = "pending-reboot"`, so a clean apply does not put them into effect. Confirm with `SHOW wal_level` on the primary — it must return `logical`, not `replica`.

## Notes

`terraform fmt` reports pre-existing alignment drift in the replica block (`vpc_name`, the PostgreSQL specifics). That is already on `main` and unrelated, so it is deliberately not touched here to keep the diff to the fix.

Ticket: https://dsdmoj.atlassian.net/browse/IR-1897
