### PR TITLE
MAPB-870 Add prisoner property UI service account for the HMPPS Audit queue in hmpps-locations-inside-prison-preprod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-preprod/resources/irsa.tf
@@ -44,3 +44,25 @@ data "aws_ssm_parameter" "irsa_policy_arns_sns" {
   for_each = local.sns_topics
   name     = "/${each.value}/sns/${each.key}/irsa-policy-arn"
 }
+
+# Service account for the prisoner property front end, so it can send page-view events to the
+# HMPPS Audit queue. Deliberately separate from the API service accounts above so the front end
+# does not inherit their RDS and SNS access.
+# The helm chart must set generic-service.serviceAccountName to match the name below.
+module "hmpps-prisoner-property-ui-service-account" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
+
+  eks_cluster_name     = var.eks_cluster_name
+  namespace            = var.namespace
+  service_account_name = "hmpps-prisoner-property-ui"
+  role_policy_arns = {
+    audit_sqs = data.aws_ssm_parameter.irsa_policy_arns_sqs["Digital-Prison-Services-preprod-hmpps_audit_queue"].value
+  }
+  # Tags
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}


### PR DESCRIPTION
Adds an IRSA service account for the prisoner property front end so it can send page-view events to the HMPPS Audit queue.

### Why

HMPPS Audit currently has no record of who *viewed* a prisoner's property, only of the writes the API makes. The front end is being changed to send page-view events (MAPB-871), and to do that its pod needs an IAM role allowed to write to the audit queue.

https://dsdmoj.atlassian.net/browse/MAPB-870

### What this does

Appends one `module "hmpps-prisoner-property-ui-service-account"` to `hmpps-locations-inside-prison-preprod/resources/irsa.tf`, granting the audit queue policy and nothing else.

Prisoner property has no namespace of its own — its resources live in the locations-inside-prison namespaces alongside `prisoner-property-*.tf`.

Everything else it needs is already in place: `locals.sqs_queues` already maps `Digital-Prison-Services-preprod-hmpps_audit_queue`, the `data.aws_ssm_parameter.irsa_policy_arns_sqs` lookup already exists, and the `sqs-hmpps-audit-secret` is already created in this namespace by `hmpps-audit-preprod/resources/audit-namespaces-secrets.tf`. So the service account is the only new thing.

### Risk

Low. Purely additive — no existing resource is modified. The existing `hmpps-locations-inside-prison-api` and `hmpps-prisoner-property-api` service accounts are untouched, so neither API's access changes, and the new account is deliberately scoped to the audit queue alone rather than sharing theirs.

Nothing consumes the service account until the helm chart sets `serviceAccountName` (MAPB-872), which is held until this has applied.

Follows the same pattern as the non-associations equivalents: #45363, #45364, #45365.

Companion PRs for the other environments are raised separately, since this repo requires one namespace per PR.