### PR TITLE
Add Route 53 hosted zone for Find a Digital Service

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-a-technology-service-prod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-a-technology-service-prod/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "find_a_digital_service" {
+  name = var.domain
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure_support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "find_a_digital_service_route53_zone" {
+  metadata {
+    name      = "find-a-digital-service-route53-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.find_a_digital_service.zone_id
+    nameservers = join("\n", aws_route53_zone.find_a_digital_service.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/find-a-technology-service-prod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/find-a-technology-service-prod/resources/variables.tf
@@ -44,6 +44,12 @@ variable "environment" {
   default     = "production"
 }
 
+variable "domain" {
+  description = "Custom domain for the Route 53 hosted zone"
+  type        = string
+  default     = "find-a-digital-service.justice.gov.uk"
+}
+
 variable "infrastructure_support" {
   description = "Email address of the team responsible this service"
   type        = string


### PR DESCRIPTION
## Summary

Create the Cloud Platform Route 53 hosted zone for:

`find-a-digital-service.justice.gov.uk`

The zone is owned by the `find-a-technology-service-prod` namespace and will support:

- `find-a-digital-service.justice.gov.uk` for production
- `dev.find-a-digital-service.justice.gov.uk` for development

## Changes

- Add the Route 53 hosted zone to the production namespace.
- Store the zone ID and delegated nameservers in the `find-a-digital-service-route53-zone-output` Kubernetes secret.