### PR TITLE
feat: add github app private key secret

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module-prod/resources/secrets-manager.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module-prod/resources/secrets-manager.tf
@@ -1,0 +1,21 @@
+module "secret" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+
+  eks_cluster_name = var.eks_cluster_name
+
+  secrets = {
+    "cloud-platform-go-get-module-private-key" = {
+      description             = "GitHub App private key for cloud-platform-go-get-module"
+      recovery_window_in_days = 7
+      k8s_secret_name         = "cloud-platform-go-get-module-private-key"
+    }
+  }
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/cloud-platform-go-get-module-prod/resources/variables.tf
@@ -6,6 +6,9 @@ variable "vpc_name" {
 variable "kubernetes_cluster" {
 }
 
+variable "eks_cluster_name" {
+}
+
 variable "application" {
   description = "Name of Application you are deploying"
   default     = "cloud-platform-go-get-module"


### PR DESCRIPTION
Adds a secret so we can authenticate to the new github app with a private key https://github.com/organizations/ministryofjustice/settings/apps/cloud-platform-go-get-module

RE: https://github.com/ministryofjustice/cloud-platform/issues/8392