### PR TITLE
Swap `hmpps-assessments` for the new `-devs`/`-live` teams in `hmpps-assess-risks-and-needs-integrations-prod`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-prod/resources/arns-assessment-view-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-prod/resources/arns-assessment-view-api.tf
@@ -4,8 +4,8 @@ module "hmpps_arns_assessment_view_api" {
   custom_token_rotation_date    = "2026-03-20"
   github_repo                   = "hmpps-arns-assessment-view-api"
   application                   = "hmpps-arns-assessment-view-api"
-  github_team                   = "hmpps-assessments"
-  reviewer_teams                = ["hmpps-assessments", "hmpps-sentence-planning"]
+  github_team                   = "hmpps-assessments-devs"
+  reviewer_teams                = ["hmpps-assessments-live", "hmpps-sentence-planning"]
   environment                   = var.environment
   is_production                 = var.is_production
   application_insights_instance = "prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-prod/resources/arns-coordinator-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-prod/resources/arns-coordinator-api.tf
@@ -4,8 +4,8 @@ module "hmpps_assess_risks_and_needs_coordinator_api" {
   custom_token_rotation_date    = "2026-03-20"
   github_repo                   = "hmpps-assess-risks-and-needs-coordinator-api"
   application                   = "hmpps-assess-risks-and-needs-coordinator-api"
-  github_team                   = "hmpps-assessments"
-  reviewer_teams                = ["hmpps-assessments", "hmpps-sentence-planning"]
+  github_team                   = "hmpps-assessments-devs"
+  reviewer_teams                = ["hmpps-assessments-live", "hmpps-sentence-planning"]
   environment                   = var.environment
   is_production                 = var.is_production
   application_insights_instance = "prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-prod/resources/arns-handover-service.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-integrations-prod/resources/arns-handover-service.tf
@@ -4,8 +4,8 @@ module "hmpps_assess_risks_and_needs_handover_service" {
   custom_token_rotation_date    = "2026-03-20"
   github_repo                   = "hmpps-assess-risks-and-needs-handover-service"
   application                   = "hmpps-assess-risks-and-needs-handover-service"
-  github_team                   = "hmpps-assessments"
-  reviewer_teams                = ["hmpps-assessments", "hmpps-sentence-planning"]
+  github_team                   = "hmpps-assessments-devs"
+  reviewer_teams                = ["hmpps-assessments-live", "hmpps-sentence-planning"]
   environment                   = var.environment
   is_production                 = var.is_production
   application_insights_instance = "prod"


### PR DESCRIPTION
The `hmpps-assessments` GitHub team has been split into `hmpps-assessments-devs` and `hmpps-assessments-live`, so this namespace was still pointing at the old team.