### PR TITLE
MAPB-835 Subscribe the prisoner property queue to prisoner merged events in prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-sqs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-sqs.tf
@@ -12,6 +12,7 @@ resource "aws_sns_topic_subscription" "prisoner_property_event_queue_subscriptio
     eventType = [
       "prison-offender-events.prisoner.released",
       "prison-offender-events.prisoner.received",
+      "prison-offender-events.prisoner.merged",
     ]
   })
 }


### PR DESCRIPTION
Adds `prison-offender-events.prisoner.merged` to the SNS subscription filter on the prisoner-property domain-events queue.

`hmpps-prisoner-property-api` now handles the event: when NOMIS merges two prisoner numbers for the same person, every property container held under the retired number moves to the surviving one. Without this filter change the queue never sees the event, and a merged prisoner's property silently disappears from their property page.

`prisoner.received` and `prisoner.released` are unchanged.

App side: ministryofjustice/hmpps-prisoner-property-api#108
