### PR TITLE
fix: postgres connection string

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-security-assurance-toolkit/resources/rds.tf
@@ -30,7 +30,7 @@ resource "kubernetes_secret" "hmpps_security_assurance_toolkit_rds" {
   }
 
   data = {
-    DATABASE_URL = "postgres://${module.hmpps_security_assurance_toolkit_rds.database_username}:${module.hmpps_security_assurance_toolkit_rds.database_password}@${module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint}/${module.hmpps_security_assurance_toolkit_rds.database_name}"
+    DATABASE_URL = "postgres://${module.hmpps_security_assurance_toolkit_rds.database_username}:${module.hmpps_security_assurance_toolkit_rds.database_password}@${module.hmpps_security_assurance_toolkit_rds.rds_instance_endpoint}/${module.hmpps_security_assurance_toolkit_rds.database_name}?uselibpqcompat=true&sslmode=require"
   }
 }
 


### PR DESCRIPTION
This pull request makes a targeted update to the `DATABASE_URL` in the `kubernetes_secret` resource for the HMPPS Security Assurance Toolkit RDS instance. The change ensures improved PostgreSQL client compatibility and enforces SSL connections.

Database connection string update:

* Added `uselibpqcompat=true` and `sslmode=require` query parameters to the `DATABASE_URL` to ensure libpq compatibility and require SSL for database connections in `rds.tf`.