### PR TITLE
Fix database URL string

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/05-certificates.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/05-certificates.yaml
@@ -5,7 +5,7 @@ metadata:
   name: security-assurance-toolkit-dev.hmpps.service.justice.gov.uk
   namespace: hmpps-security-assurance-toolkit
 spec:
-  secretName: security-assurance-toolkit-dev-cert
+  secretName: security-assurance-toolkit-cert
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
@@ -21,34 +21,16 @@ module "hmpps_security_assurance_toolkit_rds" {
   }
 
 }
+
+
 resource "kubernetes_secret" "hmpps_security_assurance_toolkit_rds" {
   metadata {
     name      = "rds-instance-output"
-    namespace = var.namespace
-  }
-
-  data = {
-    rds_instance_endpoint = module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint
-    database_name         = module.hmpps_security_assurance_toolkit_rds.database_name
-    database_username     = module.hmpps_security_assurance_toolkit_rds.database_username
-    database_password     = module.hmpps_security_assurance_toolkit_rds.database_password
-    rds_instance_address  = module.hmpps_security_assurance_toolkit_rds.rds_instance_address
-  }
-}
-
-resource "kubernetes_secret" "hmpps_security_assurance_toolkit_rds-dev" {
-  metadata {
-    name      = "rds-instance-output-dev"
     namespace = "hmpps-security-assurance-toolkit"
   }
 
   data = {
-    rds_instance_endpoint = module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint
-    database_name         = module.hmpps_security_assurance_toolkit_rds.database_name
-    database_username     = module.hmpps_security_assurance_toolkit_rds.database_username
-    database_password     = module.hmpps_security_assurance_toolkit_rds.database_password
-    database_url          = "postgresql://${module.hmpps_security_assurance_toolkit_rds.database_username}:${module.hmpps_security_assurance_toolkit_rds.database_password}@${module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint}:5432/${module.hmpps_security_assurance_toolkit_rds.database_name}"
-    rds_instance_address  = module.hmpps_security_assurance_toolkit_rds.rds_instance_address
+    DATABASE_URL = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
   }
 }
 
@@ -76,5 +58,16 @@ locals {
 
   database_details = {
     for m in local.database_list : (m.identifier) => m
+  }
+}
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
@@ -30,7 +30,7 @@ resource "kubernetes_secret" "hmpps_security_assurance_toolkit_rds" {
   }
 
   data = {
-    DATABASE_URL = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+    DATABASE_URL = "postgres://${module.hmpps_security_assurance_toolkit_rds.database_username}:${module.hmpps_security_assurance_toolkit_rds.database_password}@${module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint}/${module.hmpps_security_assurance_toolkit_rds.database_name}"
   }
 }
 
@@ -67,7 +67,7 @@ resource "kubernetes_config_map" "rds" {
   }
 
   data = {
-    database_name = module.rds.database_name
-    db_identifier = module.rds.db_identifier
+    database_name = module.hmpps_security_assurance_toolkit_rds.database_name
+    db_identifier = module.hmpps_security_assurance_toolkit_rds.db_identifier
   }
 }


### PR DESCRIPTION
This pull request updates how RDS instance connection details are provided to Kubernetes for the `hmpps-security-assurance-toolkit` service. The main changes include simplifying the Kubernetes secret for RDS credentials, standardizing the secret's format, and introducing a new ConfigMap for non-sensitive RDS metadata.

**Kubernetes resource changes:**

* The `kubernetes_secret.hmpps_security_assurance_toolkit_rds` resource is refactored to only include a single `DATABASE_URL` field, using a standardized format and referencing the `module.rds` output variables.
* The previous secret for the development environment is removed, consolidating secrets into a single resource for all environments.

**New ConfigMap for metadata:**

* A new `kubernetes_config_map.rds` resource is added to expose non-sensitive RDS instance metadata (`database_name` and `db_identifier`) to the namespace, making it available for applications that need this information but not credentials.