### PR TITLE
Create namespace for sop-derived-organogram-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/00-namespace.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/00-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "sop-derived-organogram-preprod"
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "pre-production"
+    pod-security.kubernetes.io/enforce: restricted
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "HQ"
+    cloud-platform.justice.gov.uk/slack-channel: "sop-derived-organogram"
+    cloud-platform.justice.gov.uk/application: "Sop-derived Organogram"
+    cloud-platform.justice.gov.uk/owner: "Data Management: oscar.hardy@justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/sop-derived-organogram"
+    cloud-platform.justice.gov.uk/team-name: "sop-derived-organogram"
+    cloud-platform.justice.gov.uk/review-after: ""

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/01-rbac.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/01-rbac.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sop-derived-organogram-preprod-admin
+  namespace: sop-derived-organogram-preprod
+subjects:
+  - kind: Group
+    name: "github:sop-derived-organogram"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/02-limitrange.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/02-limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: sop-derived-organogram-preprod
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/03-resourcequota.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/03-resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: sop-derived-organogram-preprod
+spec:
+  hard:
+    pods: "50"

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/04-networkpolicy.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/04-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: sop-derived-organogram-preprod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress-controllers
+  namespace: sop-derived-organogram-preprod
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/05-certificate.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/05-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: moj-org-chart-preprod-cert
+  namespace: sop-derived-organogram-preprod
+spec:
+  secretName: tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - moj-org-chart-preprod.service.justice.gov.uk

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/elasticache.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/elasticache.tf
@@ -1,0 +1,46 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "redis" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=8.2.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # Redis cluster configuration
+  node_type               = "cache.t4g.small"
+  engine_version          = "7.0"
+  parameter_group_name    = "default.redis7"
+  auth_token_rotated_date = "2026-07-31"
+
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for CLI queries,
+  # uncomment below:
+
+  # enable_irsa = true
+}
+
+resource "kubernetes_secret" "redis_secrets" {
+  metadata {
+    name      = "elasticache-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    primary_endpoint_address = module.redis.primary_endpoint_address
+    member_clusters          = jsonencode(module.redis.member_clusters)
+    auth_token               = module.redis.auth_token
+    replication_group_id     = module.redis.replication_group_id
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/main.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      business-unit = var.business_unit
+      application   = var.application
+      is-production = var.is_production
+      owner         = var.team_name
+      namespace     = var.namespace
+      service-area  = var.service_area
+      source-code   = "github.com/ministryofjustice/cloud-platform-environments"
+      slack-channel = var.slack_channel
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+provider "kubernetes" {}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/rds-postgresql.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/rds-postgresql.tf
@@ -1,0 +1,159 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "rds" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  # VPC configuration
+  vpc_name = var.vpc_name
+
+  # RDS configuration
+  allow_minor_version_upgrade  = true
+  allow_major_version_upgrade  = false
+  performance_insights_enabled = false
+  db_max_allocated_storage     = "500"
+  # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
+  # db_password_rotated_date     = "2023-04-17" # Uncomment to rotate your database password.
+
+  # PostgreSQL specifics
+  db_engine         = "postgres"
+  db_engine_version = "16" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family        = "postgres16"
+  db_instance_class = "db.t4g.micro"
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for CLI queries,
+  # uncomment below:
+
+  # enable_irsa = true
+
+  # If you want to enable Cloudwatch logging for this postgres RDS instance, uncomment the code below:
+  # opt_in_xsiam_logging = true
+}
+
+# To create a read replica, use the below code and update the values to specify the RDS instance
+# from which you are replicating. In this example, we're assuming that rds is the
+# source RDS instance and read-replica is the replica we are creating.
+
+module "read_replica" {
+  # default off
+  count  = 0
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=9.2.0"
+
+  vpc_name = var.vpc_name
+
+  # Tags
+  application            = var.application
+  business_unit          = var.business_unit
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  is_production          = var.is_production
+  namespace              = var.namespace
+  team_name              = var.team_name
+
+  # If any other inputs of the RDS is passed in the source db which are different from defaults,
+  # add them to the replica
+
+  # PostgreSQL specifics
+  db_engine         = "postgres"
+  db_engine_version = "16" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  rds_family        = "postgres16"
+  db_instance_class = "db.t4g.micro"
+  # It is mandatory to set the below values to create read replica instance
+
+  # Set the db_identifier of the source db
+  replicate_source_db = module.rds.db_identifier
+
+  # Set to true. No backups or snapshots are created for read replica
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
+
+  # If db_parameter is specified in source rds instance, use the same values.
+  # If not specified you dont need to add any. It will use the default values.
+
+  # db_parameter = [
+  #   {
+  #     name         = "rds.force_ssl"
+  #     value        = "0"
+  #     apply_method = "immediate"
+  #   }
+  # ]
+
+  # If you want to assign AWS permissions to a k8s pod in your namespace - ie service pod for CLI queries,
+  # uncomment below:
+
+  # enable_irsa = true
+
+  # If you want to enable Cloudwatch logging for this postgres RDS instance, uncomment the code below:
+  # opt_in_xsiam_logging = true
+}
+
+resource "kubernetes_secret" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    rds_instance_endpoint = module.rds.rds_instance_endpoint
+    database_name         = module.rds.database_name
+    database_username     = module.rds.database_username
+    database_password     = module.rds.database_password
+    rds_instance_address  = module.rds.rds_instance_address
+  }
+  /* You can replace all of the above with the following, if you prefer to
+     * use a single database URL value in your application code:
+     *
+     * url = "postgres://${module.rds.database_username}:${module.rds.database_password}@${module.rds.rds_instance_endpoint}/${module.rds.database_name}"
+     *
+     */
+}
+
+
+resource "kubernetes_secret" "read_replica" {
+  # default off
+  count = 0
+
+  metadata {
+    name      = "rds-postgresql-read-replica-output"
+    namespace = var.namespace
+  }
+
+  # The database_username, database_password, database_name values are same as the source RDS instance.
+  # Uncomment if count > 0
+
+  /*
+  data = {
+    rds_instance_endpoint = module.read_replica.rds_instance_endpoint
+    rds_instance_address  = module.read_replica.rds_instance_address
+    access_key_id         = module.read_replica.access_key_id
+    secret_access_key     = module.read_replica.secret_access_key
+  }
+  */
+}
+
+
+# Configmap to store non-sensitive data related to the RDS instance
+
+resource "kubernetes_config_map" "rds" {
+  metadata {
+    name      = "rds-postgresql-instance-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    database_name = module.rds.database_name
+    db_identifier = module.rds.db_identifier
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/route53.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/route53.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_zone" "sop-derived-organogram-preprod" {
+  name = "moj-org-chart-preprod.service.justice.gov.uk"
+
+  tags = {
+    business-unit          = var.business_unit
+    application            = var.application
+    is-production          = var.is_production
+    environment-name       = var.environment
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
+    namespace              = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "sop-derived-organogram-preprod_sec" {
+  metadata {
+    name      = "sop-derived-organogram-preprod-zone-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    zone_id     = aws_route53_zone.sop-derived-organogram-preprod.zone_id
+    nameservers = join("\n", aws_route53_zone.sop-derived-organogram-preprod.name_servers)
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/serviceaccount.tf
@@ -1,0 +1,12 @@
+module "serviceaccount" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=1.2.0"
+
+  namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
+
+  serviceaccount_token_rotated_date = "01-01-2000"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ca.crt and token for use in github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/serviceaccount.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/serviceaccount.tf
@@ -8,5 +8,5 @@ module "serviceaccount" {
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines
-  # github_repositories = ["my-repo"]
+  github_repositories = ["sop-derived-organogram"]
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/variables.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/variables.tf
@@ -1,0 +1,75 @@
+variable "vpc_name" {
+  description = "VPC name to create security groups in for the ElastiCache and RDS modules"
+  type        = string
+}
+
+variable "kubernetes_cluster" {
+  description = "Kubernetes cluster name for references to secrets for service accounts"
+  type        = string
+}
+
+variable "application" {
+  description = "Name of the application you are deploying"
+  type        = string
+  default     = "Sop-derived Organogram"
+}
+
+variable "namespace" {
+  description = "Name of the namespace these resources are part of"
+  type        = string
+  default     = "sop-derived-organogram-preprod"
+}
+
+variable "service_area" {
+  description = "Service area responsible for this service"
+  type        = string
+  default     = "Justice Data"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for this service"
+  type        = string
+  default     = "HQ"
+}
+
+variable "team_name" {
+  description = "Name of the development team responsible for this service"
+  type        = string
+  default     = "sop-derived-organogram"
+}
+
+variable "environment" {
+  description = "Name of the environment type for this service"
+  type        = string
+  default     = "pre-production"
+}
+
+variable "infrastructure_support" {
+  description = "Email address of the team responsible this service"
+  type        = string
+  default     = "oscar.hardy@justice.gov.uk"
+}
+
+variable "is_production" {
+  description = "Whether this environment type is production or not"
+  type        = string
+  default     = "false"
+}
+
+variable "slack_channel" {
+  description = "Slack channel name for your team, if we need to contact you about this service"
+  type        = string
+  default     = "sop-derived-organogram"
+}
+
+variable "github_owner" {
+  description = "The GitHub organization or individual user account containing the app's code repo. Used by the Github Terraform provider. See: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials"
+  type        = string
+  default     = "ministryofjustice"
+}
+
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/versions.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/sop-derived-organogram-preprod/resources/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.2.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.78.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Creates a new **pre-production** environment for the SOP derived organogram app, based on the existing `sop-derived-organogram-prod` namespace.

Namespace: `sop-derived-organogram-preprod`

## Changes vs the copied prod namespace

- `is-production` set to `false` and `environment-name` set to `pre-production` (namespace labels + Terraform `is_production` / `environment` variable defaults)
- New Route53 hosted zone and certificate hostname: `moj-org-chart-preprod.service.justice.gov.uk` (kept distinct from prod's `moj-org-chart.service.justice.gov.uk`)
- Certificate renamed to `moj-org-chart-preprod-cert`
- All `sop-derived-organogram-prod` references renamed to `sop-derived-organogram-preprod`

Resources carried over from prod: RDS (PostgreSQL), ElastiCache (Redis), Route53 zone, serviceaccount.

## Notes / to confirm

- **DNS delegation**: this PR creates the new hosted zone. After merge + Apply, the zone's nameservers will be output to the `sop-derived-organogram-preprod-zone-output` secret; delegation records for `moj-org-chart-preprod.service.justice.gov.uk` will then need adding to the parent zone (as was done for prod).
- Stateful resources (RDS + Redis) are copied from prod and will incur cost in pre-prod.
