### PR TITLE
MAPB-763 Enable RDS IRSA and service pod reboot for prisoner property in hmpps-locations-inside-prison-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/irsa.tf
@@ -23,7 +23,8 @@ module "irsa" {
     { (module.update_from_external_system_events_queue.sqs_name) = module.update_from_external_system_events_queue.irsa_policy_arn },
     { (module.update_from_external_system_events_dlq.sqs_name) = module.update_from_external_system_events_dlq.irsa_policy_arn },
     { (module.update_cell_certificate_queue.sqs_name) = module.update_cell_certificate_queue.irsa_policy_arn },
-    { (module.update_cell_certificate_dlq.sqs_name) = module.update_cell_certificate_dlq.irsa_policy_arn }
+    { (module.update_cell_certificate_dlq.sqs_name) = module.update_cell_certificate_dlq.irsa_policy_arn },
+    { prisoner_property_rds_policy = module.prisoner_property_rds.irsa_policy_arn }
   )
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/prisoner-property-rds.tf
@@ -74,6 +74,11 @@ module "prisoner_property_rds" {
   ]
 
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+
+  # Creates the IAM policy granting rds:RebootDBInstance on this instance, so the namespace
+  # service pod can apply the pending-reboot parameters above. Cloud Platform do not perform
+  # RDS reboots on request - teams do them from a service pod. Defaults to false. See MAPB-763.
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "prisoner_property_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/service-pod.tf
@@ -1,0 +1,7 @@
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.3.0" # use the latest release
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name # this uses the service account name from the irsa module
+}


### PR DESCRIPTION
Enables the namespace service pod to reboot the prisoner property RDS instance, so the Datahub CDC parameters already in place can actually take effect.

### Why

`prisoner-property-rds.tf` already sets the full Datahub parameter group. Two of those parameters — `rds.logical_replication` and `shared_preload_libraries` — are postmaster-level, so RDS only accepts `apply_method = "pending-reboot"`. Terraform applies them but does not reboot, and Cloud Platform do not perform RDS reboots on request: teams do them from a service pod.

Property cannot do that today. `enable_irsa` is absent from the property RDS module and defaults to `false`, so the IAM policy granting `rds:RebootDBInstance` is never created, and the IRSA role carries only the SQS and SNS policies.

### What changed

| File | Change |
|---|---|
| `prisoner-property-rds.tf` | `enable_irsa = true` on `module "prisoner_property_rds"` |
| `irsa.tf` | Attach `module.prisoner_property_rds.irsa_policy_arn` to the IRSA role |
| `service-pod.tf` | **New** — this namespace has no service pod at all. Added at `1.3.0` |

### One deliberate choice worth reviewing

The policy is attached to `module "irsa"` (service account `hmpps-locations-inside-prison-api`) rather than `module "prisoner_property_irsa"` (`hmpps-prisoner-property-api`), because `module.irsa` provides the service account the existing service pod assumes. A second service pod bound to the property service account would collide on resource addresses within the Cloud Platform module.

The effect is that the namespace's shared operator pod gains reboot rights on the property database. That reads as an operator capability rather than an application grant, but it is a real widening and worth a second opinion.

### Notes

- One namespace only.
- `terraform fmt` reports pre-existing drift in `github.tf`, `main.tf`, `rds.tf`, `ssm.tf`, `variables.tf` and `prisoner-property-irsa.tf` in this namespace. Unrelated to this change and left untouched.
- Same pattern as #45272, which did this for `hmpps-non-associations-prod`.

Tracked on MAPB-763. Dev is #45311; prod follows in a separate PR.
