### PR TITLE
MAPA-344 Prepare RDS for Data Hub CDC ingestion in hmpps-cell-sharing-risk-assessment-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/irsa.tf
@@ -19,7 +19,8 @@ module "irsa" {
     local.sqs_policies,
     local.sns_policies,
     { prisoner-event-queue = module.prisoner-event-queue.irsa_policy_arn },
-    { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn }
+    { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn },
+    { rds_policy = module.rds.irsa_policy_arn }
   )
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/rds-postgresql.tf
@@ -4,6 +4,12 @@
  * releases page of this repository.
  *
  */
+# Retrieve mp_dps_sg_name SG group ID, CP-MP-INGRESS. Required so the Data Hub DMS process can
+# reach this instance on 5432. MAPA-344.
+data "aws_security_group" "mp_dps_sg" {
+  name = var.mp_dps_sg_name
+}
+
 module "rds" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
 
@@ -19,10 +25,10 @@ module "rds" {
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # PostgreSQL specifics
-  db_engine         = "postgres"
-  db_engine_version = "18" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
-  rds_family        = "postgres18"
-  db_instance_class = "db.t4g.small"
+  db_engine                 = "postgres"
+  db_engine_version         = "18" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family                = "postgres18"
+  db_instance_class         = "db.t4g.small"
   prepare_for_major_upgrade = false
 
   # Tags
@@ -34,10 +40,57 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 
-  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for CLI queries,
-  # uncomment below:
+  # Datahub ingestion (MAPA-344). rds.logical_replication and shared_preload_libraries are
+  # pending-reboot, so the instance must be rebooted after this applies before `show wal_level;`
+  # reports `logical` and the pglogical extension will install.
+  # https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352
+  db_parameter = [
+    {
+      # The module's db_parameter default is a single rds.force_ssl entry, and supplying our own list
+      # replaces it rather than merging - so this must be restated here or TLS stops being enforced.
+      # This instance currently relies on that default, so omitting it would be a live change.
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "immediate"
+    },
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      # This list replaces the engine default rather than merging with it. Listing only pglogical
+      # would silently drop pg_tle and pg_stat_statements. RDS re-adds rdsutils and rds_casts itself,
+      # so they do not need listing.
+      name         = "shared_preload_libraries"
+      value        = "pg_tle,pg_stat_statements,pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
 
-  # enable_irsa = true
+  # Add security group for DPR. This is additive - the module concats it with the instance's own
+  # security group - so application connectivity is unaffected.
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+
+  # Creates the IAM policy granting rds:RebootDBInstance on this instance, so the namespace service
+  # pod can apply the pending-reboot parameters above. Cloud Platform do not perform RDS reboots on
+  # request - teams do them from a service pod. Defaults to false.
+  enable_irsa = true
 
   # If you want to enable Cloudwatch logging for this postgres RDS instance, uncomment the code below:
   # opt_in_xsiam_logging = true
@@ -50,6 +103,8 @@ resource "kubernetes_secret" "rds" {
   }
 
   data = {
+    db_identifier         = module.rds.db_identifier
+    resource_id           = module.rds.resource_id
     rds_instance_endpoint = module.rds.rds_instance_endpoint
     database_name         = module.rds.database_name
     database_username     = module.rds.database_username

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/service-pod.tf
@@ -1,0 +1,7 @@
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.3.0" # use the latest release
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name # this uses the service account name from the irsa module
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-preprod/resources/variables.tf
@@ -73,9 +73,9 @@ variable "service_area" {
 }
 
 variable "deployment_environment" {
-  type = string
+  type        = string
   description = "Environment code used when deploying, e.g. dev, preprod or prod"
-  default = "preprod"
+  default     = "preprod"
 }
 
 variable "github_owner" {
@@ -88,4 +88,10 @@ variable "github_token" {
   type        = string
   description = "Required by the GitHub Terraform provider"
   default     = ""
+}
+
+variable "mp_dps_sg_name" {
+  type        = string
+  description = "Required for MP DPR Traffic ingress into CP DPS"
+  default     = "cloudplatform-mp-dps-sg"
 }


### PR DESCRIPTION
Adds the Data Hub CDC prerequisites to CSRA **preprod**. CSRA currently has none of them.

### Why

The data dictionary work is complete (MAPA-294/295/296) and the schema report is published, but the database itself is untouched — no parameter group, no Data Hub security group, no service pod. This follows [Configure DPS RDS Service for Datahub Ingestion](https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352) and the read-only amendments in [6217335041](https://dsdmoj.atlassian.net/wiki/spaces/moveandimprove/pages/6217335041).

### What changed

| File | Change |
|---|---|
| `rds-postgresql.tf` | `db_parameter` (6 entries), `mp_dps_sg` data source, `vpc_security_group_ids`, `enable_irsa = true`, and `db_identifier`/`resource_id` on the RDS secret |
| `variables.tf` | New `mp_dps_sg_name`, default `cloudplatform-mp-dps-sg` |
| `irsa.tf` | Attach `module.rds.irsa_policy_arn` to the IRSA role |
| `service-pod.tf` | **New** — at `1.3.0` |

### `rds.force_ssl` is the one to look at

The module's `db_parameter` default is a single `rds.force_ssl = 1` entry, and supplying our own list **replaces** it rather than merging (`all_db_parameters = concat(logging, var.db_parameter)` in the module). This instance has no `db_parameter` today, so it currently relies on that default — omitting `force_ssl` from the new list would silently stop enforcing TLS on a live database. It is restated as the first entry, which is a no-op rather than a change of behaviour.

This is a trap worth knowing about: it caught the incentives and non-associations namespaces, which supply their own lists without restating it.

### Safety notes

- **The security group is additive.** The module does `concat([aws_security_group.rds-sg.id], var.vpc_security_group_ids)`, so adding the Data Hub group cannot break application connectivity.
- **A reboot is required afterwards.** `rds.logical_replication` and `shared_preload_libraries` are postmaster-level and so `pending-reboot`. Until the instance restarts, `show wal_level;` will report `replica` and `create extension pglogical;` will fail. Cloud Platform do not perform reboots on request, which is why the service pod is part of this change.
- **No `providers` block was added.** This namespace's `module "rds"` uses the default AWS provider, which is already `eu-west-2` with the same default tags as the `london` alias. Adding a provider mapping to a module with live state would risk provider-address churn for no benefit.

### Formatting

This also picks up `terraform fmt` alignment in two blocks it does not otherwise change — the PostgreSQL specifics in `rds-postgresql.tf` and `deployment_environment` in `variables.tf` — because both files were reformatted when edited. Mechanical only, flagged so it is not mistaken for a functional change.

### Notes

- One namespace only.
- Scale the service pod to zero when not in use; it holds `RebootDBInstance` and `ModifyDBInstance` on the database.
- The production read replica is deliberately **not** in this series yet. A replica built from a primary still at `wal_level = replica` comes up at `replica` itself, so it will be added in a follow-up PR once the prod primary is rebooted and reports `logical`.

Tracked on MAPA-344. IG sign-off for CSRA's 33 special-category columns is MAPA-345 and blocks the production steps.
