### PR TITLE
IR-1899 Add service pod and RDS IRSA policy to hmpps-non-associations-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/irsa.tf
@@ -22,7 +22,8 @@ module "irsa" {
     local.sqs_policies,
     local.sns_policies,
     { prisoner-event-queue = module.prisoner-event-queue.irsa_policy_arn },
-    { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn }
+    { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn },
+    { rds_policy = module.dps_rds.irsa_policy_arn }
   )
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/rds.tf
@@ -59,6 +59,11 @@ module "dps_rds" {
 
   # Add security groups for DPR
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+
+  # Allows the service pod to reboot this instance so that the pending-reboot
+  # parameters above (rds.logical_replication, shared_preload_libraries) take
+  # effect. See IR-1899.
+  enable_irsa = true
 }
 
 # To create a read replica, use the below code and update the values to specify the RDS instance

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/service-pod.tf
@@ -1,0 +1,7 @@
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.3.0"
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name # this uses the service account name from the irsa module
+}


### PR DESCRIPTION
Enables `hmpps-non-associations-prod` to reboot its own RDS primary from a service pod, so the CDC parameters merged by IR-1897 can be applied at a time we control.

### Why

The parameters from #45223 are merged but not in effect. On the production primary `cloud-platform-994c511ab5935ecc`:

```
wal_level                = replica    (pending_restart = t)
rds.logical_replication  = off        (pending_restart = t)
shared_preload_libraries = rdsutils,pg_tle,pg_stat_statements,rds_casts
                                      (pending_restart = t)
```

`shared_preload_libraries` and `rds.logical_replication` are postmaster-level, so RDS only accepts `apply_method = "pending-reboot"` and Terraform cannot apply them without a restart.

The read replica has already been rebooted and reports `wal_level = logical`, but that is not sufficient on its own — WAL is generated on the primary, so while the primary writes replica-level WAL the replica cannot decode more than it receives. A DMS task pointed at the replica reads nothing until the primary restarts.

Cloud Platform advised that teams do RDS reboots themselves from a service pod rather than raising a request.

### What changed

| File | Change |
|---|---|
| `rds.tf` | `enable_irsa = true` on `module "dps_rds"` — creates the IAM policy granting `rds:RebootDBInstance` scoped to this instance's ARN. Defaults to `false`. |
| `irsa.tf` | Attach `module.dps_rds.irsa_policy_arn` to the existing IRSA role, which until now carried only the SQS and SNS policies. |
| `service-pod.tf` | New — `cloud-platform-terraform-service-pod` at `1.3.0`, bound to the existing service account. |

Primary only. The read replica's parameters are already applied (`pending_restart = f`), so it does not need a reboot.

### Verification after apply

```
kubectl -n hmpps-non-associations-prod exec -it <service-pod> -- /bin/sh
aws rds reboot-db-instance \
  --db-instance-identifier cloud-platform-994c511ab5935ecc --force-failover
```

Then `SHOW wal_level` should return `logical`, `SHOW rds.logical_replication` should return `on`, and `shared_preload_libraries` should include `pglogical`.

The reboot will be run in the namespace's existing maintenance window (`sun:00:00-sun:03:00` UTC) rather than during the working day — this is a user-facing service used by prison staff for cell allocation and movement decisions. The service pod will be scaled to zero when not in use.

### Notes

- One namespace only.
- `terraform fmt` reports drift in the `dps_rds_replica` block (`vpc_name`, and the alignment of the PostgreSQL specifics). That is pre-existing on `main` and unrelated to this change, so it has been left untouched.

Tracked on IR-1899. Related: IR-1897 (#45223), and DHS-41 on the Data Hub side.
