### PR TITLE
chore: reduce memory limit range defaults

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/laa-get-payments-finance-data-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/laa-get-payments-finance-data-dev/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 4
-      memory: 16Gi
+      cpu: 1
+      memory: 3Gi
     defaultRequest:
-      cpu: 2
-      memory: 8Gi
+      cpu: 50m
+      memory: 1792Mi
     type: Container


### PR DESCRIPTION
Lower default container requests from 2 CPU / 8Gi to 50m / 1Gi and limits from 4 CPU / 16Gi to 1 CPU / 2Gi.
Observed usage in the namespace is 6m CPU / 1240Mi for the API container