### PR TITLE
Swap `hmpps-assessments` for the new `-devs`/`-live` teams in `hmpps-assess-risks-and-needs-integrations-test`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-test/resources/arns-assessment-view-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-test/resources/arns-assessment-view-api.tf
@@ -4,7 +4,7 @@ module "hmpps_arns_assessment_view_api" {
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-arns-assessment-view-api"
   application                   = "hmpps-arns-assessment-view-api"
-  github_team                   = "hmpps-assessments"
+  github_team                   = "hmpps-assessments-devs"
   environment                   = var.environment
   is_production                 = var.is_production
   application_insights_instance = "dev"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-test/resources/arns-coordinator-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-test/resources/arns-coordinator-api.tf
@@ -4,7 +4,7 @@ module "hmpps_assess_risks_and_needs_coordinator_api" {
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-assess-risks-and-needs-coordinator-api"
   application                   = "hmpps-assess-risks-and-needs-coordinator-api"
-  github_team                   = "hmpps-assessments"
+  github_team                   = "hmpps-assessments-devs"
   environment                   = var.environment
   is_production                 = var.is_production
   application_insights_instance = "dev"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-test/resources/arns-handover-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-test/resources/arns-handover-service.tf
@@ -4,7 +4,7 @@ module "hmpps_assess_risks_and_needs_handover_service" {
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-assess-risks-and-needs-handover-service"
   application                   = "hmpps-assess-risks-and-needs-handover-service"
-  github_team                   = "hmpps-assessments"
+  github_team                   = "hmpps-assessments-devs"
   environment                   = var.environment
   is_production                 = var.is_production
   application_insights_instance = "dev"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-test/resources/arns-oastub.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-test/resources/arns-oastub.tf
@@ -4,7 +4,7 @@ module "hmpps_assess_risks_and_needs_oastub_ui" {
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-assess-risks-and-needs-oastub-ui"
   application                   = "hmpps-assess-risks-and-needs-oastub-ui"
-  github_team                   = "hmpps-assessments"
+  github_team                   = "hmpps-assessments-devs"
   environment                   = var.environment
   is_production                 = var.is_production
   application_insights_instance = "dev"


### PR DESCRIPTION
The `hmpps-assessments` GitHub team has been split into `hmpps-assessments-devs` and `hmpps-assessments-live`, so this namespace was still pointing at the old team.