### PR TITLE
MEM-1333: Add UAT Entra secrets

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/secrets.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/secrets.tf
@@ -1,0 +1,21 @@
+module "secrets_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-secrets-manager?ref=3.0.7"
+
+  eks_cluster_name = var.eks_cluster_name
+
+  secrets = {
+    "laa-info-and-advice-datastore-entra-uat" = {
+      description             = "Microsoft Entra OAuth2 config for laa-info-and-advice-datastore UAT"
+      recovery_window_in_days = 7
+      k8s_secret_name         = "laa-info-and-advice-datastore-entra"
+    }
+  }
+
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-info-and-advice-datastore-uat/resources/variables.tf
@@ -8,6 +8,11 @@ variable "kubernetes_cluster" {
   type        = string
 }
 
+variable "eks_cluster_name" {
+  description = "EKS cluster name, used by the Secrets Manager module to create IAM role trust policies"
+  type        = string
+}
+
 variable "application" {
   description = "Name of the application you are deploying"
   type        = string


### PR DESCRIPTION
Re-adds secrets.tf and the `eks_cluster_name` variable that were
unintentionally removed when reverting `PR #44484 (MEM-1138 IRSA revert)`.
This restores the AWS Secrets Manager -> k8s secret sync for the app's
Entra OAuth2 config (`LAA_OAUTH2_ISSUER_URI`, `LAA_OAUTH2_AUDIENCE`,
`TRUSTED_CALLER_AUDIENCE`)