### PR TITLE
MAPA-344 Prepare RDS and add Data Hub read replica in hmpps-cell-sharing-risk-assessment-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/irsa.tf
@@ -20,7 +20,8 @@ module "irsa" {
     local.sns_policies,
     { prisoner-event-queue = module.prisoner-event-queue.irsa_policy_arn },
     { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn },
-    { rds_policy = module.rds.irsa_policy_arn }
+    { rds_policy = module.rds.irsa_policy_arn },
+    { rds_replica_policy = module.rds_replica[0].irsa_policy_arn }
   )
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/irsa.tf
@@ -19,7 +19,8 @@ module "irsa" {
     local.sqs_policies,
     local.sns_policies,
     { prisoner-event-queue = module.prisoner-event-queue.irsa_policy_arn },
-    { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn }
+    { prisoner-event-dlq = module.prisoner-event-dlq.irsa_policy_arn },
+    { rds_policy = module.rds.irsa_policy_arn }
   )
   # Tags
   business_unit          = var.business_unit

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/rds-postgresql.tf
@@ -4,6 +4,12 @@
  * releases page of this repository.
  *
  */
+# Retrieve mp_dps_sg_name SG group ID, CP-MP-INGRESS. Required so the Data Hub DMS process can
+# reach this instance on 5432. MAPA-344.
+data "aws_security_group" "mp_dps_sg" {
+  name = var.mp_dps_sg_name
+}
+
 module "rds" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
 
@@ -19,10 +25,10 @@ module "rds" {
   # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
 
   # PostgreSQL specifics
-  db_engine         = "postgres"
-  db_engine_version = "18" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
-  rds_family        = "postgres18"
-  db_instance_class = "db.t4g.large"
+  db_engine                 = "postgres"
+  db_engine_version         = "18" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family                = "postgres18"
+  db_instance_class         = "db.t4g.large"
   prepare_for_major_upgrade = false
 
   # Tags
@@ -34,10 +40,57 @@ module "rds" {
   namespace              = var.namespace
   team_name              = var.team_name
 
-  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for CLI queries,
-  # uncomment below:
+  # Datahub ingestion (MAPA-344). rds.logical_replication and shared_preload_libraries are
+  # pending-reboot, so the instance must be rebooted after this applies before `show wal_level;`
+  # reports `logical` and the pglogical extension will install.
+  # https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352
+  db_parameter = [
+    {
+      # The module's db_parameter default is a single rds.force_ssl entry, and supplying our own list
+      # replaces it rather than merging - so this must be restated here or TLS stops being enforced.
+      # This instance currently relies on that default, so omitting it would be a live change.
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "immediate"
+    },
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      # This list replaces the engine default rather than merging with it. Listing only pglogical
+      # would silently drop pg_tle and pg_stat_statements. RDS re-adds rdsutils and rds_casts itself,
+      # so they do not need listing.
+      name         = "shared_preload_libraries"
+      value        = "pg_tle,pg_stat_statements,pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    }
+  ]
 
-  # enable_irsa = true
+  # Add security group for DPR. This is additive - the module concats it with the instance's own
+  # security group - so application connectivity is unaffected.
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+
+  # Creates the IAM policy granting rds:RebootDBInstance on this instance, so the namespace service
+  # pod can apply the pending-reboot parameters above. Cloud Platform do not perform RDS reboots on
+  # request - teams do them from a service pod. Defaults to false.
+  enable_irsa = true
 
   # If you want to enable Cloudwatch logging for this postgres RDS instance, uncomment the code below:
   # opt_in_xsiam_logging = true
@@ -50,6 +103,8 @@ resource "kubernetes_secret" "rds" {
   }
 
   data = {
+    db_identifier         = module.rds.db_identifier
+    resource_id           = module.rds.resource_id
     rds_instance_endpoint = module.rds.rds_instance_endpoint
     database_name         = module.rds.database_name
     database_username     = module.rds.database_username

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/rds-postgresql.tf
@@ -96,6 +96,98 @@ module "rds" {
   # opt_in_xsiam_logging = true
 }
 
+# Read replica for Data Hub ingestion (MAPA-344). Data Hub's CDC capture reads from here rather
+# than the primary, so its reads cannot affect the operational database. Data Hub confirmed
+# (03/09/2026) that they use test_decoding when ingesting from a replica, so no pglogical
+# extension is needed on this instance.
+#
+# hot_standby_feedback is required on a replica: without it the replica invalidates the
+# replication slot the DMS process consumes from.
+#
+# Note this is created alongside the primary rather than after it. A replica built from a primary
+# still at wal_level = replica comes up at replica itself, so BOTH instances need rebooting once
+# this applies - the primary first, then the replica. Neither service is live yet, so the two
+# short outages are acceptable.
+module "rds_replica" {
+  count  = 1
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  vpc_name = var.vpc_name
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  # Must match the source instance
+  db_engine                    = "postgres"
+  db_engine_version            = "18"
+  rds_family                   = "postgres18"
+  db_instance_class            = "db.t4g.large"
+  db_max_allocated_storage     = "500"
+  performance_insights_enabled = false
+
+  # Conflicts with replicate_source_db, so must be null on a replica
+  db_name = null
+
+  replicate_source_db = module.rds.db_identifier
+
+  # No backups or snapshots are taken of a read replica
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  db_parameter = [
+    {
+      # As on the primary, this list replaces the module default rather than merging with it, so
+      # rds.force_ssl must be restated or TLS stops being enforced.
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "immediate"
+    },
+    {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pg_tle,pg_stat_statements,pglogical"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "max_wal_size"
+      value        = "1024"
+      apply_method = "immediate"
+    },
+    {
+      name         = "wal_sender_timeout"
+      value        = "0"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_slot_wal_keep_size"
+      value        = "40000"
+      apply_method = "immediate"
+    },
+    {
+      name         = "hot_standby_feedback"
+      value        = "1"
+      apply_method = "immediate"
+    }
+  ]
+
+  vpc_security_group_ids = [data.aws_security_group.mp_dps_sg.id]
+
+  # The policy the module emits is scoped to its own instance ARN, so the replica needs its own
+  # enable_irsa - the primary's policy does not cover it. Without this the replica cannot be
+  # rebooted, and the replica is the instance Data Hub reads from.
+  enable_irsa = true
+}
+
 resource "kubernetes_secret" "rds" {
   metadata {
     name      = "rds-postgresql-instance-output"
@@ -130,5 +222,21 @@ resource "kubernetes_config_map" "rds" {
   data = {
     database_name = module.rds.database_name
     db_identifier = module.rds.db_identifier
+  }
+}
+
+# The replica's credentials and database name are the same as the primary, so only the endpoint is
+# published here. Data Hub's DMS source endpoint points at this address.
+resource "kubernetes_secret" "rds_replica" {
+  count = 1
+
+  metadata {
+    name      = "rds-postgresql-read-replica-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds_replica[0].rds_instance_endpoint
+    rds_instance_address  = module.rds_replica[0].rds_instance_address
   }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/service-pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/service-pod.tf
@@ -1,0 +1,7 @@
+module "service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.3.0" # use the latest release
+
+  # Configuration
+  namespace            = var.namespace
+  service_account_name = module.irsa.service_account.name # this uses the service account name from the irsa module
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-prod/resources/variables.tf
@@ -73,9 +73,9 @@ variable "service_area" {
 }
 
 variable "deployment_environment" {
-  type = string
+  type        = string
   description = "Environment code used when deploying, e.g. dev, preprod or prod"
-  default = "prod"
+  default     = "prod"
 }
 
 variable "github_owner" {
@@ -88,4 +88,10 @@ variable "github_token" {
   type        = string
   description = "Required by the GitHub Terraform provider"
   default     = ""
+}
+
+variable "mp_dps_sg_name" {
+  type        = string
+  description = "Required for MP DPR Traffic ingress into CP DPS"
+  default     = "cloudplatform-mp-dps-sg"
 }


### PR DESCRIPTION
Adds the Data Hub CDC prerequisites to CSRA **prod**. CSRA currently has none of them.

### Why

The data dictionary work is complete (MAPA-294/295/296) and the schema report is published, but the database itself is untouched — no parameter group, no Data Hub security group, no service pod. This follows [Configure DPS RDS Service for Datahub Ingestion](https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/4461494352) and the read-only amendments in [6217335041](https://dsdmoj.atlassian.net/wiki/spaces/moveandimprove/pages/6217335041).

### What changed

| File | Change |
|---|---|
| `rds-postgresql.tf` | `db_parameter` (6 entries), `mp_dps_sg` data source, `vpc_security_group_ids`, `enable_irsa = true`, and `db_identifier`/`resource_id` on the RDS secret |
| `variables.tf` | New `mp_dps_sg_name`, default `cloudplatform-mp-dps-sg` |
| `irsa.tf` | Attach `module.rds.irsa_policy_arn` to the IRSA role |
| `service-pod.tf` | **New** — at `1.3.0` |

### `rds.force_ssl` is the one to look at

The module's `db_parameter` default is a single `rds.force_ssl = 1` entry, and supplying our own list **replaces** it rather than merging (`all_db_parameters = concat(logging, var.db_parameter)` in the module). This instance has no `db_parameter` today, so it currently relies on that default — omitting `force_ssl` from the new list would silently stop enforcing TLS on a live database. It is restated as the first entry, which is a no-op rather than a change of behaviour.

This is a trap worth knowing about: it caught the incentives and non-associations namespaces, which supply their own lists without restating it.

### Safety notes

- **The security group is additive.** The module does `concat([aws_security_group.rds-sg.id], var.vpc_security_group_ids)`, so adding the Data Hub group cannot break application connectivity.
- **A reboot is required afterwards.** `rds.logical_replication` and `shared_preload_libraries` are postmaster-level and so `pending-reboot`. Until the instance restarts, `show wal_level;` will report `replica` and `create extension pglogical;` will fail. Cloud Platform do not perform reboots on request, which is why the service pod is part of this change.
- **No `providers` block was added.** This namespace's `module "rds"` uses the default AWS provider, which is already `eu-west-2` with the same default tags as the `london` alias. Adding a provider mapping to a module with live state would risk provider-address churn for no benefit.

### Formatting

This also picks up `terraform fmt` alignment in two blocks it does not otherwise change — the PostgreSQL specifics in `rds-postgresql.tf` and `deployment_environment` in `variables.tf` — because both files were reformatted when edited. Mechanical only, flagged so it is not mistaken for a functional change.

### Notes

- One namespace only.
- Scale the service pod to zero when not in use; it holds `RebootDBInstance` and `ModifyDBInstance` on the database.
- No `providers` block on the replica, matching `module "rds"` in this namespace.

### Also adds the production read replica

Data Hub's CDC capture should read from a replica rather than the operational database. Property production already has one; CSRA had none in any environment. This adds `module.rds_replica` replicating from `module.rds`, with the same six CDC parameters plus `hot_standby_feedback = 1`, the Data Hub security group, `enable_irsa`, and a secret publishing its endpoint as `rds-postgresql-read-replica-output`.

`enable_irsa` is set on the replica as well as the primary. The policy the module emits is scoped to its own instance ARN, so the primary's does not cover it — and the replica is the instance Data Hub reads from, so it is the one most likely to need rebooting.

Data Hub confirmed on 3 September that they use `test_decoding` when ingesting from a replica and `pglogical` only from a primary, so **no pglogical extension is needed** on either instance here.

### Reboot ordering

The replica is created alongside the primary rather than after it, so **both need rebooting once this applies — the primary first, then the replica.** A replica built from a primary still at `wal_level = replica` comes up at `replica` itself.

This was originally planned as a separate follow-up PR to avoid a second production reboot. CSRA production is not a live service yet, so the extra outage costs nothing and one PR is simpler. `enable_rds_auto_start_stop = false` in this namespace, so neither reboot will happen on its own — both must be deliberate.

Tracked on MAPA-344. IG sign-off for CSRA's 33 special-category columns is MAPA-345 and blocks the production steps.
