### PR TITLE
MAPB-763 Enable RDS IRSA and service pod reboot for prisoner property in hmpps-locations-inside-prison-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/irsa.tf
@@ -26,7 +26,9 @@ module "irsa" {
     { (module.update_from_external_system_events_queue.sqs_name) = module.update_from_external_system_events_queue.irsa_policy_arn },
     { (module.update_from_external_system_events_dlq.sqs_name) = module.update_from_external_system_events_dlq.irsa_policy_arn },
     { (module.update_cell_certificate_queue.sqs_name) = module.update_cell_certificate_queue.irsa_policy_arn },
-    { (module.update_cell_certificate_dlq.sqs_name) = module.update_cell_certificate_dlq.irsa_policy_arn }
+    { (module.update_cell_certificate_dlq.sqs_name) = module.update_cell_certificate_dlq.irsa_policy_arn },
+    { prisoner_property_rds_policy = module.prisoner_property_rds.irsa_policy_arn },
+    { prisoner_property_rds_replica_policy = module.prisoner_property_rds_replica[0].irsa_policy_arn }
   )
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-rds.tf
@@ -73,6 +73,11 @@ module "prisoner_property_rds" {
   ]
 
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+
+  # Creates the IAM policy granting rds:RebootDBInstance on this instance, so the namespace
+  # service pod can apply the pending-reboot parameters above. Cloud Platform do not perform
+  # RDS reboots on request - teams do them from a service pod. Defaults to false. See MAPB-763.
+  enable_irsa = true
 }
 
 # Read replica for Datahub ingestion (MAPB-763). Datahub's CDC capture reads from here rather than
@@ -160,6 +165,11 @@ module "prisoner_property_rds_replica" {
   }
 
   vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+
+  # The policy the module emits is scoped to its own instance ARN, so the replica needs its own
+  # enable_irsa - the primary's policy does not cover it. Without this the replica cannot be
+  # rebooted, and the replica is the instance Datahub reads from. See MAPB-763.
+  enable_irsa = true
 }
 
 resource "kubernetes_secret" "prisoner_property_rds" {

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/service-pod.tf
@@ -1,0 +1,7 @@
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.3.0" # use the latest release
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name # this uses the service account name from the irsa module
+}


### PR DESCRIPTION
Enables the namespace service pod to reboot **both** prisoner property RDS instances in production, so the Datahub CDC parameters already in place can take effect.

### Why

`prisoner-property-rds.tf` already sets the full Datahub parameter group on the primary and the read replica. Two of those parameters — `rds.logical_replication` and `shared_preload_libraries` — are postmaster-level, so RDS only accepts `apply_method = "pending-reboot"`. Terraform applies them but does not reboot, and Cloud Platform do not perform RDS reboots on request: teams do them from a service pod.

Property cannot do that today. `enable_irsa` is absent from both property RDS modules and defaults to `false`, the IRSA role carries only SQS and SNS policies, and this namespace has no service pod at all.

### What changed

| File | Change |
|---|---|
| `prisoner-property-rds.tf` | `enable_irsa = true` on **both** `prisoner_property_rds` and `prisoner_property_rds_replica` |
| `irsa.tf` | Attach **both** policy ARNs to the IRSA role |
| `service-pod.tf` | **New** — at `1.3.0` |

### The replica needs its own policy

The IAM policy the RDS module emits is scoped to its own instance ARN, so the primary's policy does not cover the replica. Without `enable_irsa` on the replica you can reboot the primary and not the replica — and the replica is the instance Datahub reads from, so it is the one most likely to need it.

This is a real gap in the equivalent `hmpps-non-associations-prod` setup (#45272), which sets `enable_irsa` on the primary only and cannot reboot its replica. Worth correcting there separately.

### Ordering note for whoever runs the reboot

The replica already exists and was created before the primary was rebooted, so it may have come up at `wal_level = replica` and need its own reboot after the primary's. Check the replica specifically with `show wal_level` and `pg_is_in_recovery()` rather than assuming the primary's reboot is sufficient.

`hmpps-prisoner-property-api` is **not a live service yet**, so no maintenance window is needed — both reboots can be run as soon as this applies.

### Notes

- One namespace only.
- Scale the service pod to zero when not in use. It holds `RebootDBInstance`, `ModifyDBInstance` and `DeleteDBSnapshot` on a production database.
- The policy attaches to `module "irsa"` (SA `hmpps-locations-inside-prison-api`), the service account the service pod assumes, rather than `module "prisoner_property_irsa"`. A second service pod bound to the property service account would collide on resource addresses in the Cloud Platform module.
- `terraform fmt` reports pre-existing drift in `github.tf`, `rds.tf`, `ssm.tf`, `variables.tf` and `prisoner-property-irsa.tf`. Unrelated and left untouched.

Tracked on MAPB-763. Dev is #45311, preprod is #45312.
