### PR TITLE
MAPB-881 Add prisoner-property-cleanup queue to hmpps-locations-inside-prison-prod

### DIFF
--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-cleanup-sqs.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-cleanup-sqs.tf
@@ -1,0 +1,76 @@
+# Work queue (+ DLQ) for hmpps-prisoner-property-api's legacy property clean-up job.
+# The API sends a single "start" message to this queue itself after it has committed a
+# clean-up job, and its LegacyCleanupListener consumes it - there is no SNS topic
+# subscription. Modelled on prisoner-property-sqs.tf in this folder; the queue policy is
+# not needed because only the app's own IRSA role (prisoner-property-irsa.tf) sends to it.
+
+module "prisoner_property_cleanup_queue" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name                   = "prisoner-property-cleanup-queue"
+  encrypt_sqs_kms            = "true"
+  message_retention_seconds  = 43200 # 12 hours - a job that has not run within that is stale
+  visibility_timeout_seconds = 1800  # 30 minutes - a large prison takes minutes to process; must exceed that so the message is not redelivered mid-run
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = module.prisoner_property_cleanup_dlq.sqs_arn
+    maxReceiveCount     = 3
+  })
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+module "prisoner_property_cleanup_dlq" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
+
+  sqs_name        = "prisoner-property-cleanup-dlq"
+  encrypt_sqs_kms = "true"
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  namespace              = var.namespace
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+
+  providers = {
+    aws = aws.london
+  }
+}
+
+resource "kubernetes_secret" "prisoner_property_cleanup_queue" {
+  metadata {
+    name      = "sqs-prisoner-property-cleanup-queue-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    sqs_queue_url  = module.prisoner_property_cleanup_queue.sqs_id
+    sqs_queue_arn  = module.prisoner_property_cleanup_queue.sqs_arn
+    sqs_queue_name = module.prisoner_property_cleanup_queue.sqs_name
+  }
+}
+
+resource "kubernetes_secret" "prisoner_property_cleanup_dlq" {
+  metadata {
+    name      = "sqs-prisoner-property-cleanup-dlq-secret"
+    namespace = var.namespace
+  }
+
+  data = {
+    sqs_queue_url  = module.prisoner_property_cleanup_dlq.sqs_id
+    sqs_queue_arn  = module.prisoner_property_cleanup_dlq.sqs_arn
+    sqs_queue_name = module.prisoner_property_cleanup_dlq.sqs_name
+  }
+}

--- a/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-irsa.tf
+++ b/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-locations-inside-prison-prod/resources/prisoner-property-irsa.tf
@@ -1,7 +1,8 @@
 # Dedicated IRSA service account for hmpps-prisoner-property-api.
 # Scoped to this app rather than sharing the locations-inside-prison-api service account.
 # Grants: publish/subscribe to the hmpps-domain-events SNS topic (via local.sns_policies,
-# already computed in the existing irsa.tf in this folder) and access to its own queue + DLQ.
+# already computed in the existing irsa.tf in this folder), access to its own event queue + DLQ,
+# and send/receive on its legacy clean-up work queue + DLQ (prisoner-property-cleanup-sqs.tf).
 # The helm chart must set generic-service.serviceAccountName to match the name below.
 
 module "prisoner_property_irsa" {
@@ -14,7 +15,9 @@ module "prisoner_property_irsa" {
   role_policy_arns = merge(
     local.sns_policies, # domain-events topic publish/subscribe (shared local from irsa.tf)
     { (module.prisoner_property_event_queue.sqs_name) = module.prisoner_property_event_queue.irsa_policy_arn },
-    { (module.prisoner_property_event_dlq.sqs_name)   = module.prisoner_property_event_dlq.irsa_policy_arn },
+    { (module.prisoner_property_event_dlq.sqs_name) = module.prisoner_property_event_dlq.irsa_policy_arn },
+    { (module.prisoner_property_cleanup_queue.sqs_name) = module.prisoner_property_cleanup_queue.irsa_policy_arn },
+    { (module.prisoner_property_cleanup_dlq.sqs_name) = module.prisoner_property_cleanup_dlq.irsa_policy_arn },
   )
 
   business_unit          = var.business_unit


### PR DESCRIPTION
Adds an SQS work queue and DLQ (`prisoner-property-cleanup-queue` / `-dlq`) for hmpps-prisoner-property-api's legacy property clean-up job, plus send/receive on both for the app's existing IRSA role (`hmpps-prisoner-property-api`).

The API sends the start message to this queue itself after committing a clean-up job and consumes it from its own listener, so there is no SNS topic subscription or queue policy. Visibility timeout is 30 minutes so a large prison's run is not redelivered mid-way (same reasoning as `hmpps-update-cell-certfiicate-queue.tf` in this namespace).

One namespace only in this PR; the dev/preprod/prod changes are raised separately under MAPB-881.

Jira: https://dsdmoj.atlassian.net/browse/MAPB-881