### PR TITLE
MAPA-242 Subscribe the CSRA queue to prisoner received and merged events in dev

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-dev/resources/sqs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-cell-sharing-risk-assessment-dev/resources/sqs.tf
@@ -5,7 +5,8 @@ resource "aws_sns_topic_subscription" "prisoner_event_queue_subscription" {
   endpoint  = module.prisoner-event-queue.sqs_arn
   filter_policy = jsonencode({
     eventType = [
-      "dummy-event-will-filter-out-all-events",
+      "prison-offender-events.prisoner.received",
+      "prison-offender-events.prisoner.merged",
     ]
   })
 }


### PR DESCRIPTION
Widens the SNS subscription filter on the CSRA `prisoner-event-queue` so the service actually receives the domain events it consumes.

The filter has been the placeholder `dummy-event-will-filter-out-all-events` since the queue was created, so nothing has ever reached it. `hmpps-cell-sharing-risk-assessment-api` consumes two event types:

- `prison-offender-events.prisoner.received` — closes or archives in-progress reviews on admission, and resets the current rating to "No rating" on a readmission after release.
- `prison-offender-events.prisoner.merged` — moves a prisoner's CSRA data onto their surviving prisoner number when NOMIS merges two numbers for the same person.

Both handlers are deployed; only the filter has been holding them back.

Worth knowing: this switches movement handling on as well as merge handling, estate-wide. That is intended. The DPS → NOMIS sync direction is not enabled, so nothing acts on the domain events CSRA publishes as a result, and data drift is caught by the regular reconciliations.

App side: ministryofjustice/hmpps-cell-sharing-risk-assessment-api#150
