### PR TITLE
Hale-platform-prod enable AWS perfoamnce insights

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/rds.tf
@@ -8,7 +8,7 @@ module "rds" {
   namespace     = var.namespace
 
   # turn off performance insights
-  performance_insights_enabled = false
+  performance_insights_enabled = true
 
   # general options
   db_instance_class      = "db.t4g.small"


### PR DESCRIPTION
Enable AWS performance Insights on Hale platform prod