### PR TITLE
hale-platform-prod: revert insights enable flag - instance size not c…

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hale-platform-prod/resources/rds.tf
@@ -8,7 +8,7 @@ module "rds" {
   namespace     = var.namespace
 
   # turn off performance insights
-  performance_insights_enabled = true
+  performance_insights_enabled = false
 
   # general options
   db_instance_class      = "db.t4g.small"


### PR DESCRIPTION
…ompatible.

Db instance not large enough to allow performance insights to be enabled.