### PR TITLE
APG-2664: decommission NEC pipeline in preprod namespace (PR 2 of 3)

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/cronjob-s3-transfer.yaml
@@ -1,9 +1,23 @@
+# =============================================================================
+# APG-2664 — NEC pipeline decommissioned 2026-09-11
+# This CronJob is intentionally suspended. The NEC ingest pipeline is being
+# retired: the final .bak (backup-production-IM-dbo-only-20260908013109.bak,
+# ~32.5 GiB, uploaded 2026-09-09 04:04 UTC) has been preserved forever in the
+# prod archive S3 bucket. Both preprod and prod RDS instances have been
+# manually snapshotted (see APG-2664 ticket for snapshot ARNs + KMS key ARNs).
+# NEC's DataSync IAM role has been REVOKED from this bucket's policy in PR 2
+# (this PR) — any run would now fail with AccessDenied for NEC and would only
+# transfer already-transferred artefacts internally.
+# DO NOT unsuspend without first reviewing APG-2664.
+# =============================================================================
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hmpps-manage-and-deliver-acp-s3-transfer
   namespace: hmpps-manage-and-deliver-accredited-programmes-preprod
 spec:
+  # APG-2664: suspended — pipeline decommissioned. See banner above.
+  suspend: true
   #  Run every night at 05:00 UTC (06:00 BST)
   schedule: "0 5 * * *"
   concurrencyPolicy: Forbid

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/db_restore.yaml
@@ -1,9 +1,23 @@
+# =============================================================================
+# APG-2664 — NEC pipeline decommissioned 2026-09-11
+# This CronJob is intentionally suspended. The NEC ingest pipeline is being
+# retired: the final .bak (backup-production-IM-dbo-only-20260908013109.bak)
+# has been preserved forever in the prod archive S3 bucket, and both preprod
+# and prod RDS instances have been manually snapshotted (see APG-2664).
+# Both SQLSERVER_BACKUP_S3_BUCKET_NAME env vars below have been invalidated
+# to "APG-2664-DECOMMISSIONED" so any accidental unsuspend fails fast without
+# touching the DB — the find-backup-file init container will get AccessDenied
+# from S3 and the job will fail before the destructive db-restore step runs.
+# DO NOT unsuspend without first reviewing APG-2664.
+# =============================================================================
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: db-restore-cronjob
   namespace: hmpps-manage-and-deliver-accredited-programmes-preprod
 spec:
+  # APG-2664: suspended — pipeline decommissioned. See banner above.
+  suspend: true
   # Run every night at 05:45 UTC (06:45 BST) — 0:45:00 after the s3-transfer job
   schedule: "45 5 * * *"
   concurrencyPolicy: Forbid
@@ -110,10 +124,7 @@ spec:
                 - name: HOME
                   value: /tmp
                 - name: SQLSERVER_BACKUP_S3_BUCKET_NAME
-                  valueFrom:
-                    secretKeyRef:
-                      name: sqlserver-backup-s3-bucket-output
-                      key: bucket_name
+                  value: "APG-2664-DECOMMISSIONED"
               command:
                 - /bin/bash
                 - -c
@@ -230,10 +241,7 @@ spec:
                       name: rds-sqlserver-instance-output
                       key: database_password
                 - name: SQLSERVER_BACKUP_S3_BUCKET_NAME
-                  valueFrom:
-                    secretKeyRef:
-                      name: sqlserver-backup-s3-bucket-output
-                      key: bucket_name
+                  value: "APG-2664-DECOMMISSIONED"
               command:
                 - /bin/bash
                 - -c

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/irsa.tf
@@ -104,6 +104,12 @@ module "irsa-sqlserver" {
     {
       # db-restore job needs to list the backup bucket to discover the latest .bak file
       sqlserver_backup_s3_bucket_policy = module.sqlserver_backup_s3_bucket.irsa_policy_arn
+    },
+    {
+      # APG-2664: write access to the archive bucket so the sqlserver_service_pod
+      # can copy the final .bak into it. The archive bucket's deny policy blocks
+      # DeleteObject* even for this role — the pod can PUT but never delete.
+      archive_s3_bucket_policy = module.archive_s3_bucket.irsa_policy_arn
     }
   )
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/rds-sqlserver.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/rds-sqlserver.tf
@@ -21,6 +21,13 @@ module "sqlserver" {
   vpc_name                   = var.vpc_name
   character_set_name         = var.character_set_name
 
+  # APG-2664: prevents accidental deletion of the instance holding the final NEC
+  # data. If instance deletion is ever legitimately needed, flip to false via a
+  # Terraform PR first. Note: manual snapshot hmpps-acp-preprod-nec-final-20260910110000
+  # exists and is encrypted with a KMS key — do NOT delete that KMS key or the
+  # snapshot becomes unrecoverable.
+  deletion_protection = true
+
 
   enable_irsa = true
 

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/s3.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/s3.tf
@@ -1,5 +1,5 @@
 module "upload_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.1"
   team_name              = var.team_name
   business_unit          = var.business_unit
   application            = var.application
@@ -43,10 +43,13 @@ resource "aws_s3_bucket_policy" "upload_s3_bucket_policy" {
         Principal = {
           AWS = [
             module.irsa-cronjob.role_arn,
-            # NEC preprod datasync role - commented out as the IAM role does not yet exist in AWS account 778742069978.
-            # Re-enable once NEC confirm the role has been created.
+            # APG-2664 (2026-09-11): NEC's prod DataSync role REVOKED — pipeline decommissioned.
+            # The final .bak (backup-production-IM-dbo-only-20260908013109.bak) is preserved
+            # forever in the prod archive bucket. This removal is the actual access revocation.
+            # Historical (pre-existing): NEC preprod datasync role — commented out as the IAM role
+            # never existed in AWS account 778742069978. Do NOT re-enable.
             #"arn:aws:iam::778742069978:role/im-preprod-s3-datasync",
-            "arn:aws:iam::778742069978:role/im-production-s3-datasync"
+            #"arn:aws:iam::778742069978:role/im-production-s3-datasync",
           ]
         }
         Action = [
@@ -84,7 +87,7 @@ resource "kubernetes_secret" "upload_s3_bucket" {
 }
 
 module "s3_upload_logging_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.1"
   team_name              = var.team_name
   business_unit          = var.business_unit
   application            = var.application
@@ -140,7 +143,7 @@ resource "kubernetes_secret" "s3_upload_logging_bucket" {
 }
 
 module "sqlserver_backup_s3_bucket" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.0"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.1"
   team_name              = var.team_name
   business_unit          = var.business_unit
   application            = var.application
@@ -149,19 +152,13 @@ module "sqlserver_backup_s3_bucket" {
   infrastructure_support = var.infrastructure_support
   namespace              = var.namespace
 
-  # Expire old .bak files after 14 days — the DB restore only ever uses the latest file.
-  # Files accumulate at ~32GB/day so this keeps storage costs bounded.
-  lifecycle_rule = [
-    {
-      id      = "expire-old-backups"
-      enabled = true
-      expiration = [
-        {
-          days = 14
-        }
-      ]
-    }
-  ]
+  # APG-2664 (2026-09-11): 14-day lifecycle rule REMOVED — NEC pipeline decommissioned.
+  # The DB restore CronJob (db-restore-cronjob) that consumed the "latest" file is suspended,
+  # so there is no longer a moving "latest" to point at. The final .bak
+  # (backup-production-IM-dbo-only-20260908013109.bak) is already preserved forever in the
+  # prod archive bucket cloud-platform-237c423a923efb55500dc5fd4dda2ff4. Historical .bak files
+  # (~170 files, ~5.4 TB) are retained by explicit product decision for forensic/audit purposes.
+  # Deleting the bucket is out of scope for APG-2664.
 
   providers = {
     aws = aws.london
@@ -212,4 +209,82 @@ resource "aws_s3_bucket_policy" "sqlserver_backup_allow_prod_read" {
       }
     ]
   })
+}
+
+# =============================================================================
+# APG-2664: Archive bucket for permanent preservation of the final NEC .bak.
+# This bucket receives the final backup-production-IM-dbo-only-20260908013109.bak
+# (~32.5 GiB) via a post-merge `aws s3 cp` runbook step from the newly-live
+# sqlserver_rds_service_pod. Deny-delete bucket policy makes deletion require
+# a Terraform PR to relax this policy first. Matches the prod archive pattern
+# (PR #45463 merged 2026-09-11).
+# =============================================================================
+module "archive_s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=5.3.1"
+
+  team_name              = var.team_name
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+  namespace              = var.namespace
+
+  versioning = true
+
+  # No lifecycle rule — objects stay in S3 Standard forever (D2).
+  # A ~32 GB .bak costs ~$0.74/month at Standard.
+  lifecycle_rule = []
+
+  # Deny-delete bucket policy (D8, F1, F16). Blanket deny with no break-glass
+  # exemption — deletion requires a Terraform PR to relax this policy first.
+  # $${bucket_arn} is the templating token used by the shared module's
+  # replace() call (verified in module source main.tf line 54).
+  bucket_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "APG2664DenyDelete"
+        Effect    = "Deny"
+        Principal = "*"
+        Action = [
+          "s3:DeleteObject",
+          "s3:DeleteObjectTagging",
+          "s3:DeleteObjectVersion",
+          "s3:DeleteObjectVersionTagging",
+          "s3:DeleteBucket",
+          "s3:DeleteBucketPolicy"
+        ]
+        Resource = [
+          "$${bucket_arn}",
+          "$${bucket_arn}/*"
+        ]
+      }
+    ]
+  })
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+# The prevent_destroy on this secret is a Terraform tripwire (F24). If the
+# archive module block is removed from .tf, this secret's data-source references
+# become undefined and plan errors out at reference-resolution — nudging the
+# reviewer before any destructive action. The deny bucket policy above is the
+# ultimate defence.
+resource "kubernetes_secret" "archive_s3_bucket" {
+  metadata {
+    name      = "archive-s3-bucket-output"
+    namespace = var.namespace
+  }
+
+  data = {
+    bucket_arn  = module.archive_s3_bucket.bucket_arn
+    bucket_name = module.archive_s3_bucket.bucket_name
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/service_pod.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-manage-and-deliver-accredited-programmes-preprod/resources/service_pod.tf
@@ -13,3 +13,14 @@ module "s3_service_pod" {
   namespace            = var.namespace
   service_account_name = module.irsa-sqlserver.service_account.name # this uses the service account name from the irsa module
 }*/
+
+# APG-2664: service pod bound to irsa-sqlserver — needed for the post-merge runbook
+# step that copies the final .bak from sqlserver_backup_s3_bucket to archive_s3_bucket.
+# irsa-sqlserver gets archive_s3_bucket_policy in irsa.tf (write access to archive) and
+# already has sqlserver_backup_s3_bucket_policy (read access to source bucket).
+module "sqlserver_rds_service_pod" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-service-pod?ref=1.3.0"
+
+  namespace            = var.namespace
+  service_account_name = module.irsa-sqlserver.service_account.name
+}


### PR DESCRIPTION
## APG-2664 — Decommission NEC pipeline in preprod namespace (PR 2 of 3)

**Namespace scope**: `hmpps-manage-and-deliver-accredited-programmes-preprod` only.

Preprod half of the APG-2664 NEC ingest pipeline decommission. Prod half ( #45463 ) merged and applied 2026-09-11. This PR revokes NEC's IAM access to the upload bucket, suspends the ingest cronjobs, and creates the permanent archive bucket for the final `.bak` preservation copy.

### Why now
The NEC IM database ingest is being retired. Business wants to preserve the last transfer forever. Prod archive copy is already verified and deny-delete tested; this PR does the same for preprod plus revokes NEC's IAM access at the source.

### Changes

| File | Change |
|---|---|
| `cronjob-s3-transfer.yaml` | banner + `spec.suspend: true` |
| `db_restore.yaml` | banner + `spec.suspend: true` + invalidate BOTH `SQLSERVER_BACKUP_S3_BUCKET_NAME` env vars to `APG-2664-DECOMMISSIONED` (defence-in-depth) |
| `resources/s3.tf` | **Remove** `arn:aws:iam::778742069978:role/im-production-s3-datasync` from `upload_s3_bucket_policy` Principal.AWS — **this is the actual NEC access revocation.** Remove 14-day `expire-old-backups` lifecycle from `sqlserver_backup_s3_bucket` (product decision: retain ~5.4 TB historical for forensics; bucket removal out of scope). Add `module.archive_s3_bucket` + `kubernetes_secret.archive_s3_bucket` with deny-delete policy + `prevent_destroy` tripwire (mirrors merged prod). Bump 3× `s3-bucket?ref=5.3.0` → `5.3.1` (matches prod baseline). |
| `resources/rds-sqlserver.tf` | `deletion_protection = true` on `module.sqlserver`. Manual snapshot `hmpps-acp-preprod-nec-final-20260910110000` exists as recovery point. |
| `resources/irsa.tf` | Add `archive_s3_bucket_policy = module.archive_s3_bucket.irsa_policy_arn` to `irsa-sqlserver.role_policy_arns` so the runbook `aws s3 cp` can PUT into the archive. |
| `resources/service_pod.tf` | Uncomment `sqlserver_rds_service_pod` module (preserved old commented block for history), pin to `service-pod?ref=1.3.0` (latest). Needed for the post-merge `aws s3 cp`. |

### Final NEC `.bak` reference
`backup-production-IM-dbo-only-20260908013109.bak` (~32.5 GiB, uploaded 2026-09-09 04:04 UTC).

Prod archive copy already verified:
- Bucket: `cloud-platform-237c423a923efb55500dc5fd4dda2ff4`
- VersionId: `8HVmSzHbe6otg0907jBezufOiDByIBVt`
- ETag: `fffe33c51a400c40d296ba7eab548c36-4163`
- Deny-delete verified via `aws s3 rm` → `AccessDenied … explicit deny in a resource-based policy`.

### Post-merge runbook (out-of-band, not in this PR)
1. Verify apply completed (archive secret exists, cronjobs suspended, `deletion_protection=true`, NEC role removed from bucket policy).
2. Correct preprod snapshot tags via ephemeral Job (same pattern used to create the snapshot; `serviceAccountName: irsa-sqlserver`, `HOME=/tmp`, `runAsNonRoot`).
3. Copy final `.bak` from `sqlserver_backup_s3_bucket` → `archive_s3_bucket` through the newly-live `sqlserver_rds_service_pod` with `aws s3 cp --copy-props none` (workaround: `preprod_backup_s3_read` policy lacks `s3:GetObjectTagging`).
4. Verify deny-delete on preprod archive with `aws s3 rm` (must return AccessDenied).
5. Record VersionId/ETag in the Jira ticket.

### Safety belts
- `deletion_protection = true` on the RDS instance.
- Deny-delete bucket policy on archive (6 delete actions blocked including `DeleteBucket`, `DeleteBucketPolicy`).
- `prevent_destroy` on the archive kubernetes secret is a Terraform tripwire — removing the module block without removing the secret causes a plan-time error.
- Both suspended CronJobs carry banners telling anyone unsuspending to review APG-2664 first; `db_restore` env vars are additionally invalidated to fail fast at S3 before touching RDS.

### Deadline
Preprod backup bucket's 14-day lifecycle would have silently deleted the `.bak` around **2026-09-23**. Removing the rule in this PR removes the deadline. Prod archive copy already preserves the file forever regardless.

### Requesting review from cloud-platform team per repo convention.

---
Jira: https://dsdmoj.atlassian.net/browse/APG-2664
