### PR TITLE
Allow unprotected branches on dev sre obs namespace

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/hmpps-sre-observability-dev.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-sre-observability-dev/resources/hmpps-sre-observability-dev.tf
@@ -12,7 +12,7 @@ module "hmpps_template_typescript" {
   environment = var.environment # Should match environment name used in helm values file e.g. values-dev.yaml
   #reviewer_teams                = ["hmpps-dev-team-1", "hmpps-dev-team-2"] # Optional team that should review deployments to this environment.
   #selected_branch_patterns      = ["main", "release/*", "feature/*"] # Optional
-  #protected_branches_only       = true # Optional, defaults to true unless selected_branch_patterns is set
+  protected_branches_only       = false # Optional, defaults to true unless selected_branch_patterns is set
   is_production                 = var.is_production
   application_insights_instance = "dev" # Either "dev", "preprod" or "prod"
   source_template_repo          = "hmpps-template-typescript"


### PR DESCRIPTION
Allows deployment of health-kick to dev from unprotected branches.