### PR TITLE
Swap `hmpps-assessments` for the new `-devs`/`-live` teams in `hmpps-assess-risks-and-needs-preprod`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-preprod/01-rbac.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: hmpps-assess-risks-and-needs-preprod
 subjects:
   - kind: Group
-    name: "github:hmpps-assessments"
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
     name: "github:hmpps-assessments-live"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-preprod/resources/arns-api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assess-risks-and-needs-preprod/resources/arns-api.tf
@@ -4,8 +4,8 @@ module "hmpps_assess_risks_and_needs" {
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-assess-risks-and-needs"
   application                   = "hmpps-assess-risks-and-needs"
-  github_team                   = "hmpps-assessments"
-  reviewer_teams                = ["hmpps-assessments"]
+  github_team                   = "hmpps-assessments-devs"
+  reviewer_teams                = ["hmpps-assessments-live"]
   environment                   = var.environment_name
   is_production                 = var.is_production
   application_insights_instance = "preprod"


### PR DESCRIPTION
The `hmpps-assessments` GitHub team has been split into `hmpps-assessments-devs` and `hmpps-assessments-live`, so this namespace was still pointing at the old team.