### PR TITLE
IR-1920 Add non-associations UI service account for the HMPPS Audit queue in hmpps-non-associations-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-prod/resources/irsa.tf
@@ -43,3 +43,24 @@ data "aws_ssm_parameter" "irsa_policy_arns_sns" {
   for_each = local.sns_topics
   name     = "/${each.value}/sns/${each.key}/irsa-policy-arn"
 }
+
+# Service account for the non-associations front end, so it can send page-view
+# events to the HMPPS Audit queue. Deliberately separate from the API service
+# account above so the front end does not inherit the API's RDS and SNS access.
+module "hmpps-non-associations-ui-service-account" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = "hmpps-non-associations-ui"
+  role_policy_arns = {
+    audit_sqs = data.aws_ssm_parameter.irsa_policy_arns_sqs["Digital-Prison-Services-prod-hmpps_audit_queue"].value
+  }
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}


### PR DESCRIPTION
Adds a `hmpps-non-associations-ui` IRSA service account to `hmpps-non-associations-prod`, so the non-associations front end can send page-view events to the HMPPS Audit queue.

### Why

The non-associations service currently audits API writes only. There is no record of a user *viewing* non-association data, which is a gap for information governance — see [IR-1920](https://dsdmoj.atlassian.net/browse/IR-1920).

The only IRSA service account in this namespace today is `hmpps-non-associations-api`, which belongs to the API. The front end needs its own IAM identity before it can write to the audit queue.

### What this does

Adds one `cloud-platform-terraform-irsa` module granting **only** the audit queue policy, resolved from the SSM parameter already looked up in this file for the API (`data.aws_ssm_parameter.irsa_policy_arns_sqs`). No new variables, providers or data sources.

The API service account is deliberately not shared — doing so would give the front-end pod the API's RDS and SNS permissions, which it has no need for.

### Risk

Additive and inert. Nothing consumes the service account until the front-end helm chart sets `serviceAccountName`, which is a separate change in the `hmpps-non-associations` repo. The plan should show one new IAM role, one policy attachment and one service account, with **no changes to the existing `hmpps-non-associations-api` role**.

Companion PRs for the other environments are raised separately, since this repo requires one namespace per PR.


[IR-1920]: https://dsdmoj.atlassian.net/browse/IR-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ