### PR TITLE
Swap `hmpps-assessments` for the new `-devs`/`-live` teams in `hmpps-assess-risks-and-needs-dev`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/01-rbac.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: hmpps-assess-risks-and-needs-dev
 subjects:
   - kind: Group
-    name: "github:hmpps-assessments"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
     name: "github:hmpps-assessments-devs"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/resources/arns-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-dev/resources/arns-api.tf
@@ -4,7 +4,7 @@ module "hmpps_assess_risks_and_needs" {
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-assess-risks-and-needs"
   application                   = "hmpps-assess-risks-and-needs"
-  github_team                   = "hmpps-assessments"
+  github_team                   = "hmpps-assessments-devs"
   environment                   = var.environment_name
   is_production                 = var.is_production
   application_insights_instance = "dev"


### PR DESCRIPTION
The `hmpps-assessments` GitHub team has been split into `hmpps-assessments-devs` and `hmpps-assessments-live`, so this namespace was still pointing at the old team.