### PR TITLE
IR-1898 Repoint hmpps-non-associations-prod reviewer_teams to manage-safety-live

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/github.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/github.tf
@@ -8,7 +8,7 @@ module "hmpps-non-associations" {
   environment                   = var.deployment_environment
   is_production                 = var.is_production
   protected_branches_only       = true
-  reviewer_teams                = [var.team_name]
+  reviewer_teams                = ["manage-safety-live"]
   application_insights_instance = var.deployment_environment
   source_template_repo          = "hmpps-template-typescript"
   github_token                  = var.github_token
@@ -27,7 +27,7 @@ module "hmpps-non-associations-api" {
   environment                   = var.deployment_environment
   is_production                 = var.is_production
   protected_branches_only       = true
-  reviewer_teams                = [var.team_name]
+  reviewer_teams                = ["manage-safety-live"]
   application_insights_instance = var.deployment_environment
   source_template_repo          = "hmpps-template-kotlin"
   github_token                  = var.github_token


### PR DESCRIPTION
## What

Points `reviewer_teams` at `manage-safety-live` in `hmpps-non-associations-prod`. Both module blocks in `resources/github.tf`; no other file, no other namespace.

## Why

The GitHub teams `ministryofjustice/hmpps-non-associations` and `ministryofjustice/hmpps-incentives` have been deleted — both return 404. This namespace still passes its one into `cloud-platform-terraform-hmpps-template@1.2.1`, which resolves it at `main.tf:96`:

```hcl
data "github_team" "teams" {
  for_each = toset(var.reviewer_teams)
  slug     = each.value
}
```

A data source for a deleted team fails at **plan** time, so no change to this namespace can be applied at all. This is currently blocking #45223.

IR-1867 repointed the Kubernetes RBAC (`01-rbac.yaml`) and the `team-name` annotation to the `manage-safety` teams, but did not touch the Terraform variables, which is where this reference lives.

## Scope

**No AWS resource is created, destroyed or renamed.** This only changes which GitHub team approves deployments to this environment.

`var.team_name` still defaults to the deleted team name and is deliberately left alone. It is inert for this failure — `github_team` is passed by every namespace but never referenced inside the module; only `reviewer_teams` reaches the lookup. Repointing `team_name` is a separate, riskier change: it prefixes SQS queue and KMS alias names, and while queue names are protected by `lifecycle { ignore_changes = [name] }` in `cloud-platform-terraform-sqs@5.1.2`, `aws_kms_alias.name` is ForceNew with no such guard.

## Notes

Part of a set of four, one per affected namespace: `hmpps-non-associations-prod`, `hmpps-non-associations-preprod`, `hmpps-incentives-preprod`, `hmpps-incentives-prod`. The dev namespaces pass no `reviewer_teams`, so their `for_each` is empty and they are unaffected.

`terraform fmt` reports pre-existing alignment drift on the `force_rotate_token` and `custom_token_rotation_date` lines in this file. Already on `main` and unrelated, so left untouched.

Ticket: https://dsdmoj.atlassian.net/browse/IR-1898
