### PR TITLE
feat: add permission override for persistentvolumeclaims

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 2000m
       memory: 2000Mi
     defaultRequest:
-      cpu: 1000m
-      memory: 2000Mi
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-portfolio-management-dev/02-limitrange.yaml
@@ -9,6 +9,6 @@ spec:
       cpu: 2000m
       memory: 2000Mi
     defaultRequest:
-      cpu: 10m
-      memory: 100Mi
+      cpu: 1000m
+      memory: 2000Mi
     type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 2000m
-      memory: 2000Mi
-    defaultRequest:
       cpu: 1000m
       memory: 2000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
     type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/02-limitrange.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1000m
-      memory: 1000Mi
+      cpu: 2000m
+      memory: 2000Mi
     defaultRequest:
-      cpu: 10m
-      memory: 100Mi
+      cpu: 1000m
+      memory: 2000Mi
     type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
@@ -67,7 +67,7 @@ locals {
 }
 
 module "hmpps-security-assurance-discovery-agent" {
-  source                           = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=v1.2.2"
+  source                           = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.2"
   force_rotate_token               = true
   custom_token_rotation_date       = "2026-03-20"
   github_repo                      = "hmpps-security-assurance-discovery-agent"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
@@ -67,7 +67,7 @@ locals {
 }
 
 module "hmpps-security-assurance-discovery-agent" {
-  source                           = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.2"
+  source                           = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=v1.2.2"
   force_rotate_token               = true
   custom_token_rotation_date       = "2026-03-20"
   github_repo                      = "hmpps-security-assurance-discovery-agent"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
@@ -67,20 +67,20 @@ locals {
 }
 
 module "hmpps-security-assurance-discovery-agent" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.2"
-  force_rotate_token = true
-  custom_token_rotation_date = "2026-03-20"
-  github_repo                   = "hmpps-security-assurance-discovery-agent"
-  application                   = "hmpps-security-assurance-discovery-agent"
-  github_team                   = "hmpps-sre"
-  environment                   = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
-  selected_branch_patterns      = ["main", "**/**", "**"] # Optional but required if protected_branches_only is false
-  protected_branches_only       = false                                    # Optional, defaults to true unless selected_branch_patterns is set
-  is_production                 = var.is_production
-  application_insights_instance = "dev"
-  source_template_repo          = "none"
-  github_token                  = var.github_token
-  namespace                     = var.namespace
-  kubernetes_cluster            = var.kubernetes_cluster
+  source                           = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.2"
+  force_rotate_token               = true
+  custom_token_rotation_date       = "2026-03-20"
+  github_repo                      = "hmpps-security-assurance-discovery-agent"
+  application                      = "hmpps-security-assurance-discovery-agent"
+  github_team                      = "hmpps-sre"
+  environment                      = var.environment         # Should match environment name used in helm values file e.g. values-dev.yaml
+  selected_branch_patterns         = ["main", "**/**", "**"] # Optional but required if protected_branches_only is false
+  protected_branches_only          = false                   # Optional, defaults to true unless selected_branch_patterns is set
+  is_production                    = var.is_production
+  application_insights_instance    = "dev"
+  source_template_repo             = "none"
+  github_token                     = var.github_token
+  namespace                        = var.namespace
+  kubernetes_cluster               = var.kubernetes_cluster
   github_actions_sa_rules_override = local.serviceaccount_rules
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-discovery-agent.tf
@@ -1,5 +1,73 @@
+locals {
+  serviceaccount_rules = [
+    {
+      api_groups = [""]
+      resources = [
+        "pods/portforward",
+        "deployment",
+        "secrets",
+        "services",
+        "configmaps",
+        "pods",
+        "persistentvolumeclaims"
+      ]
+      verbs = [
+        "patch",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "extensions",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "policy",
+        "autoscaling",
+      ]
+      resources = [
+        "deployments",
+        "ingresses",
+        "cronjobs",
+        "jobs",
+        "replicasets",
+        "poddisruptionbudgets",
+        "networkpolicies",
+        "horizontalpodautoscalers",
+        "statefulsets"
+      ]
+      verbs = [
+        "get",
+        "update",
+        "delete",
+        "create",
+        "patch",
+        "list",
+        "watch",
+      ]
+    },
+    {
+      api_groups = [
+        "monitoring.coreos.com",
+      ]
+      resources = [
+        "prometheusrules",
+        "servicemonitors"
+      ]
+      verbs = [
+        "*",
+      ]
+    },
+  ]
+}
+
 module "hmpps-security-assurance-discovery-agent" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.2"
   force_rotate_token = true
   custom_token_rotation_date = "2026-03-20"
   github_repo                   = "hmpps-security-assurance-discovery-agent"
@@ -14,4 +82,5 @@ module "hmpps-security-assurance-discovery-agent" {
   github_token                  = var.github_token
   namespace                     = var.namespace
   kubernetes_cluster            = var.kubernetes_cluster
+  github_actions_sa_rules_override = local.serviceaccount_rules
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
@@ -1,5 +1,5 @@
 module "hmpps-security-assurance-toolkit" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=v1.2.2"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.2"
   force_rotate_token            = true
   custom_token_rotation_date    = "2026-03-20"
   github_repo                   = "hmpps-security-assurance-toolkit"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
@@ -1,13 +1,13 @@
 module "hmpps-security-assurance-toolkit" {
   source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
-  force_rotate_token = true
-  custom_token_rotation_date = "2026-03-20"
+  force_rotate_token            = true
+  custom_token_rotation_date    = "2026-03-20"
   github_repo                   = "hmpps-security-assurance-toolkit"
   application                   = "hmpps-security-assurance-toolkit"
   github_team                   = "hmpps-sre"
-  environment                   = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
+  environment                   = var.environment         # Should match environment name used in helm values file e.g. values-dev.yaml
   selected_branch_patterns      = ["main", "**/**", "**"] # Optional but required if protected_branches_only is false
-  protected_branches_only       = false                                    # Optional, defaults to true unless selected_branch_patterns is set
+  protected_branches_only       = false                   # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev"
   source_template_repo          = "none"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
@@ -1,5 +1,5 @@
 module "hmpps-security-assurance-toolkit" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.2"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=v1.2.2"
   force_rotate_token            = true
   custom_token_rotation_date    = "2026-03-20"
   github_repo                   = "hmpps-security-assurance-toolkit"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/hmpps-security-assurance-toolkit.tf
@@ -1,5 +1,5 @@
 module "hmpps-security-assurance-toolkit" {
-  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.1"
+  source                        = "github.com/ministryofjustice/cloud-platform-terraform-hmpps-template?ref=1.2.2"
   force_rotate_token            = true
   custom_token_rotation_date    = "2026-03-20"
   github_repo                   = "hmpps-security-assurance-toolkit"


### PR DESCRIPTION
Adds `persistentvolumeclaims` rbac to enable my helm chart to provision a volume. 

https://github.com/ministryofjustice/hmpps-security-assurance-discovery-agent/pull/1
