### PR TITLE
Swap `hmpps-assessments` for the new `-devs`/`-live` teams in `hmpps-assessments-prod`

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: hmpps-assessments-prod
 subjects:
   - kind: Group
-    name: "github:hmpps-assessments"
+    name: "github:hmpps-assessments-live"
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "github:hmpps-sre"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/upw_api.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/upw_api.tf
@@ -4,8 +4,8 @@ module "hmpps_assessments_api" {
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-assessments-api"
   application                   = "hmpps-assessments-api"
-  github_team                   = "hmpps-assessments"
-  reviewer_teams                = ["hmpps-assessments"]
+  github_team                   = "hmpps-assessments-devs"
+  reviewer_teams                = ["hmpps-assessments-live"]
   environment                   = var.environment_name
   is_production                 = var.is_production
   application_insights_instance = "prod"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/upw_ui.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-assessments-prod/resources/upw_ui.tf
@@ -4,8 +4,8 @@ module "hmpps_risk_assessment_ui" {
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-risk-assessment-ui"
   application                   = "hmpps-risk-assessment-ui"
-  github_team                   = "hmpps-assessments"
-  reviewer_teams                = ["hmpps-assessments"]
+  github_team                   = "hmpps-assessments-devs"
+  reviewer_teams                = ["hmpps-assessments-live"]
   environment                   = var.environment_name
   is_production                 = var.is_production
   application_insights_instance = "prod"


### PR DESCRIPTION
The `hmpps-assessments` GitHub team has been split into `hmpps-assessments-devs` and `hmpps-assessments-live`, so this namespace was still pointing at the old team.